### PR TITLE
Ignore local Cursor worktree checkouts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ dist-ssr
 *.local
 
 # Editor directories and files
+.cursor/worktrees
 .vscode/*
 !.vscode/extensions.json
 .idea


### PR DESCRIPTION
## Summary
- Adds `.cursor/worktrees` to `.gitignore` so local git worktree checkouts do not appear as untracked files in the main repo.

## Test plan
- [x] Confirm `git status` on `main` is clean when worktrees exist under `.cursor/worktrees/`

Made with [Cursor](https://cursor.com)