### PR TITLE
Auto-sync develop from main after production deploy

### DIFF
--- a/.github/workflows/sync-develop.yaml
+++ b/.github/workflows/sync-develop.yaml
@@ -1,0 +1,29 @@
+name: Sync develop from main
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Merge main into develop
+        run: |
+          git checkout develop
+          git merge origin/main --no-edit
+          git push origin develop


### PR DESCRIPTION
Adds a GitHub Actions workflow that automatically merges `main` into `develop` after every push to `main`, keeping staging in lockstep with production.

**Changes:**
- Add `.github/workflows/sync-develop.yaml` triggered on push to `main`
- Workflow checks out with full history, merges `origin/main` into `develop`, and pushes back
- Uses `contents: write` permission with the default `GITHUB_TOKEN`
- Naturally re-triggers `supabase-staging.yaml` when migrations are included in the merge

**Testing:**
- Merge a PR into `main` and confirm the "Sync develop from main" workflow runs in the Actions tab
- Verify `develop` advances to match `main` (fast-forward or merge commit)
- If `supabase/**` files changed, confirm the staging migration workflow also fires