### PR TITLE
Add Playwright e2e integration test for workout flow

### DIFF
--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -28,3 +28,23 @@ jobs:
       - run: npm ci
       - run: npm run build
       - run: npm run test
+
+      - name: Set up Supabase CLI
+        uses: supabase/setup-cli@v1
+        with:
+          version: latest
+
+      - name: Start local Supabase
+        run: supabase start
+
+      - name: Install Playwright Chromium
+        run: npx playwright install --with-deps chromium
+
+      - name: Run e2e tests
+        run: npm run test:e2e
+        env:
+          VITE_SUPABASE_URL: http://localhost:54321
+          VITE_SUPABASE_ANON_KEY: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.MLAQ4IKp3RGVoKN-Kxw5sGtJFpV9UVInlrFZaKxcLyo
+          TEST_USER_EMAIL: test@example.com
+          TEST_USER_PASSWORD: testpassword123
+          CI: true

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -29,6 +29,18 @@ jobs:
       - run: npm run build
       - run: npm run test
 
+  integration-tests:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Use Node.js 24.x
+        uses: actions/setup-node@v3
+        with:
+          node-version: 24.x
+          cache: 'npm'
+      - run: npm ci
+
       - name: Set up Supabase CLI
         uses: supabase/setup-cli@v1
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,10 @@ coverage
 # Local Supabase
 supabase/.branches
 supabase/.temp
+
+# E2E test env (contains local Supabase keys)
+.env.e2e
+
+# Playwright
+playwright-report
+test-results

