### PR TITLE
feat: implement PWA deep linking for magic link authentication

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -9,6 +9,12 @@
   "orientation": "portrait-primary",
   "scope": "/",
   "id": "/",
+  "protocol_handlers": [
+    {
+      "protocol": "bellskill",
+      "url": "/auth?%s"
+    }
+  ],
   "icons": [
     {
       "src": "/apple-touch-icon.png",

--- a/public/sw.js
+++ b/public/sw.js
@@ -6,26 +6,38 @@ const urlsToCache = [
   '/static/css/main.css',
   '/manifest.json',
   '/favicon.ico',
-  '/apple-touch-icon.png'
+  '/apple-touch-icon.png',
 ];
 
 // Install event - cache resources
 self.addEventListener('install', (event) => {
   event.waitUntil(
-    caches.open(CACHE_NAME)
+    caches
+      .open(CACHE_NAME)
       .then((cache) => {
         return cache.addAll(urlsToCache);
       })
       .catch((error) => {
         console.log('Cache installation failed:', error);
-      })
+      }),
   );
 });
 
 // Fetch event - serve from cache, fallback to network
 self.addEventListener('fetch', (event) => {
+  // Handle deep links for PWA
+  if (event.request.url.includes('bellskill://')) {
+    event.respondWith(
+      fetch(
+        event.request.url.replace('bellskill://', 'https://localhost:5173/'),
+      ),
+    );
+    return;
+  }
+
   event.respondWith(
-    caches.match(event.request)
+    caches
+      .match(event.request)
       .then((response) => {
         // Return cached version or fetch from network
         return response || fetch(event.request);
@@ -35,7 +47,7 @@ self.addEventListener('fetch', (event) => {
         if (event.request.destination === 'document') {
           return caches.match('/');
         }
-      })
+      }),
   );
 });
 
@@ -48,9 +60,9 @@ self.addEventListener('activate', (event) => {
           if (cacheName !== CACHE_NAME) {
             return caches.delete(cacheName);
           }
-        })
+        }),
       );
-    })
+    }),
   );
 });
 
@@ -72,12 +84,10 @@ self.addEventListener('push', (event) => {
       vibrate: [100, 50, 100],
       data: {
         dateOfArrival: Date.now(),
-        primaryKey: '2'
-      }
+        primaryKey: '2',
+      },
     };
-    
-    event.waitUntil(
-      self.registration.showNotification(data.title, options)
-    );
+
+    event.waitUntil(self.registration.showNotification(data.title, options));
   }
 });

--- a/src/app/routes.tsx
+++ b/src/app/routes.tsx
@@ -1,5 +1,6 @@
 import { RouteObject } from 'react-router-dom';
 
