### PR TITLE
PROD-105: stripe-webhook Edge Function (sole writer of subscription state)

### DIFF
--- a/.github/workflows/supabase-production.yaml
+++ b/.github/workflows/supabase-production.yaml
@@ -27,3 +27,4 @@ jobs:
       - run: supabase link --project-ref $SUPABASE_PROJECT_ID
       - run: supabase db push
       - run: supabase functions deploy create-checkout-session --project-ref $SUPABASE_PROJECT_ID
+      - run: supabase functions deploy stripe-webhook --project-ref $SUPABASE_PROJECT_ID

--- a/.github/workflows/supabase-staging.yaml
+++ b/.github/workflows/supabase-staging.yaml
@@ -34,3 +34,4 @@ jobs:
       - run: supabase link --project-ref $SUPABASE_PROJECT_ID
       - run: supabase db push
       - run: supabase functions deploy create-checkout-session --project-ref $SUPABASE_PROJECT_ID
+      - run: supabase functions deploy stripe-webhook --project-ref $SUPABASE_PROJECT_ID

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -265,6 +265,12 @@ enabled = true
 verify_jwt = true
 import_map = "./functions/create-checkout-session/deno.json"
 
+# Called by Stripe (no Supabase JWT) — authenticated by the Stripe signature.
+[functions.stripe-webhook]
+enabled = true
+verify_jwt = false
+import_map = "./functions/stripe-webhook/deno.json"
+
 [analytics]
 enabled = true
 port = 54327

--- a/supabase/functions/.env.example
+++ b/supabase/functions/.env.example
@@ -9,3 +9,7 @@ STRIPE_SECRET_KEY=sk_test_xxx
 STRIPE_PRICE_MONTHLY=price_1ThcqnCib7R9SbHP2cggT7O8
 STRIPE_PRICE_YEARLY=price_1ThcrACib7R9SbHPaIUjx6lS
 SITE_URL=http://localhost:5173
+
+# stripe-webhook: local signing secret from `stripe listen --forward-to \
+#   http://localhost:54321/functions/v1/stripe-webhook`
+STRIPE_WEBHOOK_SECRET=whsec_xxx

--- a/supabase/functions/stripe-webhook/deno.json
+++ b/supabase/functions/stripe-webhook/deno.json
@@ -1,0 +1,6 @@
+{
+  "imports": {
+    "stripe": "https://esm.sh/stripe@17.7.0?target=deno",
+    "@supabase/supabase-js": "https://esm.sh/@supabase/supabase-js@2.45.0"
+  }
+}

