### PR TITLE
feat: Add OTP authentication support for mobile users

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,16 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(grep:*)",
+      "Bash(npm run dev:*)",
+      "Bash(npx tsc:*)",
+      "Bash(npm run lint)",
+      "Bash(npx eslint:*)",
+      "Bash(npm test)"
+    ],
+    "deny": []
+  },
+  "git": {
+    "includeClaudeAttribution": false
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,66 @@
+# Claude Development Guidelines
+
+## Project Overview
+This is a kettlebell workout tracking application built with React, TypeScript, Vite, and Supabase. It features PWA support for mobile installation.
+
+## Custom Tailwind Sizing
+This project uses **custom spacing values** in `tailwind.config.js` that are LARGER than Tailwind's defaults. When adding new shadcn/ui components to the `src/components/ui/` folder, you MUST use these custom sizes instead of the default values:
+
+### Custom Spacing Scale:
+```javascript
+spacing: {
+  px: '1px',
+  0: '0',
+  0.5: '4px',    // default: 2px
+  1: '8px',      // default: 4px
+  1.5: '12px',   // default: 6px
+  2: '16px',     // default: 8px
+  2.5: '20px',   // default: 10px
+  3: '24px',     // default: 12px
+  4: '32px',     // default: 16px
+  5: '48px',     // default: 20px
+  6: '64px',     // default: 24px
+  7: '80px',     // default: 28px
+}
+```
+
+### Important Rules for shadcn/ui Components:
+1. **Always check existing UI components** in `src/components/ui/` for sizing patterns
+2. **Use the custom spacing scale** - don't use default shadcn sizing
+3. **Follow the existing height conventions**:
+   - Small: `h-3` (24px)
+   - Default: `h-4` (32px) 
+   - Large: `h-5` (48px)
+4. **Maintain consistency** with existing components like `input.tsx` and `button.tsx`
+
+### Example Adjustments Needed:
+- Default shadcn input: `h-10` → Use: `h-4` or `h-5`
+- Default shadcn button: `h-10` → Use: `h-4` or `h-5`
+- Default shadcn padding: `px-3` → Use: `px-2` or `px-3` (but verify against existing components)
+
+## Authentication
+- Uses Supabase Auth with both magic links and OTP (one-time passwords)
+- Magic links are primary method, OTP is fallback for mobile users
+- Session management handled via React Context
+
+## Testing
+- Uses Vitest for unit testing
+- Run tests with: `npm test`
+- All tests must pass before committing
+
+## Development Commands
+- `npm run dev` - Start development server
+- `npm run build` - Build for production
+- `npm run preview` - Preview production build
+- `npm test` - Run tests
+- `npm run lint` - Run ESLint
+- `npm run fetch-types` - Fetch Supabase types from backend
+
+## Key Technologies
+- React 18 with TypeScript
+- Vite for build tooling
+- Supabase for backend and auth
+- Tailwind CSS with custom spacing
+- Radix UI primitives
+- React Query for data fetching
+- Vitest for testing

--- a/src/components/ui/otp-input.tsx
+++ b/src/components/ui/otp-input.tsx
@@ -1,0 +1,98 @@
+import * as React from 'react';
+import { cn } from '~/lib/utils';
+
+export interface OtpInputProps {
+  value: string;
+  onChange: (value: string) => void;
+  onComplete?: (value: string) => void;
+  length?: number;
+  className?: string;
+  disabled?: boolean;
+}
+
+const OtpInput = React.forwardRef<HTMLDivElement, OtpInputProps>(
+  ({ value, onChange, onComplete, length = 6, className, disabled = false }, ref) => {
+    const inputRefs = React.useRef<(HTMLInputElement | null)[]>([]);
+
+    const handleChange = (index: number, inputValue: string) => {
+      // Only allow single digit
+      const digit = inputValue.replace(/\D/g, '').slice(-1);
+      
+      const newValue = value.split('');
+      newValue[index] = digit;
+      const updatedValue = newValue.join('');
+      
+      onChange(updatedValue);
+      
+      // Move to next input if digit was entered
+      if (digit && index < length - 1) {
+        inputRefs.current[index + 1]?.focus();
+      }
+      
+      // Call onComplete if all digits are filled
+      if (updatedValue.length === length && onComplete) {
+        onComplete(updatedValue);
+      }
+    };
+
+    const handleKeyDown = (index: number, e: React.KeyboardEvent<HTMLInputElement>) => {
+      if (e.key === 'Backspace' && !value[index] && index > 0) {
+        // Move to previous input on backspace if current is empty
+        inputRefs.current[index - 1]?.focus();
+      } else if (e.key === 'ArrowLeft' && index > 0) {
+        inputRefs.current[index - 1]?.focus();
+      } else if (e.key === 'ArrowRight' && index < length - 1) {
+        inputRefs.current[index + 1]?.focus();
+      }
+    };
+
+    const handlePaste = (e: React.ClipboardEvent) => {
+      e.preventDefault();
+      const pastedData = e.clipboardData.getData('text').replace(/\D/g, '');
+      const newValue = pastedData.slice(0, length);
+      onChange(newValue);
+      
+      // Focus the last filled input or the first empty one
+      const focusIndex = Math.min(newValue.length, length - 1);
+      setTimeout(() => {
+        inputRefs.current[focusIndex]?.focus();
+      }, 0);
+      
+      if (newValue.length === length && onComplete) {
+        onComplete(newValue);
+      }
+    };
+
+    return (
+      <div 
+        ref={ref}
+        className={cn('flex gap-2 justify-center', className)}
+        onPaste={handlePaste}
+      >
+        {Array.from({ length }, (_, index) => (
+          <input
+            key={index}
+            ref={(el) => (inputRefs.current[index] = el)}
+            type="text"
+            inputMode="numeric"
+            maxLength={1}
+            value={value[index] || ''}
+            onChange={(e) => handleChange(index, e.target.value)}
+            onKeyDown={(e) => handleKeyDown(index, e)}
+            disabled={disabled}
+            className={cn(
+              'w-5 h-5 text-center text-base font-semibold rounded-md border border-input bg-transparent shadow-sm transition-colors',
+              'focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring',
+              'disabled:cursor-not-allowed disabled:opacity-50',
+              value[index] ? 'border-primary' : 'border-input'
+            )}
+          />
+        ))}
+      </div>
+    );
+  }
+);
+
+OtpInput.displayName = 'OtpInput';
+
+export { OtpInput };

--- a/src/pages/SignupPage/SignupPage.tsx
+++ b/src/pages/SignupPage/SignupPage.tsx
@@ -2,11 +2,16 @@ import { ChangeEventHandler, FormEventHandler, useState } from 'react';
 
 import { Button } from '~/components/ui/button';
 import { Input } from '~/components/ui/input';
+import { OtpInput } from '~/components/ui/otp-input';
 import { supabase } from '~/supabaseClient';
 
 export function Signup() {
   const [loading, setLoading] = useState(false);
   const [email, setEmail] = useState('');
+  const [emailSent, setEmailSent] = useState(false);
+  const [showOtpInput, setShowOtpInput] = useState(false);
+  const [otp, setOtp] = useState('');
+  const [verifyingOtp, setVerifyingOtp] = useState(false);
 
   const handleLogin: FormEventHandler<HTMLFormElement> = async (event) => {
     event.preventDefault();
@@ -17,9 +22,40 @@ export function Signup() {
     if (error?.message) {
       alert(error.message);
     } else {
-      alert('Check your email for the login link!');
+      setEmailSent(true);
+      alert('Check your email for the login link or use the code below!');
     }
     setLoading(false);
+  };
+
+  const handleOtpVerification = async (otpCode: string) => {
+    setVerifyingOtp(true);
+    const { error } = await supabase.auth.verifyOtp({
+      email,
+      token: otpCode,
+      type: 'email'
+    });
+
+    if (error?.message) {
+      alert(error.message);
+    }
+    setVerifyingOtp(false);
+  };
+
+  const handleResend = async () => {
+    setLoading(true);
+    const { error } = await supabase.auth.signInWithOtp({ email });
+
+    if (error?.message) {
+      alert(error.message);
+    } else {
+      alert('New login link and code sent to your email!');
+    }
+    setLoading(false);
+  };
+
+  const handleTryOtp = () => {
+    setShowOtpInput(true);
   };
 
   const handleChangeEmail: ChangeEventHandler<HTMLInputElement> = (e) => {
@@ -33,21 +69,73 @@ export function Signup() {
           Sign up or Log in to BellSkill
         </div>
 
-        <form onSubmit={handleLogin} className="space-y-2">
-          <Input
-            id="email"
-            type="email"
-            placeholder="Enter your email address..."
-            value={email}
-            required={true}
-            onChange={handleChangeEmail}
-            className="h-5 text-base"
-          />
+        {!emailSent ? (
+          <form onSubmit={handleLogin} className="space-y-2">
+            <Input
+              id="email"
+              type="email"
+              placeholder="Enter your email address..."
+              value={email}
+              required={true}
+              onChange={handleChangeEmail}
+              className="h-5 text-base"
+            />
 
-          <Button type="submit" loading={loading} size="lg" className="w-full">
-            Continue with Email
-          </Button>
-        </form>
+            <Button type="submit" loading={loading} size="lg" className="w-full">
+              Continue with Email
+            </Button>
+          </form>
+        ) : (
+          <div className="space-y-4">
+            <div className="text-center text-sm text-muted-foreground">
+              We've sent a login link to <strong>{email}</strong>
+            </div>
+            
+            <div className="text-center text-sm text-muted-foreground">
+              Click the link in your email to sign in, or enter the 6-digit code below
+            </div>
+
+            {showOtpInput && (
+              <div className="space-y-3">
+                <OtpInput
+                  value={otp}
+                  onChange={setOtp}
+                  onComplete={handleOtpVerification}
+                  disabled={verifyingOtp}
+                />
+                
+                {verifyingOtp && (
+                  <div className="text-center text-sm text-muted-foreground">
+                    Verifying code...
+                  </div>
+                )}
+              </div>
+            )}
+
+            <div className="flex flex-col gap-2">
+              {!showOtpInput && (
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={handleTryOtp}
+                  className="w-full"
+                >
+                  Enter 6-digit code instead
+                </Button>
+              )}
+
+              <Button
+                type="button"
+                variant="ghost"
+                onClick={handleResend}
+                loading={loading}
+                className="w-full"
+              >
+                Resend email
+              </Button>
+            </div>
+          </div>
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
- Add OtpInput component with 6-digit code entry, auto-focus, and paste support
- Enhance SignupPage to support both magic links and OTP verification
- Add fallback authentication flow for iOS users where magic links may fail
- Create CLAUDE.md with custom Tailwind sizing guidelines for shadcn components
- Configure dual auth method: magic links primary, OTP as reliable fallback