### PR TITLE
[CB-69] Show "Complex" badge on workout history entries completed in complex mode

### DIFF
--- a/src/api/useWorkoutLog.ts
+++ b/src/api/useWorkoutLog.ts
@@ -31,6 +31,7 @@ const fetchWorkoutLog = async (id: string): Promise<WorkoutLog> => {
     completedRounds: workoutLog.completed_rounds,
     completedRungs: workoutLog.completed_rungs,
     completedVolume: workoutLog.completed_volume,
+    complexSet: workoutLog.complex_set,
     id: workoutLog.id,
     intervalTimer: workoutLog.interval_timer,
     movements: workoutLog.movements,

--- a/src/api/useWorkoutLogs.ts
+++ b/src/api/useWorkoutLogs.ts
@@ -25,6 +25,7 @@ const fetchWorkoutLogs = async (): Promise<WorkoutLog[]> => {
     completedRounds: workoutLog.completed_rounds,
     completedRungs: workoutLog.completed_rungs,
     completedVolume: workoutLog.completed_volume,
+    complexSet: workoutLog.complex_set,
     id: workoutLog.id,
     intervalTimer: workoutLog.interval_timer,
     movements: workoutLog.movements,

--- a/src/mocks/data.ts
+++ b/src/mocks/data.ts
@@ -23,6 +23,7 @@ export const workoutLogs: WorkoutLog[] = [
     completed_rounds: 9,
     completed_rungs: 9,
     completed_volume: 1000,
+    complex_set: true,
     movements: ['Clean and Press', 'Front Squat'],
     started_at: '2023-10-11T13:47:39.636+00:00',
     workout_details: 'The Giant 3.0 W1D2',

--- a/src/pages/CompletedWorkoutPage/CompletedWorkoutPage.test.jsx
+++ b/src/pages/CompletedWorkoutPage/CompletedWorkoutPage.test.jsx
@@ -34,6 +34,12 @@ describe('completed workout page', () => {
     await screen.findByTestId('workout-history-item');
   });
 
+  test('renders Complex badge in header when workout is complex', async () => {
+    render(<Default />);
+
+    await screen.findByText('Complex');
+  });
+
   test('clicking on an RPE value updates the selected value', async () => {
     render(<Default />);
 

--- a/src/pages/CompletedWorkoutPage/CompletedWorkoutPage.tsx
+++ b/src/pages/CompletedWorkoutPage/CompletedWorkoutPage.tsx
@@ -149,6 +149,7 @@ export const CompletedWorkoutPage = () => {
           completedRounds={workoutLog.completedRounds}
           completedRungs={workoutLog.completedRungs}
           completedVolume={workoutLog.completedVolume ?? 0}
+          complexSet={workoutLog.complexSet}
           intervalTimer={workoutLog.intervalTimer}
           movementLogs={movementLogs}
           movementLogsLoading={movementLogsLoading}

--- a/src/pages/CompletedWorkoutPage/components/WorkoutHistoryItem.tsx
+++ b/src/pages/CompletedWorkoutPage/components/WorkoutHistoryItem.tsx
@@ -1,6 +1,7 @@
 import { DateTime, Duration } from 'luxon';
 
 import { Loading } from '~/components';
+import { Badge } from '~/components/ui/badge';
 import {
   Card,
   CardContent,
@@ -26,6 +27,7 @@ export interface WorkoutHistoryItemProps {
   completedRounds: number;
   completedRungs: number;
   completedVolume: number;
+  complexSet?: boolean | null;
   intervalTimer: number;
   movementLogs: MovementLog[];
   movementLogsLoading: boolean;
@@ -42,6 +44,7 @@ export const WorkoutHistoryItem = ({
   completedRounds,
   completedRungs,
   completedVolume,
+  complexSet,
   intervalTimer,
   movementLogs,
   movementLogsLoading,
@@ -59,7 +62,12 @@ export const WorkoutHistoryItem = ({
     <Card data-testid="workout-history-item">
       <CardHeader>
         <CardTitle className="flex items-baseline justify-between gap-1">
-          {displayDate}
+          <div className="flex items-baseline gap-1">
+            {displayDate}
+            {complexSet === true && (
+              <Badge variant="secondary">Complex</Badge>
+            )}
+          </div>
           <CardDescription className="text-xs">{timeRange}</CardDescription>
         </CardTitle>
         {workoutDetails && (

--- a/src/pages/HistoryPage/HistoryPage.test.jsx
+++ b/src/pages/HistoryPage/HistoryPage.test.jsx
@@ -29,4 +29,14 @@ describe('workout history page', () => {
   test('renders rep count for bodyweight workouts', async () => {
     await screen.findByText('50 reps');
   });
+
+  test('renders Complex badge for workouts with complex_set true', async () => {
+    await screen.findByText('Complex');
+  });
+
+  test('does not render Complex badge for workouts without complex_set', async () => {
+    await screen.findByText('50 reps');
+    const badges = screen.getAllByText('Complex');
+    expect(badges).toHaveLength(1);
+  });
 });

--- a/src/pages/HistoryPage/HistoryPage.tsx
+++ b/src/pages/HistoryPage/HistoryPage.tsx
@@ -3,6 +3,7 @@ import { Link } from 'react-router-dom';
 
 import { useWorkoutLogs } from '~/api';
 import { Loading, Page } from '~/components';
+import { Badge } from '~/components/ui/badge';
 import { Card, CardContent, CardHeader, CardTitle } from '~/components/ui/card';
 import { WorkoutLog } from '~/types';
 
@@ -55,6 +56,9 @@ const WorkoutLogItem = ({ workoutLog }: { workoutLog: WorkoutLog }) => {
         )}
       </div>
       <div className="flex grow items-center justify-end gap-1">
+        {workoutLog.complexSet === true && (
+          <Badge variant="secondary">Complex</Badge>
+        )}
         {workoutLog.rpe !== null && <RpeBadge rpeValue={workoutLog.rpe} />}
         <div className="text-right">{displayText}</div>
       </div>

--- a/src/types/workout-log.interface.ts
+++ b/src/types/workout-log.interface.ts
@@ -7,6 +7,7 @@ export interface WorkoutLog {
   completedRounds: number;
   completedRungs: number;
   completedVolume: number | null;
+  complexSet: boolean | null;
   id: number;
   intervalTimer: number;
   movements: string[];


### PR DESCRIPTION
## Linear Ticket

https://linear.app/bellskill/issue/CB-69/show-complex-badge-on-workout-history-entries-completed-in-complex

## Acceptance Criteria

- [x] On the History page, each workout entry with `complex_set: true` displays a "Complex" badge alongside the existing workout metadata — badge rendered in `WorkoutLogItem` next to the RPE badge and volume display
- [x] On the Completed Workout detail page, a "Complex" badge appears in the header/title area when `complex_set: true` — badge rendered in `WorkoutHistoryItem`'s `CardTitle` next to the workout date
- [x] The existing `Badge` component from `src/components/ui/badge.tsx` is used; no new badge styles are introduced — both usages use `<Badge variant="secondary">`
- [x] Workouts with `complex_set: false` or `null` show no badge — conditional is `=== true`, so `false` and `null` are both excluded
- [x] The badge is unobtrusive and does not disrupt the existing layout on either page — placed inline within existing flex containers
- [x] At least one unit test covers the conditional rendering of the badge on both the history list and the detail page — two new tests added (one per page)

## Summary

**Type layer** (`src/types/workout-log.interface.ts`): Added `complexSet: boolean | null` to the `WorkoutLog` interface.

**API layer** (`src/api/useWorkoutLogs.ts`, `src/api/useWorkoutLog.ts`): Map `complex_set` → `complexSet` in both fetchers.

**History page** (`src/pages/HistoryPage/HistoryPage.tsx`): Import `Badge` and render `<Badge variant="secondary">Complex</Badge>` in `WorkoutLogItem` when `complexSet === true`.

**Detail page** (`src/pages/CompletedWorkoutPage/components/WorkoutHistoryItem.tsx`): Added optional `complexSet` prop; render badge in the `CardTitle` header. `CompletedWorkoutPage.tsx` passes `workoutLog.complexSet` through.

**Mock data** (`src/mocks/data.ts`): Set `complex_set: true` on the first mock workout entry so test stories produce observable badge output.

**Tests**: Added `renders Complex badge for workouts with complex_set true` to `HistoryPage.test.jsx` and `renders Complex badge in header when workout is complex` to `CompletedWorkoutPage.test.jsx`. All 167 tests pass.

## Deviations from Plan

None.

## Manual Verification Note

The badge renders correctly with real `complex_set` data once the "Persist complex mode flag" ticket (prerequisite) is shipped to production.

---
_Generated by [Claude Code](https://claude.ai/code/session_017tCAn4ngTLZJnGW8LBaiCi)_