### PR TITLE
fix: Add service worker cleanup to resolve cached sw.js 404 errors

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -1,0 +1,28 @@
+// Unregister service worker to clean up old installations
+self.addEventListener('install', function(event) {
+  // Skip waiting to activate immediately
+  self.skipWaiting();
+});
+
+self.addEventListener('activate', function(event) {
+  // Clear all caches
+  event.waitUntil(
+    caches.keys().then(function(cacheNames) {
+      return Promise.all(
+        cacheNames.map(function(cacheName) {
+          return caches.delete(cacheName);
+        })
+      );
+    }).then(function() {
+      // Unregister this service worker
+      return self.registration.unregister();
+    }).then(function() {
+      // Force refresh all clients
+      return self.clients.matchAll().then(function(clients) {
+        clients.forEach(function(client) {
+          client.navigate(client.url);
+        });
+      });
+    })
+  );
+});

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -16,6 +16,28 @@ async function enableMocking() {
   return worker.start();
 }
 
+// Clean up any existing service workers
+if ('serviceWorker' in navigator) {
+  navigator.serviceWorker.getRegistrations().then(function(registrations) {
+    for(let registration of registrations) {
+      registration.unregister().then(function(boolean) {
+        console.log('Service worker unregistered:', boolean);
+      });
+    }
+  }).catch(function(err) {
+    console.log('Service worker unregistration failed: ', err);
+  });
+
+  // Clear all caches
+  if ('caches' in window) {
+    caches.keys().then(function(cacheNames) {
+      cacheNames.forEach(function(cacheName) {
+        caches.delete(cacheName);
+      });
+    });
+  }
+}
+
 const rootElement = document.getElementById('root');
 
 if (rootElement !== null) {


### PR DESCRIPTION
- Create minimal sw.js that unregisters itself and clears all caches
- Add service worker cleanup code to main.tsx on app startup
- Force unregistration of any existing service workers
- Clear all cached data to prevent stale cache issues

Resolves persistent 404 errors for removed service worker file that was cached by browsers from previous app versions.