### PR TITLE
Start Workout UX: tab labels, Notes toggle, and complex mode layout

### DIFF
--- a/src/components/MovementAutocomplete/MovementAutocomplete.stories.tsx
+++ b/src/components/MovementAutocomplete/MovementAutocomplete.stories.tsx
@@ -169,7 +169,7 @@ export const ComplexSharedWeightHint: Story = {
   render: () => (
     <MovementAutocompleteDemo
       showWeightModeTabs={false}
-      weightModeHint="Using shared weight: 2H"
+      weightModeHint="Using shared weight: Two-Handed"
     />
   ),
   parameters: {

--- a/src/components/MovementAutocomplete/MovementAutocomplete.test.tsx
+++ b/src/components/MovementAutocomplete/MovementAutocomplete.test.tsx
@@ -135,17 +135,17 @@ describe('MovementAutocomplete', () => {
 
   test('renders weight mode tabs by default', () => {
     renderAutocomplete();
-    expect(screen.getByRole('tab', { name: 'None' })).toBeInTheDocument();
-    expect(screen.getByRole('tab', { name: '2H' })).toBeInTheDocument();
-    expect(screen.getByRole('tab', { name: '1H' })).toBeInTheDocument();
-    expect(screen.getByRole('tab', { name: 'Double' })).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: 'Bodyweight' })).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: 'Two-Handed' })).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: 'Single Arm' })).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: 'Double Bell' })).toBeInTheDocument();
   });
 
   test('calls onWeightModeChange when a weight tab is selected', async () => {
     const onWeightModeChange = vi.fn();
     renderAutocomplete({ onWeightModeChange });
 
-    await userEvent.click(screen.getByRole('tab', { name: '1H' }));
+    await userEvent.click(screen.getByRole('tab', { name: 'Single Arm' }));
     expect(onWeightModeChange).toHaveBeenCalledWith('1h');
   });
 
