### PR TITLE
Drop unused progress_items table

### DIFF
--- a/supabase/migrations/20260521000001_drop_progress_items_table.sql
+++ b/supabase/migrations/20260521000001_drop_progress_items_table.sql
@@ -1,0 +1,6 @@
+DROP POLICY IF EXISTS "Users can view own progress items" ON progress_items;
+DROP POLICY IF EXISTS "Users can insert own progress items" ON progress_items;
+DROP POLICY IF EXISTS "Users can update own progress items" ON progress_items;
+DROP POLICY IF EXISTS "Users can delete own progress items" ON progress_items;
+
+DROP TABLE IF EXISTS progress_items;

--- a/types/supabase.ts
+++ b/types/supabase.ts
@@ -284,51 +284,6 @@ export type Database = {
         }
         Relationships: []
       }
-      progress_items: {
-        Row: {
-          category: string
-          created_at: string | null
-          icon_name: string | null
-          id: string
-          level: number
-          max_xp: number
-          name: string
-          progress: number
-          type: string
-          updated_at: string | null
-          user_id: string
-          xp: number
-        }
-        Insert: {
-          category: string
-          created_at?: string | null
-          icon_name?: string | null
-          id?: string
-          level?: number
-          max_xp?: number
-          name: string
-          progress?: number
-          type: string
-          updated_at?: string | null
-          user_id: string
-          xp?: number
-        }
-        Update: {
-          category?: string
-          created_at?: string | null
-          icon_name?: string | null
-          id?: string
-          level?: number
-          max_xp?: number
-          name?: string
-          progress?: number
-          type?: string
-          updated_at?: string | null
-          user_id?: string
-          xp?: number
-        }
-        Relationships: []
-      }
       workout_logs: {
         Row: {
           bells: number[]


### PR DESCRIPTION
Remove the `progress_items` table, which was created for PARA-method tracking but was never wired up to the application layer.

**Changes:**
- `supabase/migrations/20260521000001_drop_progress_items_table.sql` — drops RLS policies and the table
- `types/supabase.ts` — removes the stale `progress_items` type definition

**Testing:**
- Migration applied successfully against local Supabase instance
- `progress_items` table confirmed absent after migration
- No application code references this table

🤖 Generated with [Claude Code](https://claude.com/claude-code)