### PR TITLE
Paywall v1 (Phase 1): trial infra, entitlement gating, paywall screen

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,4 +1,5 @@
 export * from './useDeleteWorkoutLog';
+export * from './useEntitlement';
 export * from './useLinkMovementLog';
 export * from './useUnlinkMovementLog';
 export * from './useLogWorkout';

--- a/src/api/useEntitlement.test.ts
+++ b/src/api/useEntitlement.test.ts
@@ -1,0 +1,88 @@
+import { deriveEntitlement } from './useEntitlement';
+
+const NOW = new Date('2026-06-12T00:00:00Z');
+const daysFromNow = (n: number) =>
+  new Date(NOW.getTime() + n * 24 * 60 * 60 * 1000).toISOString();
+
+describe('deriveEntitlement', () => {
+  test('active trial -> premium access with days remaining', () => {
+    const result = deriveEntitlement(
+      {
+        subscription_tier: 'free',
+        trial_ends_at: daysFromNow(10),
+        subscription_status: null,
+        current_period_end: null,
+      },
+      NOW,
+    );
+    expect(result.effectiveAccess).toBe('premium');
+    expect(result.isTrialing).toBe(true);
+    expect(result.trialExpired).toBe(false);
+    expect(result.trialDaysRemaining).toBe(10);
+  });
+
+  test('expired trial -> free, flagged as expired', () => {
+    const result = deriveEntitlement(
+      {
+        subscription_tier: 'free',
+        trial_ends_at: daysFromNow(-1),
+        subscription_status: null,
+        current_period_end: null,
+      },
+      NOW,
+    );
+    expect(result.effectiveAccess).toBe('free');
+    expect(result.isTrialing).toBe(false);
+    expect(result.trialExpired).toBe(true);
+    expect(result.trialDaysRemaining).toBeNull();
+  });
+
+  test('premium tier -> premium regardless of trial', () => {
+    const result = deriveEntitlement(
+      {
+        subscription_tier: 'premium',
+        trial_ends_at: daysFromNow(-99),
+        subscription_status: 'active',
+        current_period_end: daysFromNow(30),
+      },
+      NOW,
+    );
+    expect(result.effectiveAccess).toBe('premium');
+    expect(result.isPremium).toBe(true);
+    expect(result.isTrialing).toBe(false);
+  });
+
+  test('free with no trial -> free, not expired', () => {
+    const result = deriveEntitlement(
+      {
+        subscription_tier: 'free',
+        trial_ends_at: null,
+        subscription_status: null,
+        current_period_end: null,
+      },
+      NOW,
+    );
+    expect(result.effectiveAccess).toBe('free');
+    expect(result.trialExpired).toBe(false);
+    expect(result.trialDaysRemaining).toBeNull();
+  });
+
+  test('null row (not loaded) -> free', () => {
+    expect(deriveEntitlement(null, NOW).effectiveAccess).toBe('free');
+  });
+
+  test('rounds partial day up to whole days remaining', () => {
+    const result = deriveEntitlement(
+      {
+        subscription_tier: 'free',
+        trial_ends_at: new Date(
+          NOW.getTime() + 1.2 * 24 * 60 * 60 * 1000,
+        ).toISOString(),
+        subscription_status: null,
+        current_period_end: null,
+      },
+      NOW,
+    );
+    expect(result.trialDaysRemaining).toBe(2);
+  });
+});

