### PR TITLE
[CB-66] Add "complete without setting down" global toggle to start workout page

### DIFF
--- a/src/contexts/WorkoutOptionsContext.tsx
+++ b/src/contexts/WorkoutOptionsContext.tsx
@@ -12,9 +12,14 @@ export const DEFAULT_MOVEMENT_OPTIONS: MovementOptions = {
 };
 
 export const DEFAULT_WORKOUT_OPTIONS: WorkoutOptions = {
+  complexSet: false,
   intervalTimer: 0,
   movements: [{ ...DEFAULT_MOVEMENT_OPTIONS }],
   restTimer: 0,
+  sharedWeightOneUnit: DEFAULT_MOVEMENT_OPTIONS.weightOneUnit,
+  sharedWeightOneValue: DEFAULT_MOVEMENT_OPTIONS.weightOneValue,
+  sharedWeightTwoUnit: null,
+  sharedWeightTwoValue: null,
   workoutDetails: null,
   workoutGoal: 10,
   workoutGoalUnits: 'minutes',

--- a/src/pages/CompletedWorkoutPage/CompletedWorkoutPage.tsx
+++ b/src/pages/CompletedWorkoutPage/CompletedWorkoutPage.tsx
@@ -84,6 +84,7 @@ export const CompletedWorkoutPage = () => {
     let workoutGoalUnits: WorkoutGoalUnits = workoutLog.workoutGoalUnits;
 
     updateWorkoutOptions({
+      complexSet: false,
       intervalTimer: workoutLog.intervalTimer,
       movements: movementLogs.map((movementLog) => ({
         movementName: movementLog.movementName,
@@ -94,6 +95,10 @@ export const CompletedWorkoutPage = () => {
         weightTwoValue: movementLog.weightTwoValue,
       })),
       restTimer: workoutLog.restTimer,
+      sharedWeightOneUnit: null,
+      sharedWeightOneValue: null,
+      sharedWeightTwoUnit: null,
+      sharedWeightTwoValue: null,
       workoutDetails: workoutLog.workoutDetails,
       workoutGoal,
       workoutGoalUnits,

--- a/src/pages/StartWorkoutPage/StartWorkoutPage.test.jsx
+++ b/src/pages/StartWorkoutPage/StartWorkoutPage.test.jsx
@@ -442,6 +442,91 @@ describe('start workout page - without previous volume', () => {
   });
 });
 
+describe('Complex Mode', () => {
+  let startWorkout;
+
+  beforeEach(() => {
+    startWorkout = vi.fn();
+    Default.parameters.updateWorkoutOptions = startWorkout;
+    render(<Default />);
+  });
+
+  test('Complex Mode card is visible with Standard and Complex buttons; Standard is active by default', () => {
+    expect(screen.getByRole('button', { name: 'Standard' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Complex' })).toBeInTheDocument();
+    expect(screen.queryByRole('heading', { name: 'Shared Weight' })).not.toBeInTheDocument();
+  });
+
+  test('selecting Complex reveals shared weight section with all four weight-type options', async () => {
+    await userEvent.click(screen.getByRole('button', { name: 'Complex' }));
+
+    expect(screen.getByRole('heading', { name: 'Shared Weight' })).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: 'None' })).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: '2H' })).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: '1H' })).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: 'Double' })).toBeInTheDocument();
+  });
+
+  test('when Complex is active, per-movement weight sections are hidden and rep scheme sections remain visible', async () => {
+    await userEvent.click(screen.getByRole('button', { name: '+ Movement' }));
+    expect(screen.getAllByRole('heading', { name: 'Weights' })).toHaveLength(2);
+
+    await userEvent.click(screen.getByRole('button', { name: 'Complex' }));
+
+    expect(screen.queryAllByRole('heading', { name: 'Weights' })).toHaveLength(0);
+    expect(screen.getAllByRole('heading', { name: 'Rep Scheme' })).toHaveLength(2);
+  });
+
+  test('selecting Standard hides shared weight section and restores per-movement weight sections', async () => {
+    await userEvent.click(screen.getByRole('button', { name: 'Complex' }));
+    expect(screen.getByRole('heading', { name: 'Shared Weight' })).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole('button', { name: 'Standard' }));
+
+    expect(screen.queryByRole('heading', { name: 'Shared Weight' })).not.toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Weights' })).toBeInTheDocument();
+  });
+
+  test('startWorkout is called with complexSet: true and shared weight fields when Complex is active', async () => {
+    await userEvent.click(screen.getByRole('button', { name: 'Complex' }));
+    await userEvent.type(screen.getByLabelText('Movement Input'), 'Clean');
+    await userEvent.click(screen.getByRole('button', { name: /Start/i }));
+
+    expect(startWorkout).toHaveBeenCalledWith(
+      expect.objectContaining({
+        complexSet: true,
+        sharedWeightOneValue: DEFAULT_MOVEMENT_OPTIONS.weightOneValue,
+        sharedWeightOneUnit: DEFAULT_MOVEMENT_OPTIONS.weightOneUnit,
+        sharedWeightTwoValue: null,
+        sharedWeightTwoUnit: null,
+        startedAt,
+      }),
+    );
+  });
+
+  test('complex mode toggle is preserved when adding movements', async () => {
+    await userEvent.click(screen.getByRole('button', { name: 'Complex' }));
+    expect(screen.queryAllByRole('heading', { name: 'Weights' })).toHaveLength(0);
+
+    await userEvent.click(screen.getByRole('button', { name: '+ Movement' }));
+
+    expect(screen.queryAllByRole('heading', { name: 'Weights' })).toHaveLength(0);
+    expect(screen.getByRole('heading', { name: 'Shared Weight' })).toBeInTheDocument();
+  });
+
+  test('complex mode toggle is preserved when removing movements', async () => {
+    await userEvent.click(screen.getByRole('button', { name: '+ Movement' }));
+    await userEvent.click(screen.getByRole('button', { name: 'Complex' }));
+    expect(screen.queryAllByRole('heading', { name: 'Weights' })).toHaveLength(0);
+
+    const removeButtons = screen.getAllByRole('button', { name: '- Movement' });
+    await userEvent.click(removeButtons[0]);
+
+    expect(screen.queryAllByRole('heading', { name: 'Weights' })).toHaveLength(0);
+    expect(screen.getByRole('heading', { name: 'Shared Weight' })).toBeInTheDocument();
+  });
+});
+
 describe('integration tests for previous volume retrieval', () => {
   test('retrieves previous volume from workout options when available', async () => {
     const startWorkout = vi.fn();

--- a/src/pages/StartWorkoutPage/StartWorkoutPage.tsx
+++ b/src/pages/StartWorkoutPage/StartWorkoutPage.tsx
@@ -57,6 +57,21 @@ export const StartWorkoutPage = () => {
     workoutOptions.intervalTimer,
   );
   const [restTimer, setRestTimer] = useState<number>(workoutOptions.restTimer);
+  const [complexSet, setComplexSet] = useState<boolean>(
+    workoutOptions.complexSet,
+  );
+  const [sharedWeightOneValue, setSharedWeightOneValue] = useState<
+    number | null
+  >(workoutOptions.sharedWeightOneValue);
+  const [sharedWeightOneUnit, setSharedWeightOneUnit] = useState<
+    WeightUnit | null
+  >(workoutOptions.sharedWeightOneUnit);
+  const [sharedWeightTwoValue, setSharedWeightTwoValue] = useState<
+    number | null
+  >(workoutOptions.sharedWeightTwoValue);
+  const [sharedWeightTwoUnit, setSharedWeightTwoUnit] = useState<
+    WeightUnit | null
+  >(workoutOptions.sharedWeightTwoUnit);
 
   const detailsRef = useRef<HTMLInputElement>(null);
 
@@ -124,6 +139,33 @@ export const StartWorkoutPage = () => {
 
   const handleClickAddMovement = () =>
     setMovements((prev) => [...prev, DEFAULT_MOVEMENT_OPTIONS]);
+
+  const handleChangeSharedWeightTab = (value: string) => {
+    setSharedWeightOneValue(
+      value === 'none' ? null : sharedWeightOneValue || DEFAULT_WEIGHT_VALUE,
+    );
+    setSharedWeightOneUnit(value === 'none' ? null : DEFAULT_WEIGHT_UNIT);
+    setSharedWeightTwoValue(
+      value === 'double'
+        ? sharedWeightTwoValue || DEFAULT_WEIGHT_VALUE
+        : value === '1h'
+          ? 0
+          : null,
+    );
+    setSharedWeightTwoUnit(value === 'double' ? DEFAULT_WEIGHT_UNIT : null);
+  };
+
+  const handleChangeSharedWeightOneValue = (value: number) =>
+    setSharedWeightOneValue(Math.max(1, value));
+
+  const handleChangeSharedWeightOneUnit = (value: WeightUnit) =>
+    setSharedWeightOneUnit(value);
+
+  const handleChangeSharedWeightTwoValue = (value: number) =>
+    setSharedWeightTwoValue(Math.max(1, value));
+
+  const handleChangeSharedWeightTwoUnit = (value: WeightUnit) =>
+    setSharedWeightTwoUnit(value);
 
   const handleChangeWeightTab = (index: number, value: string) => {
     setMovements((prev) =>
@@ -236,9 +278,14 @@ export const StartWorkoutPage = () => {
 
   const handleClickStart = () => {
     const workoutOptions: WorkoutOptions = {
+      complexSet,
       intervalTimer,
       movements,
       restTimer,
+      sharedWeightOneUnit,
+      sharedWeightOneValue,
+      sharedWeightTwoUnit,
+      sharedWeightTwoValue,
       startedAt: new Date(),
       workoutDetails,
       workoutGoal,
@@ -247,6 +294,15 @@ export const StartWorkoutPage = () => {
     updateWorkoutOptions(workoutOptions);
     navigate('active');
   };
+
+  const sharedWeightTabValue =
+    sharedWeightOneValue === null
+      ? 'none'
+      : sharedWeightTwoValue === null
+        ? '2h'
+        : sharedWeightTwoValue === 0
+          ? '1h'
+          : 'double';
 
   const isDifferentRepSchemes =
     movements.length > 1 &&
@@ -303,6 +359,92 @@ export const StartWorkoutPage = () => {
             value={workoutGoal}
           />
         </Section>
+      </Card>
+
+      <Card>
+        <Section title="Complex Mode">
+          <div className="flex gap-2">
+            <Button
+              className="grow"
+              variant={complexSet ? 'secondary' : 'default'}
+              onClick={() => setComplexSet(false)}
+            >
+              Standard
+            </Button>
+            <Button
+              className="grow"
+              variant={complexSet ? 'default' : 'secondary'}
+              onClick={() => setComplexSet(true)}
+            >
+              Complex
+            </Button>
+          </div>
+        </Section>
+        {complexSet && (
+          <Section
+            title="Shared Weight"
+            actions={
+              <Tabs
+                value={sharedWeightTabValue}
+                onValueChange={handleChangeSharedWeightTab}
+              >
+                <TabsList>
+                  <TabsTrigger size="sm" value="none">
+                    None
+                  </TabsTrigger>
+                  <TabsTrigger size="sm" value="2h">
+                    2H
+                  </TabsTrigger>
+                  <TabsTrigger size="sm" value="1h">
+                    1H
+                  </TabsTrigger>
+                  <TabsTrigger size="sm" value="double">
+                    Double
+                  </TabsTrigger>
+                </TabsList>
+              </Tabs>
+            }
+          >
+            {sharedWeightOneValue !== null && (
+              <ModifyCountButtons
+                onClickMinus={() =>
+                  handleChangeSharedWeightOneValue(sharedWeightOneValue - 1)
+                }
+                onClickPlus={() =>
+                  handleChangeSharedWeightOneValue(sharedWeightOneValue + 1)
+                }
+                unit={getWeightUnitLabel(sharedWeightOneUnit)}
+                unitTabs={
+                  <WeightUnitTabs
+                    value={sharedWeightOneUnit}
+                    onChange={handleChangeSharedWeightOneUnit}
+                  />
+                }
+                value={sharedWeightOneValue}
+                onChange={(value) => handleChangeSharedWeightOneValue(value!)}
+              />
+            )}
+            {sharedWeightTwoValue !== null && sharedWeightTwoValue > 0 && (
+              <ModifyCountButtons
+                onClickMinus={() =>
+                  handleChangeSharedWeightTwoValue(sharedWeightTwoValue - 1)
+                }
+                onClickPlus={() =>
+                  handleChangeSharedWeightTwoValue(sharedWeightTwoValue + 1)
+                }
+                unit={getWeightUnitLabel(sharedWeightTwoUnit)}
+                unitTabs={
+                  <WeightUnitTabs
+                    value={sharedWeightTwoUnit}
+                    onChange={handleChangeSharedWeightTwoUnit}
+                  />
+                }
+                value={sharedWeightTwoValue}
+                onChange={(value) => handleChangeSharedWeightTwoValue(value)}
+              />
+            )}
+          </Section>
+        )}
       </Card>
 
       {(workoutDetails === null || intervalTimer === 0 || restTimer === 0) && (
@@ -456,90 +598,94 @@ export const StartWorkoutPage = () => {
                 id="movement"
               />
             </Section>
-            <Section
-              title="Weights"
-              actions={
-                <Tabs
-                  value={weightTabValue}
-                  onValueChange={(value) => handleChangeWeightTab(index, value)}
-                >
-                  <TabsList>
-                    <TabsTrigger size="sm" value="none">
-                      None
-                    </TabsTrigger>
-                    <TabsTrigger size="sm" value="2h">
-                      2H
-                    </TabsTrigger>
-                    <TabsTrigger size="sm" value="1h">
-                      1H
-                    </TabsTrigger>
-                    <TabsTrigger size="sm" value="double">
-                      Double
-                    </TabsTrigger>
-                  </TabsList>
-                </Tabs>
-              }
-            >
-              {movement.weightOneValue !== null && (
-                <ModifyCountButtons
-                  onClickMinus={() =>
-                    handleChangeWeightOneValue(
-                      index,
-                      movement.weightOneValue! - 1,
-                    )
-                  }
-                  onClickPlus={() =>
-                    handleChangeWeightOneValue(
-                      index,
-                      movement.weightOneValue! + 1,
-                    )
-                  }
-                  unit={getWeightUnitLabel(movement.weightOneUnit)}
-                  unitTabs={
-                    <WeightUnitTabs
-                      value={movement.weightOneUnit}
-                      onChange={(value) =>
-                        handleChangeWeightOneUnit(index, value)
-                      }
-                    />
-                  }
-                  value={movement.weightOneValue}
-                  onChange={(value) =>
-                    handleChangeWeightOneValue(index, value!)
-                  }
-                />
-              )}
-              {movement.weightTwoValue !== null &&
-                movement.weightTwoValue > 0 && (
+            {!complexSet && (
+              <Section
+                title="Weights"
+                actions={
+                  <Tabs
+                    value={weightTabValue}
+                    onValueChange={(value) =>
+                      handleChangeWeightTab(index, value)
+                    }
+                  >
+                    <TabsList>
+                      <TabsTrigger size="sm" value="none">
+                        None
+                      </TabsTrigger>
+                      <TabsTrigger size="sm" value="2h">
+                        2H
+                      </TabsTrigger>
+                      <TabsTrigger size="sm" value="1h">
+                        1H
+                      </TabsTrigger>
+                      <TabsTrigger size="sm" value="double">
+                        Double
+                      </TabsTrigger>
+                    </TabsList>
+                  </Tabs>
+                }
+              >
+                {movement.weightOneValue !== null && (
                   <ModifyCountButtons
                     onClickMinus={() =>
-                      handleChangeWeightTwoValue(
+                      handleChangeWeightOneValue(
                         index,
-                        movement.weightTwoValue! - 1,
+                        movement.weightOneValue! - 1,
                       )
                     }
                     onClickPlus={() =>
-                      handleChangeWeightTwoValue(
+                      handleChangeWeightOneValue(
                         index,
-                        movement.weightTwoValue! + 1,
+                        movement.weightOneValue! + 1,
                       )
                     }
-                    unit={getWeightUnitLabel(movement.weightTwoUnit)}
+                    unit={getWeightUnitLabel(movement.weightOneUnit)}
                     unitTabs={
                       <WeightUnitTabs
-                        value={movement.weightTwoUnit}
+                        value={movement.weightOneUnit}
                         onChange={(value) =>
-                          handleChangeWeightTwoUnit(index, value)
+                          handleChangeWeightOneUnit(index, value)
                         }
                       />
                     }
-                    value={movement.weightTwoValue}
+                    value={movement.weightOneValue}
                     onChange={(value) =>
-                      handleChangeWeightTwoValue(index, value)
+                      handleChangeWeightOneValue(index, value!)
                     }
                   />
                 )}
-            </Section>
+                {movement.weightTwoValue !== null &&
+                  movement.weightTwoValue > 0 && (
+                    <ModifyCountButtons
+                      onClickMinus={() =>
+                        handleChangeWeightTwoValue(
+                          index,
+                          movement.weightTwoValue! - 1,
+                        )
+                      }
+                      onClickPlus={() =>
+                        handleChangeWeightTwoValue(
+                          index,
+                          movement.weightTwoValue! + 1,
+                        )
+                      }
+                      unit={getWeightUnitLabel(movement.weightTwoUnit)}
+                      unitTabs={
+                        <WeightUnitTabs
+                          value={movement.weightTwoUnit}
+                          onChange={(value) =>
+                            handleChangeWeightTwoUnit(index, value)
+                          }
+                        />
+                      }
+                      value={movement.weightTwoValue}
+                      onChange={(value) =>
+                        handleChangeWeightTwoValue(index, value)
+                      }
+                    />
+                  )}
+              </Section>
+            )}
             <Section
               title="Rep Scheme"
               actions={

--- a/src/types/workout-options.interface.ts
+++ b/src/types/workout-options.interface.ts
@@ -1,10 +1,16 @@
 import { MovementOptions } from './movement-options.interface';
+import { WeightUnit } from './weight-unit.type';
 import { WorkoutGoalUnits } from './workout-goal-units.type';
 
 export interface WorkoutOptions {
+  complexSet: boolean;
   intervalTimer: number; // seconds
   movements: MovementOptions[];
   restTimer: number; // seconds
+  sharedWeightOneUnit: WeightUnit | null;
+  sharedWeightOneValue: number | null;
+  sharedWeightTwoUnit: WeightUnit | null;
+  sharedWeightTwoValue: number | null;
   startedAt?: Date;
   workoutDetails: string | null;
   workoutGoal: number; // minutes, rounds, or target volume (kg)


### PR DESCRIPTION
## Linear Ticket

https://linear.app/bellskill/issue/CB-66/add-complete-without-setting-down-global-toggle-to-start-workout-page

## Acceptance Criteria

- [x] **AC1:** A "Complex Mode" card appears on the start workout page after the Goal section, containing "Standard" and "Complex" buttons; "Standard" is active by default. Implemented as a dedicated `Card` with a `Section` titled "Complex Mode" inserted immediately after the Goal card.

- [x] **AC2:** Selecting "Complex" reveals a shared weight configuration section supporting all four weight-type options (None, 2H, 1H, Double) with the same UI controls used for per-movement weight config. A "Shared Weight" `Section` with `Tabs` (None/2H/1H/Double) and `ModifyCountButtons` appears inside the Complex Mode card when complex is active — reusing all existing weight UI primitives.

- [x] **AC3:** When "Complex" is active, per-movement weight configuration sections are hidden on every movement card; rep scheme controls remain visible and functional. The per-movement `Section title="Weights"` is conditionally rendered with `{!complexSet && <Section title="Weights" ...>}`.

- [x] **AC4:** Selecting "Standard" hides the shared weight section and restores per-movement weight configuration for all movement cards. Toggling back to Standard sets `complexSet = false`, which re-renders the per-movement weight sections and removes the Shared Weight section.

- [x] **AC5:** `WorkoutOptions` includes `complexSet: boolean` and the shared weight fields; these values are correctly populated in `WorkoutOptionsContext`. Added `complexSet`, `sharedWeightOneValue`, `sharedWeightOneUnit`, `sharedWeightTwoValue`, `sharedWeightTwoUnit` to the `WorkoutOptions` interface and to `DEFAULT_WORKOUT_OPTIONS`. All fields are passed through `handleClickStart` → `updateWorkoutOptions`.

- [x] **AC6:** The toggle state is preserved correctly when adding or removing movements. `complexSet` is independent state — adding/removing movements only updates the `movements` array, leaving `complexSet` unchanged. Covered by two dedicated tests.

- [x] **AC7:** All existing tests pass; at least one unit test covers the toggle behavior and the conditional showing/hiding of weight configuration sections. 7 new tests added in a `describe('Complex Mode', ...)` block; all 147 tests pass.

## Implementation Summary

**Files changed:**
- `src/types/workout-options.interface.ts` — added `complexSet: boolean`, `sharedWeightOneValue`, `sharedWeightOneUnit`, `sharedWeightTwoValue`, `sharedWeightTwoUnit`
- `src/contexts/WorkoutOptionsContext.tsx` — added defaults for new fields (`complexSet: false`, shared weight mirroring `DEFAULT_MOVEMENT_OPTIONS`)
- `src/pages/StartWorkoutPage/StartWorkoutPage.tsx` — new state, handlers, Complex Mode card with conditional Shared Weight section, per-movement weight section conditionally hidden
- `src/pages/StartWorkoutPage/StartWorkoutPage.test.jsx` — 7 new tests covering all AC items
- `src/pages/CompletedWorkoutPage/CompletedWorkoutPage.tsx` — fixed TypeScript error: added missing required fields when calling `updateWorkoutOptions` (repeating a workout resets complex mode to false / no shared weights, which is correct)

**No deviations from the Implementation Plan.**

## Out of Scope (not implemented here)

- Active workout page display changes (CB-67)
- Persisting `complexSet` to the database (CB-68)
- Validation that movements are compatible for a complex