### PR TITLE
Add user_movements table (PROD-71)

### DIFF
--- a/supabase/migrations/20260522000000_create_user_movements_table.sql
+++ b/supabase/migrations/20260522000000_create_user_movements_table.sql
@@ -1,0 +1,25 @@
+CREATE TABLE user_movements (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  functional_movement_id UUID REFERENCES movements(id),
+  canonical_name TEXT NOT NULL,
+  is_big_6 BOOLEAN DEFAULT false,
+  skill_tree_enabled BOOLEAN DEFAULT false,
+  created_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX idx_user_movements_user_canonical ON user_movements(user_id, canonical_name);
+
+ALTER TABLE user_movements ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users can view own user_movements" ON user_movements
+  FOR SELECT USING ((SELECT auth.uid()) = user_id);
+
+CREATE POLICY "Users can insert own user_movements" ON user_movements
+  FOR INSERT WITH CHECK ((SELECT auth.uid()) = user_id);
+
+CREATE POLICY "Users can update own user_movements" ON user_movements
+  FOR UPDATE USING ((SELECT auth.uid()) = user_id);
+
+CREATE POLICY "Users can delete own user_movements" ON user_movements
+  FOR DELETE USING ((SELECT auth.uid()) = user_id);

--- a/types/supabase.ts
+++ b/types/supabase.ts
@@ -280,6 +280,44 @@ export type Database = {
         }
         Relationships: []
       }
+      user_movements: {
+        Row: {
+          canonical_name: string
+          created_at: string | null
+          functional_movement_id: string | null
+          id: string
+          is_big_6: boolean | null
+          skill_tree_enabled: boolean | null
+          user_id: string
+        }
+        Insert: {
+          canonical_name: string
+          created_at?: string | null
+          functional_movement_id?: string | null
+          id?: string
+          is_big_6?: boolean | null
+          skill_tree_enabled?: boolean | null
+          user_id: string
+        }
+        Update: {
+          canonical_name?: string
+          created_at?: string | null
+          functional_movement_id?: string | null
+          id?: string
+          is_big_6?: boolean | null
+          skill_tree_enabled?: boolean | null
+          user_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "user_movements_functional_movement_id_fkey"
+            columns: ["functional_movement_id"]
+            isOneToOne: false
+            referencedRelation: "movements"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       workout_logs: {
         Row: {
           bells: number[]


### PR DESCRIPTION
Creates the `user_movements` table linking a user's personal movement catalog to the `movements` reference table, as specified in [PROD-71](https://linear.app/bellskill/issue/PROD-71/create-user-movements-table-linking-users-to-functional-movements).

**Changes:**
- `supabase/migrations/20260522000000_create_user_movements_table.sql` — creates `user_movements` with UUID PK, nullable `functional_movement_id` FK to `movements`, `canonical_name`, `is_big_6`, `skill_tree_enabled`, RLS policies (SELECT/INSERT/UPDATE/DELETE scoped to `user_id`), and index on `(user_id, canonical_name)`
- `types/supabase.ts` — regenerated to include `user_movements` Row/Insert/Update types and FK relationship

**Testing:**
- `db reset` applied all migrations cleanly including the new one
- `npm run gen:types` produced correct `user_movements` types with proper nullability and relationship to `movements`