### PR TITLE
Improve movement autocomplete — equipment filter, arm-type filter, frequency ranking, word-boundary boost

### DIFF
--- a/src/api/useMovementSearch.ts
+++ b/src/api/useMovementSearch.ts
@@ -9,20 +9,30 @@ export interface MovementSearchResult {
   name: string;
 }
 
-export const useMovementSearch = (query: string) =>
+export const useMovementSearch = (query: string, singleOrDoubleArm?: string | null) =>
   useQuery(
-    [QUERIES.MOVEMENTS, 'search', query],
-    () => searchMovements(query),
+    [QUERIES.MOVEMENTS, 'search', query, singleOrDoubleArm],
+    () => searchMovements(query, singleOrDoubleArm),
     { enabled: query.length >= 2, keepPreviousData: true },
   );
 
-const searchMovements = async (query: string): Promise<MovementSearchResult[]> => {
-  const { data, error } = await supabase
+const searchMovements = async (
+  query: string,
+  singleOrDoubleArm?: string | null,
+): Promise<MovementSearchResult[]> => {
+  let q = supabase
     .from('movements')
     .select('id, Movement')
     .ilike('Movement', `%${query}%`)
+    .in('"Primary Equipment"', ['Kettlebell', 'Bodyweight'])
     .order('Movement')
-    .limit(8);
+    .limit(20);
+
+  if (singleOrDoubleArm) {
+    q = q.eq('"Single or Double Arm"', singleOrDoubleArm);
+  }
+
+  const { data, error } = await q;
 
   if (error) throw error;
   return (data ?? []).map((m) => ({ id: m.id, name: m['Movement'] }));

--- a/src/api/useUserMovementFrequency.ts
+++ b/src/api/useUserMovementFrequency.ts
@@ -1,0 +1,44 @@
+import { useQuery } from 'react-query';
+
+import { QUERIES } from '~/constants';
+import { useSession } from '~/contexts';
+
+import { supabase } from '../supabaseClient';
+
+export interface UserMovementWithFrequency {
+  id: string;
+  canonicalName: string;
+  functionalMovementId: string | null;
+  logCount: number;
+}
+
+export const useUserMovementFrequency = () => {
+  const session = useSession();
+  const userId = session?.user?.id;
+
+  return useQuery(
+    [QUERIES.USER_MOVEMENTS, 'frequency', userId],
+    () => fetchUserMovementFrequency(userId!),
+    { enabled: !!userId },
+  );
+};
+
+const fetchUserMovementFrequency = async (
+  userId: string,
+): Promise<UserMovementWithFrequency[]> => {
+  const { data, error } = await supabase
+    .from('user_movements')
+    .select('id, canonical_name, functional_movement_id, movement_logs(count)')
+    .eq('user_id', userId);
+
+  if (error) throw error;
+
+  return (data ?? [])
+    .map((m) => ({
+      id: m.id,
+      canonicalName: m.canonical_name,
+      functionalMovementId: m.functional_movement_id,
+      logCount: Number((m.movement_logs as { count: number }[] | undefined)?.[0]?.count ?? 0),
+    }))
+    .sort((a, b) => b.logCount - a.logCount);
+};

--- a/src/pages/StartWorkoutPage/StartWorkoutPage.tsx
+++ b/src/pages/StartWorkoutPage/StartWorkoutPage.tsx
@@ -595,6 +595,7 @@ export const StartWorkoutPage = () => {
                 autoFocus
                 value={movement.movementName}
                 onChange={(name) => handleChangeMovementName(index, name)}
+                weightTab={weightTabValue}
               />
             </Section>
             {!complexSet && (

--- a/src/pages/StartWorkoutPage/components/MovementAutocomplete.tsx
+++ b/src/pages/StartWorkoutPage/components/MovementAutocomplete.tsx
@@ -2,14 +2,25 @@ import { useEffect, useRef, useState } from 'react';
 
 import { useCreateUserMovement } from '~/api/useCreateUserMovement';
 import { useMovementSearch } from '~/api/useMovementSearch';
-import { useUserMovements } from '~/api/useUserMovements';
+import { useUserMovementFrequency } from '~/api/useUserMovementFrequency';
 import { cn } from '~/lib/utils';
+import { rankMovements } from '~/utils';
+
+type WeightTab = 'none' | '2h' | '1h' | 'double';
+
+const ARM_TYPE: Record<WeightTab, string> = {
+  none: 'No Arms',
+  '2h': 'Double Arm',
+  '1h': 'Single Arm',
+  double: 'Double Arm',
+};
 
 interface MovementAutocompleteProps {
   value: string;
   onChange: (name: string) => void;
   autoFocus?: boolean;
   className?: string;
+  weightTab?: WeightTab | null;
 }
 
 export const MovementAutocomplete = ({
@@ -17,6 +28,7 @@ export const MovementAutocomplete = ({
   onChange,
   autoFocus,
   className,
+  weightTab,
 }: MovementAutocompleteProps) => {
   const [inputValue, setInputValue] = useState(value);
   const [isOpen, setIsOpen] = useState(false);
@@ -27,23 +39,31 @@ export const MovementAutocomplete = ({
     setInputValue(value);
   }, [value]);
 
-  const { data: recentMovements = [] } = useUserMovements();
-  const { data: catalogResults = [] } = useMovementSearch(inputValue);
+  const singleOrDoubleArm = weightTab ? ARM_TYPE[weightTab] : null;
+
+  const { data: frequentMovements = [] } = useUserMovementFrequency();
+  const { data: catalogResults = [] } = useMovementSearch(inputValue, singleOrDoubleArm);
   const createUserMovement = useCreateUserMovement();
+
+  const frequentNames = new Set(
+    frequentMovements.map((m) => m.canonicalName.toLowerCase()),
+  );
 
   const filteredRecent =
     inputValue.length >= 1
-      ? recentMovements.filter((m) =>
+      ? frequentMovements.filter((m) =>
           m.canonicalName.toLowerCase().includes(inputValue.toLowerCase()),
         )
-      : recentMovements.slice(0, 8);
+      : frequentMovements.slice(0, 8);
 
   const catalogNames = new Set(filteredRecent.map((m) => m.canonicalName.toLowerCase()));
   const uniqueCatalog = catalogResults.filter(
     (m) => !catalogNames.has(m.name.toLowerCase()),
   );
+  const rankedCatalog =
+    inputValue.length >= 2 ? rankMovements(uniqueCatalog, inputValue, frequentNames) : uniqueCatalog;
 
-  const hasOptions = filteredRecent.length > 0 || uniqueCatalog.length > 0;
+  const hasOptions = filteredRecent.length > 0 || rankedCatalog.length > 0;
   const showCustomEntry =
     inputValue.length > 0 &&
     !filteredRecent.some(
@@ -127,14 +147,14 @@ export const MovementAutocomplete = ({
             </>
           )}
 
-          {uniqueCatalog.length > 0 && (
+          {rankedCatalog.length > 0 && (
             <>
               {filteredRecent.length > 0 && (
                 <li className="px-2 py-0.5 text-xs font-medium text-muted-foreground">
                   From catalog
                 </li>
               )}
-              {uniqueCatalog.map((movement) => (
+              {rankedCatalog.map((movement) => (
                 <li
                   key={movement.id}
                   role="option"

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,2 +1,3 @@
 export * from './ordinalSuffixOf';
+export * from './rankMovements';
 export * from './weightUnits';

--- a/src/utils/rankMovements.ts
+++ b/src/utils/rankMovements.ts
@@ -1,0 +1,23 @@
+export interface Rankable {
+  name: string;
+}
+
+function scoreMatch(name: string, query: string): number {
+  const lower = name.toLowerCase();
+  const q = query.toLowerCase();
+  if (lower.startsWith(q)) return 3;
+  if (lower.includes(` ${q}`)) return 2;
+  return 1;
+}
+
+export function rankMovements<T extends Rankable>(
+  results: T[],
+  query: string,
+  frequentNames: Set<string>,
+): T[] {
+  return [...results].sort((a, b) => {
+    const scoreA = scoreMatch(a.name, query) + (frequentNames.has(a.name.toLowerCase()) ? 1 : 0);
+    const scoreB = scoreMatch(b.name, query) + (frequentNames.has(b.name.toLowerCase()) ? 1 : 0);
+    return scoreB - scoreA;
+  });
+}


### PR DESCRIPTION
Searching for a movement like \"Press\" previously returned dozens of alphabetically-sorted results including many Alternating/Dumbbell/Clubbell entries irrelevant to the user's current weight configuration, with no usage-based ranking. This PR makes the search significantly more useful.

**Changes:**
- **Global equipment filter**: catalog search now only returns Kettlebell and Bodyweight movements, cutting the searchable set from ~2,500 to ~1,040 entries
- **Arm-type filter**: `useMovementSearch` accepts a `singleOrDoubleArm` parameter wired to the selected weight tab — 2H→Double Arm, 1H→Single Arm, None→No Arms, Double→Double Arm (alternating not yet supported so Continuous filter is not needed)
- **Frequency-based ranking**: new `useUserMovementFrequency` hook queries `user_movements` with `movement_logs(count)`, replacing creation-date ordering with log-count ordering in the Recent section
- **Word-boundary boost**: new `rankMovements` utility scores catalog results by match position (starts-with=3, word-boundary=2, substring=1) with an additional +1 for movements already in the user's history
- `MovementAutocomplete` receives a `weightTab` prop from `StartWorkoutPage` and applies all filters and ranking
- Catalog search limit bumped from 8→20 to give the client-side ranker enough results to work with

**Testing:**
- All 175 existing tests pass
- Select 2H, search "Press" → Alternating/Dumbbell results absent
- Select 1H, search "Swing" → only single-arm swings appear
- Open search with no query → most frequently logged movements appear first
- Search "Press" → "Kettlebell Press" ranks above "Alternating Double Dumbbell Bench Press"