### PR TITLE
fix: Enhance cache busting with stronger headers and build config

### DIFF
--- a/public/_headers
+++ b/public/_headers
@@ -4,15 +4,17 @@
 
 # Never cache the main HTML file
 /
-  Cache-Control: no-cache, no-store, must-revalidate
+  Cache-Control: no-cache, no-store, must-revalidate, proxy-revalidate
   Pragma: no-cache
   Expires: 0
+  Last-Modified: Thu, 01 Jan 1970 00:00:00 GMT
 
 # Never cache the HTML file even with explicit path
 /index.html
-  Cache-Control: no-cache, no-store, must-revalidate
+  Cache-Control: no-cache, no-store, must-revalidate, proxy-revalidate
   Pragma: no-cache
   Expires: 0
+  Last-Modified: Thu, 01 Jan 1970 00:00:00 GMT
 
 # Cache manifest and other PWA files for a short time
 /manifest.json

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -10,4 +10,14 @@ export default defineConfig({
       '~': fileURLToPath(new URL('./src', import.meta.url)),
     },
   },
+  build: {
+    rollupOptions: {
+      output: {
+        // Force new file hashes on every build
+        entryFileNames: 'assets/[name]-[hash].js',
+        chunkFileNames: 'assets/[name]-[hash].js',
+        assetFileNames: 'assets/[name]-[hash].[ext]'
+      }
+    }
+  }
 });


### PR DESCRIPTION
- Add proxy-revalidate and Last-Modified headers for aggressive cache prevention
- Configure Vite build to ensure unique hashes on every build
- Force asset file naming pattern to guarantee fresh file references
- Prevent any proxy or CDN caching of HTML files

Addresses persistent browser caching where users still see old asset references even after deployments with proper cache headers.