### PR TITLE
Redesign completed workout page

### DIFF
--- a/e2e/workout-flow.spec.ts
+++ b/e2e/workout-flow.spec.ts
@@ -210,8 +210,11 @@ test.describe('full workout flow', () => {
     const workoutLogId = parseInt(match![1], 10);
     createdWorkoutLogId = workoutLogId;
 
-    // Confirm the page rendered the completed workout title
-    await expect(page.getByText('Workout Log')).toBeVisible();
+    // Confirm the redesigned completed workout page rendered
+    await expect(page.getByTestId('workout-history-item')).toBeVisible();
+    await expect(page.getByText('You moved')).toBeVisible();
+    await expect(page.getByText('Clean and Press')).toBeVisible();
+    await expect(page.getByText('1 ROUND GOAL')).toBeVisible();
 
     // ── 9. Verify the database record ─────────────────────────────────────
     const workoutLog = await queryWorkoutLog(workoutLogId, authSession.access_token);

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,5 +1,6 @@
 export * from './useDeleteWorkoutLog';
 export * from './useLinkMovementLog';
+export * from './useUnlinkMovementLog';
 export * from './useLogWorkout';
 export * from './useMovementLogs';
 export * from './useMovements';

--- a/src/api/useUnlinkMovementLog.test.ts
+++ b/src/api/useUnlinkMovementLog.test.ts
@@ -1,0 +1,55 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { HttpResponse, http } from 'msw';
+import React from 'react';
+import { QueryClient, QueryClientProvider } from 'react-query';
+
+import { server } from '~/mocks/server';
+
+import { VITE_SUPABASE_URL } from '../env';
+import { unlinkMovementLog, useUnlinkMovementLog } from './useUnlinkMovementLog';
+
+const MOVEMENT_LOGS_URL = `${VITE_SUPABASE_URL}/rest/v1/movement_logs`;
+
+describe('unlinkMovementLog', () => {
+  test('clears user_movement_id on the movement log', async () => {
+    let movementLogPatch: Record<string, unknown> | null = null;
+
+    server.use(
+      http.patch(MOVEMENT_LOGS_URL, async ({ request }) => {
+        movementLogPatch = (await request.json()) as Record<string, unknown>;
+        return HttpResponse.json([]);
+      }),
+    );
+
+    await unlinkMovementLog({ movementLogId: 7 });
+
+    expect(movementLogPatch).toEqual({ user_movement_id: null });
+  });
+});
+
+describe('useUnlinkMovementLog', () => {
+  test('calls unlinkMovementLog via mutate', async () => {
+    server.use(
+      http.patch(MOVEMENT_LOGS_URL, () => HttpResponse.json([])),
+    );
+
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+
+    const { result } = renderHook(() => useUnlinkMovementLog(42), {
+      wrapper: ({ children }: { children: React.ReactNode }) =>
+        React.createElement(
+          QueryClientProvider,
+          { client: queryClient },
+          children,
+        ),
+    });
+
+    act(() => {
+      result.current.mutate({ movementLogId: 1 });
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+  });
+});

--- a/src/api/useUnlinkMovementLog.ts
+++ b/src/api/useUnlinkMovementLog.ts
@@ -1,0 +1,43 @@
+import { useMutation, useQueryClient } from 'react-query';
+
+import { QUERIES } from '~/constants';
+import { signOutIfStaleAuthUser } from '~/utils';
+
+import { supabase } from '../supabaseClient';
+
+export interface UnlinkMovementLogInput {
+  movementLogId: number;
+}
+
+export const unlinkMovementLog = async ({
+  movementLogId,
+}: UnlinkMovementLogInput) => {
+  const { error } = await supabase
+    .from('movement_logs')
+    .update({ user_movement_id: null })
+    .eq('id', movementLogId);
+
+  if (error) {
+    if (await signOutIfStaleAuthUser(error)) {
+      return;
+    }
+    throw error;
+  }
+};
+
+export const useUnlinkMovementLog = (workoutLogId: number) => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: unlinkMovementLog,
+    onSuccess: () => {
+      queryClient.invalidateQueries([QUERIES.MOVEMENT_LOGS]);
+      queryClient.invalidateQueries([
+        QUERIES.WORKOUT_LOG,
+        String(workoutLogId),
+      ]);
+      queryClient.invalidateQueries([QUERIES.WORKOUT_LOGS]);
+      queryClient.invalidateQueries([QUERIES.USER_MOVEMENTS]);
+    },
+  });
+};

--- a/src/pages/CompletedWorkoutPage/CompletedWorkoutPage.test.jsx
+++ b/src/pages/CompletedWorkoutPage/CompletedWorkoutPage.test.jsx
@@ -46,10 +46,12 @@ describe('completed workout page', () => {
     await screen.findByTestId('workout-history-item');
   });
 
-  test('renders Complex badge in header when workout is complex', async () => {
+  test('renders workout header with complex badge and date', async () => {
     render(<Default />);
 
-    await screen.findByText('Complex');
+    await screen.findByTestId('workout-history-item');
+    expect(screen.getByText('Workout')).toBeInTheDocument();
+    expect(screen.getByText('Complex')).toBeInTheDocument();
   });
 
   test('clicking Repeat on a complex workout restores complex set and shared weights', async () => {
@@ -104,12 +106,10 @@ describe('completed workout page', () => {
     expect(hardOption).toBeChecked();
   });
 
-  test('users can enter post-workout notes', async () => {
+  test('users can toggle and enter post-workout notes', async () => {
     render(<Default />);
 
-    await userEvent.click(
-      await screen.findByRole('button', { name: 'Add Notes' }),
-    );
+    await userEvent.click(await screen.findByRole('button', { name: 'Notes' }));
 
     const notesInput = await screen.findByRole('textbox', {
       name: 'Workout Notes',

--- a/src/pages/CompletedWorkoutPage/CompletedWorkoutPage.tsx
+++ b/src/pages/CompletedWorkoutPage/CompletedWorkoutPage.tsx
@@ -1,5 +1,5 @@
-import { ArrowRightIcon, TrashIcon } from '@heroicons/react/24/outline';
-import { useEffect, useRef } from 'react';
+import { ArrowRightIcon } from '@heroicons/react/24/outline';
+import { useEffect, useRef, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 
 import {
@@ -10,8 +10,8 @@ import {
   useWorkoutLog,
 } from '~/api';
 import { Loading, Page } from '~/components';
+import { Badge } from '~/components/ui/badge';
 import { Button } from '~/components/ui/button';
-import { Card } from '~/components/ui/card';
 import {
   Dialog,
   DialogContent,
@@ -25,9 +25,8 @@ import { Textarea } from '~/components/ui/textarea';
 import { useWorkoutOptions } from '~/contexts';
 import { WorkoutGoalUnits, WorkoutLog } from '~/types';
 
-import { Section } from '../StartWorkoutPage/components';
 import { RPESelector, WorkoutHistoryItem } from './components';
-import { resolveSharedWeights } from './utils';
+import { getShortDateAndStartTime, resolveSharedWeights } from './utils';
 
 export const CompletedWorkoutPage = () => {
   const { id = '' } = useParams<{ id: string }>();
@@ -49,10 +48,17 @@ export const CompletedWorkoutPage = () => {
   const { mutate: updateWorkoutNotes } = useUpdateWorkoutNotes(id);
 
   const notesRef = useRef<HTMLTextAreaElement>(null);
+  const [showNotes, setShowNotes] = useState(false);
+
+  useEffect(() => {
+    if (workoutLog) {
+      setShowNotes(workoutLog.workoutNotes !== null);
+    }
+  }, [workoutLog?.id, workoutLog?.workoutNotes]);
 
   useEffect(() => {
     if (deletedWorkoutLogId) navigate('/history');
-  }, [deletedWorkoutLogId]);
+  }, [deletedWorkoutLogId, navigate]);
 
   if (workoutLogLoading) return <Loading />;
   if (!workoutLog) return <>Not Found</>;
@@ -65,17 +71,23 @@ export const CompletedWorkoutPage = () => {
     selectRPE(selectedRPE);
 
   const handleAddNotes = () => updateWorkoutNotes('');
-  const handleClearNotes = () => updateWorkoutNotes(null);
   const handleBlurNotes = () =>
     updateWorkoutNotes(notesRef.current?.value || null);
 
+  const handleClickNotes = () => {
+    if (workoutLog.workoutNotes === null) {
+      handleAddNotes();
+      setShowNotes(true);
+      return;
+    }
+    setShowNotes((prev) => !prev);
+  };
+
   const handleClickRepeat = () => {
-    // Calculate actual completed duration in minutes
     const completedDurationMs =
       workoutLog.completedAt.getTime() - workoutLog.startedAt.getTime();
     const completedDurationMinutes = Math.round(completedDurationMs / 60000);
 
-    // Use actual completed values for all unit types
     const previousMinutes = completedDurationMinutes;
     const previousRounds = workoutLog.completedRounds ?? 0;
     const previousVolume =
@@ -83,9 +95,8 @@ export const CompletedWorkoutPage = () => {
         ? workoutLog.completedVolume
         : undefined;
 
-    // Determine workoutGoal and workoutGoalUnits based on original workout
-    let workoutGoal: number = workoutLog.workoutGoal;
-    let workoutGoalUnits: WorkoutGoalUnits = workoutLog.workoutGoalUnits;
+    const workoutGoal: number = workoutLog.workoutGoal;
+    const workoutGoalUnits: WorkoutGoalUnits = workoutLog.workoutGoalUnits;
 
     const isComplexSet = workoutLog.complexSet === true;
     const sharedWeights = resolveSharedWeights(
@@ -130,40 +141,63 @@ export const CompletedWorkoutPage = () => {
     navigate('/');
   };
 
+  const isComplexSet = workoutLog.complexSet === true;
+  const headerDateTime = getShortDateAndStartTime(workoutLog.startedAt);
+
   return (
     <Dialog>
       <Page
-        title="Workout Log"
         actions={
-          <div className="flex flex-col items-center gap-1">
-            <div className="grid grid-cols-3 gap-1">
+          <div className="flex w-full flex-col items-center gap-1">
+            <div className="grid w-full grid-cols-3 gap-1">
               <Button variant="ghost" onClick={handleClickRepeat}>
                 Repeat
               </Button>
               <Button
                 onClick={handleClickContinue}
-                className="flex items-center gap-0.5"
+                className="flex items-center justify-center gap-0.5"
               >
                 Continue
                 <ArrowRightIcon className="h-2 w-2" />
               </Button>
-              {workoutLog.workoutNotes === null && (
-                <Button variant="ghost" onClick={handleAddNotes}>
-                  Add Notes
-                </Button>
-              )}
+              <Button variant="ghost" onClick={handleClickNotes}>
+                Notes
+              </Button>
             </div>
             <DialogTrigger asChild>
               <Button
                 variant="ghost"
-                className="flex items-center gap-0.5 text-red-500"
+                size="sm"
+                className="text-xs text-red-500 hover:text-red-600"
               >
-                Delete <TrashIcon className="h-2.5 w-2.5" />
+                Delete
               </Button>
             </DialogTrigger>
           </div>
         }
       >
+        <header className="border-b border-border pb-2">
+          <div className="flex items-start justify-between gap-2">
+            <div className="flex flex-col gap-0.5">
+              {/* TODO: prepend workout number when backend exposes it (e.g. NO. 143) */}
+              <span className="text-xs uppercase tracking-wide text-muted-foreground">
+                Workout
+              </span>
+              {isComplexSet && (
+                <Badge variant="secondary" className="w-fit text-xs uppercase">
+                  Complex
+                </Badge>
+              )}
+            </div>
+            <time
+              className="text-xs text-muted-foreground"
+              dateTime={workoutLog.startedAt.toISOString()}
+            >
+              {headerDateTime}
+            </time>
+          </div>
+        </header>
+
         <WorkoutHistoryItem
           completedAt={workoutLog.completedAt}
           completedReps={workoutLog.completedReps}
@@ -188,31 +222,14 @@ export const CompletedWorkoutPage = () => {
 
         <RPESelector onSelectRPE={handleSelectRPE} rpeValue={workoutLog.rpe} />
 
-        {workoutLog.workoutNotes !== null && (
-          <Card>
-            <Section
-              title="Workout Notes"
-              actions={
-                workoutLog.workoutNotes?.length > 0 && (
-                  <Button
-                    variant="secondary"
-                    size="sm"
-                    onClick={handleClearNotes}
-                  >
-                    Clear Notes
-                  </Button>
-                )
-              }
-            >
-              <Textarea
-                aria-label="Workout Notes"
-                className="w-full"
-                defaultValue={workoutLog.workoutNotes}
-                onBlur={handleBlurNotes}
-                ref={notesRef}
-              />
-            </Section>
-          </Card>
+        {showNotes && workoutLog.workoutNotes !== null && (
+          <Textarea
+            aria-label="Workout Notes"
+            className="w-full"
+            defaultValue={workoutLog.workoutNotes}
+            onBlur={handleBlurNotes}
+            ref={notesRef}
+          />
         )}
       </Page>
 

--- a/src/pages/CompletedWorkoutPage/components/CatalogedBadge.tsx
+++ b/src/pages/CompletedWorkoutPage/components/CatalogedBadge.tsx
@@ -1,0 +1,36 @@
+import { XMarkIcon } from '@heroicons/react/24/outline';
+
+import { useUnlinkMovementLog } from '~/api';
+import { Badge } from '~/components/ui/badge';
+
+export interface CatalogedBadgeProps {
+  movementLogId: number;
+  workoutLogId: number;
+}
+
+export const CatalogedBadge = ({
+  movementLogId,
+  workoutLogId,
+}: CatalogedBadgeProps) => {
+  const { mutate: unlinkMovementLog, isLoading } = useUnlinkMovementLog(
+    workoutLogId,
+  );
+
+  return (
+    <Badge
+      variant="secondary"
+      className="inline-flex items-center gap-0.5 pr-0.5 text-xs"
+    >
+      Cataloged
+      <button
+        type="button"
+        aria-label="Unlink from catalog"
+        className="inline-flex shrink-0 items-center justify-center rounded-full p-0.5 hover:bg-secondary-foreground/10 disabled:opacity-50"
+        disabled={isLoading}
+        onClick={() => unlinkMovementLog({ movementLogId })}
+      >
+        <XMarkIcon className="h-1.5 w-1.5" />
+      </button>
+    </Badge>
+  );
+};

--- a/src/pages/CompletedWorkoutPage/components/LinkMovementDialog.test.tsx
+++ b/src/pages/CompletedWorkoutPage/components/LinkMovementDialog.test.tsx
@@ -120,7 +120,9 @@ describe('LinkMovementDialog', () => {
   test('opens dialog and shows current movement name', async () => {
     renderDialog();
 
-    await userEvent.click(screen.getByRole('button', { name: 'Link' }));
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Link to catalog' }),
+    );
 
     expect(screen.getByRole('dialog')).toBeInTheDocument();
     expect(screen.getByText(/Currently: My Custom Swing/)).toBeInTheDocument();
@@ -160,7 +162,9 @@ describe('LinkMovementDialog', () => {
 
     renderDialog();
 
-    await userEvent.click(screen.getByRole('button', { name: 'Link' }));
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Link to catalog' }),
+    );
 
     const input = screen.getByRole('textbox', { name: 'Movement Input' });
     await userEvent.clear(input);

--- a/src/pages/CompletedWorkoutPage/components/LinkMovementDialog.tsx
+++ b/src/pages/CompletedWorkoutPage/components/LinkMovementDialog.tsx
@@ -116,8 +116,8 @@ export const LinkMovementDialog = ({
   return (
     <Dialog open={open} onOpenChange={handleOpenChange}>
       <DialogTrigger asChild>
-        <Button variant="ghost" size="sm" className="h-auto shrink-0 px-1 py-0">
-          Link
+        <Button variant="link" className="h-auto p-0 text-xs">
+          Link to catalog
         </Button>
       </DialogTrigger>
       <DialogContent>

--- a/src/pages/CompletedWorkoutPage/components/RPESelector.test.jsx
+++ b/src/pages/CompletedWorkoutPage/components/RPESelector.test.jsx
@@ -10,6 +10,12 @@ beforeEach(() => {
   render(<Default />);
 });
 
+test('shows description text for the selected RPE', () => {
+  expect(
+    screen.getByText(RPE_CONFIG.ideal.description, { exact: false }),
+  ).toBeInTheDocument();
+});
+
 test('renders all RPE options', () => {
   Object.values(RPE_CONFIG).forEach(({ text }) => {
     screen.getByRole('radio', { name: text });

--- a/src/pages/CompletedWorkoutPage/components/RPESelector.tsx
+++ b/src/pages/CompletedWorkoutPage/components/RPESelector.tsx
@@ -14,23 +14,19 @@ export const RPESelector = ({ onSelectRPE, rpeValue }: RPESelectorProps) => {
     <RadioGroup
       value={rpeValue}
       onChange={onSelectRPE}
-      className="flex flex-col gap-2 rounded-md bg-accent p-2 text-accent-foreground"
+      className="flex flex-col gap-2"
+      aria-label="Exertion"
     >
-      <RadioGroup.Label className="text-sm font-medium text-muted-foreground">
-        Exertion Rating
-      </RadioGroup.Label>
-
-      <RadioGroup.Description as="div" className="flex flex-col gap-1">
-        <div className="text-center text-sm font-medium text-foreground">
-          How difficult was your workout?
-        </div>
-
+      <div className="flex items-baseline justify-between">
+        <RadioGroup.Label className="text-xs uppercase tracking-wide text-muted-foreground">
+          Exertion
+        </RadioGroup.Label>
         {rpeValue && (
-          <div className="text-center text-sm text-foreground">
-            {RPE_CONFIG[rpeValue].description} <RpeBadge rpeValue={rpeValue} />
-          </div>
+          <span className="text-sm italic text-foreground">
+            &ldquo;{RPE_CONFIG[rpeValue].text}&rdquo;
+          </span>
         )}
-      </RadioGroup.Description>
+      </div>
 
       <div className="grid grid-cols-5 gap-2 px-3">
         <Option rpeValue="noEffort" />
@@ -56,7 +52,7 @@ const Option = ({ rpeValue }: { rpeValue: string }) => {
               'h-2.5 w-2.5 rounded-full hover:cursor-pointer hover:ring',
               RPE_CONFIG[rpeValue].bgColor,
               RPE_CONFIG[rpeValue].ringColor,
-              'ring-offset-4 ring-offset-accent',
+              'ring-offset-4 ring-offset-background',
               { ring: checked },
             )}
           />

--- a/src/pages/CompletedWorkoutPage/components/RPESelector.tsx
+++ b/src/pages/CompletedWorkoutPage/components/RPESelector.tsx
@@ -23,7 +23,7 @@ export const RPESelector = ({ onSelectRPE, rpeValue }: RPESelectorProps) => {
         </RadioGroup.Label>
         {rpeValue && (
           <span className="text-sm italic text-foreground">
-            &ldquo;{RPE_CONFIG[rpeValue].text}&rdquo;
+            &ldquo;{RPE_CONFIG[rpeValue].description}&rdquo;
           </span>
         )}
       </div>

--- a/src/pages/CompletedWorkoutPage/components/WorkoutHistoryItem.test.jsx
+++ b/src/pages/CompletedWorkoutPage/components/WorkoutHistoryItem.test.jsx
@@ -3,8 +3,14 @@ import { render, screen } from '@testing-library/react';
 
 import * as stories from './WorkoutHistoryItem.stories';
 
-const { Default, RoundsGoal, ComplexSet, CatalogLinkedLongName, Bodyweight } =
-  composeStories(stories);
+const {
+  Default,
+  RoundsGoal,
+  ComplexSet,
+  CatalogLinkedLongName,
+  Bodyweight,
+  WithTimers,
+} = composeStories(stories);
 
 vi.setSystemTime(new Date('2024-01-02T12:00:00'));
 
@@ -26,6 +32,22 @@ describe('hero metric', () => {
   test('displays workout details when provided', async () => {
     render(<Default />);
     await screen.findByText('The Giant 3.0 W1D2');
+  });
+});
+
+describe('workout timers', () => {
+  test('displays interval and rest when timers were used', async () => {
+    render(<WithTimers />);
+    expect(screen.getByText('Intervals')).toBeInTheDocument();
+    expect(screen.getByText('60s')).toBeInTheDocument();
+    expect(screen.getByText('Rest')).toBeInTheDocument();
+    expect(screen.getByText('30s')).toBeInTheDocument();
+  });
+
+  test('omits timer row when interval and rest are zero', async () => {
+    render(<Default />);
+    expect(screen.queryByText('Intervals')).not.toBeInTheDocument();
+    expect(screen.queryByText('Rest')).not.toBeInTheDocument();
   });
 });
 

--- a/src/pages/CompletedWorkoutPage/components/WorkoutHistoryItem.test.jsx
+++ b/src/pages/CompletedWorkoutPage/components/WorkoutHistoryItem.test.jsx
@@ -3,140 +3,67 @@ import { render, screen } from '@testing-library/react';
 
 import * as stories from './WorkoutHistoryItem.stories';
 
-const { Default, WithTimers, RoundsGoal, ComplexSet, CatalogLinkedLongName } =
+const { Default, RoundsGoal, ComplexSet, CatalogLinkedLongName, Bodyweight } =
   composeStories(stories);
 
 vi.setSystemTime(new Date('2024-01-02T12:00:00'));
 
-describe('workout overview', () => {
-  test('displays the date of the workout', async () => {
+describe('hero metric', () => {
+  test('displays total volume and round/rep summary', async () => {
     render(<Default />);
-    await screen.findByText('Monday, Jan 1');
+    expect(screen.getByText('You moved')).toBeInTheDocument();
+    expect(screen.getByText('1,000')).toBeInTheDocument();
+    expect(
+      screen.getByText('across 10 rounds · 50 reps'),
+    ).toBeInTheDocument();
   });
 
-  test('displays the time range of the workout', async () => {
-    render(<Default />);
-    await screen.findByText('12:00 PM - 1:15 PM');
+  test('displays workout goal pill', async () => {
+    render(<RoundsGoal />);
+    expect(screen.getByText('15 ROUNDS GOAL')).toBeInTheDocument();
   });
 
-  test('displays workout details', async () => {
+  test('displays workout details when provided', async () => {
     render(<Default />);
     await screen.findByText('The Giant 3.0 W1D2');
   });
 });
 
-describe('workout options', () => {
-  test('displays the movements performed in the workout', async () => {
+describe('movement rows', () => {
+  test('displays movements with compact rep scheme and per-movement volume', async () => {
     render(<Default />);
     await screen.findByText('Single Arm Front Squat');
     await screen.findByText('Single Arm Overhead Press');
+    expect(screen.getAllByText(/5 reps . 10/).length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText(/800 kg/).length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText(/×50/).length).toBeGreaterThanOrEqual(2);
   });
 
-  test('displays rep scheme', async () => {
-    render(<Default />);
-    expect(screen.getAllByLabelText('Rep Scheme')[0]).toHaveTextContent(
-      '5 / 5',
-    );
-  });
-
-  test('displays weights and number of hands used', async () => {
-    render(<Default />);
-    expect(screen.getAllByLabelText('Weights')[0]).toHaveTextContent(
-      '16 kg (1h)',
-    );
-  });
-
-  test('displays workout goal', async () => {
-    render(<RoundsGoal />);
-    expect(screen.getByLabelText('Goal')).toHaveTextContent('15 rounds');
-  });
-
-  test('displays interval timer', async () => {
-    render(<WithTimers />);
-    expect(screen.getByLabelText('Intervals')).toHaveTextContent('60s');
-  });
-
-  test('displays rest timer', async () => {
-    render(<WithTimers />);
-    expect(screen.getByLabelText('Rest')).toHaveTextContent('30s');
+  test('omits per-movement volume for bodyweight movements', async () => {
+    render(<Bodyweight />);
+    expect(screen.getByText(/×50/)).toBeInTheDocument();
+    expect(screen.queryByText(/\d+ kg/)).not.toBeInTheDocument();
   });
 });
 
 describe('complex set workouts', () => {
-  test('displays shared weight once instead of per-movement weights', async () => {
+  test('displays carried weights block without per-movement weights', async () => {
     render(<ComplexSet />);
 
-    expect(screen.getByLabelText('Shared Weight')).toHaveTextContent(
-      '24 kg (2h)',
-    );
-    expect(screen.queryAllByLabelText('Weights')).toHaveLength(0);
-  });
-
-  test('displays rep scheme using shared weight for unilateral formatting', async () => {
-    render(
-      <ComplexSet
-        sharedWeightTwoValue={0}
-        sharedWeightTwoUnit="kilograms"
-        movementLogs={[
-          {
-            movementName: 'Clean and Press',
-            id: 1,
-            repScheme: [5],
-            userMovementId: null,
-            functionalMovementId: null,
-            weightOneUnit: 'kilograms',
-            weightOneValue: 16,
-            weightTwoUnit: null,
-            weightTwoValue: 0,
-          },
-          {
-            movementName: 'Front Squat',
-            id: 2,
-            repScheme: [5],
-            userMovementId: null,
-            functionalMovementId: null,
-            weightOneUnit: 'kilograms',
-            weightOneValue: 16,
-            weightTwoUnit: null,
-            weightTwoValue: 0,
-          },
-        ]}
-      />,
-    );
-
-    expect(screen.getAllByLabelText('Rep Scheme')[0]).toHaveTextContent(
-      '5 / 5',
-    );
-  });
-});
-
-describe('workout summary', () => {
-  test('displays the duration of the workout', async () => {
-    render(<Default />);
-    expect(screen.getByLabelText('Elapsed')).toHaveTextContent('1h 15m');
-  });
-
-  test('displays number of rounds completed', async () => {
-    render(<Default />);
-    expect(screen.getByLabelText('Rounds')).toHaveTextContent('10');
-  });
-
-  test('displays number of reps completed', async () => {
-    render(<Default />);
-    expect(screen.getByLabelText('Reps')).toHaveTextContent('50');
-  });
-
-  test('displays volume completed in the workout', async () => {
-    render(<Default />);
-    expect(screen.getByLabelText('Volume')).toHaveTextContent('1000 kg');
+    expect(screen.getByText('Carried')).toBeInTheDocument();
+    expect(screen.getByText('24 kg')).toBeInTheDocument();
+    expect(screen.getByText('shared across the complex')).toBeInTheDocument();
+    expect(screen.queryByText('800 kg')).not.toBeInTheDocument();
   });
 });
 
 describe('movement linking', () => {
-  test('shows catalog badge and link button for linked movements', async () => {
+  test('shows cataloged badge for linked movements', async () => {
     render(<CatalogLinkedLongName />);
-    expect(screen.getByText('Catalog')).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Link' })).toBeInTheDocument();
+    expect(screen.getByText('Cataloged')).toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: 'Link to catalog' }),
+    ).not.toBeInTheDocument();
     expect(
       screen.getByText('Double Kettlebell Push Press'),
     ).toBeInTheDocument();

--- a/src/pages/CompletedWorkoutPage/components/WorkoutHistoryItem.test.jsx
+++ b/src/pages/CompletedWorkoutPage/components/WorkoutHistoryItem.test.jsx
@@ -58,9 +58,12 @@ describe('complex set workouts', () => {
 });
 
 describe('movement linking', () => {
-  test('shows cataloged badge for linked movements', async () => {
+  test('shows cataloged badge with unlink control for linked movements', async () => {
     render(<CatalogLinkedLongName />);
     expect(screen.getByText('Cataloged')).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Unlink from catalog' }),
+    ).toBeInTheDocument();
     expect(
       screen.queryByRole('button', { name: 'Link to catalog' }),
     ).not.toBeInTheDocument();

--- a/src/pages/CompletedWorkoutPage/components/WorkoutHistoryItem.tsx
+++ b/src/pages/CompletedWorkoutPage/components/WorkoutHistoryItem.tsx
@@ -1,22 +1,16 @@
+import { ScaleIcon } from '@heroicons/react/24/outline';
+
 import { Loading } from '~/components';
 import { Badge } from '~/components/ui/badge';
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardFooter,
-  CardHeader,
-  CardTitle,
-} from '~/components/ui/card';
-import { Separator } from '~/components/ui/separator';
 import { MovementLog, WeightUnit } from '~/types';
 
 import {
-  getDisplayDate,
-  getDuration,
-  getRepSchemeDisplayValue,
-  getTimeRange,
-  getWeightsDisplayValue,
+  formatCarriedWeights,
+  formatMovementWeightLine,
+  getCompactRepScheme,
+  getGoalPillLabel,
+  getMovementTotalReps,
+  getMovementVolume,
   resolveSharedWeights,
 } from '../utils';
 import { LinkMovementDialog } from './LinkMovementDialog';
@@ -43,30 +37,32 @@ export interface WorkoutHistoryItemProps {
   workoutLogId: number;
 }
 
+const TheWorkDivider = () => (
+  <div className="flex items-center gap-2 py-2">
+    <div className="h-px flex-1 bg-border" />
+    <span className="text-xs uppercase tracking-wide text-muted-foreground">
+      The work
+    </span>
+    <div className="h-px flex-1 bg-border" />
+  </div>
+);
+
 export const WorkoutHistoryItem = ({
-  completedAt,
   completedReps,
   completedRounds,
-  completedRungs,
   completedVolume,
   complexSet,
-  intervalTimer,
   movementLogs,
   movementLogsLoading,
-  restTimer,
   sharedWeightOneUnit,
   sharedWeightOneValue,
   sharedWeightTwoUnit,
   sharedWeightTwoValue,
-  startedAt,
   workoutDetails,
   workoutGoal,
   workoutGoalUnits,
   workoutLogId,
 }: WorkoutHistoryItemProps) => {
-  const displayDate = getDisplayDate(completedAt);
-  const duration = getDuration(startedAt, completedAt);
-  const timeRange = getTimeRange(startedAt, completedAt);
   const isComplexSet = complexSet === true;
   const sharedWeights = resolveSharedWeights(
     sharedWeightOneValue,
@@ -75,164 +71,147 @@ export const WorkoutHistoryItem = ({
     sharedWeightTwoUnit,
     movementLogs,
   );
+  const goalPillLabel = getGoalPillLabel(workoutGoal, workoutGoalUnits);
 
   return (
-    <Card data-testid="workout-history-item">
-      <CardHeader>
-        <CardTitle className="flex items-baseline justify-between gap-1">
-          <div className="flex items-baseline gap-1">
-            {displayDate}
-            {isComplexSet && <Badge variant="secondary">Complex</Badge>}
-          </div>
-          <CardDescription className="text-xs">{timeRange}</CardDescription>
-        </CardTitle>
-        {workoutDetails && (
-          <CardDescription className="italic">{workoutDetails}</CardDescription>
-        )}
-      </CardHeader>
+    <div className="flex flex-col gap-2" data-testid="workout-history-item">
+      <div className="relative">
+        <Badge
+          variant="outline"
+          className="absolute right-0 top-0 text-xs uppercase tracking-wide"
+        >
+          {goalPillLabel}
+        </Badge>
 
-      <CardContent className="flex gap-2">
-        <div className="grow">
-          <CardDescription id="goal">Goal</CardDescription>
-          <div aria-labelledby="goal">
-            {workoutGoalUnits === 'kilograms'
-              ? `${workoutGoal} kg`
-              : workoutGoalUnits === 'minutes'
-                ? `${workoutGoal}m`
-                : `${workoutGoal} ${workoutGoalUnits}`}
-          </div>
+        <p className="text-xs text-muted-foreground">You moved</p>
+        <div className="flex items-baseline gap-1">
+          <span className="text-5xl font-medium leading-none">
+            {completedVolume.toLocaleString()}
+          </span>
+          <span className="text-sm text-muted-foreground">kg</span>
         </div>
-        <div className="grow text-right">
-          <CardDescription id="intervals">Intervals</CardDescription>
-          <div aria-labelledby="intervals">
-            {intervalTimer > 0 ? `${intervalTimer}s` : 'None'}
-          </div>
-        </div>
-        <div className="grow text-right">
-          <CardDescription id="rest">Rest</CardDescription>
-          <div aria-labelledby="rest">
-            {restTimer > 0 ? `${restTimer}s` : 'None'}
-          </div>
-        </div>
-      </CardContent>
+        <p className="text-sm text-muted-foreground">
+          across {completedRounds} rounds · {completedReps} reps
+        </p>
+      </div>
+
+      {workoutDetails && (
+        <p className="text-sm italic text-muted-foreground">{workoutDetails}</p>
+      )}
+
+      <TheWorkDivider />
 
       {movementLogsLoading ? (
-        <div className="flex justify-center p-3">
+        <div className="flex justify-center py-3">
           <Loading />
         </div>
       ) : (
-        <>
-          {isComplexSet && (
-            <CardContent>
-              <CardDescription id="shared-weight">
-                Shared Weight
-              </CardDescription>
-              <div aria-labelledby="shared-weight">
-                {getWeightsDisplayValue(
-                  sharedWeights.weightOneValue,
-                  sharedWeights.weightOneUnit,
-                  sharedWeights.weightTwoValue,
-                  sharedWeights.weightTwoUnit,
-                )}
-              </div>
-            </CardContent>
-          )}
-          {movementLogs.map((movement, index) => (
-            <CardContent key={movement.id}>
-              <div
-                className={`grid gap-2 ${isComplexSet ? 'grid-cols-2' : 'grid-cols-3'}`}
-              >
-                <div className="flex min-w-0 flex-col gap-0.5">
-                  <CardDescription>Movement #{index + 1}</CardDescription>
-                  <div className="flex flex-col gap-0.5">
-                    <div>{movement.movementName}</div>
-                    <div className="flex gap-1">
-                      {movement.functionalMovementId !== null && (
-                        <Badge variant="secondary" className="shrink-0 text-xs">
-                          Catalog
-                        </Badge>
-                      )}
-                      <LinkMovementDialog
-                        workoutLogId={workoutLogId}
-                        movementLog={movement}
-                        movementIndex={index}
-                        complexSet={isComplexSet}
-                        sharedWeights={sharedWeights}
-                      />
-                    </div>
-                  </div>
-                </div>
+        <div className="flex flex-col">
+          {movementLogs.map((movement, index) => {
+            const totalReps = getMovementTotalReps(
+              movement.repScheme,
+              completedRounds,
+            );
+            const movementVolume = getMovementVolume(
+              movement,
+              completedRounds,
+            );
+            const weightLine = formatMovementWeightLine(movement);
+            const repSchemeLine = getCompactRepScheme(
+              movement.repScheme,
+              completedRounds,
+            );
+            const isLinked = movement.functionalMovementId !== null;
 
-                {!isComplexSet && (
-                  <div className="flex flex-col gap-0.5 text-right">
-                    <CardDescription id="weights">Weights</CardDescription>
-                    <div aria-labelledby="weights">
-                      {getWeightsDisplayValue(
-                        movement.weightOneValue,
-                        movement.weightOneUnit,
-                        movement.weightTwoValue,
-                        movement.weightTwoUnit,
-                      )}
+            return (
+              <div key={movement.id}>
+                {index > 0 && <div className="h-px bg-border" />}
+                <div className="flex gap-2 py-2">
+                  <div className="min-w-0 flex-1">
+                    <div className="flex gap-2">
+                      <span className="shrink-0 italic text-muted-foreground">
+                        {String(index + 1).padStart(2, '0')}
+                      </span>
+                      <div className="min-w-0 flex-1">
+                        <p className="font-semibold">{movement.movementName}</p>
+                        {!isComplexSet && weightLine && (
+                          <p className="flex items-center gap-0.5 text-sm text-muted-foreground">
+                            <ScaleIcon className="h-2 w-2 shrink-0" />
+                            <span>
+                              {weightLine}
+                              <span className="mx-0.5">·</span>
+                              {repSchemeLine}
+                            </span>
+                          </p>
+                        )}
+                        {!isComplexSet && !weightLine && (
+                          <p className="text-sm text-muted-foreground">
+                            {repSchemeLine}
+                          </p>
+                        )}
+                        {isComplexSet && (
+                          <p className="text-sm text-muted-foreground">
+                            {repSchemeLine}
+                          </p>
+                        )}
+                        <div className="mt-0.5">
+                          {isLinked ? (
+                            <Badge
+                              variant="secondary"
+                              className="text-xs"
+                            >
+                              Cataloged
+                            </Badge>
+                          ) : (
+                            <LinkMovementDialog
+                              workoutLogId={workoutLogId}
+                              movementLog={movement}
+                              movementIndex={index}
+                              complexSet={isComplexSet}
+                              sharedWeights={sharedWeights}
+                            />
+                          )}
+                        </div>
+                      </div>
                     </div>
                   </div>
-                )}
-                <div className="flex flex-col gap-0.5 text-right">
-                  <CardDescription
-                    id="rep-scheme"
-                    className="whitespace-nowrap"
-                  >
-                    Rep Scheme
-                  </CardDescription>
-                  <div aria-labelledby="rep-scheme">
-                    {getRepSchemeDisplayValue(
-                      movement.repScheme,
-                      isComplexSet
-                        ? [
-                            sharedWeights.weightOneValue,
-                            sharedWeights.weightTwoValue,
-                          ]
-                        : [movement.weightOneValue, movement.weightTwoValue],
+                  <div className="shrink-0 text-right">
+                    <p className="text-2xl italic">{`×${totalReps}`}</p>
+                    {!isComplexSet && movementVolume !== null && (
+                      <p className="text-sm text-muted-foreground">
+                        {movementVolume.toLocaleString()} kg
+                      </p>
                     )}
                   </div>
                 </div>
               </div>
-            </CardContent>
-          ))}
-        </>
+            );
+          })}
+
+          {isComplexSet && (
+            <div className="mt-1 border-t border-border pt-2">
+              <div className="flex items-start justify-between gap-2">
+                <div>
+                  <p className="text-xs uppercase tracking-wide underline">
+                    Carried
+                  </p>
+                  <p className="text-sm">
+                    {formatCarriedWeights(
+                      sharedWeights.weightOneValue,
+                      sharedWeights.weightOneUnit,
+                      sharedWeights.weightTwoValue,
+                      sharedWeights.weightTwoUnit,
+                    )}
+                  </p>
+                </div>
+                <p className="text-right text-xs italic text-muted-foreground">
+                  shared across the complex
+                </p>
+              </div>
+            </div>
+          )}
+        </div>
       )}
-
-      <CardContent>
-        <Separator />
-      </CardContent>
-
-      <CardContent>
-        <CardTitle>Workout Summary</CardTitle>
-      </CardContent>
-
-      <CardFooter className="flex gap-2">
-        <div className="grow">
-          <CardDescription id="elapsed">Elapsed</CardDescription>
-          <div aria-labelledby="elapsed">{duration}</div>
-        </div>
-        <div className="grow text-right">
-          <CardDescription id="rounds">Rounds</CardDescription>
-          <div aria-labelledby="rounds">{completedRounds}</div>
-        </div>
-        <div className="grow text-right">
-          <CardDescription id="rungs">Rungs</CardDescription>
-          <div aria-labelledby="rungs">{completedRungs}</div>
-        </div>
-        <div className="grow text-right">
-          <CardDescription id="reps">Reps</CardDescription>
-          <div aria-labelledby="reps">{completedReps}</div>
-        </div>
-        <div className="grow text-right">
-          <CardDescription id="volume">Volume</CardDescription>
-          <div aria-labelledby="volume">
-            {completedVolume > 0 ? `${completedVolume} kg` : 'N/A'}
-          </div>
-        </div>
-      </CardFooter>
-    </Card>
+    </div>
   );
 };

--- a/src/pages/CompletedWorkoutPage/components/WorkoutHistoryItem.tsx
+++ b/src/pages/CompletedWorkoutPage/components/WorkoutHistoryItem.tsx
@@ -7,6 +7,7 @@ import { MovementLog, WeightUnit } from '~/types';
 import {
   formatCarriedWeights,
   formatMovementWeightLine,
+  formatTimerSeconds,
   getCompactRepScheme,
   getGoalPillLabel,
   getMovementTotalReps,
@@ -53,8 +54,10 @@ export const WorkoutHistoryItem = ({
   completedRounds,
   completedVolume,
   complexSet,
+  intervalTimer,
   movementLogs,
   movementLogsLoading,
+  restTimer,
   sharedWeightOneUnit,
   sharedWeightOneValue,
   sharedWeightTwoUnit,
@@ -73,6 +76,7 @@ export const WorkoutHistoryItem = ({
     movementLogs,
   );
   const goalPillLabel = getGoalPillLabel(workoutGoal, workoutGoalUnits);
+  const hasTimers = intervalTimer > 0 || restTimer > 0;
 
   return (
     <div className="flex flex-col gap-2" data-testid="workout-history-item">
@@ -95,6 +99,31 @@ export const WorkoutHistoryItem = ({
           across {completedRounds} rounds · {completedReps} reps
         </p>
       </div>
+
+      {hasTimers && (
+        <div className="flex gap-3">
+          {intervalTimer > 0 && (
+            <div className="flex flex-col">
+              <span className="text-xs uppercase tracking-wide text-muted-foreground">
+                Intervals
+              </span>
+              <span className="text-sm text-foreground">
+                {formatTimerSeconds(intervalTimer)}
+              </span>
+            </div>
+          )}
+          {restTimer > 0 && (
+            <div className="flex flex-col">
+              <span className="text-xs uppercase tracking-wide text-muted-foreground">
+                Rest
+              </span>
+              <span className="text-sm text-foreground">
+                {formatTimerSeconds(restTimer)}
+              </span>
+            </div>
+          )}
+        </div>
+      )}
 
       {workoutDetails && (
         <p className="text-sm italic text-muted-foreground">{workoutDetails}</p>

--- a/src/pages/CompletedWorkoutPage/components/WorkoutHistoryItem.tsx
+++ b/src/pages/CompletedWorkoutPage/components/WorkoutHistoryItem.tsx
@@ -13,6 +13,7 @@ import {
   getMovementVolume,
   resolveSharedWeights,
 } from '../utils';
+import { CatalogedBadge } from './CatalogedBadge';
 import { LinkMovementDialog } from './LinkMovementDialog';
 
 export interface WorkoutHistoryItemProps {
@@ -156,12 +157,10 @@ export const WorkoutHistoryItem = ({
                         )}
                         <div className="mt-0.5">
                           {isLinked ? (
-                            <Badge
-                              variant="secondary"
-                              className="text-xs"
-                            >
-                              Cataloged
-                            </Badge>
+                            <CatalogedBadge
+                              movementLogId={movement.id}
+                              workoutLogId={workoutLogId}
+                            />
                           ) : (
                             <LinkMovementDialog
                               workoutLogId={workoutLogId}

--- a/src/pages/CompletedWorkoutPage/components/index.ts
+++ b/src/pages/CompletedWorkoutPage/components/index.ts
@@ -1,3 +1,4 @@
+export * from './CatalogedBadge';
 export * from './LinkMovementDialog';
 export * from './RPESelector';
 export * from './WorkoutHistoryItem';

--- a/src/pages/CompletedWorkoutPage/utils/datetimes.test.ts
+++ b/src/pages/CompletedWorkoutPage/utils/datetimes.test.ts
@@ -1,4 +1,8 @@
-import { getDisplayDate, getDuration } from './datetimes';
+import {
+  getDisplayDate,
+  getDuration,
+  getShortDateAndStartTime,
+} from './datetimes';
 
 describe('getDisplayDate', () => {
   test('formats date with year when not current year', () => {
@@ -11,6 +15,24 @@ describe('getDisplayDate', () => {
     vi.setSystemTime(new Date('2024-01-01T12:00:00.000Z'));
     const date = new Date('2024-06-15T12:00:00.000Z');
     expect(getDisplayDate(date)).toBe('Saturday, Jun 15');
+  });
+});
+
+describe('getShortDateAndStartTime', () => {
+  test('formats short date and start time in current year', () => {
+    vi.setSystemTime(new Date('2024-05-25T12:00:00.000Z'));
+    const startedAt = new Date('2024-05-23T14:05:00.000Z');
+    expect(getShortDateAndStartTime(startedAt)).toMatch(
+      /^Thu, May 23 · \d{1,2}:\d{2} (AM|PM)$/,
+    );
+  });
+
+  test('includes year when workout is not in the current year', () => {
+    vi.setSystemTime(new Date('2024-01-01T12:00:00.000Z'));
+    const startedAt = new Date('2023-05-23T14:05:00.000Z');
+    expect(getShortDateAndStartTime(startedAt)).toMatch(
+      /^Tue, May 23 2023 · \d{1,2}:\d{2} (AM|PM)$/,
+    );
   });
 });
 

--- a/src/pages/CompletedWorkoutPage/utils/datetimes.ts
+++ b/src/pages/CompletedWorkoutPage/utils/datetimes.ts
@@ -29,3 +29,13 @@ export const getTimeRange = (startedAt: Date, completedAt: Date) => {
     'h:mm a',
   )}`;
 };
+
+export const getShortDateAndStartTime = (startedAt: Date) => {
+  const dateTime = DateTime.fromJSDate(startedAt);
+  const isCurrentYear = dateTime.year === DateTime.now().year;
+  const datePart = dateTime.toFormat(
+    isCurrentYear ? 'ccc, LLL d' : 'ccc, LLL d y',
+  );
+  const timePart = dateTime.toFormat('h:mm a');
+  return `${datePart} · ${timePart}`;
+};

--- a/src/pages/CompletedWorkoutPage/utils/displayValues.test.ts
+++ b/src/pages/CompletedWorkoutPage/utils/displayValues.test.ts
@@ -1,4 +1,7 @@
 import {
+  getCompactRepScheme,
+  getMovementTotalReps,
+  getMovementVolume,
   getRepSchemeDisplayValue,
   getWeightsDisplayValue,
 } from './displayValues';
@@ -46,5 +49,53 @@ describe('getRepSchemeDisplayValue', () => {
 
   test('returns single rep count as is when no bells specified', () => {
     expect(getRepSchemeDisplayValue([5], [0, 0])).toBe('5');
+  });
+});
+
+describe('getMovementTotalReps', () => {
+  test('multiplies rep scheme sum by completed rounds', () => {
+    expect(getMovementTotalReps([5, 3], 4)).toBe(32);
+  });
+});
+
+describe('getMovementVolume', () => {
+  test('returns total kg for loaded movements', () => {
+    expect(
+      getMovementVolume(
+        {
+          repScheme: [5],
+          weightOneValue: 16,
+          weightTwoValue: 0,
+        },
+        10,
+      ),
+    ).toBe(800);
+  });
+
+  test('returns null for bodyweight movements', () => {
+    expect(
+      getMovementVolume(
+        {
+          repScheme: [5],
+          weightOneValue: null,
+          weightTwoValue: null,
+        },
+        10,
+      ),
+    ).toBeNull();
+  });
+});
+
+describe('getCompactRepScheme', () => {
+  test('formats uniform rep scheme with rung count multiplier', () => {
+    expect(getCompactRepScheme([5], 4)).toBe('5 reps × 4');
+  });
+
+  test('uses singular rep when rung value is 1', () => {
+    expect(getCompactRepScheme([1], 3)).toBe('1 rep × 3');
+  });
+
+  test('falls back to ladder format for non-uniform schemes', () => {
+    expect(getCompactRepScheme([3, 2, 1], 4)).toBe('3, 2, 1 reps × 4');
   });
 });

--- a/src/pages/CompletedWorkoutPage/utils/displayValues.test.ts
+++ b/src/pages/CompletedWorkoutPage/utils/displayValues.test.ts
@@ -1,4 +1,5 @@
 import {
+  formatTimerSeconds,
   getCompactRepScheme,
   getMovementTotalReps,
   getMovementVolume,
@@ -49,6 +50,12 @@ describe('getRepSchemeDisplayValue', () => {
 
   test('returns single rep count as is when no bells specified', () => {
     expect(getRepSchemeDisplayValue([5], [0, 0])).toBe('5');
+  });
+});
+
+describe('formatTimerSeconds', () => {
+  test('formats seconds with s suffix', () => {
+    expect(formatTimerSeconds(60)).toBe('60s');
   });
 });
 

--- a/src/pages/CompletedWorkoutPage/utils/displayValues.ts
+++ b/src/pages/CompletedWorkoutPage/utils/displayValues.ts
@@ -95,6 +95,8 @@ export const formatCarriedWeights = (
   return parts.join(' + ');
 };
 
+export const formatTimerSeconds = (seconds: number) => `${seconds}s`;
+
 export const getGoalPillLabel = (workoutGoal: number, workoutGoalUnits: string) => {
   switch (workoutGoalUnits) {
     case 'minutes':

--- a/src/pages/CompletedWorkoutPage/utils/displayValues.ts
+++ b/src/pages/CompletedWorkoutPage/utils/displayValues.ts
@@ -1,4 +1,4 @@
-import { WeightUnit } from '~/types';
+import { MovementLog, WeightUnit } from '~/types';
 import { getWeightUnitLabel } from '~/utils';
 
 export const getWeightsDisplayValue = (
@@ -31,3 +31,89 @@ export const getRepSchemeDisplayValue = (
     if (reps === '') return rungDisplayValue;
     return reps + ', ' + rungDisplayValue;
   }, '');
+
+export const getMovementTotalReps = (
+  repScheme: number[],
+  completedRounds: number,
+) => repScheme.reduce((sum, r) => sum + r, 0) * completedRounds;
+
+export const getMovementVolume = (
+  movement: Pick<MovementLog, 'repScheme' | 'weightOneValue' | 'weightTwoValue'>,
+  completedRounds: number,
+): number | null => {
+  if (movement.weightOneValue === null && movement.weightTwoValue === null) {
+    return null;
+  }
+  const weightPerRep =
+    (movement.weightOneValue ?? 0) + (movement.weightTwoValue ?? 0);
+  const totalReps = getMovementTotalReps(movement.repScheme, completedRounds);
+  return weightPerRep * totalReps;
+};
+
+export const getCompactRepScheme = (
+  repScheme: number[],
+  completedRounds: number,
+): string => {
+  if (repScheme.every((r) => r === repScheme[0])) {
+    const rep = repScheme[0];
+    return `${rep} ${rep === 1 ? 'rep' : 'reps'} × ${
+      completedRounds * repScheme.length
+    }`;
+  }
+  return `${repScheme.join(', ')} reps × ${completedRounds}`;
+};
+
+export const formatMovementWeightLine = (
+  movement: Pick<
+    MovementLog,
+    'weightOneValue' | 'weightOneUnit' | 'weightTwoValue' | 'weightTwoUnit'
+  >,
+): string | null => {
+  if (movement.weightOneValue === null && movement.weightTwoValue === null) {
+    return null;
+  }
+  const unit = getWeightUnitLabel(movement.weightOneUnit);
+  if (movement.weightTwoValue != null && movement.weightTwoValue > 0) {
+    return `${movement.weightOneValue} + ${movement.weightTwoValue} ${unit}`;
+  }
+  return `${movement.weightOneValue} ${unit}`;
+};
+
+export const formatCarriedWeights = (
+  weightOneValue: number | null,
+  weightOneUnit: WeightUnit | null,
+  weightTwoValue: number | null,
+  weightTwoUnit: WeightUnit | null,
+): string => {
+  const parts: string[] = [];
+  if (weightOneValue != null) {
+    parts.push(`${weightOneValue} ${getWeightUnitLabel(weightOneUnit)}`);
+  }
+  if (weightTwoValue != null && weightTwoValue > 0) {
+    parts.push(`${weightTwoValue} ${getWeightUnitLabel(weightTwoUnit)}`);
+  }
+  return parts.join(' + ');
+};
+
+export const getGoalPillLabel = (workoutGoal: number, workoutGoalUnits: string) => {
+  switch (workoutGoalUnits) {
+    case 'minutes':
+      return `${workoutGoal}M GOAL`;
+    case 'rounds':
+      return workoutGoal === 1
+        ? `${workoutGoal} ROUND GOAL`
+        : `${workoutGoal} ROUNDS GOAL`;
+    case 'reps':
+      return workoutGoal === 1
+        ? `${workoutGoal} REP GOAL`
+        : `${workoutGoal} REPS GOAL`;
+    case 'kilograms':
+      return `${workoutGoal}KG GOAL`;
+    case 'rungs':
+      return workoutGoal === 1
+        ? `${workoutGoal} RUNG GOAL`
+        : `${workoutGoal} RUNGS GOAL`;
+    default:
+      return `${workoutGoal} ${workoutGoalUnits.toUpperCase()} GOAL`;
+  }
+};


### PR DESCRIPTION
## Summary
- Redesign the completed workout page with an editorial layout: volume hero, compact movement rows, complex **CARRIED** block, simplified **Repeat · Continue · Notes** actions, and toggled notes.
- Add display helpers for movement totals, volume, compact rep schemes, and short date/time header formatting.
- Show RPE **description** text in the exertion header (not the label name).
- Add a **Cataloged** badge with unlink (×) so users can clear a wrong catalog link and relink via **Link to catalog**.

## Test plan
- [x] Open a standard completed workout from `/history` — verify hero volume, movement rows with ×N and per-movement kg, goal pill, exertion dots + description
- [x] Open a complex completed workout — verify **COMPLEX** badge, no per-movement weights/volume, **CARRIED** block
- [x] Link a movement to catalog, then click × on **Cataloged** — confirm **Link to catalog** returns
- [x] Toggle **Notes**, type and blur — notes persist
- [x] **Repeat** seeds workout options and routes to `/`; **Delete** confirm still works
- [x] `npm test` (Completed Workout Page + unlink API tests)


Made with [Cursor](https://cursor.com)