### PR TITLE
Fix 15 Supabase Security Advisor warnings

### DIFF
--- a/supabase/migrations/20260521000003_fix_security_warnings.sql
+++ b/supabase/migrations/20260521000003_fix_security_warnings.sql
@@ -1,0 +1,52 @@
+-- Fix 13 of 15 Supabase Security Advisor warnings.
+-- The remaining 2 (anon + authenticated SELECT on progress_items) are cleared
+-- by the preceding migration 20260521000002_drop_progress_items_table.sql.
+
+-- 1. Fix RLS INSERT/UPDATE policies that used WITH CHECK (true), which allowed
+--    authenticated users to insert/update rows with any user_id.
+
+DROP POLICY IF EXISTS "Enable insert for authenticated users only" ON public.movement_logs;
+CREATE POLICY "Enable insert for authenticated users only" ON public.movement_logs
+  FOR INSERT TO authenticated
+  WITH CHECK (((select auth.uid()) = user_id));
+
+DROP POLICY IF EXISTS "Enable insert for authenticated users only" ON public.workout_logs;
+CREATE POLICY "Enable insert for authenticated users only" ON public.workout_logs
+  FOR INSERT TO authenticated
+  WITH CHECK (((select auth.uid()) = user_id));
+
+DROP POLICY IF EXISTS "Enable update access for workout logs based on user id" ON public.workout_logs;
+CREATE POLICY "Enable update access for workout logs based on user id" ON public.workout_logs
+  FOR UPDATE TO authenticated
+  USING (((select auth.uid()) = user_id))
+  WITH CHECK (((select auth.uid()) = user_id));
+
+-- 2. Revoke all anon table grants. The app requires authentication before any
+--    data access; the anon role should have no direct table privileges.
+
+REVOKE ALL ON TABLE public.movement_logs FROM anon;
+REVOKE ALL ON TABLE public.movements FROM anon;
+REVOKE ALL ON TABLE public.profiles FROM anon;
+REVOKE ALL ON TABLE public.workout_logs FROM anon;
+
+-- 3. Narrow authenticated table grants from GRANT ALL to only the operations
+--    each table actually uses. RLS policies remain the enforcement boundary.
+
+REVOKE ALL ON TABLE public.workout_logs FROM authenticated;
+GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.workout_logs TO authenticated;
+
+REVOKE ALL ON TABLE public.movement_logs FROM authenticated;
+GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.movement_logs TO authenticated;
+
+REVOKE ALL ON TABLE public.movements FROM authenticated;
+GRANT SELECT ON TABLE public.movements TO authenticated;
+
+REVOKE ALL ON TABLE public.profiles FROM authenticated;
+GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.profiles TO authenticated;
+
+-- 4. Revoke EXECUTE on handle_new_user() from anon and authenticated.
+--    This is a trigger function invoked automatically on auth.users INSERT;
+--    it is never called directly by client code.
+
+REVOKE ALL ON FUNCTION public.handle_new_user() FROM anon;
+REVOKE ALL ON FUNCTION public.handle_new_user() FROM authenticated;


### PR DESCRIPTION
Adds a single migration to resolve 13 of the 15 Security Advisor warnings. The remaining 2 (anon + authenticated SELECT on `progress_items`) are cleared by the preceding `20260521000002_drop_progress_items_table.sql` migration once both are pushed to the remote.

**Changes:**
- Fix 3 RLS policies with `WITH CHECK (true)` on non-SELECT operations:
  - `movement_logs` INSERT policy: constrain to `(select auth.uid()) = user_id`
  - `workout_logs` INSERT policy: constrain to `(select auth.uid()) = user_id`
  - `workout_logs` UPDATE policy: constrain both `USING` and `WITH CHECK` to `(select auth.uid()) = user_id`
- Revoke all `anon` table grants from `movement_logs`, `movements`, `profiles`, `workout_logs` — the app requires authentication before any data access
- Narrow `authenticated` grants from `GRANT ALL` to only needed operations: full CRUD on user tables, SELECT-only on `movements` (read-only reference data)
- Revoke `EXECUTE` on `public.handle_new_user()` from `anon` and `authenticated` — it's a trigger function, never called directly by clients

**Testing:**
- All 167 unit tests pass (`npm test`)
- After `supabase db push`, re-run the Security Advisor linter in the Supabase dashboard to confirm 0 warnings remain