### PR TITLE
Fix weight mode tab overflow on mobile

### DIFF
--- a/src/components/MovementAutocomplete/MovementAutocomplete.stories.tsx
+++ b/src/components/MovementAutocomplete/MovementAutocomplete.stories.tsx
@@ -169,7 +169,7 @@ export const ComplexSharedWeightHint: Story = {
   render: () => (
     <MovementAutocompleteDemo
       showWeightModeTabs={false}
-      weightModeHint="Using shared weight: Two-Handed"
+      weightModeHint="Using shared weight: Two-Hand"
     />
   ),
   parameters: {

--- a/src/components/MovementAutocomplete/MovementAutocomplete.test.tsx
+++ b/src/components/MovementAutocomplete/MovementAutocomplete.test.tsx
@@ -136,16 +136,16 @@ describe('MovementAutocomplete', () => {
   test('renders weight mode tabs by default', () => {
     renderAutocomplete();
     expect(screen.getByRole('tab', { name: 'Bodyweight' })).toBeInTheDocument();
-    expect(screen.getByRole('tab', { name: 'Two-Handed' })).toBeInTheDocument();
-    expect(screen.getByRole('tab', { name: 'Single Arm' })).toBeInTheDocument();
-    expect(screen.getByRole('tab', { name: 'Double Bell' })).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: 'Two-Hand' })).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: 'Single' })).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: 'Double' })).toBeInTheDocument();
   });
 
   test('calls onWeightModeChange when a weight tab is selected', async () => {
     const onWeightModeChange = vi.fn();
     renderAutocomplete({ onWeightModeChange });
 
-    await userEvent.click(screen.getByRole('tab', { name: 'Single Arm' }));
+    await userEvent.click(screen.getByRole('tab', { name: 'Single' }));
     expect(onWeightModeChange).toHaveBeenCalledWith('1h');
   });
 