--- a/src/api/useEntitlement.ts
+++ b/src/api/useEntitlement.ts
@@ -1,0 +1,98 @@
+import { useQuery } from 'react-query';
+
+import { QUERIES } from '~/constants';
+import { useSession } from '~/contexts';
+
+import { supabase } from '../supabaseClient';
+
+/**
+ * The subscription columns the client reads to derive access. The real gate is
+ * server-side (has_premium_access + RLS, PROD-100); this is UX only.
+ */
+export interface SubscriptionRow {
+  // NOT NULL in the DB (defaults to 'free'); keep non-nullable to match.
+  subscription_tier: string;
+  trial_ends_at: string | null;
+  subscription_status: string | null;
+  current_period_end: string | null;
+}
+
+export interface Entitlement {
+  isPremium: boolean;
+  isTrialing: boolean;
+  /** True only when a trial existed and has since lapsed (vs. never trialed). */
+  trialExpired: boolean;
+  trialDaysRemaining: number | null;
+  effectiveAccess: 'premium' | 'free';
+}
+
+const DAY_MS = 1000 * 60 * 60 * 24;
+
+/**
+ * Derives entitlement from a subscription row. Mirrors the SQL has_premium_access
+ * rule exactly: premium = tier 'premium' OR (trial_ends_at set AND not yet past).
+ * Kept pure so it can be unit-tested across all four states.
+ */
+export const deriveEntitlement = (
+  row: SubscriptionRow | null,
+  now: Date = new Date(),
+): Entitlement => {
+  const isPremium = row?.subscription_tier === 'premium';
+
+  const trialEndsAt = row?.trial_ends_at ? new Date(row.trial_ends_at) : null;
+  const trialActive =
+    trialEndsAt !== null && now.getTime() < trialEndsAt.getTime();
+  const isTrialing = !isPremium && trialActive;
+  const trialExpired =
+    trialEndsAt !== null && now.getTime() >= trialEndsAt.getTime();
+
+  const trialDaysRemaining = trialActive
+    ? Math.ceil((trialEndsAt!.getTime() - now.getTime()) / DAY_MS)
+    : null;
+
+  return {
+    isPremium,
+    isTrialing,
+    trialExpired,
+    trialDaysRemaining,
+    effectiveAccess: isPremium || isTrialing ? 'premium' : 'free',
+  };
+};
+
+const fetchSubscriptionRow = async (
+  userId: string | undefined,
+): Promise<SubscriptionRow | null> => {
+  // refetch() bypasses react-query's `enabled` guard, so guard here too: without
+  // a user there's nothing to read (derives to free, the safe default).
+  if (!userId) return null;
+
+  const { data, error } = await supabase
+    .from('profiles')
+    .select(
+      'subscription_tier, trial_ends_at, subscription_status, current_period_end',
+    )
+    .eq('id', userId)
+    .single();
+
+  if (error) {
+    console.error(error);
+    throw error;
+  }
+
+  return data;
+};
+
+/**
+ * Reads the user's subscription row and derives entitlement. Refetchable on
+ * demand (needed for the Phase-2 post-checkout return flow).
+ */
+export const useEntitlementQuery = () => {
+  const session = useSession();
+  const userId = session?.user?.id;
+
+  return useQuery(
+    [QUERIES.ENTITLEMENT, userId],
+    () => fetchSubscriptionRow(userId),
+    { enabled: !!userId, select: (row) => deriveEntitlement(row) },
+  );
+};

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -3,6 +3,7 @@ import { useEffect, useState } from 'react';
 import { RouterProvider, createBrowserRouter } from 'react-router-dom';
 
 import { Loading, PWAInstallPrompt, SafeAreaWrapper } from '~/components';
+import { EntitlementProvider } from '~/contexts/EntitlementContext';
 import { WorkoutOptionsProvider } from '~/contexts/WorkoutOptionsContext';
 import { resolveAuthSession } from '~/utils';
 
@@ -39,9 +40,11 @@ export function App() {
 
       {session && (
         <SessionProvider value={session}>
-          <WorkoutOptionsProvider>
-            <RouterProvider router={router} />
-          </WorkoutOptionsProvider>
+          <EntitlementProvider>
+            <WorkoutOptionsProvider>
+              <RouterProvider router={router} />
+            </WorkoutOptionsProvider>
+          </EntitlementProvider>
         </SessionProvider>
       )}
 

--- a/src/app/routes.tsx
+++ b/src/app/routes.tsx
@@ -7,6 +7,8 @@ import {
   CompletedWorkoutPage,
   HistoryPage,
   MovementsPage,
+  PaywallPage,
+  RecommendationsPage,
   StartWorkoutPage,
 } from '../pages';
 import { Root } from './Root';
@@ -36,7 +38,14 @@ export const routes: RouteObject[] = [
         path: 'history/:id',
         element: <CompletedWorkoutPage />,
       },
+      {
+        path: 'paywall',
+        element: <PaywallPage />,
+      },
       ...(features.explore ? [{ path: 'movements', element: <MovementsPage /> }] : []),
+      ...(features.premium
+        ? [{ path: 'recommendations', element: <RecommendationsPage /> }]
+        : []),
     ],
   },
 ];

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -88,6 +88,13 @@ export const Header = () => {
             </NavigationMenuLink>
           </NavigationMenuItem>
         )}
+        {features.premium && (
+          <NavigationMenuItem>
+            <NavigationMenuLink asChild className={navigationMenuTriggerStyle()}>
+              <NavLink to="/recommendations">AI</NavLink>
+            </NavigationMenuLink>
+          </NavigationMenuItem>
+        )}
         <NavigationMenuItem>
           <NavigationMenuLink asChild className={navigationMenuTriggerStyle()}>
             <NavLink to="/history">History</NavLink>

