### PR TITLE
fix(kb-49): workouts tracked twice with minutes goal and interval timer

### DIFF
--- a/apps/web/src/pages/ActiveWorkout/ActiveWorkoutPage.tsx
+++ b/apps/web/src/pages/ActiveWorkout/ActiveWorkoutPage.tsx
@@ -255,13 +255,20 @@ export const ActiveWorkoutPage = ({
   };
 
   useEffect(
-    function handleGoalReached() {
-      if (workoutGoalUnits === 'rounds' && completedRounds >= workoutGoal)
-        finishWorkout();
-      if (workoutGoalUnits === 'minutes' && remainingMilliseconds === 0)
-        finishWorkout();
+    function handleRoundsGoalReached() {
+      if (workoutGoalUnits !== 'rounds') return;
+      if (completedRounds >= workoutGoal) finishWorkout();
     },
-    [completedRounds, remainingMilliseconds],
+    [completedRounds],
+  );
+
+  useEffect(
+    function handleMinutesGoalReached() {
+      if (workoutGoalUnits !== 'minutes') return;
+      // small delay for all rounds to be counted from interval timer
+      if (remainingMilliseconds <= -500) finishWorkout();
+    },
+    [remainingMilliseconds],
   );
 
   useEffect(


### PR DESCRIPTION
I found that splitting this single effect into two separate effects could prevent it from being triggered twice when an interval timer is used with a minutes goal. 

I also found that adding a 500ms delay into the effect for reaching the minutes goal would give interval timers enough time to fire and count all reps and rounds correctly. 