--- a/e2e/workout-flow.spec.ts
+++ b/e2e/workout-flow.spec.ts
@@ -1,0 +1,229 @@
+import { expect, Page, test } from '@playwright/test';
+
+// ── Constants ────────────────────────────────────────────────────────────────
+
+const SUPABASE_URL = process.env.VITE_SUPABASE_URL!;
+const SUPABASE_ANON_KEY = process.env.VITE_SUPABASE_ANON_KEY!;
+const TEST_EMAIL = process.env.TEST_USER_EMAIL ?? 'test@example.com';
+const TEST_PASSWORD = process.env.TEST_USER_PASSWORD ?? 'testpassword123';
+
+// ── Types ────────────────────────────────────────────────────────────────────
+
+interface AuthSession {
+  access_token: string;
+  refresh_token: string;
+  expires_in: number;
+  expires_at: number;
+  token_type: string;
+  user: {
+    id: string;
+    email: string;
+    [key: string]: unknown;
+  };
+}
+
+interface WorkoutLogRow {
+  id: number;
+  user_id: string;
+  movements: string[];
+  workout_goal_units: string;
+  workout_goal: number;
+  completed_rounds: number;
+  completed_reps: number;
+  completed_rungs: number;
+  completed_volume: number;
+}
+
+// ── Auth helpers ─────────────────────────────────────────────────────────────
+
+async function signInWithPassword(
+  email: string,
+  password: string,
+): Promise<AuthSession> {
+  const res = await fetch(
+    `${SUPABASE_URL}/auth/v1/token?grant_type=password`,
+    {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        apikey: SUPABASE_ANON_KEY,
+      },
+      body: JSON.stringify({ email, password }),
+    },
+  );
+
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`Supabase sign-in failed (${res.status}): ${text}`);
+  }
+
+  return res.json() as Promise<AuthSession>;
+}
+
+/**
+ * Registers an init script that writes the Supabase session to localStorage
+ * before the React app mounts. Must be called before page.goto().
+ *
+ * supabase-js v2 derives the storage key as sb-<hostname>-auth-token.
+ * For http://localhost:54321 → sb-localhost-auth-token.
+ */
+async function injectAuthSession(
+  page: Page,
+  session: AuthSession,
+): Promise<void> {
+  const { hostname } = new URL(SUPABASE_URL);
+  const key = `sb-${hostname}-auth-token`;
+
+  const value = JSON.stringify({
+    access_token: session.access_token,
+    token_type: 'bearer',
+    expires_in: session.expires_in,
+    expires_at: session.expires_at,
+    refresh_token: session.refresh_token,
+    user: session.user,
+  });
+
+  await page.addInitScript(
+    ({ k, v }: { k: string; v: string }) => {
+      window.localStorage.setItem(k, v);
+    },
+    { k: key, v: value },
+  );
+}
+
+// ── DB helpers ───────────────────────────────────────────────────────────────
+
+// Uses the signed-in user's access_token for REST queries.
+// RLS policies allow users to read and delete their own workout_logs rows.
+async function queryWorkoutLog(
+  workoutLogId: number,
+  accessToken: string,
+): Promise<WorkoutLogRow | null> {
+  const url = `${SUPABASE_URL}/rest/v1/workout_logs?id=eq.${workoutLogId}&select=*`;
+
+  const res = await fetch(url, {
+    headers: {
+      apikey: SUPABASE_ANON_KEY,
+      Authorization: `Bearer ${accessToken}`,
+    },
+  });
+
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`workout_logs query failed (${res.status}): ${text}`);
+  }
+
+  const rows = (await res.json()) as WorkoutLogRow[];
+  return rows[0] ?? null;
+}
+
+async function deleteWorkoutLog(id: number, accessToken: string): Promise<void> {
+  // movement_logs has ON DELETE CASCADE so only the parent row needs deleting
+  const res = await fetch(
+    `${SUPABASE_URL}/rest/v1/workout_logs?id=eq.${id}`,
+    {
+      method: 'DELETE',
+      headers: {
+        apikey: SUPABASE_ANON_KEY,
+        Authorization: `Bearer ${accessToken}`,
+      },
+    },
+  );
+
+  if (!res.ok) {
+    console.warn(`Cleanup: could not delete workout_log id=${id}: ${res.status}`);
+  }
+}
+
+// ── Test ─────────────────────────────────────────────────────────────────────
+
+test.describe('full workout flow', () => {
+  let authSession: AuthSession;
+  let createdWorkoutLogId: number | null = null;
+
+  test.beforeAll(async () => {
+    authSession = await signInWithPassword(TEST_EMAIL, TEST_PASSWORD);
+  });
+
+  test.afterAll(async () => {
+    if (createdWorkoutLogId !== null) {
+      await deleteWorkoutLog(createdWorkoutLogId, authSession.access_token);
+    }
+  });
+
+  test('fills out form, completes workout, verifies DB record', async ({
+    page,
+  }) => {
+    // ── 1. Inject auth before page load ──────────────────────────────────
+    await injectAuthSession(page, authSession);
+
+    // ── 2. Load the app ───────────────────────────────────────────────────
+    await page.goto('/');
+
+    // Confirm we bypassed the Signup screen and landed on StartWorkoutPage
+    const startWorkoutButton = page.getByRole('button', {
+      name: 'Start workout',
+    });
+    await expect(startWorkoutButton).toBeVisible({ timeout: 10_000 });
+
+    // ── 3. Switch goal unit to "Rounds" ───────────────────────────────────
+    // Default is "minutes" (10 min). Switching to rounds sets goal to
+    // previousRounds=10 from context defaults.
+    await page.getByRole('tab', { name: 'Rounds' }).click();
+
+    // ── 4. Set goal to 1 round ────────────────────────────────────────────
+    // After switching to Rounds, workoutGoal is set to previousRounds=10.
+    // Click the minus button 9 times to decrement from 10 → 1.
+    // Using the button's aria-label (aria-label="- rounds") is more reliable
+    // than fill() on a controlled React input, which bypasses synthetic events.
+    const minusRoundsButton = page.getByRole('button', { name: '- rounds' });
+    for (let i = 0; i < 9; i++) {
+      await minusRoundsButton.click();
+    }
+
+    // ── 5. Enter movement name ────────────────────────────────────────────
+    // aria-label="Movement Input" is set on the movement name Input in
+    // StartWorkoutPage.tsx. Filling this enables the "Start workout" button.
+    await page.getByLabel('Movement Input').fill('Clean and Press');
+
+    // ── 6. Start the workout ──────────────────────────────────────────────
+    await expect(startWorkoutButton).toBeEnabled();
+    await startWorkoutButton.click();
+
+    await expect(page).toHaveURL(/\/active$/);
+
+    // ── 7. Complete the workout ───────────────────────────────────────────
+    // With rounds goal, intervalTimer=0, restTimer=0:
+    //   workoutTimerPaused = false → "Continue" renders immediately
+    //
+    // Clicking once: completedRounds→1 ≥ workoutGoal→1
+    //   → handleRoundsGoalReached → finishWorkout() → logWorkout()
+    //   → handleFinishWorkout → navigate('/history/{id}')
+    const continueButton = page.getByRole('button', { name: 'Continue' });
+    await expect(continueButton).toBeVisible();
+    await continueButton.click();
+
+    // ── 8. Assert navigation to CompletedWorkoutPage ──────────────────────
+    await expect(page).toHaveURL(/\/history\/\d+$/, { timeout: 10_000 });
+
+    const match = page.url().match(/\/history\/(\d+)$/);
+    const workoutLogId = parseInt(match![1], 10);
+    createdWorkoutLogId = workoutLogId;
+
+    // Confirm the page rendered the completed workout title
+    await expect(page.getByText('Workout Log')).toBeVisible();
+
+    // ── 9. Verify the database record ─────────────────────────────────────
+    const workoutLog = await queryWorkoutLog(workoutLogId, authSession.access_token);
+
+    expect(workoutLog, 'workout log should exist in DB').not.toBeNull();
+    expect(workoutLog!.user_id).toBe(authSession.user.id);
+    expect(workoutLog!.movements).toEqual(['Clean and Press']);
+    expect(workoutLog!.workout_goal_units).toBe('rounds');
+    expect(workoutLog!.workout_goal).toBe(1);
+    expect(workoutLog!.completed_rounds).toBe(1);
+    expect(workoutLog!.completed_reps).toBe(5); // repScheme=[5]
+    expect(workoutLog!.completed_rungs).toBe(1);
+    expect(workoutLog!.completed_volume).toBe(80); // 16 kg × 5 reps
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,7 @@
         "use-query-params": "^2.2.1"
       },
       "devDependencies": {
+        "@playwright/test": "^1.60.0",
         "@storybook/addon-essentials": "^7.2.3",
         "@storybook/addon-interactions": "^7.2.3",
         "@storybook/addon-links": "^7.2.3",
@@ -54,6 +55,7 @@
         "@vitejs/plugin-react": "^4.0.3",
         "@vitest/coverage-v8": "^1.2.1",
         "autoprefixer": "^10.4.14",
+        "dotenv": "^17.4.2",
         "eslint": "^8.45.0",
         "eslint-plugin-react": "^7.32.2",
         "eslint-plugin-react-hooks": "^4.6.0",
@@ -3265,6 +3267,22 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@radix-ui/number": {
@@ -10202,9 +10220,9 @@
       }
     },
     "node_modules/dotenv": {
-      "version": "16.5.0",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.5.0.tgz",
-      "integrity": "sha512-m/C+AwOAr9/W1UOIZUo232ejMNnJAJtYQjUbHoNTBNTJSvqzzDh7vnrei3o3r3m9blf6ZoDkvcw0VmozNRFJxg==",
+      "version": "17.4.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
+      "integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
       "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
@@ -13730,6 +13748,19 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/lazy-universal-dotenv/node_modules/dotenv": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
     "node_modules/less": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/less/-/less-4.3.0.tgz",
@@ -15292,6 +15323,53 @@
         "confbox": "^0.1.8",
         "mlly": "^1.7.4",
         "pathe": "^2.0.1"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/polished": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,10 @@
     "coverage": "vitest run --coverage",
     "compile:ts": "npx tsc --noEmit",
     "start:server": "supabase start",
-    "prettier": "prettier --write ."
+    "prettier": "prettier --write .",
+    "test:e2e": "playwright test",
+    "test:e2e:ui": "playwright test --ui",
+    "test:e2e:debug": "PWDEBUG=1 playwright test"
   },
   "dependencies": {
     "@headlessui/react": "^1.7.16",
@@ -49,6 +52,7 @@
     "use-query-params": "^2.2.1"
   },
   "devDependencies": {
+    "@playwright/test": "^1.60.0",
     "@storybook/addon-essentials": "^7.2.3",
     "@storybook/addon-interactions": "^7.2.3",
     "@storybook/addon-links": "^7.2.3",
@@ -69,6 +73,7 @@
     "@vitejs/plugin-react": "^4.0.3",
     "@vitest/coverage-v8": "^1.2.1",
     "autoprefixer": "^10.4.14",
+    "dotenv": "^17.4.2",
     "eslint": "^8.45.0",
     "eslint-plugin-react": "^7.32.2",
     "eslint-plugin-react-hooks": "^4.6.0",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,32 @@
+import { defineConfig, devices } from '@playwright/test';
+import dotenv from 'dotenv';
+import path from 'path';
+
+dotenv.config({ path: path.resolve(process.cwd(), '.env.e2e') });
+
+export default defineConfig({
+  testDir: './e2e',
+  fullyParallel: false,
+  workers: 1,
+  retries: process.env.CI ? 1 : 0,
+  reporter: [['list']],
+  use: {
+    baseURL: 'http://localhost:5173',
+    trace: 'on-first-retry',
+  },
+  projects: [
+    { name: 'chromium', use: { ...devices['Desktop Chrome'] } },
+  ],
+  webServer: {
+    command: 'npm run dev',
+    url: 'http://localhost:5173',
+    reuseExistingServer: !process.env.CI,
+    timeout: 30_000,
+    env: {
+      VITE_SUPABASE_URL: process.env.VITE_SUPABASE_URL ?? '',
+      VITE_SUPABASE_ANON_KEY: process.env.VITE_SUPABASE_ANON_KEY ?? '',
+      VITE_FEATURE_COMPLEX_MODE: 'true',
+      VITE_FEATURE_EXPLORE: 'true',
+    },
+  },
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -10,6 +10,7 @@ export default mergeConfig(
       globals: true,
       environment: 'jsdom',
       setupFiles: './config/vitest.setup.ts',
+      exclude: ['**/node_modules/**', 'e2e/**'],
       // Reduce test output verbosity
       reporters: ['basic'],
       logHeapUsage: false,


### PR DESCRIPTION
Adds a Playwright integration test that exercises the full workout flow end-to-end against a local Supabase instance, and wires it into the existing CI pipeline.

**Changes:**
- `e2e/workout-flow.spec.ts` — test that signs in via Supabase password grant, fills out the StartWorkoutPage (1-round goal, "Clean and Press" movement), completes the workout with one Continue click, then queries the database to assert the `workout_logs` row has the correct values
- `playwright.config.ts` — Playwright config pointing to the Vite dev server, loading Supabase env vars, Chromium only, single worker
- `package.json` — `test:e2e`, `test:e2e:ui`, `test:e2e:debug` scripts
- `.gitignore` — exclude `.env.e2e`, `playwright-report/`, `test-results/`
- `.github/workflows/unit-tests.yaml` — after unit tests: install Supabase CLI, `supabase start`, install Chromium, run `npm run test:e2e`

**Testing:**
- Test passes locally against the running local Supabase instance (`npm run start:server` required before `npm run test:e2e`)
- Auth is handled by injecting a session into `localStorage` before the React app mounts — no interaction with the magic link / OTP signup UI
- DB verification uses the signed-in user's JWT (RLS allows users to read their own `workout_logs` rows)
- Test cleans up the created row in `afterAll`