--- a/src/components/PremiumGate.test.tsx
+++ b/src/components/PremiumGate.test.tsx
@@ -1,0 +1,51 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+
+import {
+  EntitlementContext,
+  EntitlementContextValue,
+} from '~/contexts';
+
+import { PremiumGate } from './PremiumGate';
+
+const base: EntitlementContextValue = {
+  isPremium: false,
+  isTrialing: false,
+  trialExpired: false,
+  trialDaysRemaining: null,
+  effectiveAccess: 'free',
+  isLoading: false,
+  refetch: () => {},
+};
+
+const renderGate = (value: EntitlementContextValue) =>
+  render(
+    <MemoryRouter>
+      <EntitlementContext.Provider value={value}>
+        <PremiumGate featureName="AI Recommendations">
+          <div>secret premium content</div>
+        </PremiumGate>
+      </EntitlementContext.Provider>
+    </MemoryRouter>,
+  );
+
+describe('PremiumGate', () => {
+  test('renders children when access is premium', () => {
+    renderGate({ ...base, effectiveAccess: 'premium' });
+    expect(screen.getByText('secret premium content')).toBeInTheDocument();
+  });
+
+  test('renders locked state when access is free', () => {
+    renderGate(base);
+    expect(screen.queryByText('secret premium content')).not.toBeInTheDocument();
+    expect(screen.getByText('Premium feature')).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: "See what's included" }),
+    ).toBeInTheDocument();
+  });
+
+  test('renders nothing while loading', () => {
+    const { container } = renderGate({ ...base, isLoading: true });
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/src/components/PremiumGate.tsx
+++ b/src/components/PremiumGate.tsx
@@ -1,0 +1,48 @@
+import { LockClosedIcon } from '@radix-ui/react-icons';
+import { ReactNode } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+import { useEntitlement } from '~/contexts';
+
+import { Button } from './ui/button';
+import { Card, CardContent } from './ui/card';
+
+interface PremiumGateProps {
+  children: ReactNode;
+  /** Name of the gated surface, shown in the locked state. */
+  featureName?: string;
+}
+
+/**
+ * Wraps a premium surface. When the user has premium access (paid or trialing)
+ * the children render; otherwise a clean lock treatment routes to the paywall.
+ * This is UX only — the authoritative gate is server-side (has_premium_access +
+ * RLS). Never assume client state is authoritative.
+ */
+export const PremiumGate = ({
+  children,
+  featureName = 'This feature',
+}: PremiumGateProps) => {
+  const { effectiveAccess, isLoading } = useEntitlement();
+  const navigate = useNavigate();
+
+  if (isLoading) return null;
+
+  if (effectiveAccess === 'premium') return <>{children}</>;
+
+  return (
+    <Card className="mx-auto my-2 w-full max-w-md">
+      <CardContent className="flex flex-col items-center gap-2 p-3 text-center">
+        <div className="flex h-5 w-5 items-center justify-center rounded-full bg-secondary text-secondary-foreground">
+          <LockClosedIcon className="h-2.5 w-2.5" />
+        </div>
+        <div className="text-lg font-semibold">Premium feature</div>
+        <p className="text-sm text-muted-foreground">
+          {featureName} is part of BellSkill Premium — the intelligence layer on
+          top of your training.
+        </p>
+        <Button onClick={() => navigate('/paywall')}>See what's included</Button>
+      </CardContent>
+    </Card>
+  );
+};

--- a/src/components/TrialStatusPill.tsx
+++ b/src/components/TrialStatusPill.tsx
@@ -1,0 +1,32 @@
+import { NavLink } from 'react-router-dom';
+
+import { useEntitlement } from '~/contexts';
+
+import { Badge } from './ui/badge';
+
+/**
+ * Subtle trial countdown. Practitioner-grade restraint: nothing until 7 days
+ * remain, a quiet pill from there, and a slightly more visible (destructive)
+ * treatment in the final 48 hours. Never a blocking banner.
+ */
+export const TrialStatusPill = () => {
+  const { isTrialing, trialDaysRemaining } = useEntitlement();
+
+  if (!isTrialing || trialDaysRemaining === null || trialDaysRemaining > 7) {
+    return null;
+  }
+
+  const finalStretch = trialDaysRemaining <= 2;
+  const label =
+    trialDaysRemaining === 1
+      ? '1 day left in trial'
+      : `${trialDaysRemaining} days left in trial`;
+
+  return (
+    <NavLink to="/paywall">
+      <Badge variant={finalStretch ? 'destructive' : 'secondary'}>
+        {label}
+      </Badge>
+    </NavLink>
+  );
+};

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -2,4 +2,6 @@ export * from './Header';
 export * from './Loading';
 export * from './PWAInstallPrompt';
 export * from './Page';
+export * from './PremiumGate';
 export * from './SafeAreaWrapper';
+export * from './TrialStatusPill';

--- a/src/config/features.ts
+++ b/src/config/features.ts
@@ -1,4 +1,5 @@
 export const features = {
   complexMode: import.meta.env.VITE_FEATURE_COMPLEX_MODE === 'true',
   explore: import.meta.env.VITE_FEATURE_EXPLORE === 'true',
+  premium: import.meta.env.VITE_FEATURE_PREMIUM === 'true',
 } as const;

--- a/src/constants/queries.enum.ts
+++ b/src/constants/queries.enum.ts
@@ -1,4 +1,5 @@
 export enum QUERIES {
+  ENTITLEMENT = 'entitlement',
   MOVEMENT_LOGS = 'movementLogs',
   MOVEMENTS = 'movements',
   USER_MOVEMENTS = 'userMovements',

--- a/src/contexts/EntitlementContext.tsx
+++ b/src/contexts/EntitlementContext.tsx
@@ -1,0 +1,41 @@
+import { createContext, useContext } from 'react';
+
+import { Entitlement, useEntitlementQuery } from '~/api/useEntitlement';
+
+export interface EntitlementContextValue extends Entitlement {
+  isLoading: boolean;
+  refetch: () => void;
+}
+
+/**
+ * Conservative default used before the subscription row loads: treat the user as
+ * free so premium surfaces never flash unlocked. Client gating is UX only — the
+ * authoritative gate is server-side (has_premium_access + RLS).
+ */
+const DEFAULT_ENTITLEMENT: Entitlement = {
+  isPremium: false,
+  isTrialing: false,
+  trialExpired: false,
+  trialDaysRemaining: null,
+  effectiveAccess: 'free',
+};
+
+export const EntitlementContext = createContext<EntitlementContextValue>(
+  undefined!,
+);
+
+export const EntitlementProvider = ({ ...props }) => {
+  const { data, isLoading, refetch } = useEntitlementQuery();
+
+  const value: EntitlementContextValue = {
+    ...(data ?? DEFAULT_ENTITLEMENT),
+    isLoading,
+    refetch: () => {
+      refetch();
+    },
+  };
+
+  return <EntitlementContext.Provider value={value} {...props} />;
+};
+
+export const useEntitlement = () => useContext(EntitlementContext);

--- a/src/contexts/index.ts
+++ b/src/contexts/index.ts
@@ -1,2 +1,3 @@
+export * from './EntitlementContext';
 export * from './SessionContext';
 export * from './WorkoutOptionsContext';

--- a/src/examples/profile.examples.ts
+++ b/src/examples/profile.examples.ts
@@ -6,22 +6,40 @@ let id = 1;
 
 export class ExampleProfile implements Profile {
   avatar_url: string | null;
+  current_period_end: string | null;
   full_name: string | null;
   id: string;
+  stripe_customer_id: string | null;
+  stripe_subscription_id: string | null;
+  subscription_status: string | null;
+  subscription_tier: string;
+  trial_ends_at: string | null;
   updated_at: string | null;
   username: string | null;
   website: string | null;
 
   constructor({
     avatar_url = null,
+    current_period_end = null,
     full_name = null,
+    stripe_customer_id = null,
+    stripe_subscription_id = null,
+    subscription_status = null,
+    subscription_tier = 'free',
+    trial_ends_at = null,
     updated_at = '2024-02-20T14:12:05.335714+00:00',
     username = 'lukeskywalker',
     website = null,
   }: Partial<Profile>) {
     this.avatar_url = avatar_url;
+    this.current_period_end = current_period_end;
     this.full_name = full_name;
     this.id = id.toString();
+    this.stripe_customer_id = stripe_customer_id;
+    this.stripe_subscription_id = stripe_subscription_id;
+    this.subscription_status = subscription_status;
+    this.subscription_tier = subscription_tier;
+    this.trial_ends_at = trial_ends_at;
     this.updated_at = updated_at;
     this.username = username;
     this.website = website;

--- a/src/pages/AccountPage/AccountPage.stories.jsx
+++ b/src/pages/AccountPage/AccountPage.stories.jsx
@@ -1,13 +1,25 @@
-import { SessionProvider } from '~/contexts';
+import { EntitlementContext, SessionProvider } from '~/contexts';
 
 import { AccountPage } from './AccountPage';
+
+const freeEntitlement = {
+  isPremium: false,
+  isTrialing: false,
+  trialExpired: false,
+  trialDaysRemaining: null,
+  effectiveAccess: 'free',
+  isLoading: false,
+  refetch: () => {},
+};
 
 export default {
   component: AccountPage,
   decorators: [
     (Story) => (
       <SessionProvider value={{ user: { email: 'luke@skywalker.com' } }}>
-        <Story />
+        <EntitlementContext.Provider value={freeEntitlement}>
+          <Story />
+        </EntitlementContext.Provider>
       </SessionProvider>
     ),
   ],

--- a/src/pages/AccountPage/AccountPage.tsx
+++ b/src/pages/AccountPage/AccountPage.tsx
@@ -5,7 +5,7 @@ import {
   useState,
 } from 'react';
 
-import { Page } from '~/components';
+import { Page, TrialStatusPill } from '~/components';
 import { Button } from '~/components/ui/button';
 import { Input } from '~/components/ui/input';
 import { Label } from '~/components/ui/label';
@@ -67,6 +67,8 @@ export const AccountPage = () => {
 
   return (
     <Page title="Account">
+      <TrialStatusPill />
+
       <form onSubmit={updateProfile} className="flex flex-col space-y-2">
         <Label htmlFor="email">Email</Label>
         <Input id="email" value={session.user.email} disabled={true} />

--- a/src/pages/PaywallPage/PaywallPage.stories.tsx
+++ b/src/pages/PaywallPage/PaywallPage.stories.tsx
@@ -1,0 +1,55 @@
+import { MemoryRouter } from 'react-router-dom';
+
+import {
+  EntitlementContext,
+  EntitlementContextValue,
+} from '~/contexts';
+
+import { PaywallPage } from './PaywallPage';
+
+const withEntitlement = (value: EntitlementContextValue) => (Story: any) =>
+  (
+    <EntitlementContext.Provider value={value}>
+      <Story />
+    </EntitlementContext.Provider>
+  );
+
+const base: EntitlementContextValue = {
+  isPremium: false,
+  isTrialing: false,
+  trialExpired: false,
+  trialDaysRemaining: null,
+  effectiveAccess: 'free',
+  isLoading: false,
+  refetch: () => {},
+};
+
+export default {
+  component: PaywallPage,
+  decorators: [
+    (Story: any) => (
+      <MemoryRouter>
+        <Story />
+      </MemoryRouter>
+    ),
+  ],
+};
+
+export const Trialing = {
+  decorators: [
+    withEntitlement({
+      ...base,
+      isTrialing: true,
+      trialDaysRemaining: 12,
+      effectiveAccess: 'premium',
+    }),
+  ],
+};
+
+export const Expired = {
+  decorators: [withEntitlement({ ...base, trialExpired: true })],
+};
+
+export const Free = {
+  decorators: [withEntitlement(base)],
+};

--- a/src/pages/PaywallPage/PaywallPage.test.tsx
+++ b/src/pages/PaywallPage/PaywallPage.test.tsx
@@ -1,0 +1,36 @@
+import { composeStories } from '@storybook/react';
+import { fireEvent, render, screen } from '@testing-library/react';
+
+import * as stories from './PaywallPage.stories';
+
+const { Trialing, Expired, Free } = composeStories(stories);
+
+describe('paywall page', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  test('trialing variant shows days remaining', () => {
+    render(<Trialing />);
+    expect(screen.getByText('12 days left in your trial')).toBeInTheDocument();
+  });
+
+  test('expired variant reads as the unlock path', () => {
+    render(<Expired />);
+    expect(screen.getByText('Your trial has ended')).toBeInTheDocument();
+  });
+
+  test('free variant shows the generic unlock pitch', () => {
+    render(<Free />);
+    expect(screen.getByText('Unlock BellSkill Premium')).toBeInTheDocument();
+  });
+
+  test('notify-me CTA records intent and confirms', () => {
+    render(<Free />);
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Notify me when Premium launches' }),
+    );
+    expect(localStorage.getItem('premium_notify_intent')).toBe('true');
+    expect(screen.getByText("We'll let you know — thanks!")).toBeInTheDocument();
+  });
+});

--- a/src/pages/PaywallPage/PaywallPage.tsx
+++ b/src/pages/PaywallPage/PaywallPage.tsx
@@ -1,0 +1,149 @@
+import { CheckIcon } from '@radix-ui/react-icons';
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+import { Page } from '~/components';
+import { Badge } from '~/components/ui/badge';
+import { Button } from '~/components/ui/button';
+import { Card, CardContent } from '~/components/ui/card';
+import { useEntitlement } from '~/contexts';
+
+const NOTIFY_INTENT_KEY = 'premium_notify_intent';
+
+const PREMIUM_FEATURES = [
+  'AI session recommendations tuned to your training',
+  'Tetris programming — auto-fitted workouts',
+];
+
+const FREE_FOREVER = [
+  'Workout logging',
+  'Skill tree',
+  'Basic analytics',
+];
+
+interface PaywallHeadline {
+  eyebrow: string | null;
+  title: string;
+  subtitle: string;
+}
+
+const getHeadline = (
+  isTrialing: boolean,
+  trialExpired: boolean,
+  trialDaysRemaining: number | null,
+): PaywallHeadline => {
+  if (isTrialing) {
+    const days = trialDaysRemaining ?? 0;
+    return {
+      eyebrow: `${days} ${days === 1 ? 'day' : 'days'} left in your trial`,
+      title: 'Keep the intelligence layer',
+      subtitle:
+        "You're on full Premium right now. Here's what stays unlocked when your trial ends.",
+    };
+  }
+
+  if (trialExpired) {
+    return {
+      eyebrow: 'Your trial has ended',
+      title: 'Unlock BellSkill Premium',
+      subtitle:
+        'Your logging, skill tree, and analytics are still here. Premium brings back the intelligence layer.',
+    };
+  }
+
+  return {
+    eyebrow: null,
+    title: 'Unlock BellSkill Premium',
+    subtitle: 'The intelligence layer on top of your training.',
+  };
+};
+
+export const PaywallPage = () => {
+  const navigate = useNavigate();
+  const { isTrialing, trialExpired, trialDaysRemaining } = useEntitlement();
+  const [notified, setNotified] = useState<boolean>(
+    () => localStorage.getItem(NOTIFY_INTENT_KEY) === 'true',
+  );
+
+  const headline = getHeadline(isTrialing, trialExpired, trialDaysRemaining);
+
+  const handleNotify = () => {
+    localStorage.setItem(NOTIFY_INTENT_KEY, 'true');
+    setNotified(true);
+    // Phase 2: replace with create-checkout-session + open Stripe Checkout.
+  };
+
+  return (
+    <Page title={null}>
+      <div className="flex flex-col gap-2">
+        <div className="flex flex-col gap-0.5 text-center">
+          {headline.eyebrow && (
+            <Badge variant="secondary" className="mx-auto">
+              {headline.eyebrow}
+            </Badge>
+          )}
+          <h1 className="text-xl font-semibold">{headline.title}</h1>
+          <p className="text-sm text-muted-foreground">{headline.subtitle}</p>
+        </div>
+
+        <Card>
+          <CardContent className="flex flex-col gap-1.5 p-2">
+            <div className="text-sm font-semibold">Premium unlocks</div>
+            {PREMIUM_FEATURES.map((feature) => (
+              <div key={feature} className="flex items-start gap-1 text-sm">
+                <CheckIcon className="mt-0.5 h-2 w-2 shrink-0 text-primary" />
+                <span>{feature}</span>
+              </div>
+            ))}
+            <div className="pt-0.5 text-xs text-muted-foreground">
+              Free forever: {FREE_FOREVER.join(', ')}.
+            </div>
+          </CardContent>
+        </Card>
+
+        <div className="flex gap-1">
+          <Card className="flex-1">
+            <CardContent className="flex flex-col items-center gap-0.5 p-2 text-center">
+              <div className="text-sm text-muted-foreground">Monthly</div>
+              <div className="text-lg font-semibold">$9.99</div>
+              <div className="text-xs text-muted-foreground">per month</div>
+            </CardContent>
+          </Card>
+          <Card className="flex-1 border-primary">
+            <CardContent className="flex flex-col items-center gap-0.5 p-2 text-center">
+              <Badge className="mb-0.5">Best value</Badge>
+              <div className="text-sm text-muted-foreground">Yearly</div>
+              <div className="text-lg font-semibold">$79</div>
+              <div className="text-xs text-muted-foreground">
+                per year — under $6.59/mo
+              </div>
+            </CardContent>
+          </Card>
+        </div>
+
+        <p className="text-center text-xs text-muted-foreground">
+          Cancel anytime. No card required during your trial.
+        </p>
+
+        {/* Phase 1: payments are not live yet, so the CTA records interest. */}
+        {notified ? (
+          <Button variant="secondary" disabled className="w-full">
+            We'll let you know — thanks!
+          </Button>
+        ) : (
+          <Button onClick={handleNotify} className="w-full">
+            Notify me when Premium launches
+          </Button>
+        )}
+
+        <Button
+          variant="ghost"
+          onClick={() => navigate(-1)}
+          className="w-full"
+        >
+          Not now
+        </Button>
+      </div>
+    </Page>
+  );
+};

--- a/src/pages/PaywallPage/index.ts
+++ b/src/pages/PaywallPage/index.ts
@@ -1,0 +1,1 @@
+export * from './PaywallPage';

--- a/src/pages/RecommendationsPage/RecommendationsPage.tsx
+++ b/src/pages/RecommendationsPage/RecommendationsPage.tsx
@@ -1,0 +1,19 @@
+import { Page, PremiumGate } from '~/components';
+
+/**
+ * Placeholder premium surface (PROD-103 demo). The real AI recommendations
+ * feature ships later; for now this gives PremiumGate something real to wrap so
+ * the gate -> paywall flow is testable end to end.
+ */
+export const RecommendationsPage = () => {
+  return (
+    <PremiumGate featureName="AI Recommendations">
+      <Page title="AI Recommendations">
+        <p className="text-sm text-muted-foreground">
+          Personalized session recommendations are coming soon. As a Premium
+          member you'll get AI-tuned workouts based on your training history.
+        </p>
+      </Page>
+    </PremiumGate>
+  );
+};

--- a/src/pages/RecommendationsPage/index.ts
+++ b/src/pages/RecommendationsPage/index.ts
@@ -1,0 +1,1 @@
+export * from './RecommendationsPage';

--- a/src/pages/index.ts
+++ b/src/pages/index.ts
@@ -3,5 +3,7 @@ export * from './ActiveWorkoutPage';
 export * from './CompletedWorkoutPage';
 export * from './HistoryPage';
 export * from './MovementsPage';
+export * from './PaywallPage';
+export * from './RecommendationsPage';
 export * from './SignupPage';
 export * from './StartWorkoutPage';

--- a/supabase/manual/premium_launch_backfill.sql
+++ b/supabase/manual/premium_launch_backfill.sql
@@ -1,0 +1,44 @@
+-- Paywall v1 (PROD-102): premium-launch trial backfill — DO NOT AUTO-APPLY.
+--
+-- This file lives OUTSIDE supabase/migrations/ on purpose. Migrations in that
+-- directory auto-deploy on merge via .github/workflows/supabase-*.yaml. Per the
+-- PROD-99 epic decision, the 30-day trial clock starts at *premium launch* (when
+-- the first premium feature ships), not at signup — so this must run exactly
+-- once, at launch, not before.
+--
+-- HOW TO RUN AT LAUNCH:
+--   1. Replace the launch timestamp below with the actual launch date.
+--   2. Copy this file into supabase/migrations/ with a fresh timestamp prefix
+--      (e.g. 2026MMDDHHMMSS_premium_launch_trial_backfill.sql) and merge — CI
+--      will apply it. Then delete this manual copy.
+--
+-- Epic decision: EVERY existing user gets a fresh 30-day clock regardless of
+-- signup date.
+
+BEGIN;
+
+-- 1. Backfill all existing users to a fresh 30-day trial from launch.
+--    Only stamp rows that don't already have a trial set, so re-running is safe.
+--    The DO block aborts with a clear message if the launch date is still unset,
+--    rather than failing later with a cryptic timestamp parse error.
+DO $$
+DECLARE
+  -- TODO at launch: set to the launch date, e.g. TIMESTAMPTZ '2026-07-01 00:00:00+00'.
+  launch_date timestamptz := NULL;
+BEGIN
+  IF launch_date IS NULL THEN
+    RAISE EXCEPTION 'Set launch_date before running the premium launch backfill.';
+  END IF;
+
+  UPDATE public.profiles
+  SET trial_ends_at = launch_date + interval '30 days'
+  WHERE trial_ends_at IS NULL;
+END $$;
+
+-- 2. New signups from launch onward are auto-stamped server-side (no client
+--    code). The handle_new_user trigger inserts profiles without trial_ends_at,
+--    so this column default supplies the 30-day clock.
+ALTER TABLE public.profiles
+  ALTER COLUMN trial_ends_at SET DEFAULT now() + interval '30 days';
+
+COMMIT;

--- a/supabase/migrations/20260612000000_add_subscription_entitlement.sql
+++ b/supabase/migrations/20260612000000_add_subscription_entitlement.sql
@@ -1,0 +1,55 @@
+-- Paywall v1 (PROD-100): subscription state on profiles + has_premium_access().
+--
+-- Phase 1: no payments wired. trial_ends_at is left nullable with NO default;
+-- the trial-start default and the launch backfill are gated to premium launch
+-- (see supabase/manual/premium_launch_backfill.sql). Until then nobody is
+-- "trialing" — has_premium_access returns false for everyone, which is correct
+-- because no premium feature exists to gate yet.
+
+ALTER TABLE public.profiles
+  ADD COLUMN subscription_tier text NOT NULL DEFAULT 'free'
+    CHECK (subscription_tier IN ('free', 'premium')),
+  ADD COLUMN trial_ends_at timestamptz,
+  ADD COLUMN stripe_customer_id text,
+  ADD COLUMN stripe_subscription_id text,
+  ADD COLUMN subscription_status text,
+  ADD COLUMN current_period_end timestamptz;
+
+-- Write-lock the subscription columns from clients. RLS governs row access but
+-- cannot restrict individual columns, so we use column-level privileges: revoke
+-- blanket UPDATE/INSERT from authenticated and grant them back only on the
+-- user-editable profile columns. The subscription columns become writable solely
+-- by the service role (the Stripe webhook Edge Function in Phase 2 / PROD-105).
+--
+-- INSERT must be locked too, not just UPDATE: profiles has an INSERT policy
+-- (auth.uid() = id) AND a DELETE policy, so a user could otherwise delete their
+-- own row and re-insert it with subscription_tier='premium', self-granting
+-- premium. Column-level INSERT keeps the legitimate client insert path
+-- (resolveAuthSession's ensureProfile inserts id/full_name/avatar_url) working
+-- while making the subscription columns un-settable from the client.
+REVOKE UPDATE, INSERT ON public.profiles FROM authenticated;
+GRANT UPDATE (username, full_name, avatar_url, website, updated_at)
+  ON public.profiles TO authenticated;
+GRANT INSERT (id, username, full_name, avatar_url, website, updated_at)
+  ON public.profiles TO authenticated;
+
+-- Single source of truth for the entitlement rule. Phase-2 RLS policies on
+-- premium feature tables and any future FastAPI endpoint derive from this; the
+-- client useEntitlement hook mirrors the same rule for UX only.
+CREATE OR REPLACE FUNCTION public.has_premium_access(user_id uuid)
+  RETURNS boolean
+  LANGUAGE sql
+  STABLE
+  SECURITY DEFINER
+  SET search_path = ''
+AS $$
+  SELECT EXISTS (
+    SELECT 1
+    FROM public.profiles p
+    WHERE p.id = user_id
+      AND (
+        p.subscription_tier = 'premium'
+        OR (p.trial_ends_at IS NOT NULL AND now() < p.trial_ends_at)
+      )
+  );
+$$;

--- a/types/supabase.ts
+++ b/types/supabase.ts
@@ -266,24 +266,42 @@ export type Database = {
       profiles: {
         Row: {
           avatar_url: string | null
+          current_period_end: string | null
           full_name: string | null
           id: string
+          stripe_customer_id: string | null
+          stripe_subscription_id: string | null
+          subscription_status: string | null
+          subscription_tier: string
+          trial_ends_at: string | null
           updated_at: string | null
           username: string | null
           website: string | null
         }
         Insert: {
           avatar_url?: string | null
+          current_period_end?: string | null
           full_name?: string | null
           id: string
+          stripe_customer_id?: string | null
+          stripe_subscription_id?: string | null
+          subscription_status?: string | null
+          subscription_tier?: string
+          trial_ends_at?: string | null
           updated_at?: string | null
           username?: string | null
           website?: string | null
         }
         Update: {
           avatar_url?: string | null
+          current_period_end?: string | null
           full_name?: string | null
           id?: string
+          stripe_customer_id?: string | null
+          stripe_subscription_id?: string | null
+          subscription_status?: string | null
+          subscription_tier?: string
+          trial_ends_at?: string | null
           updated_at?: string | null
           username?: string | null
           website?: string | null
@@ -465,7 +483,12 @@ export type Database = {
       }
     }
     Functions: {
-      [_ in never]: never
+      has_premium_access: {
+        Args: {
+          user_id: string
+        }
+        Returns: boolean
+      }
     }
     Enums: {
       "Body Region":

--- a/types/supabase.ts
+++ b/types/supabase.ts
@@ -483,12 +483,7 @@ export type Database = {
       }
     }
     Functions: {
-      has_premium_access: {
-        Args: {
-          user_id: string
-        }
-        Returns: boolean
-      }
+      has_premium_access: { Args: { user_id: string }; Returns: boolean }
     }
     Enums: {
       "Body Region":


### PR DESCRIPTION
Phase 1 of the [PROD-99](https://linear.app/bellskill/issue/PROD-99) paywall epic — trial infrastructure, entitlement gating, and the paywall screen. Premium unlocks future AI features; the free tier keeps logging, skill tree, and analytics. Every user gets a 30-day full-access trial. **Payments are not wired in this PR** (Phase 2 = Stripe, Phase 3 = Apple — both out of scope and blocked on external setup + Capacitor, which isn't installed).

Closes PROD-100, PROD-101, PROD-102, PROD-103.

**Changes:**
- **DB (PROD-100):** `supabase/migrations/20260612000000_add_subscription_entitlement.sql` adds subscription columns to `profiles`, the `has_premium_access(user_id)` function (single source of truth: `tier='premium' OR (trial_ends_at IS NOT NULL AND now() < trial_ends_at)`), and **column-level INSERT/UPDATE locks** so clients cannot write subscription state — only the service role (Phase-2 webhook) can.
- **Entitlement layer (PROD-101):** `useEntitlement` hook with a pure, tested `deriveEntitlement()` that mirrors the SQL rule; `EntitlementContext` provided app-wide in `App.tsx`; `PremiumGate` component. Client gating is UX-only — the authoritative gate is server-side RLS + `has_premium_access`.
- **Trial lifecycle (PROD-102):** `TrialStatusPill` (hidden until ≤7 days, emphasized in the final 48h) on the Account page; graceful auto-downgrade at expiry. The premium-launch backfill lives in `supabase/manual/` and is intentionally **not** auto-deployed — it runs once at launch (everyone gets a fresh 30-day clock).
- **Paywall (PROD-103):** `PaywallPage` with trial-aware variants (trialing / expired / free), \$9.99·mo or \$79·yr pricing, honest copy, and a notify-me CTA (Phase-2 checkout seam left in place).
- Placeholder gated `RecommendationsPage` behind the `premium` feature flag so the gate→paywall flow is real and testable.

**Security note (caught in review):** the original migration only locked `UPDATE`. Because `profiles` also has INSERT + DELETE RLS policies, a user could have deleted and re-inserted their own row with `subscription_tier='premium'` to self-grant premium. The migration now locks INSERT with column-level grants too — verified that escalation inserts are rejected while legitimate `ensureProfile` inserts still succeed.

**Testing:**
- 13 new unit/integration tests (entitlement derivation across all 4 states, `PremiumGate`, paywall variants, notify-me CTA). Full suite: **251/251 green**.
- `tsc` clean for all changed files; project lint unaffected.
- Verified against local Postgres (rolled-back transactions): `has_premium_access` returns correct results for active-trial / expired / premium / free; the column-level write-lock blocks `subscription_tier` updates **and** inserts while leaving `username` edits and legitimate profile inserts working.

**Follow-ups before merge:** run `npm run gen:types` to regenerate `types/supabase.ts` (columns were hand-added to keep TS compiling). The migration deploys via the existing GitHub Actions path on merge. The `recommendations` route/nav are gated behind `VITE_FEATURE_PREMIUM` (off by default).

🤖 Generated with [Claude Code](https://claude.com/claude-code)