### PR TITLE
PROD-104: create-checkout-session Edge Function (Stripe, web PWA)

### DIFF
--- a/.github/workflows/supabase-production.yaml
+++ b/.github/workflows/supabase-production.yaml
@@ -26,3 +26,4 @@ jobs:
 
       - run: supabase link --project-ref $SUPABASE_PROJECT_ID
       - run: supabase db push
+      - run: supabase functions deploy create-checkout-session --project-ref $SUPABASE_PROJECT_ID

--- a/.github/workflows/supabase-staging.yaml
+++ b/.github/workflows/supabase-staging.yaml
@@ -33,3 +33,4 @@ jobs:
 
       - run: supabase link --project-ref $SUPABASE_PROJECT_ID
       - run: supabase db push
+      - run: supabase functions deploy create-checkout-session --project-ref $SUPABASE_PROJECT_ID

--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,9 @@ supabase/.temp
 # E2E test env (contains local Supabase keys)
 .env.e2e
 
+# Edge Function local secrets (Stripe keys etc.)
+supabase/functions/.env
+
 # Playwright
 playwright-report
 test-results

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,3 +1,4 @@
+export * from './useCreateCheckoutSession';
 export * from './useDeleteWorkoutLog';
 export * from './useEntitlement';
 export * from './useLinkMovementLog';

--- a/src/api/useCreateCheckoutSession.ts
+++ b/src/api/useCreateCheckoutSession.ts
@@ -1,0 +1,25 @@
+import { useMutation } from 'react-query';
+
+import { supabase } from '../supabaseClient';
+
+export type CheckoutPlan = 'monthly' | 'yearly';
+
+const createCheckoutSession = async (plan: CheckoutPlan): Promise<string> => {
+  const { data, error } = await supabase.functions.invoke<{ url: string }>(
+    'create-checkout-session',
+    { body: { plan } },
+  );
+
+  if (error) throw error;
+  if (!data?.url) throw new Error('No checkout URL returned');
+
+  return data.url;
+};
+
+/**
+ * Calls the create-checkout-session Edge Function and resolves to the Stripe
+ * Checkout URL. The caller is responsible for the redirect — the full CTA →
+ * redirect → return flow lands in PROD-106.
+ */
+export const useCreateCheckoutSession = () =>
+  useMutation((plan: CheckoutPlan) => createCheckoutSession(plan));

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -260,6 +260,11 @@ inspector_port = 8083
 # Supported file extensions are: .ts, .js, .mjs, .jsx, .tsx
 # entrypoint = "./functions/MY_FUNCTION_NAME/index.ts"
 
+[functions.create-checkout-session]
+enabled = true
+verify_jwt = true
+import_map = "./functions/create-checkout-session/deno.json"
+
 [analytics]
 enabled = true
 port = 54327

--- a/supabase/functions/.env.example
+++ b/supabase/functions/.env.example
@@ -1,0 +1,11 @@
+# Local secrets for `supabase functions serve --env-file supabase/functions/.env`.
+# Copy to `supabase/functions/.env` (gitignored) and fill in TEST-mode values.
+# Deployed secrets are set separately via the Supabase Dashboard (Edge Functions -> Secrets).
+#
+# SUPABASE_URL / SUPABASE_ANON_KEY / SUPABASE_SERVICE_ROLE_KEY are injected
+# automatically by the local stack, so they don't need to go here.
+
+STRIPE_SECRET_KEY=sk_test_xxx
+STRIPE_PRICE_MONTHLY=price_1ThcqnCib7R9SbHP2cggT7O8
+STRIPE_PRICE_YEARLY=price_1ThcrACib7R9SbHPaIUjx6lS
+SITE_URL=http://localhost:5173

--- a/supabase/functions/_shared/cors.ts
+++ b/supabase/functions/_shared/cors.ts
@@ -1,0 +1,16 @@
+// Shared CORS handling for Edge Functions. The browser calls these via
+// supabase.functions.invoke, which issues an OPTIONS preflight first.
+export const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers':
+    'authorization, x-client-info, apikey, content-type',
+  'Access-Control-Allow-Methods': 'POST, OPTIONS',
+};
+
+/** Returns a preflight response for OPTIONS requests, or null otherwise. */
+export function handleCors(req: Request): Response | null {
+  if (req.method === 'OPTIONS') {
+    return new Response('ok', { headers: corsHeaders });
+  }
+  return null;
+}

--- a/supabase/functions/create-checkout-session/deno.json
+++ b/supabase/functions/create-checkout-session/deno.json
@@ -1,0 +1,6 @@
+{
+  "imports": {
+    "stripe": "https://esm.sh/stripe@17.7.0?target=deno",
+    "@supabase/supabase-js": "https://esm.sh/@supabase/supabase-js@2.45.0"
+  }
+}

