### PR TITLE
Expand CLAUDE.md and update Movement Foundation critical path

### DIFF
--- a/AGENT_GUIDELINES.md
+++ b/AGENT_GUIDELINES.md
@@ -4,7 +4,17 @@ This section defines what the automated agents (Bellskill PM and Bellskill Build
 
 ## Current critical path
 
-**Advanced config options for complexes and chains.** Enables users to configure movements to be completed without setting down the weight (e.g., for ABC-style workouts) and other advanced patterns. Currently in progress: "Set weight down after" feature. Planned: "Repeat all movements" and "Switch to opposite side after" options. The PM agent should bias toward tickets that move this initiative forward until it ships.
+**Movement Foundation (CB-70, CB-71, CB-72, CB-73, CB-74).** Bellskill is becoming an AI-powered kettlebell coaching platform. The single blocking dependency for the entire intelligent-features roadmap is replacing free-text movement entry with a structured movement selection UI backed by the ingested functional movement database (3,000+ exercises tagged with pattern, equipment, plane, and difficulty).
+
+Downstream features that are blocked until this ships:
+- **Pattern Debt Engine** — needs movements tagged by pattern
+- **AI Next Session Recommender** — needs a structured catalog to draw from
+- **Skill Tree** — needs reliable movement identity for progression logic
+- **Analytics and gamification** — blocked on movement identity
+
+Features that may proceed in parallel (no movement-identity dependency): UI polish, bug fixes, infrastructure, and advanced config options for complexes/chains.
+
+The PM agent must triage any ticket in the Movement Foundation initiative (CB-70 through CB-74) as highest priority. Do not deprioritize these for any other feature work unless a human explicitly directs otherwise.
 
 When the critical path changes, update this section — the agents will pick up the new focus on their next run.
 
@@ -107,4 +117,4 @@ Both agents should prefer stopping and asking to improvising when they hit:
 
 ---
 
-*Last updated: 2026-04-21. Both agents read this file at the start of every run — edit here to change their behavior.*
+*Last updated: 2026-05-20. Both agents read this file at the start of every run — edit here to change their behavior.*

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,33 +47,102 @@ spacing: {
 - Default shadcn button: `h-10` → Use: `h-4` or `h-5`
 - Default shadcn padding: `px-3` → Use: `px-2` or `px-3` (but verify against existing components)
 
+## Project Structure
+
+```
+src/
+  api/          # React Query hooks (useMovements, useLogWorkout, etc.) + Supabase calls
+  app/          # App.tsx, Root.tsx, routes.tsx — router and top-level providers
+  components/   # Shared components (Header, Page, SafeAreaWrapper) and ui/ (shadcn)
+  constants/    # Enums and static values (query keys, etc.)
+  contexts/     # React contexts (SessionContext, WorkoutOptionsContext)
+  examples/     # Test fixture factories
+  hooks/        # Shared hooks (useCountdownTimer, useDebouncedCallback)
+  lib/          # Utility library wrappers (cn() from tailwind-merge + clsx)
+  mocks/        # MSW handlers, Node server, browser SW setup
+  pages/        # One folder per route (see Page Structure below)
+  types/        # TypeScript interfaces and types (supabase.ts is auto-generated)
+  utils/        # Pure utility functions
+```
+
+## Import Path Alias
+
+`~` resolves to `src/`. Always use `~/api`, `~/components`, `~/contexts`, `~/types`, etc. rather than relative `../` paths when crossing module boundaries.
+
+## Domain Concepts
+
+- **Movement**: a single exercise (e.g. "Kettlebell Swing") with a name, rep scheme, and optional weight(s).
+- **Rep scheme / ladder**: ordered list of rep counts per rung — e.g. `[1, 2, 3, 4, 5]`.
+- **Rung**: one step in a ladder (one element of the `repScheme` array).
+- **Complex set** (`complexSet: true`): movements performed back-to-back without setting the weight down.
+- **Weight configuration**: each movement supports up to two weights. Tabs: `None`, `2H` (two-handed), `1H` (one-handed/offset), `Double` (two separate bells).
+- **Workout goal**: time-based (minutes), rounds-based, or volume-based (kg lifted).
+- **Workout options**: the full session configuration — movements, goal, timers, and weight setup — held in `WorkoutOptionsContext` and written to Supabase on completion.
+
+## Page Structure
+
+Each page is a self-contained folder under `src/pages/`:
+
+```
+pages/
+  StartWorkoutPage/
+    StartWorkoutPage.tsx        # Page component
+    StartWorkoutPage.test.tsx   # Tests
+    StartWorkoutPage.stories.tsx
+    components/                 # Components used only by this page
+    hooks/                      # Hooks used only by this page
+    utils/                      # Pure utilities for this page
+    index.ts                    # Re-exports the page component
+```
+
+## API Layer
+
+- All data-fetching hooks live in `src/api/`.
+- Queries use `useQuery`, mutations use `useMutation` (react-query v3).
+- Supabase client is the `supabase` named export from `~/supabaseClient`.
+- Query keys are defined in `src/constants/queries.enum.ts`.
+- `src/types/supabase.ts` is auto-generated — regenerate with `npm run fetch-types` after any schema change.
+
+## Testing Setup
+
+- Vitest + React Testing Library.
+- MSW (Mock Service Worker) handles API mocking:
+  - `src/mocks/server.ts` — Node server for unit tests
+  - `src/mocks/browser.ts` — browser SW for dev mode
+  - `src/mocks/handlers.ts` — shared request handlers
+- Test data lives in `src/examples/` and `src/mocks/mocked-*.ts`.
+- Test files collocate with source: `ComponentName.test.tsx`.
+
 ## Authentication
 
 - Uses Supabase Auth with both magic links and OTP (one-time passwords)
 - Magic links are primary method, OTP is fallback for mobile users
 - Session management handled via React Context
 
-## Testing
-
-- Uses Vitest for unit testing
-- Run tests with: `npm test`
-- All tests must pass before committing
-
 ## Development Commands
 
-- `npm run dev` - Start development server
+- `npm run dev` - Start development server (port 5173)
+- `npm run dev:host` - Dev server exposed on local network IP
 - `npm run build` - Build for production
 - `npm run preview` - Preview production build
-- `npm test` - Run tests
+- `npm test` - Run tests (Vitest, single run)
+- `npm run test-watch` - Run tests in watch mode
+- `npm run coverage` - Run tests with coverage report
+- `npm run compile:ts` - TypeScript type-check without emitting
 - `npm run lint` - Run ESLint
+- `npm run prettier` - Format all files with Prettier
+- `npm run storybook` - Storybook on port 6006
 - `npm run fetch-types` - Fetch Supabase types from backend
 
 ## Key Technologies
 
 - React 18 with TypeScript
 - Vite for build tooling
+- React Router v6 for routing
 - Supabase for backend and auth
 - Tailwind CSS with custom spacing
-- Radix UI primitives
-- React Query for data fetching
-- Vitest for testing
+- Radix UI primitives (via shadcn/ui)
+- React Query v3 for data fetching
+- MSW for API mocking in tests
+- Vitest + React Testing Library for testing
+- Storybook for component development


### PR DESCRIPTION
## Summary

- **CLAUDE.md**: Added six new sections covering project directory structure, the `~` import alias, domain glossary (movement, rung, ladder, complex set, weight config), page folder convention, API layer patterns, and MSW test setup. Also expanded the dev commands list with `dev:host`, `test-watch`, `coverage`, `compile:ts`, `prettier`, and `storybook`.
- **AGENT_GUIDELINES.md**: Replaced the stale "advanced config" critical path with the Movement Foundation initiative (CB-70–74), including the list of blocked downstream features (Pattern Debt Engine, AI Recommender, Skill Tree, analytics). Updated the last-modified date to 2026-05-20.

## Why

The previous CLAUDE.md lacked enough context for agents and new contributors to understand the codebase layout, domain vocabulary, or test setup. The previous critical path in AGENT_GUIDELINES.md was out of date — CB-66 (Complex Mode toggle) shipped, and the roadmap has shifted to Movement Foundation as the primary blocking initiative.

## Reviewer notes

- No code changes — documentation only.
- The Movement Foundation framing in AGENT_GUIDELINES.md will take effect on the PM agent's next run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)