@@ -416,7 +416,7 @@ describe('MovementAutocomplete', () => {
 
     await waitFor(() => {
       expect(screen.getByText('Kettlebell Snatch')).toBeInTheDocument();
-      expect(screen.getByText('Catalog (Two-Handed)')).toBeInTheDocument();
+      expect(screen.getByText('Catalog (Two-Hand)')).toBeInTheDocument();
     });
 
     await userEvent.click(screen.getByText('Kettlebell Snatch'));
@@ -470,7 +470,7 @@ describe('MovementAutocomplete', () => {
 
     await waitFor(() => {
       expect(
-        screen.getByText(/No two-handed movements for.*Swing.*try another mode/i),
+        screen.getByText(/No two-hand movements for.*Swing.*try another mode/i),
       ).toBeInTheDocument();
     });
   });
@@ -500,11 +500,11 @@ describe('MovementAutocomplete', () => {
   test('shows shared weight hint when tabs are hidden', () => {
     renderAutocomplete({
       showWeightModeTabs: false,
-      weightModeHint: 'Using shared weight: Two-Handed',
+      weightModeHint: 'Using shared weight: Two-Hand',
     });
 
-    expect(screen.getByText('Using shared weight: Two-Handed')).toBeInTheDocument();
-    expect(screen.queryByRole('tab', { name: 'Two-Handed' })).not.toBeInTheDocument();
+    expect(screen.getByText('Using shared weight: Two-Hand')).toBeInTheDocument();
+    expect(screen.queryByRole('tab', { name: 'Two-Hand' })).not.toBeInTheDocument();
   });
 
   test('does not show recent movements when there is no session', async () => {

--- a/src/components/MovementAutocomplete/WeightModeTabs.tsx
+++ b/src/components/MovementAutocomplete/WeightModeTabs.tsx
@@ -20,16 +20,16 @@ export const WeightModeTabs = ({
     className={cn('w-full', className)}
   >
     <TabsList className="flex w-full">
-      <TabsTrigger className="flex-1" size="sm" value="none">
+      <TabsTrigger className="min-w-0 flex-1 px-0.5" size="sm" value="none">
         {WEIGHT_MODE_LABELS.none}
       </TabsTrigger>
-      <TabsTrigger className="flex-1" size="sm" value="2h">
+      <TabsTrigger className="min-w-0 flex-1 px-0.5" size="sm" value="2h">
         {WEIGHT_MODE_LABELS['2h']}
       </TabsTrigger>
-      <TabsTrigger className="flex-1" size="sm" value="1h">
+      <TabsTrigger className="min-w-0 flex-1 px-0.5" size="sm" value="1h">
         {WEIGHT_MODE_LABELS['1h']}
       </TabsTrigger>
-      <TabsTrigger className="flex-1" size="sm" value="double">
+      <TabsTrigger className="min-w-0 flex-1 px-0.5" size="sm" value="double">
         {WEIGHT_MODE_LABELS.double}
       </TabsTrigger>
     </TabsList>

--- a/src/pages/CompletedWorkoutPage/components/LinkMovementDialog.test.tsx
+++ b/src/pages/CompletedWorkoutPage/components/LinkMovementDialog.test.tsx
@@ -126,7 +126,7 @@ describe('LinkMovementDialog', () => {
 
     expect(screen.getByRole('dialog')).toBeInTheDocument();
     expect(screen.getByText(/Currently: My Custom Swing/)).toBeInTheDocument();
-    expect(screen.getByText(/Catalog filtered to Two-Handed/)).toBeInTheDocument();
+    expect(screen.getByText(/Catalog filtered to Two-Hand/)).toBeInTheDocument();
   });
 
   test('confirm is enabled with typed input and persists link on confirm', async () => {

--- a/src/pages/StartWorkoutPage/StartWorkoutPage.test.jsx
+++ b/src/pages/StartWorkoutPage/StartWorkoutPage.test.jsx
@@ -140,7 +140,7 @@ describe('start workout page', () => {
     });
 
     test('can select "2h" for two-handed movements', async () => {
-      await userEvent.click(screen.getByRole('tab', { name: 'Two-Handed' }));
+      await userEvent.click(screen.getByRole('tab', { name: 'Two-Hand' }));
       await userEvent.type(
         screen.getByLabelText('Movement Input'),
         'Kettlebell Swing',
@@ -161,7 +161,7 @@ describe('start workout page', () => {
     });
 
     test('can select "1h" for one-handed movements', async () => {
-      await userEvent.click(screen.getByRole('tab', { name: 'Single Arm' }));
+      await userEvent.click(screen.getByRole('tab', { name: 'Single' }));
       await userEvent.type(
         screen.getByLabelText('Movement Input'),
         'Single Arm Press',
@@ -183,7 +183,7 @@ describe('start workout page', () => {
     });
 
     test('can select "double" for two-weight movements', async () => {
-      await userEvent.click(screen.getByRole('tab', { name: 'Double Bell' }));
+      await userEvent.click(screen.getByRole('tab', { name: 'Double' }));
       await userEvent.type(
         screen.getByLabelText('Movement Input'),
         'Double Clean',
@@ -538,9 +538,9 @@ describe('Complex Mode', () => {
     ).toBeInTheDocument();
     expect(screen.getByRole('heading', { name: 'Shared Weight' })).toBeInTheDocument();
     expect(screen.getByRole('tab', { name: 'Bodyweight' })).toBeInTheDocument();
-    expect(screen.getByRole('tab', { name: 'Two-Handed' })).toBeInTheDocument();
-    expect(screen.getByRole('tab', { name: 'Single Arm' })).toBeInTheDocument();
-    expect(screen.getByRole('tab', { name: 'Double Bell' })).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: 'Two-Hand' })).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: 'Single' })).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: 'Double' })).toBeInTheDocument();
   });
 
   test('when Complex is active, per-movement weight sections are hidden and rep scheme sections remain visible', async () => {

--- a/src/utils/movementWeightModeFilter.ts
+++ b/src/utils/movementWeightModeFilter.ts
@@ -8,9 +8,9 @@ export interface MovementWeightModeFields {
 
 export const WEIGHT_MODE_LABELS: Record<WeightTabValue, string> = {
   none: 'Bodyweight',
-  '2h': 'Two-Handed',
-  '1h': 'Single Arm',
-  double: 'Double Bell',
+  '2h': 'Two-Hand',
+  '1h': 'Single',
+  double: 'Double',
 };
 
 export const getWeightTabValue = (movement: {


### PR DESCRIPTION
## Summary
- Shorten weight mode tab labels (Two-Hand, Single, Double) so four tabs fit on narrow movement cards.
- Tighten tab trigger layout with `min-w-0` and reduced horizontal padding.
- Update tests and Storybook for the new label copy.

## Test plan
- [x] `npm test -- src/components/MovementAutocomplete/MovementAutocomplete.test.tsx`
- [x] `npm test -- src/pages/StartWorkoutPage/StartWorkoutPage.test.jsx`
- [x] `npm test -- src/pages/CompletedWorkoutPage/components/LinkMovementDialog.test.tsx`
- [x] Confirm on mobile viewport: Start Workout → Movement #1 — all four tabs visible without clipping


Made with [Cursor](https://cursor.com)