### PR TITLE
Add .claude/settings.json with permission allowlist

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,10 @@
+{
+  "permissions": {
+    "allow": [
+      "mcp__e7560fe6-e0dc-4e41-8b81-77e2cf92370e__get_issue",
+      "Bash(npm test *)",
+      "Bash(npm run compile:ts *)",
+      "Bash(npx supabase status *)"
+    ]
+  }
+}


### PR DESCRIPTION
Persists common read-only tool permissions in the repo so they survive worktree cleanup after PR merges, eliminating repeated permission prompts across sessions.

**Changes:**
- Add `.claude/settings.json` with `permissions.allow` for 4 read-only patterns:
  - `mcp__e7560fe6...__get_issue` — Linear: read issue details
  - `Bash(npm test *)` — Vitest tests (MSW-mocked, no side effects)
  - `Bash(npm run compile:ts *)` — TypeScript type-check (`tsc --noEmit`)
  - `Bash(npx supabase status *)` — local Supabase status check

**Testing:**
- Verified patterns are read-only and appeared ≥3 times across recent session transcripts
- Confirmed no existing `settings.json` was overwritten