### PR TITLE
Fix TypeScript error for import.meta.env

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,7 +18,7 @@
     "paths": {
       "~/*": ["./src/*"]
     },
-    "types": ["vitest/globals", "@testing-library/jest-dom"]
+    "types": ["vitest/globals", "@testing-library/jest-dom", "vite/client"]
   },
   "include": ["src/**/*", "msw-utils.js"]
 }


### PR DESCRIPTION
Add `vite/client` to `tsconfig.json` types so `import.meta.env` is recognized by TypeScript.

**Changes:**
- Added `"vite/client"` to the `types` array in `tsconfig.json`

**Testing:**
- `npm run compile:ts` now exits with code 0