### PR TITLE
Add sync and prune modes to movements CSV ingest

### DIFF
--- a/scripts/ingest-movements.mjs
+++ b/scripts/ingest-movements.mjs
@@ -587,9 +587,10 @@ function chunk(array, size) {
   return chunks;
 }
 
-/** @returns {Map<string, string>} movement name → id */
+/** @returns {{ byName: Map<string, string>, duplicateIds: string[] }} */
 async function fetchExistingMovementIds(supabase) {
   const byName = new Map();
+  const duplicateIds = [];
   const pageSize = 1000;
   let from = 0;
 
@@ -615,9 +616,8 @@ async function fetchExistingMovementIds(supabase) {
       }
 
       if (byName.has(name)) {
-        throw new Error(
-          `Database has duplicate movement names ("${name}"). Resolve duplicates before using --sync.`,
-        );
+        duplicateIds.push(row.id);
+        continue;
       }
 
       byName.set(name, row.id);
@@ -630,7 +630,19 @@ async function fetchExistingMovementIds(supabase) {
     from += pageSize;
   }
 
-  return byName;
+  return { byName, duplicateIds };
+}
+
+async function removeDuplicateMovementIds(supabase, duplicateIds, batchSize) {
+  if (duplicateIds.length === 0) {
+    return 0;
+  }
+
+  console.log(
+    `Removing ${duplicateIds.length} duplicate catalog row(s) with the same Movement name...`,
+  );
+  await unlinkUserMovementsFromMovementIds(supabase, duplicateIds);
+  return deleteMovementsById(supabase, duplicateIds, batchSize);
 }
 
 function partitionRecordsForSync(records, existingByName) {
@@ -897,7 +909,13 @@ async function main() {
   }
 
   if (options.sync) {
-    const existingByName = await fetchExistingMovementIds(supabase);
+    const { byName: existingByName, duplicateIds } =
+      await fetchExistingMovementIds(supabase);
+
+    if (duplicateIds.length > 0) {
+      await removeDuplicateMovementIds(supabase, duplicateIds, options.batchSize);
+    }
+
     const { toInsert, toUpdate } = partitionRecordsForSync(records, existingByName);
     const csvNames = csvMovementNames(records);
     const toPrune = options.prune


### PR DESCRIPTION
## Summary

- Adds `--sync` to update existing catalog rows by `Movement` name (preserves UUIDs and `user_movements.functional_movement_id` links) and insert only new exercises.
- Adds `--prune` (with `--sync`) to delete catalog rows absent from the CSV after clearing user links.
- Deduplicates repeated movement names in the CSV (keeps last row) and removes duplicate-name rows already in the database before syncing.
- Keeps `--truncate` for full catalog rebuilds.

## Test plan

- [ ] `npm run ingest:movements -- <csv> --dry-run` parses without errors
- [ ] `npm run ingest:movements -- <csv> --sync` updates existing rows without changing IDs
- [ ] Re-run with `--sync --prune` removes DB-only movements and leaves row count matching deduped CSV
- [ ] Confirm `user_movements.functional_movement_id` remains set for linked rows after `--sync` (no truncate)
- [ ] `--truncate` still replaces entire catalog when needed


Made with [Cursor](https://cursor.com)