### PR TITLE
fix: Exclude static assets from SPA routing in production

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -1,1 +1,9 @@
+# Exclude assets from SPA routing
+/assets/*  /assets/:splat  200
+/favicon.ico  /favicon.ico  200
+/manifest.json  /manifest.json  200
+/sw.js  /sw.js  200
+/apple-touch-icon.png  /apple-touch-icon.png  200
+
+# SPA routing for everything else
 /*    /index.html   200


### PR DESCRIPTION
- Add specific rules to serve /assets/* files directly instead of redirecting to index.html
- Exclude favicon, manifest, service worker, and other static files from catch-all redirect
- Fixes production JavaScript module loading error: "Expected a JavaScript-or-Wasm module script but the server responded with a MIME type of 'text/html'"
- Maintains SPA routing for actual page routes while serving assets with correct MIME types