--- a/supabase/functions/create-checkout-session/index.ts
+++ b/supabase/functions/create-checkout-session/index.ts
@@ -1,0 +1,105 @@
+// create-checkout-session (PROD-104)
+//
+// Authenticated endpoint that creates a Stripe Checkout Session for a premium
+// subscription. The user is derived from the JWT (never trusted from the body),
+// and the price is mapped server-side from a `plan` selector so the client can
+// never choose an arbitrary price.
+//
+// This function creates/reuses the Stripe customer and writes stripe_customer_id
+// via the service role (that column is write-locked from clients). The webhook
+// (PROD-105) owns the rest of the subscription state.
+
+import { createClient } from '@supabase/supabase-js';
+import Stripe from 'stripe';
+
+import { corsHeaders, handleCors } from '../_shared/cors.ts';
+
+const stripe = new Stripe(Deno.env.get('STRIPE_SECRET_KEY') ?? '', {
+  httpClient: Stripe.createFetchHttpClient(),
+});
+
+const PRICE_BY_PLAN: Record<string, string | undefined> = {
+  monthly: Deno.env.get('STRIPE_PRICE_MONTHLY'),
+  yearly: Deno.env.get('STRIPE_PRICE_YEARLY'),
+};
+
+function json(body: unknown, status: number): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+  });
+}
+
+Deno.serve(async (req: Request) => {
+  const preflight = handleCors(req);
+  if (preflight) return preflight;
+
+  if (req.method !== 'POST') return json({ error: 'Method not allowed' }, 405);
+
+  try {
+    const authHeader = req.headers.get('Authorization');
+    if (!authHeader) return json({ error: 'Missing authorization' }, 401);
+
+    // (1) Identity: anon client bound to the caller's JWT.
+    const authClient = createClient(
+      Deno.env.get('SUPABASE_URL') ?? '',
+      Deno.env.get('SUPABASE_ANON_KEY') ?? '',
+      { global: { headers: { Authorization: authHeader } } },
+    );
+    const {
+      data: { user },
+      error: userErr,
+    } = await authClient.auth.getUser();
+    if (userErr || !user) return json({ error: 'Unauthorized' }, 401);
+
+    // Map plan -> price id server-side; never trust a client-supplied price.
+    const { plan } = await req.json().catch(() => ({}));
+    const price = PRICE_BY_PLAN[plan];
+    if (!price) return json({ error: 'Invalid plan' }, 400);
+
+    // (2) Service-role client for the write-locked stripe_customer_id column.
+    const admin = createClient(
+      Deno.env.get('SUPABASE_URL') ?? '',
+      Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') ?? '',
+    );
+
+    const { data: profile, error: profErr } = await admin
+      .from('profiles')
+      .select('stripe_customer_id')
+      .eq('id', user.id)
+      .single();
+    if (profErr) throw profErr;
+
+    // Create or reuse the Stripe customer; persist on first creation.
+    let customerId: string | null = profile?.stripe_customer_id ?? null;
+    if (!customerId) {
+      const customer = await stripe.customers.create({
+        email: user.email,
+        metadata: { supabase_user_id: user.id },
+      });
+      customerId = customer.id;
+
+      const { error: updErr } = await admin
+        .from('profiles')
+        .update({ stripe_customer_id: customerId })
+        .eq('id', user.id);
+      if (updErr) throw updErr;
+    }
+
+    const siteUrl = Deno.env.get('SITE_URL') ?? '';
+    const session = await stripe.checkout.sessions.create({
+      mode: 'subscription',
+      customer: customerId,
+      line_items: [{ price, quantity: 1 }],
+      client_reference_id: user.id,
+      success_url: `${siteUrl}/checkout/success?session_id={CHECKOUT_SESSION_ID}`,
+      cancel_url: `${siteUrl}/checkout/cancel`,
+      allow_promotion_codes: false,
+    });
+
+    return json({ url: session.url }, 200);
+  } catch (err) {
+    console.error('create-checkout-session error:', err);
+    return json({ error: 'Internal error' }, 500);
+  }
+});


### PR DESCRIPTION
First Supabase Edge Function in the repo — the server side of paywall checkout ([PROD-104](https://linear.app/bellskill/issue/PROD-104)), part of Phase 2 (web-only PWA; Capacitor deferred). Creates a Stripe Checkout Session for a premium subscription. Webhook (PROD-105) and the CTA→redirect→return flow (PROD-106) are separate tickets.

**Changes:**
- `supabase/functions/create-checkout-session/index.ts` — authenticated endpoint. Derives the user from the JWT (never trusts a body-supplied user id), maps `{plan: monthly|yearly}` → price id from env (never trusts a client price). Creates/reuses the Stripe customer and writes `stripe_customer_id` via the **service role** (that column is write-locked from clients); the webhook owns the rest of the subscription state. Returns the Checkout URL with `client_reference_id = user.id`; success/cancel URLs point at `/checkout/*` web routes (built in PROD-106).
- `supabase/functions/_shared/cors.ts` + `create-checkout-session/deno.json` — establish the Edge Function convention (shared CORS, per-function import map).
- `supabase/config.toml` — `[functions.create-checkout-session]` with `verify_jwt = true`.
- `src/api/useCreateCheckoutSession.ts` — client invoke hook (exported; **not yet wired to the paywall CTA** — that's PROD-106).
- Both CI workflows now `supabase functions deploy create-checkout-session` after `db push` (they previously only pushed migrations).
- `.gitignore` + `.env.example` for the local function secrets; no Stripe key is in the repo.

**Testing (local, up to the Stripe call):**
| Case | Result |
|---|---|
| OPTIONS preflight | 200 + CORS header |
| No `Authorization` | 401 |
| Valid JWT + invalid plan | 400 (auth + validation run pre-Stripe) |
| Valid JWT + valid plan (dummy key) | reaches `stripe.customers.create()` → `StripeAuthenticationError` |

The last case proves the full path is wired (authed user → service-role profile read → Stripe call), failing only on the placeholder key. Full happy-path with a real test key (open Checkout URL, verify `client_reference_id` + `stripe_customer_id` written) is run separately with secrets set. App test suite: 251/251; client typechecks clean.

**Deploy note:** the new `functions deploy` CI step runs on merge; it deploys fine even before runtime secrets are set (the function just 500s until they exist), and nothing is user-facing yet (CTA is still notify-me). Secrets are set via the Supabase Dashboard, not committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)