@@ -416,7 +416,7 @@ describe('MovementAutocomplete', () => {
 
     await waitFor(() => {
       expect(screen.getByText('Kettlebell Snatch')).toBeInTheDocument();
-      expect(screen.getByText('Catalog (2H)')).toBeInTheDocument();
+      expect(screen.getByText('Catalog (Two-Handed)')).toBeInTheDocument();
     });
 
     await userEvent.click(screen.getByText('Kettlebell Snatch'));
@@ -470,7 +470,7 @@ describe('MovementAutocomplete', () => {
 
     await waitFor(() => {
       expect(
-        screen.getByText(/No 2h movements for.*Swing.*try another mode/i),
+        screen.getByText(/No two-handed movements for.*Swing.*try another mode/i),
       ).toBeInTheDocument();
     });
   });
@@ -500,11 +500,11 @@ describe('MovementAutocomplete', () => {
   test('shows shared weight hint when tabs are hidden', () => {
     renderAutocomplete({
       showWeightModeTabs: false,
-      weightModeHint: 'Using shared weight: 2H',
+      weightModeHint: 'Using shared weight: Two-Handed',
     });
 
-    expect(screen.getByText('Using shared weight: 2H')).toBeInTheDocument();
-    expect(screen.queryByRole('tab', { name: '2H' })).not.toBeInTheDocument();
+    expect(screen.getByText('Using shared weight: Two-Handed')).toBeInTheDocument();
+    expect(screen.queryByRole('tab', { name: 'Two-Handed' })).not.toBeInTheDocument();
   });
 
   test('does not show recent movements when there is no session', async () => {

--- a/src/components/MovementAutocomplete/WeightModeTabs.tsx
+++ b/src/components/MovementAutocomplete/WeightModeTabs.tsx
@@ -1,6 +1,7 @@
 import { Tabs, TabsList, TabsTrigger } from '~/components/ui/tabs';
 import { cn } from '~/lib/utils';
 import { WeightTabValue } from '~/types';
+import { WEIGHT_MODE_LABELS } from '~/utils';
 
 interface WeightModeTabsProps {
   value: WeightTabValue;
@@ -20,16 +21,16 @@ export const WeightModeTabs = ({
   >
     <TabsList className="flex w-full">
       <TabsTrigger className="flex-1" size="sm" value="none">
-        None
+        {WEIGHT_MODE_LABELS.none}
       </TabsTrigger>
       <TabsTrigger className="flex-1" size="sm" value="2h">
-        2H
+        {WEIGHT_MODE_LABELS['2h']}
       </TabsTrigger>
       <TabsTrigger className="flex-1" size="sm" value="1h">
-        1H
+        {WEIGHT_MODE_LABELS['1h']}
       </TabsTrigger>
       <TabsTrigger className="flex-1" size="sm" value="double">
-        Double
+        {WEIGHT_MODE_LABELS.double}
       </TabsTrigger>
     </TabsList>
   </Tabs>

--- a/src/pages/CompletedWorkoutPage/components/LinkMovementDialog.test.tsx
+++ b/src/pages/CompletedWorkoutPage/components/LinkMovementDialog.test.tsx
@@ -126,7 +126,7 @@ describe('LinkMovementDialog', () => {
 
     expect(screen.getByRole('dialog')).toBeInTheDocument();
     expect(screen.getByText(/Currently: My Custom Swing/)).toBeInTheDocument();
-    expect(screen.getByText(/Catalog filtered to 2H/)).toBeInTheDocument();
+    expect(screen.getByText(/Catalog filtered to Two-Handed/)).toBeInTheDocument();
   });
 
   test('confirm is enabled with typed input and persists link on confirm', async () => {

--- a/src/pages/StartWorkoutPage/StartWorkoutPage.test.jsx
+++ b/src/pages/StartWorkoutPage/StartWorkoutPage.test.jsx
@@ -458,6 +458,61 @@ describe('start workout page - without previous volume', () => {
   });
 });
 
+describe('Notes', () => {
+  let startWorkout;
+
+  beforeEach(() => {
+    startWorkout = vi.fn();
+    Default.parameters.updateWorkoutOptions = startWorkout;
+    render(<Default />);
+  });
+
+  test('clicking Notes toggle on shows the notes section', async () => {
+    await userEvent.click(screen.getByRole('button', { name: 'Notes, off' }));
+
+    expect(screen.getByRole('heading', { name: 'Notes' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Notes, on' })).toBeInTheDocument();
+  });
+
+  test('clicking Notes toggle off hides the notes section when input is focused and empty', async () => {
+    await userEvent.click(screen.getByRole('button', { name: 'Notes, off' }));
+    await userEvent.click(screen.getByRole('button', { name: 'Notes, on' }));
+
+    expect(screen.queryByRole('heading', { name: 'Notes' })).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Notes, off' })).toBeInTheDocument();
+  });
+
+  test('clicking Notes toggle off hides the notes section when input has text', async () => {
+    await userEvent.click(screen.getByRole('button', { name: 'Notes, off' }));
+    await userEvent.keyboard('Heavy day');
+    await userEvent.click(screen.getByRole('button', { name: 'Notes, on' }));
+
+    expect(screen.queryByRole('heading', { name: 'Notes' })).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Notes, off' })).toBeInTheDocument();
+  });
+
+  test('clicking away from empty notes input keeps the section visible', async () => {
+    await userEvent.click(screen.getByRole('button', { name: 'Notes, off' }));
+    await userEvent.click(screen.getByLabelText('Movement Input'));
+
+    expect(screen.getByRole('heading', { name: 'Notes' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Notes, on' })).toBeInTheDocument();
+  });
+
+  test('starting a workout with Notes on but empty saves workoutDetails as null', async () => {
+    await userEvent.click(screen.getByRole('button', { name: 'Notes, off' }));
+    await userEvent.type(screen.getByLabelText('Movement Input'), 'Clean');
+    await userEvent.click(screen.getByRole('button', { name: /Start/i }));
+
+    expect(startWorkout).toHaveBeenCalledWith(
+      expect.objectContaining({
+        workoutDetails: null,
+        startedAt,
+      }),
+    );
+  });
+});
+
 describe('Complex Mode', () => {
   let startWorkout;
 

--- a/src/pages/StartWorkoutPage/StartWorkoutPage.test.jsx
+++ b/src/pages/StartWorkoutPage/StartWorkoutPage.test.jsx
@@ -118,7 +118,7 @@ describe('start workout page', () => {
 
   describe('Load', () => {
     test('can select "none" for bodyweight movements', async () => {
-      await userEvent.click(screen.getByRole('tab', { name: 'None' }));
+      await userEvent.click(screen.getByRole('tab', { name: 'Bodyweight' }));
       await userEvent.type(screen.getByLabelText('Movement Input'), 'Pushups');
       await userEvent.click(screen.getByRole('button', { name: /Start/i }));
 
@@ -140,7 +140,7 @@ describe('start workout page', () => {
     });
 
     test('can select "2h" for two-handed movements', async () => {
-      await userEvent.click(screen.getByRole('tab', { name: '2H' }));
+      await userEvent.click(screen.getByRole('tab', { name: 'Two-Handed' }));
       await userEvent.type(
         screen.getByLabelText('Movement Input'),
         'Kettlebell Swing',
@@ -161,7 +161,7 @@ describe('start workout page', () => {
     });
 
     test('can select "1h" for one-handed movements', async () => {
-      await userEvent.click(screen.getByRole('tab', { name: '1H' }));
+      await userEvent.click(screen.getByRole('tab', { name: 'Single Arm' }));
       await userEvent.type(
         screen.getByLabelText('Movement Input'),
         'Single Arm Press',
@@ -183,7 +183,7 @@ describe('start workout page', () => {
     });
 
     test('can select "double" for two-weight movements', async () => {
-      await userEvent.click(screen.getByRole('tab', { name: 'Double' }));
+      await userEvent.click(screen.getByRole('tab', { name: 'Double Bell' }));
       await userEvent.type(
         screen.getByLabelText('Movement Input'),
         'Double Clean',
@@ -482,10 +482,10 @@ describe('Complex Mode', () => {
       screen.getByText('Complete all movements before setting the weight down.'),
     ).toBeInTheDocument();
     expect(screen.getByRole('heading', { name: 'Shared Weight' })).toBeInTheDocument();
-    expect(screen.getByRole('tab', { name: 'None' })).toBeInTheDocument();
-    expect(screen.getByRole('tab', { name: '2H' })).toBeInTheDocument();
-    expect(screen.getByRole('tab', { name: '1H' })).toBeInTheDocument();
-    expect(screen.getByRole('tab', { name: 'Double' })).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: 'Bodyweight' })).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: 'Two-Handed' })).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: 'Single Arm' })).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: 'Double Bell' })).toBeInTheDocument();
   });
 
   test('when Complex is active, per-movement weight sections are hidden and rep scheme sections remain visible', async () => {

--- a/src/pages/StartWorkoutPage/StartWorkoutPage.tsx
+++ b/src/pages/StartWorkoutPage/StartWorkoutPage.tsx
@@ -134,8 +134,9 @@ export const StartWorkoutPage = () => {
 
   const handleAddDetails = () => setWorkoutDetails('');
 
-  const handleBlurDetails = () =>
-    setWorkoutDetails(() => detailsRef.current?.value || null);
+  const handleBlurDetails = () => {
+    setWorkoutDetails(detailsRef.current?.value ?? '');
+  };
 
   const handleToggleNotes = () => {
     if (workoutDetails !== null) {
@@ -323,7 +324,7 @@ export const StartWorkoutPage = () => {
       sharedWeightTwoUnit,
       sharedWeightTwoValue,
       startedAt: new Date(),
-      workoutDetails,
+      workoutDetails: workoutDetails?.trim() || null,
       workoutGoal,
       workoutGoalUnits,
     };
@@ -409,18 +410,14 @@ export const StartWorkoutPage = () => {
 
       {features.complexMode && complexSet && (
         <Card>
-          <p className="px-2 pt-2 text-xs text-muted-foreground">
-            Complete all movements before setting the weight down.
-          </p>
-          <Section
-            title="Shared Weight"
-            actions={
-              <WeightModeTabs
-                value={sharedWeightTabValue}
-                onValueChange={handleChangeSharedWeightTab}
-              />
-            }
-          >
+          <Section title="Shared Weight">
+            <p className="text-xs text-muted-foreground">
+              Complete all movements before setting the weight down.
+            </p>
+            <WeightModeTabs
+              value={sharedWeightTabValue}
+              onValueChange={handleChangeSharedWeightTab}
+            />
             {sharedWeightOneValue !== null && (
               <ModifyCountButtons
                 onClickMinus={() =>

--- a/src/utils/movementWeightModeFilter.ts
+++ b/src/utils/movementWeightModeFilter.ts
@@ -8,9 +8,9 @@ export interface MovementWeightModeFields {
 
 export const WEIGHT_MODE_LABELS: Record<WeightTabValue, string> = {
   none: 'Bodyweight',
-  '2h': '2H',
-  '1h': '1H',
-  double: 'Double',
+  '2h': 'Two-Handed',
+  '1h': 'Single Arm',
+  double: 'Double Bell',
 };
 
 export const getWeightTabValue = (movement: {


### PR DESCRIPTION
## Summary
- Renames movement weight mode tabs from abbreviated labels (None, 2H, 1H, Double) to descriptive names (Bodyweight, Two-Handed, Single Arm, Double Bell).
- Centralizes tab text in `WEIGHT_MODE_LABELS` so labels stay consistent across tabs, catalog filters, and shared-weight hints.
- Fixes Notes toggle-off behavior by removing auto-dismiss on blur; the toggle is now the only way to hide the Notes section (matching Interval/Rest/Complex toggles).
- Reorganizes complex mode shared weight into a vertical layout: title, description, weight mode tabs, then weight selector.

## Test plan
- [x] Full unit test suite (`npm test -- --run`) — 238 tests passing
- [x] Notes toggle on/off, blur, and empty-notes-on-start regression tests
- [x] Verify weight mode tabs and shared weight layout on Start Workout page
- [x] Confirm Notes toggle dismisses cleanly when input is focused and empty
- [x] Confirm catalog section headers and empty states use the updated labels