### PR TITLE
Refine Start Workout setup UI

### DIFF
--- a/src/pages/StartWorkoutPage/StartWorkoutPage.test.jsx
+++ b/src/pages/StartWorkoutPage/StartWorkoutPage.test.jsx
@@ -35,6 +35,10 @@ describe('start workout page', () => {
     expect(startButton).toBeDisabled();
   });
 
+  test('renders the "Build new workout" divider label', () => {
+    expect(screen.getByText(/build new workout/i)).toBeInTheDocument();
+  });
+
   test('can change the workout goal to "rounds"', async () => {
     const workoutGoalUnits = screen.getByRole('tab', { name: 'Rounds' });
     await userEvent.click(workoutGoalUnits);

--- a/src/pages/StartWorkoutPage/StartWorkoutPage.test.jsx
+++ b/src/pages/StartWorkoutPage/StartWorkoutPage.test.jsx
@@ -458,12 +458,8 @@ describe('Complex Mode', () => {
     render(<Default />);
   });
 
-  test('Complex Mode card is visible with Standard and Complex buttons; Standard is active by default', () => {
-    expect(screen.getByRole('button', { name: 'Standard' })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Complex' })).toBeInTheDocument();
-    expect(
-      screen.getByText('Set the weight down between each movement.'),
-    ).toBeInTheDocument();
+  test('Add to workout row includes Complex toggle off by default', () => {
+    expect(screen.getByRole('button', { name: 'Complex, off' })).toBeInTheDocument();
     expect(
       screen.queryByText('Complete all movements before setting the weight down.'),
     ).not.toBeInTheDocument();
@@ -471,14 +467,11 @@ describe('Complex Mode', () => {
   });
 
   test('selecting Complex reveals shared weight section with all four weight-type options', async () => {
-    await userEvent.click(screen.getByRole('button', { name: 'Complex' }));
+    await userEvent.click(screen.getByRole('button', { name: 'Complex, off' }));
 
     expect(
       screen.getByText('Complete all movements before setting the weight down.'),
     ).toBeInTheDocument();
-    expect(
-      screen.queryByText('Set the weight down between each movement.'),
-    ).not.toBeInTheDocument();
     expect(screen.getByRole('heading', { name: 'Shared Weight' })).toBeInTheDocument();
     expect(screen.getByRole('tab', { name: 'None' })).toBeInTheDocument();
     expect(screen.getByRole('tab', { name: '2H' })).toBeInTheDocument();
@@ -490,24 +483,24 @@ describe('Complex Mode', () => {
     await userEvent.click(screen.getByRole('button', { name: '+ Movement' }));
     expect(screen.getAllByRole('heading', { name: 'Load' })).toHaveLength(2);
 
-    await userEvent.click(screen.getByRole('button', { name: 'Complex' }));
+    await userEvent.click(screen.getByRole('button', { name: 'Complex, off' }));
 
     expect(screen.queryAllByRole('heading', { name: 'Load' })).toHaveLength(0);
     expect(screen.getAllByRole('heading', { name: 'Rep Scheme' })).toHaveLength(2);
   });
 
-  test('selecting Standard hides shared weight section and restores per-movement weight sections', async () => {
-    await userEvent.click(screen.getByRole('button', { name: 'Complex' }));
+  test('toggling Complex off hides shared weight section and restores per-movement weight sections', async () => {
+    await userEvent.click(screen.getByRole('button', { name: 'Complex, off' }));
     expect(screen.getByRole('heading', { name: 'Shared Weight' })).toBeInTheDocument();
 
-    await userEvent.click(screen.getByRole('button', { name: 'Standard' }));
+    await userEvent.click(screen.getByRole('button', { name: 'Complex, on' }));
 
     expect(screen.queryByRole('heading', { name: 'Shared Weight' })).not.toBeInTheDocument();
     expect(screen.getByRole('heading', { name: 'Load' })).toBeInTheDocument();
   });
 
   test('startWorkout is called with complexSet: true and shared weight fields when Complex is active', async () => {
-    await userEvent.click(screen.getByRole('button', { name: 'Complex' }));
+    await userEvent.click(screen.getByRole('button', { name: 'Complex, off' }));
     await userEvent.type(screen.getByLabelText('Movement Input'), 'Clean');
     await userEvent.click(screen.getByRole('button', { name: /Start/i }));
 
@@ -524,7 +517,7 @@ describe('Complex Mode', () => {
   });
 
   test('complex mode toggle is preserved when adding movements', async () => {
-    await userEvent.click(screen.getByRole('button', { name: 'Complex' }));
+    await userEvent.click(screen.getByRole('button', { name: 'Complex, off' }));
     expect(screen.queryAllByRole('heading', { name: 'Load' })).toHaveLength(0);
 
     await userEvent.click(screen.getByRole('button', { name: '+ Movement' }));
@@ -535,7 +528,7 @@ describe('Complex Mode', () => {
 
   test('complex mode toggle is preserved when removing movements', async () => {
     await userEvent.click(screen.getByRole('button', { name: '+ Movement' }));
-    await userEvent.click(screen.getByRole('button', { name: 'Complex' }));
+    await userEvent.click(screen.getByRole('button', { name: 'Complex, off' }));
     expect(screen.queryAllByRole('heading', { name: 'Load' })).toHaveLength(0);
 
     const removeButtons = screen.getAllByRole('button', { name: '- Movement' });

--- a/src/pages/StartWorkoutPage/StartWorkoutPage.test.jsx
+++ b/src/pages/StartWorkoutPage/StartWorkoutPage.test.jsx
@@ -39,6 +39,11 @@ describe('start workout page', () => {
     expect(screen.getByText(/build new workout/i)).toBeInTheDocument();
   });
 
+  test('renders the Movements header with count', () => {
+    expect(screen.getByRole('heading', { name: 'Movements' })).toBeInTheDocument();
+    expect(screen.getByLabelText('1 movements')).toBeInTheDocument();
+  });
+
   test('can change the workout goal to "rounds"', async () => {
     const workoutGoalUnits = screen.getByRole('tab', { name: 'Rounds' });
     await userEvent.click(workoutGoalUnits);
@@ -97,7 +102,7 @@ describe('start workout page', () => {
   test('can remove movements', async () => {
     await userEvent.click(screen.getByRole('button', { name: '+ Movement' }));
 
-    const removeButtons = screen.getAllByRole('button', { name: '- Movement' });
+    const removeButtons = screen.getAllByRole('button', { name: 'Remove movement' });
     await userEvent.click(removeButtons[0]);
 
     const movementInputs = screen.getAllByLabelText('Movement Input');
@@ -535,7 +540,7 @@ describe('Complex Mode', () => {
     await userEvent.click(screen.getByRole('button', { name: 'Complex, off' }));
     expect(screen.queryAllByRole('heading', { name: 'Load' })).toHaveLength(0);
 
-    const removeButtons = screen.getAllByRole('button', { name: '- Movement' });
+    const removeButtons = screen.getAllByRole('button', { name: 'Remove movement' });
     await userEvent.click(removeButtons[0]);
 
     expect(screen.queryAllByRole('heading', { name: 'Load' })).toHaveLength(0);

--- a/src/pages/StartWorkoutPage/StartWorkoutPage.tsx
+++ b/src/pages/StartWorkoutPage/StartWorkoutPage.tsx
@@ -1,3 +1,4 @@
+import { XMarkIcon } from '@heroicons/react/24/outline';
 import { useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
@@ -25,6 +26,7 @@ import {
   ModifyCountButtons,
   MovementAutocomplete,
   ModifyWorkoutButtons,
+  MovementsHeader,
   Section,
   WeightModeTabs,
   WeightUnitTabs,
@@ -503,6 +505,8 @@ export const StartWorkoutPage = () => {
         </Card>
       )}
 
+      <MovementsHeader count={movements.length} />
+
       {movements.map((movement, index) => {
         const weightTabValue = getWeightTabValue(movement);
         const activeWeightMode: WeightTabValue = complexSet
@@ -524,11 +528,12 @@ export const StartWorkoutPage = () => {
               title={`Movement #${index + 1}`}
               actions={
                 <Button
-                  variant="secondary"
-                  size="sm"
+                  variant="ghost"
+                  size="icon"
+                  aria-label="Remove movement"
                   onClick={() => handleClickRemoveMovement(index)}
                 >
-                  - Movement
+                  <XMarkIcon className="h-2.5 w-2.5" />
                 </Button>
               }
             >

--- a/src/pages/StartWorkoutPage/StartWorkoutPage.tsx
+++ b/src/pages/StartWorkoutPage/StartWorkoutPage.tsx
@@ -20,6 +20,7 @@ import { getWeightTabValue, getWeightUnitLabel, WEIGHT_MODE_LABELS } from '~/uti
 import { features } from '~/config/features';
 
 import {
+  AddToWorkoutSection,
   ModifyCountButtons,
   MovementAutocomplete,
   ModifyWorkoutButtons,
@@ -132,6 +133,32 @@ export const StartWorkoutPage = () => {
 
   const handleBlurDetails = () =>
     setWorkoutDetails(() => detailsRef.current?.value || null);
+
+  const handleToggleNotes = () => {
+    if (workoutDetails !== null) {
+      setWorkoutDetails(null);
+    } else {
+      handleAddDetails();
+    }
+  };
+
+  const handleToggleInterval = () => {
+    if (intervalTimer > 0) {
+      setIntervalTimer(0);
+    } else {
+      handleIncrementInterval();
+    }
+  };
+
+  const handleToggleRest = () => {
+    if (restTimer > 0) {
+      setRestTimer(0);
+    } else {
+      handleIncrementRest();
+    }
+  };
+
+  const handleToggleComplex = () => setComplexSet((prev) => !prev);
 
   const handleChangeMovementName = (index: number, value: string) =>
     setMovements((prev) =>
@@ -363,135 +390,77 @@ export const StartWorkoutPage = () => {
         </Section>
       </Card>
 
-      {features.complexMode && (
-        <Card>
-          <Section title="Complex Mode">
-            <div className="flex gap-2">
-              <Button
-                className="grow"
-                variant={complexSet ? 'secondary' : 'default'}
-                onClick={() => setComplexSet(false)}
-              >
-                Standard
-              </Button>
-              <Button
-                className="grow"
-                variant={complexSet ? 'default' : 'secondary'}
-                onClick={() => setComplexSet(true)}
-              >
-                Complex
-              </Button>
-            </div>
-            <p className="text-xs text-muted-foreground">
-              {complexSet
-                ? 'Complete all movements before setting the weight down.'
-                : 'Set the weight down between each movement.'}
-            </p>
-          </Section>
-          {complexSet && (
-            <Section
-              title="Shared Weight"
-              actions={
-                <WeightModeTabs
-                  value={sharedWeightTabValue}
-                  onValueChange={handleChangeSharedWeightTab}
-                />
-              }
-            >
-              {sharedWeightOneValue !== null && (
-                <ModifyCountButtons
-                  onClickMinus={() =>
-                    handleChangeSharedWeightOneValue(sharedWeightOneValue - 1)
-                  }
-                  onClickPlus={() =>
-                    handleChangeSharedWeightOneValue(sharedWeightOneValue + 1)
-                  }
-                  unit={getWeightUnitLabel(sharedWeightOneUnit)}
-                  unitTabs={
-                    <WeightUnitTabs
-                      value={sharedWeightOneUnit}
-                      onChange={handleChangeSharedWeightOneUnit}
-                    />
-                  }
-                  value={sharedWeightOneValue}
-                  onChange={(value) => handleChangeSharedWeightOneValue(value!)}
-                />
-              )}
-              {sharedWeightTwoValue !== null && sharedWeightTwoValue > 0 && (
-                <ModifyCountButtons
-                  onClickMinus={() =>
-                    handleChangeSharedWeightTwoValue(sharedWeightTwoValue - 1)
-                  }
-                  onClickPlus={() =>
-                    handleChangeSharedWeightTwoValue(sharedWeightTwoValue + 1)
-                  }
-                  unit={getWeightUnitLabel(sharedWeightTwoUnit)}
-                  unitTabs={
-                    <WeightUnitTabs
-                      value={sharedWeightTwoUnit}
-                      onChange={handleChangeSharedWeightTwoUnit}
-                    />
-                  }
-                  value={sharedWeightTwoValue}
-                  onChange={(value) => handleChangeSharedWeightTwoValue(value)}
-                />
-              )}
-            </Section>
-          )}
-        </Card>
-      )}
+      <AddToWorkoutSection
+        complexSet={complexSet}
+        hasNotes={workoutDetails !== null}
+        hasInterval={intervalTimer > 0}
+        hasRest={restTimer > 0}
+        showComplex={features.complexMode}
+        onToggleComplex={handleToggleComplex}
+        onToggleInterval={handleToggleInterval}
+        onToggleNotes={handleToggleNotes}
+        onToggleRest={handleToggleRest}
+      />
 
-      {(workoutDetails === null || intervalTimer === 0 || restTimer === 0) && (
-        <div className="flex gap-2">
-          {workoutDetails === null && (
-            <Button
-              variant="secondary"
-              size="sm"
-              onClick={handleAddDetails}
-              className="grow"
-            >
-              + Details
-            </Button>
-          )}
-          {intervalTimer === 0 && (
-            <Button
-              variant="secondary"
-              size="sm"
-              onClick={handleIncrementInterval}
-              className="grow"
-            >
-              + Interval
-            </Button>
-          )}
-          {restTimer === 0 && (
-            <Button
-              variant="secondary"
-              size="sm"
-              onClick={handleIncrementRest}
-              className="grow"
-            >
-              + Rest
-            </Button>
-          )}
-        </div>
+      {features.complexMode && complexSet && (
+        <Card>
+          <p className="px-2 pt-2 text-xs text-muted-foreground">
+            Complete all movements before setting the weight down.
+          </p>
+          <Section
+            title="Shared Weight"
+            actions={
+              <WeightModeTabs
+                value={sharedWeightTabValue}
+                onValueChange={handleChangeSharedWeightTab}
+              />
+            }
+          >
+            {sharedWeightOneValue !== null && (
+              <ModifyCountButtons
+                onClickMinus={() =>
+                  handleChangeSharedWeightOneValue(sharedWeightOneValue - 1)
+                }
+                onClickPlus={() =>
+                  handleChangeSharedWeightOneValue(sharedWeightOneValue + 1)
+                }
+                unit={getWeightUnitLabel(sharedWeightOneUnit)}
+                unitTabs={
+                  <WeightUnitTabs
+                    value={sharedWeightOneUnit}
+                    onChange={handleChangeSharedWeightOneUnit}
+                  />
+                }
+                value={sharedWeightOneValue}
+                onChange={(value) => handleChangeSharedWeightOneValue(value!)}
+              />
+            )}
+            {sharedWeightTwoValue !== null && sharedWeightTwoValue > 0 && (
+              <ModifyCountButtons
+                onClickMinus={() =>
+                  handleChangeSharedWeightTwoValue(sharedWeightTwoValue - 1)
+                }
+                onClickPlus={() =>
+                  handleChangeSharedWeightTwoValue(sharedWeightTwoValue + 1)
+                }
+                unit={getWeightUnitLabel(sharedWeightTwoUnit)}
+                unitTabs={
+                  <WeightUnitTabs
+                    value={sharedWeightTwoUnit}
+                    onChange={handleChangeSharedWeightTwoUnit}
+                  />
+                }
+                value={sharedWeightTwoValue}
+                onChange={(value) => handleChangeSharedWeightTwoValue(value)}
+              />
+            )}
+          </Section>
+        </Card>
       )}
 
       {workoutDetails !== null && (
         <Card>
-          <Section
-            title="Workout Details"
-            actions={
-              workoutDetails?.length > 0 && (
-                <Button
-                  variant="secondary"
-                  size="sm"
-                  onClick={() => setWorkoutDetails(null)}
-                >
-                  - Details
-                </Button>
-              )
-            }
-          >
+          <Section title="Notes">
             <Input
               autoFocus
               className="w-full"
@@ -505,20 +474,7 @@ export const StartWorkoutPage = () => {
 
       {intervalTimer > 0 && (
         <Card>
-          <Section
-            title="Interval Timer"
-            actions={
-              intervalTimer !== 0 && (
-                <Button
-                  variant="secondary"
-                  size="sm"
-                  onClick={() => setIntervalTimer(0)}
-                >
-                  - Interval
-                </Button>
-              )
-            }
-          >
+          <Section title="Interval Timer">
             <ModifyCountButtons
               onClickMinus={handleDecrementInterval}
               onClickPlus={handleIncrementInterval}
@@ -532,20 +488,7 @@ export const StartWorkoutPage = () => {
 
       {restTimer > 0 && (
         <Card>
-          <Section
-            title="Rest Timer"
-            actions={
-              restTimer !== 0 && (
-                <Button
-                  variant="secondary"
-                  size="sm"
-                  onClick={() => setRestTimer(0)}
-                >
-                  - Rest
-                </Button>
-              )
-            }
-          >
+          <Section title="Rest Timer">
             <ModifyCountButtons
               onClickMinus={handleDecrementRest}
               onClickPlus={handleIncrementRest}

--- a/src/pages/StartWorkoutPage/StartWorkoutPage.tsx
+++ b/src/pages/StartWorkoutPage/StartWorkoutPage.tsx
@@ -21,6 +21,7 @@ import { features } from '~/config/features';
 
 import {
   AddToWorkoutSection,
+  BuildNewWorkoutDivider,
   ModifyCountButtons,
   MovementAutocomplete,
   ModifyWorkoutButtons,
@@ -358,6 +359,8 @@ export const StartWorkoutPage = () => {
         </Button>
       }
     >
+      <BuildNewWorkoutDivider />
+
       <Card>
         <Section
           title="Goal"

--- a/src/pages/StartWorkoutPage/components/AddToWorkoutSection.stories.tsx
+++ b/src/pages/StartWorkoutPage/components/AddToWorkoutSection.stories.tsx
@@ -1,0 +1,87 @@
+import { Meta, StoryObj } from '@storybook/react';
+import { useState } from 'react';
+
+import { AddToWorkoutSection } from './AddToWorkoutSection';
+
+const meta = {
+  component: AddToWorkoutSection,
+  decorators: [
+    (Story) => (
+      <div className="max-w-md bg-card p-3">
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof AddToWorkoutSection>;
+
+export default meta;
+
+type Story = StoryObj<typeof AddToWorkoutSection>;
+
+export const AllOff: Story = {
+  args: {
+    complexSet: false,
+    hasNotes: false,
+    hasInterval: false,
+    hasRest: false,
+    showComplex: true,
+    onToggleComplex: () => {},
+    onToggleInterval: () => {},
+    onToggleNotes: () => {},
+    onToggleRest: () => {},
+  },
+};
+
+export const AllOn: Story = {
+  args: {
+    complexSet: true,
+    hasNotes: true,
+    hasInterval: true,
+    hasRest: true,
+    showComplex: true,
+    onToggleComplex: () => {},
+    onToggleInterval: () => {},
+    onToggleNotes: () => {},
+    onToggleRest: () => {},
+  },
+};
+
+export const WithoutComplexToggle: Story = {
+  args: {
+    ...AllOff.args,
+    showComplex: false,
+  },
+};
+
+const InteractiveTemplate = ({
+  showComplex,
+}: {
+  showComplex: boolean;
+}) => {
+  const [complexSet, setComplexSet] = useState(false);
+  const [hasNotes, setHasNotes] = useState(false);
+  const [hasInterval, setHasInterval] = useState(false);
+  const [hasRest, setHasRest] = useState(false);
+
+  return (
+    <AddToWorkoutSection
+      complexSet={complexSet}
+      hasNotes={hasNotes}
+      hasInterval={hasInterval}
+      hasRest={hasRest}
+      showComplex={showComplex}
+      onToggleComplex={() => setComplexSet((prev) => !prev)}
+      onToggleNotes={() => setHasNotes((prev) => !prev)}
+      onToggleInterval={() => setHasInterval((prev) => !prev)}
+      onToggleRest={() => setHasRest((prev) => !prev)}
+    />
+  );
+};
+
+export const Interactive: Story = {
+  render: () => <InteractiveTemplate showComplex />,
+};
+
+export const InteractiveWithoutComplex: Story = {
+  render: () => <InteractiveTemplate showComplex={false} />,
+};

--- a/src/pages/StartWorkoutPage/components/AddToWorkoutSection.tsx
+++ b/src/pages/StartWorkoutPage/components/AddToWorkoutSection.tsx
@@ -1,0 +1,59 @@
+import { WorkoutAddonToggle } from './WorkoutAddonToggle';
+
+export const AddToWorkoutSection = ({
+  complexSet,
+  hasNotes,
+  hasInterval,
+  hasRest,
+  onToggleComplex,
+  onToggleInterval,
+  onToggleNotes,
+  onToggleRest,
+  showComplex,
+}: {
+  complexSet: boolean;
+  hasNotes: boolean;
+  hasInterval: boolean;
+  hasRest: boolean;
+  onToggleComplex: () => void;
+  onToggleInterval: () => void;
+  onToggleNotes: () => void;
+  onToggleRest: () => void;
+  showComplex: boolean;
+}) => {
+  return (
+    <section aria-label="Add to workout">
+      <h2 className="mb-1 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+        Add to workout
+      </h2>
+      <div className="flex gap-1">
+        <WorkoutAddonToggle
+          id="notes"
+          label="Notes"
+          isOn={hasNotes}
+          onToggle={onToggleNotes}
+        />
+        <WorkoutAddonToggle
+          id="interval"
+          label="Interval"
+          isOn={hasInterval}
+          onToggle={onToggleInterval}
+        />
+        <WorkoutAddonToggle
+          id="rest"
+          label="Rest"
+          isOn={hasRest}
+          onToggle={onToggleRest}
+        />
+        {showComplex && (
+          <WorkoutAddonToggle
+            id="complex"
+            label="Complex"
+            isOn={complexSet}
+            onToggle={onToggleComplex}
+          />
+        )}
+      </div>
+    </section>
+  );
+};

--- a/src/pages/StartWorkoutPage/components/BuildNewWorkoutDivider.tsx
+++ b/src/pages/StartWorkoutPage/components/BuildNewWorkoutDivider.tsx
@@ -1,0 +1,13 @@
+import { Separator } from '~/components/ui/separator';
+
+export const BuildNewWorkoutDivider = () => {
+  return (
+    <div className="flex items-center gap-2 py-0.5">
+      <Separator className="flex-1" />
+      <span className="whitespace-nowrap text-xs font-medium uppercase tracking-wide text-muted-foreground">
+        Build new workout
+      </span>
+      <Separator className="flex-1" />
+    </div>
+  );
+};

--- a/src/pages/StartWorkoutPage/components/MovementsHeader.tsx
+++ b/src/pages/StartWorkoutPage/components/MovementsHeader.tsx
@@ -1,0 +1,12 @@
+export const MovementsHeader = ({ count }: { count: number }) => {
+  return (
+    <div className="flex items-center justify-between">
+      <h2 className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+        Movements
+      </h2>
+      <span className="text-xs text-muted-foreground" aria-label={`${count} movements`}>
+        {count}
+      </span>
+    </div>
+  );
+};

--- a/src/pages/StartWorkoutPage/components/Section.tsx
+++ b/src/pages/StartWorkoutPage/components/Section.tsx
@@ -15,7 +15,7 @@ export const Section = ({
     <>
       <CardHeader>
         <div className="flex w-full items-center justify-between gap-x-1">
-          <CardTitle>{title}</CardTitle>
+          <CardTitle className="text-sm font-medium">{title}</CardTitle>
           {actions}
         </div>
       </CardHeader>

--- a/src/pages/StartWorkoutPage/components/WorkoutAddonToggle.tsx
+++ b/src/pages/StartWorkoutPage/components/WorkoutAddonToggle.tsx
@@ -1,0 +1,55 @@
+import {
+  ClockIcon,
+  CubeIcon,
+  DocumentTextIcon,
+  PauseIcon,
+} from '@heroicons/react/24/outline';
+import { ComponentType, SVGProps } from 'react';
+
+import { cn } from '~/lib/utils';
+
+const ICONS = {
+  notes: DocumentTextIcon,
+  interval: ClockIcon,
+  rest: PauseIcon,
+  complex: CubeIcon,
+} as const;
+
+export type WorkoutAddonId = keyof typeof ICONS;
+
+export const WorkoutAddonToggle = ({
+  id,
+  label,
+  isOn,
+  onToggle,
+}: {
+  id: WorkoutAddonId;
+  label: string;
+  isOn: boolean;
+  onToggle: () => void;
+}) => {
+  const Icon = ICONS[id] as ComponentType<SVGProps<SVGSVGElement>>;
+
+  return (
+    <button
+      type="button"
+      aria-pressed={isOn}
+      aria-label={`${label}, ${isOn ? 'on' : 'off'}`}
+      onClick={onToggle}
+      className={cn(
+        'flex min-w-0 flex-1 flex-col items-center gap-0.5 rounded-lg border bg-card px-0.5 py-1.5 transition-colors',
+        isOn
+          ? 'border-primary/40 bg-secondary ring-1 ring-primary/30'
+          : 'border-border',
+      )}
+    >
+      <Icon className="h-2.5 w-2.5 shrink-0 text-foreground" aria-hidden />
+      <span className="text-xs font-semibold leading-tight text-foreground">
+        {label}
+      </span>
+      <span className="text-[10px] leading-tight text-muted-foreground">
+        {isOn ? 'on' : 'off'}
+      </span>
+    </button>
+  );
+};

--- a/src/pages/StartWorkoutPage/components/index.ts
+++ b/src/pages/StartWorkoutPage/components/index.ts
@@ -1,4 +1,6 @@
+export * from './AddToWorkoutSection';
 export * from './ModifyCountButtons';
+export * from './WorkoutAddonToggle';
 export * from './MovementAutocomplete';
 export * from './ModifyWorkoutButtons';
 export * from './Section';

--- a/src/pages/StartWorkoutPage/components/index.ts
+++ b/src/pages/StartWorkoutPage/components/index.ts
@@ -1,6 +1,7 @@
 export * from './AddToWorkoutSection';
 export * from './BuildNewWorkoutDivider';
 export * from './ModifyCountButtons';
+export * from './MovementsHeader';
 export * from './WorkoutAddonToggle';
 export * from './MovementAutocomplete';
 export * from './ModifyWorkoutButtons';

--- a/src/pages/StartWorkoutPage/components/index.ts
+++ b/src/pages/StartWorkoutPage/components/index.ts
@@ -1,4 +1,5 @@
 export * from './AddToWorkoutSection';
+export * from './BuildNewWorkoutDivider';
 export * from './ModifyCountButtons';
 export * from './WorkoutAddonToggle';
 export * from './MovementAutocomplete';


### PR DESCRIPTION
## Summary
- replace separate add-on controls with a single `Add to workout` icon toggle row for Notes, Interval, Rest, and Complex
- add a centered `Build new workout` divider above the Goal card and a `Movements` header above movement cards
- switch movement removal from a text button to an icon-only close action and update Start Workout tests accordingly

## Test plan
- [x] Run `npx vitest run --reporter=basic src/pages/StartWorkoutPage/StartWorkoutPage.test.jsx`
- [ ] Manually verify Start Workout layout/spacing on the page (goal divider, add-to-workout row, movements header, remove icon)

Made with [Cursor](https://cursor.com)