### PR TITLE
chore: convert workout notes input to textarea

### DIFF
--- a/apps/web/src/components/ui/textarea.tsx
+++ b/apps/web/src/components/ui/textarea.tsx
@@ -1,0 +1,24 @@
+import * as React from 'react';
+
+import { cn } from '~/lib/utils';
+
+export interface TextareaProps
+  extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
+
+const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
+  ({ className, ...props }, ref) => {
+    return (
+      <textarea
+        className={cn(
+          'border-input placeholder:text-muted-foreground focus-visible:ring-ring flex min-h-[60px] w-full rounded-md border bg-transparent px-2 py-1 text-sm shadow-sm focus-visible:outline-none focus-visible:ring-1 disabled:cursor-not-allowed disabled:opacity-50',
+          className,
+        )}
+        ref={ref}
+        {...props}
+      />
+    );
+  },
+);
+Textarea.displayName = 'Textarea';
+
+export { Textarea };

--- a/apps/web/src/pages/CompletedWorkout/CompletedWorkoutPage.tsx
+++ b/apps/web/src/pages/CompletedWorkout/CompletedWorkoutPage.tsx
@@ -1,11 +1,11 @@
 import { DateTime } from 'luxon';
-import { useRef, useState } from 'react';
+import { useRef } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 
 import { useSelectRPE, useUpdateWorkoutNotes, useWorkoutLog } from '~/api';
 import { Loading, Page } from '~/components';
 import { Button } from '~/components/ui/button';
-import { Input } from '~/components/ui/input';
+import { Textarea } from '~/components/ui/textarea';
 import { useWorkoutOptions } from '~/contexts';
 import { WorkoutLog } from '~/types';
 
@@ -23,7 +23,7 @@ export const CompletedWorkoutPage = () => {
   const { mutate: selectRPE } = useSelectRPE(id);
   const { mutate: updateWorkoutNotes } = useUpdateWorkoutNotes(id);
 
-  const notesRef = useRef<HTMLInputElement>(null);
+  const notesRef = useRef<HTMLTextAreaElement>(null);
 
   if (isLoading) return <Loading />;
   if (!completedWorkout) return <>Not Found</>;
@@ -87,7 +87,7 @@ export const CompletedWorkoutPage = () => {
             )
           }
         >
-          <Input
+          <Textarea
             aria-label="Workout Notes"
             autoFocus
             className="w-full"


### PR DESCRIPTION
Realized very quickly after merging my last pull request that this workout notes input needed to be a textarea so that the user can type more than a couple of words. 