--- a/supabase/functions/stripe-webhook/index.ts
+++ b/supabase/functions/stripe-webhook/index.ts
@@ -1,0 +1,140 @@
+// stripe-webhook (PROD-105)
+//
+// The ONLY writer of the subscription state columns. Keeps Supabase in sync with
+// Stripe. Authenticated by the Stripe signature (no Supabase JWT). On every
+// subscription event it re-fetches the live subscription from Stripe and writes
+// that authoritative state, which makes handling idempotent and safe against
+// out-of-order / replayed events.
+
+import { createClient } from '@supabase/supabase-js';
+import Stripe from 'stripe';
+
+const stripe = new Stripe(Deno.env.get('STRIPE_SECRET_KEY') ?? '', {
+  httpClient: Stripe.createFetchHttpClient(),
+});
+// Deno requires the async/SubtleCrypto signature verification path.
+const cryptoProvider = Stripe.createSubtleCryptoProvider();
+const webhookSecret = Deno.env.get('STRIPE_WEBHOOK_SECRET') ?? '';
+
+// Service-role client: bypasses RLS / the column write-lock to write the
+// service-role-only subscription columns.
+const admin = createClient(
+  Deno.env.get('SUPABASE_URL') ?? '',
+  Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') ?? '',
+);
+
+// Stripe statuses that should retain premium access. past_due keeps access
+// through the dunning window Stripe manages; terminal states downgrade to free.
+const PREMIUM_STATUSES = new Set(['active', 'trialing', 'past_due']);
+const tierFor = (status: string) =>
+  PREMIUM_STATUSES.has(status) ? 'premium' : 'free';
+
+type ProfileFilter = { column: 'id' | 'stripe_customer_id'; value: string };
+
+// deno-lint-ignore no-explicit-any
+async function writeSubscriptionState(filter: ProfileFilter, sub: any) {
+  const update: Record<string, unknown> = {
+    subscription_tier: tierFor(sub.status),
+    subscription_status: sub.status,
+    stripe_subscription_id: sub.id,
+    current_period_end: sub.current_period_end
+      ? new Date(sub.current_period_end * 1000).toISOString()
+      : null,
+  };
+
+  const { error, count } = await admin
+    .from('profiles')
+    .update(update, { count: 'exact' })
+    .eq(filter.column, filter.value);
+
+  if (error) throw error;
+  return count ?? 0;
+}
+
+Deno.serve(async (req: Request) => {
+  if (req.method !== 'POST') {
+    return new Response('Method not allowed', { status: 405 });
+  }
+
+  const signature = req.headers.get('stripe-signature');
+  const body = await req.text(); // raw body — required for signature verification
+
+  let event: Stripe.Event;
+  try {
+    event = await stripe.webhooks.constructEventAsync(
+      body,
+      signature ?? '',
+      webhookSecret,
+      undefined,
+      cryptoProvider,
+    );
+  } catch (err) {
+    console.error('[stripe-webhook] signature verification failed:', err.message);
+    return new Response('Invalid signature', { status: 400 });
+  }
+
+  try {
+    switch (event.type) {
+      case 'checkout.session.completed': {
+        // deno-lint-ignore no-explicit-any
+        const session = event.data.object as any;
+        const userId: string | null = session.client_reference_id ?? null;
+        const customerId: string | null = session.customer ?? null;
+        const subId: string | null = session.subscription ?? null;
+
+        if (!userId || !subId) {
+          console.warn(
+            `[stripe-webhook] ${event.id} checkout.session.completed missing user/subscription`,
+          );
+          break;
+        }
+
+        const sub = await stripe.subscriptions.retrieve(subId);
+        // (Re)link the customer in case create-checkout-session didn't persist it.
+        if (customerId) {
+          await admin
+            .from('profiles')
+            .update({ stripe_customer_id: customerId })
+            .eq('id', userId);
+        }
+        const rows = await writeSubscriptionState(
+          { column: 'id', value: userId },
+          sub,
+        );
+        console.log(
+          `[stripe-webhook] ${event.id} checkout.session.completed user=${userId} status=${sub.status} rows=${rows}`,
+        );
+        break;
+      }
+
+      case 'customer.subscription.updated':
+      case 'customer.subscription.deleted': {
+        // deno-lint-ignore no-explicit-any
+        const obj = event.data.object as any;
+        // Re-fetch for authoritative latest state (out-of-order safety).
+        const sub = await stripe.subscriptions.retrieve(obj.id);
+        const customerId = String(sub.customer);
+        const rows = await writeSubscriptionState(
+          { column: 'stripe_customer_id', value: customerId },
+          sub,
+        );
+        console.log(
+          `[stripe-webhook] ${event.id} ${event.type} customer=${customerId} status=${sub.status} rows=${rows}`,
+        );
+        break;
+      }
+
+      default:
+        console.log(`[stripe-webhook] ${event.id} ${event.type} ignored`);
+    }
+
+    return new Response(JSON.stringify({ received: true }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  } catch (err) {
+    // 500 so Stripe retries.
+    console.error(`[stripe-webhook] ${event.id} ${event.type} handler error:`, err);
+    return new Response('Handler error', { status: 500 });
+  }
+});


### PR DESCRIPTION
The webhook that keeps Supabase in sync with Stripe — the **sole writer** of the subscription state columns ([PROD-105](https://linear.app/bellskill/issue/PROD-105)). Closes the loop [PROD-104](https://linear.app/bellskill/issue/PROD-104) left open: completing a payment now flips the user to premium. Phase 2 (web-only). No client changes.

**Changes:**
- `supabase/functions/stripe-webhook/index.ts` — authenticated by the **Stripe signature** (`verify_jwt = false`), verified off the raw body via `constructEventAsync` + SubtleCrypto. Handles:
  - `checkout.session.completed` → maps by `client_reference_id`, (re)links `stripe_customer_id`.
  - `customer.subscription.updated` / `deleted` → maps by `stripe_customer_id` (these carry no `client_reference_id`, which is why PROD-104 persisted it).
  - On every event it **re-fetches the live subscription from Stripe** and writes the authoritative state via the **service role**, making handling idempotent and safe against replayed / out-of-order events (no schema change).
  - **`past_due` keeps premium**; downgrade to `free` only on terminal states → cancel-at-period-end stays premium until the `deleted` event at period end.
  - Per-event logging (`event.id`, type, user/customer, outcome).
- `supabase/config.toml` — `[functions.stripe-webhook]` with `verify_jwt = false`.
- Both CI workflows now also `supabase functions deploy stripe-webhook`.
- `.env.example` documents `STRIPE_WEBHOOK_SECRET` (local value from `stripe listen`).

**Testing (local, real Stripe test subscription + self-signed events):** drove a real test subscription on a real customer and posted properly-signed webhook events. **11/11 checks passed:**

| Case | Result |
|---|---|
| Bad signature | 400 |
| `customer.subscription.updated` (active) | → premium by customer mapping; `has_premium_access = true`; `stripe_subscription_id` stored |
| `checkout.session.completed` | → premium by `client_reference_id` |
| `customer.subscription.deleted` | → free; `has_premium_access = false` (re-fetch saw `canceled`) |
| Replay deleted event | no state change (idempotent) |

`past_due` (keeps premium) is covered by the `active`/`past_due → premium` mapping, bracketed by the verified active→premium and canceled→free cases.

**Out-of-band before this works in deployed envs (DJ):** register the Stripe webhook endpoint per mode → `https://<project>.supabase.co/functions/v1/stripe-webhook` (events: `checkout.session.completed`, `customer.subscription.updated`, `customer.subscription.deleted`), and set `STRIPE_WEBHOOK_SECRET` per environment in the Supabase Dashboard. The CI deploy step runs on merge regardless (function just won't verify events until the secret is set).

🤖 Generated with [Claude Code](https://claude.com/claude-code)