### PR TITLE
Improve movement autocomplete weight mode UX

### DIFF
--- a/src/api/useMovementSearch.ts
+++ b/src/api/useMovementSearch.ts
@@ -1,6 +1,8 @@
 import { useQuery } from 'react-query';
 
 import { QUERIES } from '~/constants';
+import { WeightTabValue } from '~/types';
+import { applyWeightModeToMovementsQuery } from '~/utils';
 
 import { supabase } from '../supabaseClient';
 
@@ -9,20 +11,25 @@ export interface MovementSearchResult {
   name: string;
 }
 
-export const useMovementSearch = (query: string) =>
+export const useMovementSearch = (query: string, weightMode: WeightTabValue) =>
   useQuery(
-    [QUERIES.MOVEMENTS, 'search', query],
-    () => searchMovements(query),
+    [QUERIES.MOVEMENTS, 'search', query, weightMode],
+    () => searchMovements(query, weightMode),
     { enabled: query.length >= 2, keepPreviousData: true },
   );
 
-const searchMovements = async (query: string): Promise<MovementSearchResult[]> => {
-  const { data, error } = await supabase
+const searchMovements = async (
+  query: string,
+  weightMode: WeightTabValue,
+): Promise<MovementSearchResult[]> => {
+  let movementsQuery = supabase
     .from('movements')
     .select('id, Movement')
-    .ilike('Movement', `%${query}%`)
-    .order('Movement')
-    .limit(8);
+    .ilike('Movement', `%${query}%`);
+
+  movementsQuery = applyWeightModeToMovementsQuery(movementsQuery, weightMode);
+
+  const { data, error } = await movementsQuery.order('Movement').limit(8);
 
   if (error) throw error;
   return (data ?? []).map((m) => ({ id: m.id, name: m['Movement'] }));

--- a/src/pages/StartWorkoutPage/StartWorkoutPage.test.jsx
+++ b/src/pages/StartWorkoutPage/StartWorkoutPage.test.jsx
@@ -107,7 +107,7 @@ describe('start workout page', () => {
     expect(movementInput).toHaveValue('Clean and Press');
   });
 
-  describe('Weights', () => {
+  describe('Load', () => {
     test('can select "none" for bodyweight movements', async () => {
       await userEvent.click(screen.getByRole('tab', { name: 'None' }));
       await userEvent.type(screen.getByLabelText('Movement Input'), 'Pushups');
@@ -476,11 +476,11 @@ describe('Complex Mode', () => {
 
   test('when Complex is active, per-movement weight sections are hidden and rep scheme sections remain visible', async () => {
     await userEvent.click(screen.getByRole('button', { name: '+ Movement' }));
-    expect(screen.getAllByRole('heading', { name: 'Weights' })).toHaveLength(2);
+    expect(screen.getAllByRole('heading', { name: 'Load' })).toHaveLength(2);
 
     await userEvent.click(screen.getByRole('button', { name: 'Complex' }));
 
-    expect(screen.queryAllByRole('heading', { name: 'Weights' })).toHaveLength(0);
+    expect(screen.queryAllByRole('heading', { name: 'Load' })).toHaveLength(0);
     expect(screen.getAllByRole('heading', { name: 'Rep Scheme' })).toHaveLength(2);
   });
 
@@ -491,7 +491,7 @@ describe('Complex Mode', () => {
     await userEvent.click(screen.getByRole('button', { name: 'Standard' }));
 
     expect(screen.queryByRole('heading', { name: 'Shared Weight' })).not.toBeInTheDocument();
-    expect(screen.getByRole('heading', { name: 'Weights' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Load' })).toBeInTheDocument();
   });
 
   test('startWorkout is called with complexSet: true and shared weight fields when Complex is active', async () => {
@@ -513,23 +513,23 @@ describe('Complex Mode', () => {
 
   test('complex mode toggle is preserved when adding movements', async () => {
     await userEvent.click(screen.getByRole('button', { name: 'Complex' }));
-    expect(screen.queryAllByRole('heading', { name: 'Weights' })).toHaveLength(0);
+    expect(screen.queryAllByRole('heading', { name: 'Load' })).toHaveLength(0);
 
     await userEvent.click(screen.getByRole('button', { name: '+ Movement' }));
 
-    expect(screen.queryAllByRole('heading', { name: 'Weights' })).toHaveLength(0);
+    expect(screen.queryAllByRole('heading', { name: 'Load' })).toHaveLength(0);
     expect(screen.getByRole('heading', { name: 'Shared Weight' })).toBeInTheDocument();
   });
 
   test('complex mode toggle is preserved when removing movements', async () => {
     await userEvent.click(screen.getByRole('button', { name: '+ Movement' }));
     await userEvent.click(screen.getByRole('button', { name: 'Complex' }));
-    expect(screen.queryAllByRole('heading', { name: 'Weights' })).toHaveLength(0);
+    expect(screen.queryAllByRole('heading', { name: 'Load' })).toHaveLength(0);
 
     const removeButtons = screen.getAllByRole('button', { name: '- Movement' });
     await userEvent.click(removeButtons[0]);
 
-    expect(screen.queryAllByRole('heading', { name: 'Weights' })).toHaveLength(0);
+    expect(screen.queryAllByRole('heading', { name: 'Load' })).toHaveLength(0);
     expect(screen.getByRole('heading', { name: 'Shared Weight' })).toBeInTheDocument();
   });
 });

--- a/src/pages/StartWorkoutPage/StartWorkoutPage.tsx
+++ b/src/pages/StartWorkoutPage/StartWorkoutPage.tsx
@@ -4,15 +4,18 @@ import { useNavigate } from 'react-router-dom';
 import { Page } from '~/components';
 import { Button } from '~/components/ui/button';
 import { Card } from '~/components/ui/card';
+import { Input } from '~/components/ui/input';
 import { Tabs, TabsList, TabsTrigger } from '~/components/ui/tabs';
 import { DEFAULT_MOVEMENT_OPTIONS, useWorkoutOptions } from '~/contexts';
+import { getWeightsDisplayValue } from '~/pages/CompletedWorkoutPage/utils/displayValues';
 import {
   MovementOptions,
+  WeightTabValue,
   WeightUnit,
   WorkoutGoalUnits,
   WorkoutOptions,
 } from '~/types';
-import { getWeightUnitLabel } from '~/utils';
+import { getWeightTabValue, getWeightUnitLabel, WEIGHT_MODE_LABELS } from '~/utils';
 
 import { features } from '~/config/features';
 
@@ -21,6 +24,7 @@ import {
   MovementAutocomplete,
   ModifyWorkoutButtons,
   Section,
+  WeightModeTabs,
   WeightUnitTabs,
 } from './components';
 
@@ -297,14 +301,10 @@ export const StartWorkoutPage = () => {
     navigate('active');
   };
 
-  const sharedWeightTabValue =
-    sharedWeightOneValue === null
-      ? 'none'
-      : sharedWeightTwoValue === null
-        ? '2h'
-        : sharedWeightTwoValue === 0
-          ? '1h'
-          : 'double';
+  const sharedWeightTabValue = getWeightTabValue({
+    weightOneValue: sharedWeightOneValue,
+    weightTwoValue: sharedWeightTwoValue,
+  });
 
   const isDifferentRepSchemes =
     movements.length > 1 &&
@@ -387,25 +387,10 @@ export const StartWorkoutPage = () => {
             <Section
               title="Shared Weight"
               actions={
-                <Tabs
+                <WeightModeTabs
                   value={sharedWeightTabValue}
                   onValueChange={handleChangeSharedWeightTab}
-                >
-                  <TabsList>
-                    <TabsTrigger size="sm" value="none">
-                      None
-                    </TabsTrigger>
-                    <TabsTrigger size="sm" value="2h">
-                      2H
-                    </TabsTrigger>
-                    <TabsTrigger size="sm" value="1h">
-                      1H
-                    </TabsTrigger>
-                    <TabsTrigger size="sm" value="double">
-                      Double
-                    </TabsTrigger>
-                  </TabsList>
-                </Tabs>
+                />
               }
             >
               {sharedWeightOneValue !== null && (
@@ -568,14 +553,19 @@ export const StartWorkoutPage = () => {
       )}
 
       {movements.map((movement, index) => {
-        const weightTabValue =
-          movement.weightOneValue === null
-            ? 'none'
-            : movement.weightTwoValue === null
-              ? '2h'
-              : movement.weightTwoValue === 0
-                ? '1h'
-                : 'double';
+        const weightTabValue = getWeightTabValue(movement);
+        const activeWeightMode: WeightTabValue = complexSet
+          ? sharedWeightTabValue
+          : weightTabValue;
+        const weightSummary =
+          movement.movementName.length > 0
+            ? getWeightsDisplayValue(
+                movement.weightOneValue,
+                movement.weightOneUnit,
+                movement.weightTwoValue,
+                movement.weightTwoUnit,
+              )
+            : null;
 
         return (
           <Card key={index}>
@@ -595,37 +585,24 @@ export const StartWorkoutPage = () => {
                 autoFocus
                 value={movement.movementName}
                 onChange={(name) => handleChangeMovementName(index, name)}
+                weightMode={activeWeightMode}
+                onWeightModeChange={(mode) =>
+                  complexSet
+                    ? handleChangeSharedWeightTab(mode)
+                    : handleChangeWeightTab(index, mode)
+                }
+                showWeightModeTabs={!complexSet}
+                weightModeHint={
+                  complexSet
+                    ? `Using shared weight: ${WEIGHT_MODE_LABELS[sharedWeightTabValue]}`
+                    : null
+                }
+                weightSummary={weightSummary}
               />
             </Section>
-            {!complexSet && (
-              <Section
-                title="Weights"
-                actions={
-                  <Tabs
-                    value={weightTabValue}
-                    onValueChange={(value) =>
-                      handleChangeWeightTab(index, value)
-                    }
-                  >
-                    <TabsList>
-                      <TabsTrigger size="sm" value="none">
-                        None
-                      </TabsTrigger>
-                      <TabsTrigger size="sm" value="2h">
-                        2H
-                      </TabsTrigger>
-                      <TabsTrigger size="sm" value="1h">
-                        1H
-                      </TabsTrigger>
-                      <TabsTrigger size="sm" value="double">
-                        Double
-                      </TabsTrigger>
-                    </TabsList>
-                  </Tabs>
-                }
-              >
-                {movement.weightOneValue !== null && (
-                  <ModifyCountButtons
+            {!complexSet && weightTabValue !== 'none' && (
+              <Section title="Load">
+                <ModifyCountButtons
                     onClickMinus={() =>
                       handleChangeWeightOneValue(
                         index,
@@ -652,7 +629,6 @@ export const StartWorkoutPage = () => {
                       handleChangeWeightOneValue(index, value!)
                     }
                   />
-                )}
                 {movement.weightTwoValue !== null &&
                   movement.weightTwoValue > 0 && (
                     <ModifyCountButtons

--- a/src/pages/StartWorkoutPage/components/MovementAutocomplete.stories.tsx
+++ b/src/pages/StartWorkoutPage/components/MovementAutocomplete.stories.tsx
@@ -1,8 +1,10 @@
 import { Meta, StoryObj } from '@storybook/react';
 import { QueryClient, QueryClientProvider } from 'react-query';
 import { http, HttpResponse } from 'msw';
+import { useState } from 'react';
 
 import { VITE_SUPABASE_URL } from '~/env';
+import { WeightTabValue } from '~/types';
 
 import { MovementAutocomplete } from './MovementAutocomplete';
 
@@ -41,26 +43,46 @@ const makeQueryClient = () =>
     defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
   });
 
+const MovementAutocompleteDemo = ({
+  initialValue = '',
+  initialWeightMode = '2h' as WeightTabValue,
+  showWeightModeTabs = true,
+  weightModeHint = null as string | null,
+  weightSummary = null as string | null,
+}) => {
+  const [value, setValue] = useState(initialValue);
+  const [weightMode, setWeightMode] = useState<WeightTabValue>(initialWeightMode);
+
+  return (
+    <MovementAutocomplete
+      value={value}
+      onChange={setValue}
+      weightMode={weightMode}
+      onWeightModeChange={setWeightMode}
+      showWeightModeTabs={showWeightModeTabs}
+      weightModeHint={weightModeHint}
+      weightSummary={weightSummary}
+    />
+  );
+};
+
 export default {
   component: MovementAutocomplete,
   decorators: [
     (Story) => (
       <QueryClientProvider client={makeQueryClient()}>
-        <div className="p-4 max-w-sm">
+        <div className="max-w-sm p-4">
           <Story />
         </div>
       </QueryClientProvider>
     ),
   ],
-  args: {
-    value: '',
-    onChange: () => {},
-  },
 } satisfies Meta<typeof MovementAutocomplete>;
 
 type Story = StoryObj<typeof MovementAutocomplete>;
 
 export const Default: Story = {
+  render: () => <MovementAutocompleteDemo />,
   parameters: {
     msw: {
       handlers: [
@@ -72,7 +94,7 @@ export const Default: Story = {
 };
 
 export const WithRecentMovements: Story = {
-  args: { value: '' },
+  render: () => <MovementAutocompleteDemo />,
   parameters: {
     msw: {
       handlers: [
@@ -84,7 +106,7 @@ export const WithRecentMovements: Story = {
 };
 
 export const WithCatalogResults: Story = {
-  args: { value: 'Kettlebell' },
+  render: () => <MovementAutocompleteDemo initialValue="Kettlebell" />,
   parameters: {
     msw: {
       handlers: [
@@ -95,8 +117,56 @@ export const WithCatalogResults: Story = {
   },
 };
 
+export const BodyweightMode: Story = {
+  render: () => (
+    <MovementAutocompleteDemo initialValue="Push" initialWeightMode="none" />
+  ),
+  parameters: {
+    msw: {
+      handlers: [
+        http.get(MOVEMENTS_URL, () => HttpResponse.json([])),
+        http.get(USER_MOVEMENTS_URL, () => HttpResponse.json([])),
+      ],
+    },
+  },
+};
+
+export const WithWeightSummary: Story = {
+  render: () => (
+    <MovementAutocompleteDemo
+      initialValue="Kettlebell Swing"
+      weightSummary="16 kg (2h)"
+    />
+  ),
+  parameters: {
+    msw: {
+      handlers: [
+        http.get(MOVEMENTS_URL, () => HttpResponse.json([])),
+        http.get(USER_MOVEMENTS_URL, () => HttpResponse.json([])),
+      ],
+    },
+  },
+};
+
+export const ComplexSharedWeightHint: Story = {
+  render: () => (
+    <MovementAutocompleteDemo
+      showWeightModeTabs={false}
+      weightModeHint="Using shared weight: 2H"
+    />
+  ),
+  parameters: {
+    msw: {
+      handlers: [
+        http.get(MOVEMENTS_URL, () => HttpResponse.json([])),
+        http.get(USER_MOVEMENTS_URL, () => HttpResponse.json([])),
+      ],
+    },
+  },
+};
+
 export const CustomEntry: Story = {
-  args: { value: 'My Special Move' },
+  render: () => <MovementAutocompleteDemo initialValue="My Special Move" />,
   parameters: {
     msw: {
       handlers: [

--- a/src/pages/StartWorkoutPage/components/MovementAutocomplete.test.tsx
+++ b/src/pages/StartWorkoutPage/components/MovementAutocomplete.test.tsx
@@ -7,6 +7,7 @@ import { QueryClient, QueryClientProvider } from 'react-query';
 import { SessionProvider } from '~/contexts';
 import { server } from '~/mocks/server';
 import { VITE_SUPABASE_URL } from '~/env';
+import { WeightTabValue } from '~/types';
 
 import { MovementAutocomplete } from './MovementAutocomplete';
 
@@ -41,10 +42,38 @@ function makeWrapper(withSession = true) {
     );
 }
 
-function renderAutocomplete(value = '', onChange = vi.fn(), withSession = true) {
+interface RenderOptions {
+  value?: string;
+  onChange?: ReturnType<typeof vi.fn>;
+  weightMode?: WeightTabValue;
+  onWeightModeChange?: ReturnType<typeof vi.fn>;
+  withSession?: boolean;
+  showWeightModeTabs?: boolean;
+  weightSummary?: string | null;
+  weightModeHint?: string | null;
+}
+
+function renderAutocomplete({
+  value = '',
+  onChange = vi.fn(),
+  weightMode = '2h',
+  onWeightModeChange = vi.fn(),
+  withSession = true,
+  showWeightModeTabs = true,
+  weightSummary = null,
+  weightModeHint = null,
+}: RenderOptions = {}) {
   const wrapper = makeWrapper(withSession);
   return render(
-    <MovementAutocomplete value={value} onChange={onChange} />,
+    <MovementAutocomplete
+      value={value}
+      onChange={onChange}
+      weightMode={weightMode}
+      onWeightModeChange={onWeightModeChange}
+      showWeightModeTabs={showWeightModeTabs}
+      weightSummary={weightSummary}
+      weightModeHint={weightModeHint}
+    />,
     { wrapper },
   );
 }
@@ -62,15 +91,30 @@ describe('MovementAutocomplete', () => {
     expect(screen.getByRole('textbox', { name: 'Movement Input' })).toBeInTheDocument();
   });
 
+  test('renders weight mode tabs by default', () => {
+    renderAutocomplete();
+    expect(screen.getByRole('tab', { name: 'None' })).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: '2H' })).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: '1H' })).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: 'Double' })).toBeInTheDocument();
+  });
+
+  test('calls onWeightModeChange when a weight tab is selected', async () => {
+    const onWeightModeChange = vi.fn();
+    renderAutocomplete({ onWeightModeChange });
+
+    await userEvent.click(screen.getByRole('tab', { name: '1H' }));
+    expect(onWeightModeChange).toHaveBeenCalledWith('1h');
+  });
+
   test('calls onChange on every keystroke with accumulated value', async () => {
     const onChange = vi.fn();
-    renderAutocomplete('', onChange);
+    renderAutocomplete({ onChange });
 
     const input = screen.getByRole('textbox', { name: 'Movement Input' });
     await userEvent.type(input, 'Swing');
 
     expect(onChange).toHaveBeenCalledTimes(5);
-    // Component maintains internal state, so accumulated value is passed on each keypress
     expect(onChange).toHaveBeenNthCalledWith(1, 'S');
     expect(onChange).toHaveBeenNthCalledWith(2, 'Sw');
     expect(onChange).toHaveBeenNthCalledWith(3, 'Swi');
@@ -171,7 +215,7 @@ describe('MovementAutocomplete', () => {
     );
 
     const onChange = vi.fn();
-    renderAutocomplete('', onChange);
+    renderAutocomplete({ onChange });
 
     const input = screen.getByRole('textbox', { name: 'Movement Input' });
     await userEvent.click(input);
@@ -207,13 +251,14 @@ describe('MovementAutocomplete', () => {
     );
 
     const onChange = vi.fn();
-    renderAutocomplete('Kettlebell', onChange);
+    renderAutocomplete({ value: 'Kettlebell', onChange });
 
     const input = screen.getByRole('textbox', { name: 'Movement Input' });
     await userEvent.click(input);
 
     await waitFor(() => {
       expect(screen.getByText('Kettlebell Snatch')).toBeInTheDocument();
+      expect(screen.getByText('Catalog (2H)')).toBeInTheDocument();
     });
 
     await userEvent.click(screen.getByText('Kettlebell Snatch'));
@@ -224,8 +269,21 @@ describe('MovementAutocomplete', () => {
     });
   });
 
+  test('shows catalog empty state when search has no catalog matches', async () => {
+    renderAutocomplete({ value: 'Swing' });
+
+    const input = screen.getByRole('textbox', { name: 'Movement Input' });
+    await userEvent.click(input);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/No 2h movements for.*Swing.*try another mode/i),
+      ).toBeInTheDocument();
+    });
+  });
+
   test('shows custom entry option when no exact match exists', async () => {
-    renderAutocomplete('My Custom Move');
+    renderAutocomplete({ value: 'My Custom Move' });
 
     const input = screen.getByRole('textbox', { name: 'Movement Input' });
     await userEvent.click(input);
@@ -235,16 +293,43 @@ describe('MovementAutocomplete', () => {
     });
   });
 
+  test('shows weight summary chip when value is set and dropdown is closed', () => {
+    renderAutocomplete({
+      value: 'Kettlebell Swing',
+      weightSummary: '16 kg (2h)',
+    });
+
+    expect(screen.getByText('16 kg (2h)')).toBeInTheDocument();
+  });
+
+  test('shows shared weight hint when tabs are hidden', () => {
+    renderAutocomplete({
+      showWeightModeTabs: false,
+      weightModeHint: 'Using shared weight: 2H',
+    });
+
+    expect(screen.getByText('Using shared weight: 2H')).toBeInTheDocument();
+    expect(screen.queryByRole('tab', { name: '2H' })).not.toBeInTheDocument();
+  });
+
   test('does not show recent movements when there is no session', async () => {
     server.use(
       http.get(USER_MOVEMENTS_URL, () =>
         HttpResponse.json([
-          { id: 'um-1', canonical_name: 'Clean and Press', functional_movement_id: null, created_at: '2026-05-20T10:00:00Z', user_id: 'user-123', is_big_6: false, skill_tree_enabled: false },
+          {
+            id: 'um-1',
+            canonical_name: 'Clean and Press',
+            functional_movement_id: null,
+            created_at: '2026-05-20T10:00:00Z',
+            user_id: 'user-123',
+            is_big_6: false,
+            skill_tree_enabled: false,
+          },
         ]),
       ),
     );
 
-    renderAutocomplete('', vi.fn(), false);
+    renderAutocomplete({ withSession: false });
 
     const input = screen.getByRole('textbox', { name: 'Movement Input' });
     await userEvent.click(input);

--- a/src/pages/StartWorkoutPage/components/MovementAutocomplete.tsx
+++ b/src/pages/StartWorkoutPage/components/MovementAutocomplete.tsx
@@ -4,10 +4,19 @@ import { useCreateUserMovement } from '~/api/useCreateUserMovement';
 import { useMovementSearch } from '~/api/useMovementSearch';
 import { useUserMovements } from '~/api/useUserMovements';
 import { cn } from '~/lib/utils';
+import { WeightTabValue } from '~/types';
+import { WEIGHT_MODE_LABELS } from '~/utils';
+
+import { WeightModeTabs } from './WeightModeTabs';
 
 interface MovementAutocompleteProps {
   value: string;
   onChange: (name: string) => void;
+  weightMode: WeightTabValue;
+  onWeightModeChange: (mode: WeightTabValue) => void;
+  weightSummary?: string | null;
+  showWeightModeTabs?: boolean;
+  weightModeHint?: string | null;
   autoFocus?: boolean;
   className?: string;
 }
@@ -15,6 +24,11 @@ interface MovementAutocompleteProps {
 export const MovementAutocomplete = ({
   value,
   onChange,
+  weightMode,
+  onWeightModeChange,
+  weightSummary = null,
+  showWeightModeTabs = true,
+  weightModeHint = null,
   autoFocus,
   className,
 }: MovementAutocompleteProps) => {
@@ -22,13 +36,12 @@ export const MovementAutocomplete = ({
   const [isOpen, setIsOpen] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
 
-  // Sync external value changes (e.g., when parent resets the field)
   useEffect(() => {
     setInputValue(value);
   }, [value]);
 
   const { data: recentMovements = [] } = useUserMovements();
-  const { data: catalogResults = [] } = useMovementSearch(inputValue);
+  const { data: catalogResults = [] } = useMovementSearch(inputValue, weightMode);
   const createUserMovement = useCreateUserMovement();
 
   const filteredRecent =
@@ -43,12 +56,19 @@ export const MovementAutocomplete = ({
     (m) => !catalogNames.has(m.name.toLowerCase()),
   );
 
-  const hasOptions = filteredRecent.length > 0 || uniqueCatalog.length > 0;
+  const catalogSearched = inputValue.length >= 2;
+  const showCatalogEmpty = catalogSearched && uniqueCatalog.length === 0;
+
   const showCustomEntry =
     inputValue.length > 0 &&
     !filteredRecent.some(
       (m) => m.canonicalName.toLowerCase() === inputValue.toLowerCase(),
     );
+
+  const hasOptions =
+    filteredRecent.length > 0 || uniqueCatalog.length > 0 || showCatalogEmpty;
+
+  const catalogSectionLabel = `Catalog (${WEIGHT_MODE_LABELS[weightMode]})`;
 
   useEffect(() => {
     const handleClickOutside = (e: MouseEvent) => {
@@ -67,6 +87,11 @@ export const MovementAutocomplete = ({
     setIsOpen(true);
   };
 
+  const handleWeightModeChange = (mode: WeightTabValue) => {
+    onWeightModeChange(mode);
+    setIsOpen(true);
+  };
+
   const handleSelect = (name: string, functionalMovementId?: string | null) => {
     setInputValue(name);
     onChange(name);
@@ -80,9 +105,22 @@ export const MovementAutocomplete = ({
   };
 
   const showDropdown = isOpen && (hasOptions || showCustomEntry);
+  const showSummaryChip = value.length > 0 && weightSummary && !isOpen;
 
   return (
     <div ref={containerRef} className="relative w-full">
+      {showWeightModeTabs && (
+        <WeightModeTabs
+          value={weightMode}
+          onValueChange={handleWeightModeChange}
+          className="mb-1"
+        />
+      )}
+
+      {weightModeHint && (
+        <p className="mb-1 text-xs text-muted-foreground">{weightModeHint}</p>
+      )}
+
       <input
         aria-label="Movement Input"
         autoFocus={autoFocus}
@@ -99,6 +137,10 @@ export const MovementAutocomplete = ({
         onChange={handleInputChange}
         onFocus={() => setIsOpen(true)}
       />
+
+      {showSummaryChip && (
+        <p className="mt-1 text-xs text-muted-foreground">{weightSummary}</p>
+      )}
 
       {showDropdown && (
         <ul
@@ -129,11 +171,9 @@ export const MovementAutocomplete = ({
 
           {uniqueCatalog.length > 0 && (
             <>
-              {filteredRecent.length > 0 && (
-                <li className="px-2 py-0.5 text-xs font-medium text-muted-foreground">
-                  From catalog
-                </li>
-              )}
+              <li className="px-2 py-0.5 text-xs font-medium text-muted-foreground">
+                {catalogSectionLabel}
+              </li>
               {uniqueCatalog.map((movement) => (
                 <li
                   key={movement.id}
@@ -149,6 +189,13 @@ export const MovementAutocomplete = ({
                 </li>
               ))}
             </>
+          )}
+
+          {showCatalogEmpty && (
+            <li className="px-2 py-1 text-sm text-muted-foreground">
+              No {WEIGHT_MODE_LABELS[weightMode].toLowerCase()} movements for &ldquo;
+              {inputValue}&rdquo; — try another mode
+            </li>
           )}
 
           {showCustomEntry && (

--- a/src/pages/StartWorkoutPage/components/WeightModeTabs.tsx
+++ b/src/pages/StartWorkoutPage/components/WeightModeTabs.tsx
@@ -1,0 +1,36 @@
+import { Tabs, TabsList, TabsTrigger } from '~/components/ui/tabs';
+import { cn } from '~/lib/utils';
+import { WeightTabValue } from '~/types';
+
+interface WeightModeTabsProps {
+  value: WeightTabValue;
+  onValueChange: (value: WeightTabValue) => void;
+  className?: string;
+}
+
+export const WeightModeTabs = ({
+  value,
+  onValueChange,
+  className,
+}: WeightModeTabsProps) => (
+  <Tabs
+    value={value}
+    onValueChange={(next) => onValueChange(next as WeightTabValue)}
+    className={cn(className)}
+  >
+    <TabsList>
+      <TabsTrigger size="sm" value="none">
+        None
+      </TabsTrigger>
+      <TabsTrigger size="sm" value="2h">
+        2H
+      </TabsTrigger>
+      <TabsTrigger size="sm" value="1h">
+        1H
+      </TabsTrigger>
+      <TabsTrigger size="sm" value="double">
+        Double
+      </TabsTrigger>
+    </TabsList>
+  </Tabs>
+);

--- a/src/pages/StartWorkoutPage/components/index.ts
+++ b/src/pages/StartWorkoutPage/components/index.ts
@@ -2,4 +2,5 @@ export * from './ModifyCountButtons';
 export * from './MovementAutocomplete';
 export * from './ModifyWorkoutButtons';
 export * from './Section';
+export * from './WeightModeTabs';
 export * from './WeightUnitTabs';

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -5,6 +5,7 @@ export * from './movement-options.interface';
 export * from './movement.interface';
 export * from './muscle-group.type';
 export * from './rpe-options.type';
+export * from './weight-tab.type';
 export * from './weight-unit.type';
 export * from './workout-goal-units.type';
 export * from './workout-log.interface';

--- a/src/types/weight-tab.type.ts
+++ b/src/types/weight-tab.type.ts
@@ -1,0 +1,1 @@
+export type WeightTabValue = 'none' | '2h' | '1h' | 'double';

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,2 +1,3 @@
+export * from './movementWeightModeFilter';
 export * from './ordinalSuffixOf';
 export * from './weightUnits';

--- a/src/utils/movementWeightModeFilter.test.ts
+++ b/src/utils/movementWeightModeFilter.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, test } from 'vitest';
+
+import {
+  getWeightTabValue,
+  movementMatchesWeightMode,
+  type MovementWeightModeFields,
+} from './movementWeightModeFilter';
+
+const row = (
+  overrides: Partial<MovementWeightModeFields>,
+): MovementWeightModeFields => ({
+  primaryEquipment: null,
+  primaryItemCount: null,
+  singleOrDoubleArm: null,
+  ...overrides,
+});
+
+describe('getWeightTabValue', () => {
+  test('none when no weight', () => {
+    expect(getWeightTabValue({ weightOneValue: null, weightTwoValue: null })).toBe(
+      'none',
+    );
+  });
+
+  test('2h when one weight value', () => {
+    expect(getWeightTabValue({ weightOneValue: 16, weightTwoValue: null })).toBe('2h');
+  });
+
+  test('1h when second weight is zero', () => {
+    expect(getWeightTabValue({ weightOneValue: 16, weightTwoValue: 0 })).toBe('1h');
+  });
+
+  test('double when two weight values', () => {
+    expect(getWeightTabValue({ weightOneValue: 16, weightTwoValue: 16 })).toBe(
+      'double',
+    );
+  });
+});
+
+describe('movementMatchesWeightMode', () => {
+  test('none matches bodyweight only', () => {
+    expect(
+      movementMatchesWeightMode(
+        row({ primaryEquipment: 'Bodyweight' }),
+        'none',
+      ),
+    ).toBe(true);
+    expect(
+      movementMatchesWeightMode(
+        row({ primaryEquipment: 'Kettlebell', primaryItemCount: 1 }),
+        'none',
+      ),
+    ).toBe(false);
+  });
+
+  test('2h matches two-handed kettlebell', () => {
+    expect(
+      movementMatchesWeightMode(
+        row({
+          primaryEquipment: 'Kettlebell',
+          primaryItemCount: 1,
+          singleOrDoubleArm: 'No Arms',
+        }),
+        '2h',
+      ),
+    ).toBe(true);
+    expect(
+      movementMatchesWeightMode(
+        row({
+          primaryEquipment: 'Kettlebell',
+          primaryItemCount: 1,
+          singleOrDoubleArm: 'Single Arm',
+        }),
+        '2h',
+      ),
+    ).toBe(false);
+  });
+
+  test('1h matches single-arm kettlebell', () => {
+    expect(
+      movementMatchesWeightMode(
+        row({
+          primaryEquipment: 'Kettlebell',
+          singleOrDoubleArm: 'Single Arm',
+        }),
+        '1h',
+      ),
+    ).toBe(true);
+  });
+
+  test('double matches two items or double arm', () => {
+    expect(
+      movementMatchesWeightMode(
+        row({
+          primaryEquipment: 'Kettlebell',
+          primaryItemCount: 2,
+          singleOrDoubleArm: 'No Arms',
+        }),
+        'double',
+      ),
+    ).toBe(true);
+    expect(
+      movementMatchesWeightMode(
+        row({
+          primaryEquipment: 'Kettlebell',
+          primaryItemCount: 1,
+          singleOrDoubleArm: 'Double Arm',
+        }),
+        'double',
+      ),
+    ).toBe(true);
+    expect(
+      movementMatchesWeightMode(
+        row({
+          primaryEquipment: 'Kettlebell',
+          primaryItemCount: 1,
+          singleOrDoubleArm: 'Single Arm',
+        }),
+        'double',
+      ),
+    ).toBe(false);
+  });
+});

--- a/src/utils/movementWeightModeFilter.ts
+++ b/src/utils/movementWeightModeFilter.ts
@@ -1,0 +1,75 @@
+import { MovementOptions, WeightTabValue } from '~/types';
+
+export interface MovementWeightModeFields {
+  primaryEquipment: string | null;
+  primaryItemCount: number | null;
+  singleOrDoubleArm: string | null;
+}
+
+export const WEIGHT_MODE_LABELS: Record<WeightTabValue, string> = {
+  none: 'Bodyweight',
+  '2h': '2H',
+  '1h': '1H',
+  double: 'Double',
+};
+
+export const getWeightTabValue = (movement: {
+  weightOneValue: MovementOptions['weightOneValue'];
+  weightTwoValue: MovementOptions['weightTwoValue'];
+}): WeightTabValue => {
+  if (movement.weightOneValue === null) return 'none';
+  if (movement.weightTwoValue === null) return '2h';
+  if (movement.weightTwoValue === 0) return '1h';
+  return 'double';
+};
+
+export const movementMatchesWeightMode = (
+  row: MovementWeightModeFields,
+  mode: WeightTabValue,
+): boolean => {
+  switch (mode) {
+    case 'none':
+      return row.primaryEquipment === 'Bodyweight';
+    case '2h':
+      return (
+        row.primaryEquipment === 'Kettlebell' &&
+        row.primaryItemCount === 1 &&
+        row.singleOrDoubleArm !== 'Single Arm'
+      );
+    case '1h':
+      return (
+        row.primaryEquipment === 'Kettlebell' &&
+        row.singleOrDoubleArm === 'Single Arm'
+      );
+    case 'double':
+      return (
+        row.primaryEquipment === 'Kettlebell' &&
+        (row.primaryItemCount === 2 || row.singleOrDoubleArm === 'Double Arm')
+      );
+    default:
+      return false;
+  }
+};
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const applyWeightModeToMovementsQuery = (query: any, mode: WeightTabValue) => {
+  switch (mode) {
+    case 'none':
+      return query.eq('Primary Equipment', 'Bodyweight');
+    case '2h':
+      return query
+        .eq('Primary Equipment', 'Kettlebell')
+        .eq('# Primary Items', 1)
+        .neq('Single or Double Arm', 'Single Arm');
+    case '1h':
+      return query
+        .eq('Primary Equipment', 'Kettlebell')
+        .eq('Single or Double Arm', 'Single Arm');
+    case 'double':
+      return query
+        .eq('Primary Equipment', 'Kettlebell')
+        .or('# Primary Items.eq.2,"Single or Double Arm".eq.Double Arm');
+    default:
+      return query;
+  }
+};


### PR DESCRIPTION
## Summary

- Moves weight mode tabs (None / 2H / 1H / Double) above the movement autocomplete input so they stay visible while the dropdown is open.
- Filters catalog search by weight mode server-side (`None` = bodyweight only); recent movements remain unfiltered.
- Renames the per-movement **Weights** section to **Load** (numeric steppers only); complex mode uses shared weight tabs with a hint on each movement card.

## Test plan

- [x] `npm test` — `movementWeightModeFilter`, `MovementAutocomplete`, `StartWorkoutPage` suites pass
- [ ] On Start Workout, confirm weight tabs sit above the movement input and stay visible while typing
- [ ] Switch None / 2H / 1H / Double and verify catalog results change (recents unchanged)
- [ ] Select a movement and confirm summary chip shows load (e.g. `16 kg (2h)` or `bw`)
- [ ] Enable Complex mode — per-movement tabs hidden, shared weight hint shown, Load sections hidden
- [ ] Storybook: `MovementAutocomplete` stories render with tabs and catalog labels


Made with [Cursor](https://cursor.com)