### PR TITLE
fix: Add proper cache headers to prevent stale asset 404 errors

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,6 +8,11 @@
       content="width=device-width, initial-scale=1.0, viewport-fit=cover"
     />
     <title>BellSkill App</title>
+    
+    <!-- Cache control meta tags -->
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
+    <meta http-equiv="Pragma" content="no-cache" />
+    <meta http-equiv="Expires" content="0" />
 
     <!-- Web App Manifest -->
     <link rel="manifest" href="/manifest.json" />

--- a/public/_headers
+++ b/public/_headers
@@ -1,0 +1,25 @@
+# Cache static assets with hashes for 1 year
+/assets/*
+  Cache-Control: public, max-age=31536000, immutable
+
+# Never cache the main HTML file
+/
+  Cache-Control: no-cache, no-store, must-revalidate
+  Pragma: no-cache
+  Expires: 0
+
+# Never cache the HTML file even with explicit path
+/index.html
+  Cache-Control: no-cache, no-store, must-revalidate
+  Pragma: no-cache
+  Expires: 0
+
+# Cache manifest and other PWA files for a short time
+/manifest.json
+  Cache-Control: public, max-age=3600
+
+/favicon.ico
+  Cache-Control: public, max-age=86400
+
+/apple-touch-icon.png
+  Cache-Control: public, max-age=86400


### PR DESCRIPTION
- Add public/_headers file with cache control for Netlify deployment
- Cache static assets (/assets/*) for 1 year with immutable flag
- Never cache HTML files to ensure fresh asset references on each visit
- Add cache control meta tags to index.html as fallback
- Configure appropriate cache times for manifest and icon files

Resolves browser caching issues where users needed to hard refresh to load the app after deployments due to cached references to non-existent asset files.