### PR TITLE
Fix staging migrations not deploying after develop sync

### DIFF
--- a/.github/workflows/supabase-staging.yaml
+++ b/.github/workflows/supabase-staging.yaml
@@ -6,11 +6,16 @@ on:
       - develop
     paths:
       - supabase/**
+  workflow_run:
+    workflows: ["Sync develop from main"]
+    types:
+      - completed
   workflow_dispatch:
 
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
 
     env:
       SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
@@ -19,6 +24,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+        with:
+          ref: develop
 
       - uses: supabase/setup-cli@v1
         with:


### PR DESCRIPTION
GITHUB_TOKEN pushes don't trigger other workflows, so the sync-develop job merging main into develop never fired `Deploy Migrations to Staging`. The staging/dev database was silently falling behind after each main merge.

**Changes:**
- Add `workflow_run` trigger to `supabase-staging.yaml` so it fires after `Sync develop from main` completes
- Explicitly checkout `ref: develop` so the job deploys the right branch (workflow_run defaults to the repo default branch)
- Add `if:` condition on the deploy job to skip when the sync workflow failed

**Testing:** Merge a PR with a new migration to main, confirm `Sync develop from main` completes, then confirm `Deploy Migrations to Staging` fires automatically via the `workflow_run` trigger.