### PR TITLE
[CB-68] Persist complex mode flag to workout_logs when saving a completed workout

### DIFF
--- a/src/api/useLogWorkout.test.ts
+++ b/src/api/useLogWorkout.test.ts
@@ -1,0 +1,127 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { http, HttpResponse } from 'msw';
+import React from 'react';
+import { QueryClient, QueryClientProvider } from 'react-query';
+
+import {
+  DEFAULT_MOVEMENT_OPTIONS,
+  DEFAULT_WORKOUT_OPTIONS,
+  SessionProvider,
+  WorkoutOptionsContext,
+} from '~/contexts';
+import { VITE_SUPABASE_URL } from '../env';
+import { server } from '~/mocks/server';
+
+import { useLogWorkout } from './useLogWorkout';
+
+const WORKOUT_LOGS_URL = `${VITE_SUPABASE_URL}/rest/v1/workout_logs`;
+const MOVEMENT_LOGS_URL = `${VITE_SUPABASE_URL}/rest/v1/movement_logs`;
+
+const mockSession = {
+  user: {
+    id: 'user-123',
+    app_metadata: {},
+    user_metadata: {},
+    created_at: '',
+    aud: '',
+  },
+  access_token: '',
+  refresh_token: '',
+  expires_in: 10000,
+  token_type: '',
+};
+
+const defaultMovement = {
+  ...DEFAULT_MOVEMENT_OPTIONS,
+  movementName: 'Kettlebell Swing',
+};
+
+function makeWrapper(complexSet: boolean) {
+  const workoutOptions = {
+    ...DEFAULT_WORKOUT_OPTIONS,
+    complexSet,
+    movements: [defaultMovement],
+  };
+
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+
+  return ({ children }: { children: React.ReactNode }) =>
+    React.createElement(
+      QueryClientProvider,
+      { client: queryClient },
+      React.createElement(
+        SessionProvider,
+        { value: mockSession },
+        React.createElement(
+          WorkoutOptionsContext.Provider,
+          { value: [workoutOptions, () => {}] },
+          children,
+        ),
+      ),
+    );
+}
+
+const logWorkoutInput = {
+  completedReps: 5,
+  completedRounds: 1,
+  completedRungs: 1,
+  completedVolume: 120,
+};
+
+describe('useLogWorkout — complex_set persistence', () => {
+  beforeEach(() => {
+    server.use(
+      http.post(MOVEMENT_LOGS_URL, () => HttpResponse.json([])),
+    );
+  });
+
+  test('sends complex_set: true when complexSet is true', async () => {
+    let capturedBody: Record<string, unknown> | null = null;
+
+    server.use(
+      http.post(WORKOUT_LOGS_URL, async ({ request }) => {
+        capturedBody = (await request.json()) as Record<string, unknown>;
+        return HttpResponse.json([{ id: 1 }]);
+      }),
+    );
+
+    const { result } = renderHook(() => useLogWorkout(), {
+      wrapper: makeWrapper(true),
+    });
+
+    act(() => {
+      result.current.mutate(logWorkoutInput);
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(capturedBody).not.toBeNull();
+    expect(capturedBody!.complex_set).toBe(true);
+  });
+
+  test('sends complex_set: false when complexSet is false', async () => {
+    let capturedBody: Record<string, unknown> | null = null;
+
+    server.use(
+      http.post(WORKOUT_LOGS_URL, async ({ request }) => {
+        capturedBody = (await request.json()) as Record<string, unknown>;
+        return HttpResponse.json([{ id: 1 }]);
+      }),
+    );
+
+    const { result } = renderHook(() => useLogWorkout(), {
+      wrapper: makeWrapper(false),
+    });
+
+    act(() => {
+      result.current.mutate(logWorkoutInput);
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(capturedBody).not.toBeNull();
+    expect(capturedBody!.complex_set).toBe(false);
+  });
+});

--- a/src/api/useLogWorkout.ts
+++ b/src/api/useLogWorkout.ts
@@ -50,6 +50,7 @@ const logWorkout = async ({
   workoutOptions: WorkoutOptions;
 }) => {
   const {
+    complexSet,
     intervalTimer,
     movements,
     restTimer,
@@ -67,6 +68,7 @@ const logWorkout = async ({
       completed_rounds: completedRounds,
       completed_rungs: completedRungs,
       completed_volume: completedVolume,
+      complex_set: complexSet,
       interval_timer: intervalTimer,
       movements: movements.map((movement) => movement.movementName),
       rest_timer: restTimer,

--- a/src/examples/workout-log.examples.ts
+++ b/src/examples/workout-log.examples.ts
@@ -12,6 +12,7 @@ export class ExampleWorkoutLog implements WorkoutLog {
   completed_rounds: number;
   completed_rungs: number;
   completed_volume: number | null;
+  complex_set: boolean | null;
   id: number;
   interval_timer: number;
   movements: string[];
@@ -40,6 +41,7 @@ export class ExampleWorkoutLog implements WorkoutLog {
     completed_rounds = 0,
     completed_rungs = 0,
     completed_volume = 0,
+    complex_set = null,
     interval_timer = 0,
     movements = [],
     rest_timer = 0,
@@ -61,6 +63,7 @@ export class ExampleWorkoutLog implements WorkoutLog {
     this.completed_rounds = completed_rounds;
     this.completed_rungs = completed_rungs;
     this.completed_volume = completed_volume;
+    this.complex_set = complex_set;
     this.id = id;
     this.interval_timer = interval_timer;
     this.movements = movements;

--- a/types/supabase.ts
+++ b/types/supabase.ts
@@ -337,6 +337,7 @@ export type Database = {
           completed_rounds: number
           completed_rungs: number
           completed_volume: number | null
+          complex_set: boolean | null
           id: number
           interval_timer: number
           is_one_handed: boolean | null
@@ -359,6 +360,7 @@ export type Database = {
           completed_rounds: number
           completed_rungs: number
           completed_volume?: number | null
+          complex_set?: boolean | null
           id?: number
           interval_timer?: number
           is_one_handed?: boolean | null
@@ -381,6 +383,7 @@ export type Database = {
           completed_rounds?: number
           completed_rungs?: number
           completed_volume?: number | null
+          complex_set?: boolean | null
           id?: number
           interval_timer?: number
           is_one_handed?: boolean | null


### PR DESCRIPTION
## Linear ticket

https://linear.app/bellskill/issue/CB-68/persist-complex-mode-flag-to-workout-logs-when-saving-a-completed

## Acceptance criteria

- [x] **When a workout is saved in complex mode (`workoutOptions.complexSet === true`), `workout_logs` has `complex_set: true`** — tested in `useLogWorkout.test.ts` ("sends complex_set: true when complexSet is true"), verified via MSW request interception.
- [x] **When a workout is saved in standard mode (`workoutOptions.complexSet === false`), `workout_logs` has `complex_set: false`** — tested in `useLogWorkout.test.ts` ("sends complex_set: false when complexSet is false").
- [x] **`complexSet` is read from `WorkoutOptionsContext` and included in the Supabase insert payload** — `useLogWorkout.ts` now destructures `complexSet` from `workoutOptions` and maps it to `complex_set` in the `.insert({...})` call.
- [x] **`types/supabase.ts` includes the `complex_set` column** — manually added to `Row`, `Insert`, and `Update` on `workout_logs`. Will be overwritten by auto-generated output once the prerequisite migration ticket runs `npm run fetch-types`. Also updated `ExampleWorkoutLog` in `src/examples/workout-log.examples.ts` to satisfy the interface.
- [x] **No TypeScript errors related to the new field** — `tsc --noEmit` is clean (only pre-existing `features.ts` error unrelated to this change).
- [x] **Existing workout save behavior is unchanged for standard-mode workouts** — all 147 pre-existing tests still pass (149 total including the 2 new ones).

## Implementation summary

Three files changed, one new test file added:

- **`types/supabase.ts`** — added `complex_set: boolean | null` to `workout_logs` Row / Insert / Update. This is the hand-crafted entry that will be replaced once the DB migration for the column runs and `npm run fetch-types` is re-executed.
- **`src/examples/workout-log.examples.ts`** — added `complex_set: boolean | null` property and constructor default (`null`) to `ExampleWorkoutLog` so it continues to implement the updated `WorkoutLog` interface.
- **`src/api/useLogWorkout.ts`** — destructures `complexSet` from `workoutOptions` alongside the other fields, then passes `complex_set: complexSet` in the Supabase `.insert({...})` payload.
- **`src/api/useLogWorkout.test.ts`** _(new)_ — two unit tests using MSW request interception and `renderHook` to assert that the POST body sent to `workout_logs` contains the correct `complex_set` value for both `true` and `false` cases.

## Deviations from plan

None. Implementation matched the plan exactly.

## Notes for reviewers

- The column write is safe before the DB migration runs — Supabase will silently ignore unknown fields in the insert until the column exists, then start persisting the value once the migration is applied.
- The `features.ts` TypeScript error visible in `tsc` output is pre-existing on `main` and unrelated to this PR.

---
_Generated by [Claude Code](https://claude.ai/code/session_0167ghxXdHzxPypfEiMtiHRP)_