+import { AuthHandler } from '../components/AuthHandler';
 import {
   AccountPage,
   ActiveWorkoutPage,
@@ -11,6 +12,10 @@ import {
 import { Root } from './Root';
 
 export const routes: RouteObject[] = [
+  {
+    path: '/auth',
+    element: <AuthHandler />,
+  },
   {
     path: '/',
     element: <Root />,

--- a/src/components/AuthHandler.tsx
+++ b/src/components/AuthHandler.tsx
@@ -1,0 +1,77 @@
+import { useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+import { supabase } from '../supabaseClient';
+
+export function AuthHandler() {
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    // Handle auth state changes
+    const {
+      data: { subscription },
+    } = supabase.auth.onAuthStateChange(async (event, session) => {
+      if (event === 'SIGNED_IN' && session) {
+        // User signed in successfully
+        console.log('User signed in:', session.user.email);
+        // Navigate to the main app
+        navigate('/');
+      } else if (event === 'SIGNED_OUT') {
+        // User signed out
+        console.log('User signed out');
+        navigate('/');
+      }
+    });
+
+    // Handle URL parameters for magic link authentication
+    const handleAuthRedirect = async () => {
+      const urlParams = new URLSearchParams(window.location.search);
+      const accessToken = urlParams.get('access_token');
+      const refreshToken = urlParams.get('refresh_token');
+      const error = urlParams.get('error');
+      const errorDescription = urlParams.get('error_description');
+
+      if (error) {
+        console.error('Auth error:', error, errorDescription);
+        alert(`Authentication error: ${errorDescription || error}`);
+        navigate('/');
+        return;
+      }
+
+      if (accessToken && refreshToken) {
+        try {
+          const { data, error } = await supabase.auth.setSession({
+            access_token: accessToken,
+            refresh_token: refreshToken,
+          });
+
+          if (error) {
+            console.error('Error setting session:', error);
+            alert('Failed to complete authentication');
+            navigate('/');
+          } else {
+            console.log('Session set successfully');
+            // The auth state change handler will handle navigation
+          }
+        } catch (err) {
+          console.error('Error during auth redirect:', err);
+          navigate('/');
+        }
+      }
+    };
+
+    // Check if we're on an auth redirect page
+    if (
+      window.location.pathname === '/auth' ||
+      window.location.search.includes('access_token')
+    ) {
+      handleAuthRedirect();
+    }
+
+    return () => {
+      subscription.unsubscribe();
+    };
+  }, [navigate]);
+
+  return null; // This component doesn't render anything
+}

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,3 +1,4 @@
+export * from './AuthHandler';
 export * from './Header';
 export * from './Loading';
 export * from './PWAInstallPrompt';

--- a/src/pages/SignupPage/SignupPage.tsx
+++ b/src/pages/SignupPage/SignupPage.tsx
@@ -12,7 +12,23 @@ export function Signup() {
     event.preventDefault();
 
     setLoading(true);
-    const { error } = await supabase.auth.signInWithOtp({ email });
+
+    // Determine the redirect URL based on the environment
+    const isStandalone =
+      window.matchMedia('(display-mode: standalone)').matches ||
+      (window.navigator as any).standalone ||
+      document.referrer.includes('android-app://');
+
+    const redirectTo = isStandalone
+      ? 'bellskill://auth/callback'
+      : `${window.location.origin}/auth`;
+
+    const { error } = await supabase.auth.signInWithOtp({
+      email,
+      options: {
+        emailRedirectTo: redirectTo,
+      },
+    });
 
     if (error?.message) {
       alert(error.message);

--- a/src/supabaseClient.ts
+++ b/src/supabaseClient.ts
@@ -3,7 +3,29 @@ import { createClient } from '@supabase/supabase-js';
 import { Database } from '../types/supabase';
 import { VITE_SUPABASE_ANON_KEY, VITE_SUPABASE_URL } from './env';
 
+// Determine the redirect URL based on the environment
+const getRedirectUrl = () => {
+  // Check if we're in standalone mode (PWA)
+  const isStandalone =
+    window.matchMedia('(display-mode: standalone)').matches ||
+    (window.navigator as any).standalone ||
+    document.referrer.includes('android-app://');
+
+  if (isStandalone) {
+    // Use the custom protocol for PWA
+    return 'bellskill://auth/callback';
+  }
+
+  // Use the regular URL for browser
+  return `${window.location.origin}/auth`;
+};
+
 export const supabase = createClient<Database>(
   VITE_SUPABASE_URL,
   VITE_SUPABASE_ANON_KEY,
+  {
+    auth: {
+      flowType: 'pkce',
+    },
+  },
 );

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -98,7 +98,12 @@ enabled = true
 # in emails.
 site_url = "http://localhost:5173"
 # A list of *exact* URLs that auth providers are permitted to redirect to post authentication.
-additional_redirect_urls = ["https://localhost:5173"]
+additional_redirect_urls = [
+  "https://localhost:5173",
+  "http://localhost:5173",
+  "bellskill://auth",
+  "bellskill://auth/callback"
+]
 # How long tokens are valid for, in seconds. Defaults to 3600 (1 hour), maximum 604,800 (1 week).
 jwt_expiry = 3600
 # If disabled, the refresh token will never expire.


### PR DESCRIPTION
- Add custom protocol handlers (bellskill://) to manifest.json
- Create AuthHandler component to process auth redirects
- Update Supabase config with PWA-specific redirect URLs
- Enhance service worker to handle deep links
- Add dynamic redirect URL logic based on PWA vs browser mode
- Add /auth route for handling authentication callbacks

Fixes magic link authentication opening in browser instead of PWA