### PR TITLE
PROD-106: checkout round-trip + Customer Portal (web PWA)

### DIFF
--- a/.github/workflows/supabase-production.yaml
+++ b/.github/workflows/supabase-production.yaml
@@ -28,3 +28,4 @@ jobs:
       - run: supabase db push
       - run: supabase functions deploy create-checkout-session --project-ref $SUPABASE_PROJECT_ID
       - run: supabase functions deploy stripe-webhook --project-ref $SUPABASE_PROJECT_ID
+      - run: supabase functions deploy create-portal-session --project-ref $SUPABASE_PROJECT_ID

--- a/.github/workflows/supabase-staging.yaml
+++ b/.github/workflows/supabase-staging.yaml
@@ -35,3 +35,4 @@ jobs:
       - run: supabase db push
       - run: supabase functions deploy create-checkout-session --project-ref $SUPABASE_PROJECT_ID
       - run: supabase functions deploy stripe-webhook --project-ref $SUPABASE_PROJECT_ID
+      - run: supabase functions deploy create-portal-session --project-ref $SUPABASE_PROJECT_ID

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,4 +1,5 @@
 export * from './useCreateCheckoutSession';
+export * from './useCreatePortalSession';
 export * from './useDeleteWorkoutLog';
 export * from './useEntitlement';
 export * from './useLinkMovementLog';

--- a/src/api/useCreatePortalSession.ts
+++ b/src/api/useCreatePortalSession.ts
@@ -1,0 +1,21 @@
+import { useMutation } from 'react-query';
+
+import { supabase } from '../supabaseClient';
+
+const createPortalSession = async (): Promise<string> => {
+  const { data, error } = await supabase.functions.invoke<{ url: string }>(
+    'create-portal-session',
+  );
+
+  if (error) throw error;
+  if (!data?.url) throw new Error('No portal URL returned');
+
+  return data.url;
+};
+
+/**
+ * Calls the create-portal-session Edge Function and resolves to the Stripe
+ * Customer Portal URL. The caller redirects to it.
+ */
+export const useCreatePortalSession = () =>
+  useMutation(() => createPortalSession());

--- a/src/app/routes.tsx
+++ b/src/app/routes.tsx
@@ -4,6 +4,8 @@ import { features } from '../config/features';
 import {
   AccountPage,
   ActiveWorkoutPage,
+  CheckoutCancelPage,
+  CheckoutSuccessPage,
   CompletedWorkoutPage,
   HistoryPage,
   MovementsPage,
@@ -41,6 +43,14 @@ export const routes: RouteObject[] = [
       {
         path: 'paywall',
         element: <PaywallPage />,
+      },
+      {
+        path: 'checkout/success',
+        element: <CheckoutSuccessPage />,
+      },
+      {
+        path: 'checkout/cancel',
+        element: <CheckoutCancelPage />,
       },
       ...(features.explore ? [{ path: 'movements', element: <MovementsPage /> }] : []),
       ...(features.premium

--- a/src/pages/AccountPage/AccountPage.stories.jsx
+++ b/src/pages/AccountPage/AccountPage.stories.jsx
@@ -1,3 +1,6 @@
+import { QueryClient, QueryClientProvider } from 'react-query';
+import { MemoryRouter } from 'react-router-dom';
+
 import { EntitlementContext, SessionProvider } from '~/contexts';
 
 import { AccountPage } from './AccountPage';
@@ -16,11 +19,15 @@ export default {
   component: AccountPage,
   decorators: [
     (Story) => (
-      <SessionProvider value={{ user: { email: 'luke@skywalker.com' } }}>
-        <EntitlementContext.Provider value={freeEntitlement}>
-          <Story />
-        </EntitlementContext.Provider>
-      </SessionProvider>
+      <QueryClientProvider client={new QueryClient()}>
+        <MemoryRouter>
+          <SessionProvider value={{ user: { email: 'luke@skywalker.com' } }}>
+            <EntitlementContext.Provider value={freeEntitlement}>
+              <Story />
+            </EntitlementContext.Provider>
+          </SessionProvider>
+        </MemoryRouter>
+      </QueryClientProvider>
     ),
   ],
 };

--- a/src/pages/AccountPage/AccountPage.tsx
+++ b/src/pages/AccountPage/AccountPage.tsx
@@ -5,18 +5,30 @@ import {
   useState,
 } from 'react';
 
+import { useCreatePortalSession } from '~/api';
 import { Page, TrialStatusPill } from '~/components';
 import { Button } from '~/components/ui/button';
 import { Input } from '~/components/ui/input';
 import { Label } from '~/components/ui/label';
-import { useSession } from '~/contexts';
+import { useEntitlement, useSession } from '~/contexts';
 import { supabase } from '~/supabaseClient';
 
 export const AccountPage = () => {
   const session = useSession();
+  const { isPremium } = useEntitlement();
+  const { mutate: openPortal, isLoading: portalLoading } =
+    useCreatePortalSession();
 
   const [loading, setLoading] = useState<boolean>(true);
   const [username, setUsername] = useState<string>('');
+
+  const handleManageSubscription = () => {
+    openPortal(undefined, {
+      onSuccess: (url) => {
+        window.location.href = url;
+      },
+    });
+  };
 
   useEffect(() => {
     async function getProfile() {
@@ -82,6 +94,19 @@ export const AccountPage = () => {
           </Button>
         </div>
       </form>
+
+      {isPremium && (
+        <div className="flex flex-col gap-1 border-t pt-2">
+          <Label>Subscription</Label>
+          <Button
+            variant="outline"
+            onClick={handleManageSubscription}
+            loading={portalLoading}
+          >
+            Manage Subscription
+          </Button>
+        </div>
+      )}
     </Page>
   );
 };

--- a/src/pages/CheckoutCancelPage/CheckoutCancelPage.test.tsx
+++ b/src/pages/CheckoutCancelPage/CheckoutCancelPage.test.tsx
@@ -1,0 +1,19 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+
+import { CheckoutCancelPage } from './CheckoutCancelPage';
+
+describe('CheckoutCancelPage', () => {
+  test('reads as canceled with no guilt and offers a way back', () => {
+    render(
+      <MemoryRouter>
+        <CheckoutCancelPage />
+      </MemoryRouter>,
+    );
+    expect(screen.getByText('Checkout canceled')).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Back to plans' }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Not now' })).toBeInTheDocument();
+  });
+});

--- a/src/pages/CheckoutCancelPage/CheckoutCancelPage.tsx
+++ b/src/pages/CheckoutCancelPage/CheckoutCancelPage.tsx
@@ -1,0 +1,31 @@
+import { useNavigate } from 'react-router-dom';
+
+import { Page } from '~/components';
+import { Button } from '~/components/ui/button';
+
+export const CheckoutCancelPage = () => {
+  const navigate = useNavigate();
+
+  return (
+    <Page title={null}>
+      <div className="flex flex-col items-center gap-2 py-3 text-center">
+        <h1 className="text-xl font-semibold">Checkout canceled</h1>
+        <p className="text-sm text-muted-foreground">
+          No charge was made. You can upgrade whenever you're ready.
+        </p>
+        <div className="flex w-full flex-col gap-1">
+          <Button onClick={() => navigate('/paywall')} className="w-full">
+            Back to plans
+          </Button>
+          <Button
+            variant="ghost"
+            onClick={() => navigate('/')}
+            className="w-full"
+          >
+            Not now
+          </Button>
+        </div>
+      </div>
+    </Page>
+  );
+};

--- a/src/pages/CheckoutCancelPage/index.ts
+++ b/src/pages/CheckoutCancelPage/index.ts
@@ -1,0 +1,1 @@
+export * from './CheckoutCancelPage';

--- a/src/pages/CheckoutSuccessPage/CheckoutSuccessPage.test.tsx
+++ b/src/pages/CheckoutSuccessPage/CheckoutSuccessPage.test.tsx
@@ -1,0 +1,48 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { vi } from 'vitest';
+
+import {
+  EntitlementContext,
+  EntitlementContextValue,
+} from '~/contexts';
+
+import { CheckoutSuccessPage } from './CheckoutSuccessPage';
+
+const base: EntitlementContextValue = {
+  isPremium: false,
+  isTrialing: false,
+  trialExpired: false,
+  trialDaysRemaining: null,
+  effectiveAccess: 'free',
+  isLoading: false,
+  refetch: () => {},
+};
+
+const renderPage = (value: EntitlementContextValue) =>
+  render(
+    <MemoryRouter>
+      <EntitlementContext.Provider value={value}>
+        <CheckoutSuccessPage />
+      </EntitlementContext.Provider>
+    </MemoryRouter>,
+  );
+
+describe('CheckoutSuccessPage', () => {
+  test('shows success once entitlement is premium', () => {
+    renderPage({ ...base, isPremium: true, effectiveAccess: 'premium' });
+    expect(screen.getByText("You're Premium 🎉")).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Continue' }),
+    ).toBeInTheDocument();
+  });
+
+  test('shows pending state and polls (refetch) while still free', async () => {
+    const refetch = vi.fn();
+    renderPage({ ...base, refetch });
+    expect(
+      screen.getByText('Activating your subscription…'),
+    ).toBeInTheDocument();
+    await waitFor(() => expect(refetch).toHaveBeenCalled());
+  });
+});

--- a/src/pages/CheckoutSuccessPage/CheckoutSuccessPage.tsx
+++ b/src/pages/CheckoutSuccessPage/CheckoutSuccessPage.tsx
@@ -1,0 +1,77 @@
+import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+import { Page } from '~/components';
+import { Button } from '~/components/ui/button';
+import { useEntitlement } from '~/contexts';
+
+// Poll for the webhook race: Stripe redirects back here a beat before the
+// webhook flips the user to premium. Refetch immediately, then every 2s.
+const POLL_MS = 2000;
+const MAX_ATTEMPTS = 8; // ~16s before showing the calm "it'll update shortly" state
+
+export const CheckoutSuccessPage = () => {
+  const navigate = useNavigate();
+  const { effectiveAccess, refetch } = useEntitlement();
+  const [attempts, setAttempts] = useState(0);
+
+  const active = effectiveAccess === 'premium';
+  const exhausted = attempts >= MAX_ATTEMPTS;
+
+  useEffect(() => {
+    if (active || exhausted) return;
+    const delay = attempts === 0 ? 0 : POLL_MS;
+    const timer = setTimeout(() => {
+      refetch();
+      setAttempts((a) => a + 1);
+    }, delay);
+    return () => clearTimeout(timer);
+    // refetch is intentionally omitted — its identity changes each render.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [attempts, active, exhausted]);
+
+  if (active) {
+    return (
+      <Page title={null}>
+        <div className="flex flex-col items-center gap-2 py-3 text-center">
+          <h1 className="text-xl font-semibold">You're Premium 🎉</h1>
+          <p className="text-sm text-muted-foreground">
+            Your subscription is active. The intelligence layer is unlocked.
+          </p>
+          <Button onClick={() => navigate('/')} className="w-full">
+            Continue
+          </Button>
+        </div>
+      </Page>
+    );
+  }
+
+  return (
+    <Page title={null}>
+      <div className="flex flex-col items-center gap-2 py-3 text-center">
+        <h1 className="text-xl font-semibold">
+          {exhausted ? 'Almost there' : 'Activating your subscription…'}
+        </h1>
+        <p className="text-sm text-muted-foreground">
+          {exhausted
+            ? "Payment received — your account will update shortly. You can keep using the app; it'll unlock automatically."
+            : 'Hang tight while we confirm your payment.'}
+        </p>
+        {exhausted && (
+          <div className="flex w-full flex-col gap-1">
+            <Button
+              variant="secondary"
+              onClick={() => setAttempts(0)}
+              className="w-full"
+            >
+              Check again
+            </Button>
+            <Button onClick={() => navigate('/')} className="w-full">
+              Continue
+            </Button>
+          </div>
+        )}
+      </div>
+    </Page>
+  );
+};

--- a/src/pages/CheckoutSuccessPage/index.ts
+++ b/src/pages/CheckoutSuccessPage/index.ts
@@ -1,0 +1,1 @@
+export * from './CheckoutSuccessPage';

--- a/src/pages/PaywallPage/PaywallPage.stories.tsx
+++ b/src/pages/PaywallPage/PaywallPage.stories.tsx
@@ -1,3 +1,4 @@
+import { QueryClient, QueryClientProvider } from 'react-query';
 import { MemoryRouter } from 'react-router-dom';
 
 import {
@@ -28,9 +29,11 @@ export default {
   component: PaywallPage,
   decorators: [
     (Story: any) => (
-      <MemoryRouter>
-        <Story />
-      </MemoryRouter>
+      <QueryClientProvider client={new QueryClient()}>
+        <MemoryRouter>
+          <Story />
+        </MemoryRouter>
+      </QueryClientProvider>
     ),
   ],
 };

--- a/src/pages/PaywallPage/PaywallPage.test.tsx
+++ b/src/pages/PaywallPage/PaywallPage.test.tsx
@@ -1,13 +1,20 @@
 import { composeStories } from '@storybook/react';
 import { fireEvent, render, screen } from '@testing-library/react';
+import { vi } from 'vitest';
+
+import { features } from '~/config/features';
 
 import * as stories from './PaywallPage.stories';
+
+// Control the launch flag per test (drives notify-me vs real Subscribe).
+vi.mock('~/config/features', () => ({ features: { premium: false } }));
 
 const { Trialing, Expired, Free } = composeStories(stories);
 
 describe('paywall page', () => {
   beforeEach(() => {
     localStorage.clear();
+    (features as { premium: boolean }).premium = false;
   });
 
   test('trialing variant shows days remaining', () => {
@@ -25,12 +32,45 @@ describe('paywall page', () => {
     expect(screen.getByText('Unlock BellSkill Premium')).toBeInTheDocument();
   });
 
-  test('notify-me CTA records intent and confirms', () => {
-    render(<Free />);
-    fireEvent.click(
-      screen.getByRole('button', { name: 'Notify me when Premium launches' }),
-    );
-    expect(localStorage.getItem('premium_notify_intent')).toBe('true');
-    expect(screen.getByText("We'll let you know — thanks!")).toBeInTheDocument();
+  describe('premium flag OFF (pre-launch)', () => {
+    test('notify-me CTA records intent and confirms', () => {
+      render(<Free />);
+      fireEvent.click(
+        screen.getByRole('button', { name: 'Notify me when Premium launches' }),
+      );
+      expect(localStorage.getItem('premium_notify_intent')).toBe('true');
+      expect(
+        screen.getByText("We'll let you know — thanks!"),
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe('premium flag ON (launched)', () => {
+    beforeEach(() => {
+      (features as { premium: boolean }).premium = true;
+    });
+
+    test('shows real Subscribe CTA, not notify-me', () => {
+      render(<Free />);
+      expect(
+        screen.getByRole('button', { name: /Subscribe/ }),
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByText('Notify me when Premium launches'),
+      ).not.toBeInTheDocument();
+    });
+
+    test('Subscribe label reflects the selected plan (yearly default → monthly)', () => {
+      render(<Free />);
+      // Yearly is preselected.
+      expect(
+        screen.getByRole('button', { name: 'Subscribe — $79/yr' }),
+      ).toBeInTheDocument();
+      // Select monthly.
+      fireEvent.click(screen.getByRole('button', { name: /Monthly/ }));
+      expect(
+        screen.getByRole('button', { name: 'Subscribe — $9.99/mo' }),
+      ).toBeInTheDocument();
+    });
   });
 });

--- a/src/pages/PaywallPage/PaywallPage.tsx
+++ b/src/pages/PaywallPage/PaywallPage.tsx
@@ -2,11 +2,14 @@ import { CheckIcon } from '@radix-ui/react-icons';
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
+import { CheckoutPlan, useCreateCheckoutSession } from '~/api';
 import { Page } from '~/components';
 import { Badge } from '~/components/ui/badge';
 import { Button } from '~/components/ui/button';
 import { Card, CardContent } from '~/components/ui/card';
+import { features } from '~/config/features';
 import { useEntitlement } from '~/contexts';
+import { cn } from '~/lib/utils';
 
 const NOTIFY_INTENT_KEY = 'premium_notify_intent';
 
@@ -15,11 +18,7 @@ const PREMIUM_FEATURES = [
   'Tetris programming — auto-fitted workouts',
 ];
 
-const FREE_FOREVER = [
-  'Workout logging',
-  'Skill tree',
-  'Basic analytics',
-];
+const FREE_FOREVER = ['Workout logging', 'Skill tree', 'Basic analytics'];
 
 interface PaywallHeadline {
   eyebrow: string | null;
@@ -58,19 +57,70 @@ const getHeadline = (
   };
 };
 
+interface PlanCardProps {
+  selected: boolean;
+  onSelect: () => void;
+  label: string;
+  price: string;
+  caption: string;
+  badge?: string;
+}
+
+const PlanCard = ({
+  selected,
+  onSelect,
+  label,
+  price,
+  caption,
+  badge,
+}: PlanCardProps) => (
+  <button
+    type="button"
+    onClick={onSelect}
+    aria-pressed={selected}
+    className="flex-1"
+  >
+    <Card
+      className={cn('h-full', selected && 'border-primary ring-1 ring-primary')}
+    >
+      <CardContent className="flex flex-col items-center gap-0.5 p-2 text-center">
+        {badge && <Badge className="mb-0.5">{badge}</Badge>}
+        <div className="text-sm text-muted-foreground">{label}</div>
+        <div className="text-lg font-semibold">{price}</div>
+        <div className="text-xs text-muted-foreground">{caption}</div>
+      </CardContent>
+    </Card>
+  </button>
+);
+
 export const PaywallPage = () => {
   const navigate = useNavigate();
   const { isTrialing, trialExpired, trialDaysRemaining } = useEntitlement();
+
+  const [plan, setPlan] = useState<CheckoutPlan>('yearly');
+  const {
+    mutate: startCheckout,
+    isLoading: checkoutLoading,
+    isError: checkoutError,
+  } = useCreateCheckoutSession();
+
   const [notified, setNotified] = useState<boolean>(
     () => localStorage.getItem(NOTIFY_INTENT_KEY) === 'true',
   );
 
   const headline = getHeadline(isTrialing, trialExpired, trialDaysRemaining);
 
+  const handleSubscribe = () => {
+    startCheckout(plan, {
+      onSuccess: (url) => {
+        window.location.href = url;
+      },
+    });
+  };
+
   const handleNotify = () => {
     localStorage.setItem(NOTIFY_INTENT_KEY, 'true');
     setNotified(true);
-    // Phase 2: replace with create-checkout-session + open Stripe Checkout.
   };
 
   return (
@@ -102,31 +152,44 @@ export const PaywallPage = () => {
         </Card>
 
         <div className="flex gap-1">
-          <Card className="flex-1">
-            <CardContent className="flex flex-col items-center gap-0.5 p-2 text-center">
-              <div className="text-sm text-muted-foreground">Monthly</div>
-              <div className="text-lg font-semibold">$9.99</div>
-              <div className="text-xs text-muted-foreground">per month</div>
-            </CardContent>
-          </Card>
-          <Card className="flex-1 border-primary">
-            <CardContent className="flex flex-col items-center gap-0.5 p-2 text-center">
-              <Badge className="mb-0.5">Best value</Badge>
-              <div className="text-sm text-muted-foreground">Yearly</div>
-              <div className="text-lg font-semibold">$79</div>
-              <div className="text-xs text-muted-foreground">
-                per year — under $6.59/mo
-              </div>
-            </CardContent>
-          </Card>
+          <PlanCard
+            selected={plan === 'monthly'}
+            onSelect={() => setPlan('monthly')}
+            label="Monthly"
+            price="$9.99"
+            caption="per month"
+          />
+          <PlanCard
+            selected={plan === 'yearly'}
+            onSelect={() => setPlan('yearly')}
+            label="Yearly"
+            price="$79"
+            caption="per year — under $6.59/mo"
+            badge="Best value"
+          />
         </div>
 
         <p className="text-center text-xs text-muted-foreground">
           Cancel anytime. No card required during your trial.
         </p>
 
-        {/* Phase 1: payments are not live yet, so the CTA records interest. */}
-        {notified ? (
+        {features.premium ? (
+          <>
+            <Button
+              onClick={handleSubscribe}
+              loading={checkoutLoading}
+              className="w-full"
+            >
+              Subscribe — {plan === 'yearly' ? '$79/yr' : '$9.99/mo'}
+            </Button>
+            {checkoutError && (
+              <p className="text-center text-xs text-destructive">
+                Something went wrong starting checkout. Please try again.
+              </p>
+            )}
+          </>
+        ) : /* Premium not launched yet — record interest instead of charging. */
+        notified ? (
           <Button variant="secondary" disabled className="w-full">
             We'll let you know — thanks!
           </Button>
@@ -136,11 +199,7 @@ export const PaywallPage = () => {
           </Button>
         )}
 
-        <Button
-          variant="ghost"
-          onClick={() => navigate(-1)}
-          className="w-full"
-        >
+        <Button variant="ghost" onClick={() => navigate(-1)} className="w-full">
           Not now
         </Button>
       </div>

--- a/src/pages/index.ts
+++ b/src/pages/index.ts
@@ -1,5 +1,7 @@
 export * from './AccountPage';
 export * from './ActiveWorkoutPage';
+export * from './CheckoutCancelPage';
+export * from './CheckoutSuccessPage';
 export * from './CompletedWorkoutPage';
 export * from './HistoryPage';
 export * from './MovementsPage';

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -271,6 +271,11 @@ enabled = true
 verify_jwt = false
 import_map = "./functions/stripe-webhook/deno.json"
 
+[functions.create-portal-session]
+enabled = true
+verify_jwt = true
+import_map = "./functions/create-portal-session/deno.json"
+
 [analytics]
 enabled = true
 port = 54327

--- a/supabase/functions/create-portal-session/deno.json
+++ b/supabase/functions/create-portal-session/deno.json
@@ -1,0 +1,6 @@
+{
+  "imports": {
+    "stripe": "https://esm.sh/stripe@17.7.0?target=deno",
+    "@supabase/supabase-js": "https://esm.sh/@supabase/supabase-js@2.45.0"
+  }
+}

--- a/supabase/functions/create-portal-session/index.ts
+++ b/supabase/functions/create-portal-session/index.ts
@@ -1,0 +1,71 @@
+// create-portal-session (PROD-106)
+//
+// Authenticated endpoint that opens a Stripe Customer Portal session for the
+// current user so they can manage/cancel their subscription and update payment
+// methods. The user is derived from the JWT; the customer is looked up from the
+// user's profile (service role).
+
+import { createClient } from '@supabase/supabase-js';
+import Stripe from 'stripe';
+
+import { corsHeaders, handleCors } from '../_shared/cors.ts';
+
+const stripe = new Stripe(Deno.env.get('STRIPE_SECRET_KEY') ?? '', {
+  httpClient: Stripe.createFetchHttpClient(),
+});
+
+function json(body: unknown, status: number): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+  });
+}
+
+Deno.serve(async (req: Request) => {
+  const preflight = handleCors(req);
+  if (preflight) return preflight;
+
+  if (req.method !== 'POST') return json({ error: 'Method not allowed' }, 405);
+
+  try {
+    const authHeader = req.headers.get('Authorization');
+    if (!authHeader) return json({ error: 'Missing authorization' }, 401);
+
+    const authClient = createClient(
+      Deno.env.get('SUPABASE_URL') ?? '',
+      Deno.env.get('SUPABASE_ANON_KEY') ?? '',
+      { global: { headers: { Authorization: authHeader } } },
+    );
+    const {
+      data: { user },
+      error: userErr,
+    } = await authClient.auth.getUser();
+    if (userErr || !user) return json({ error: 'Unauthorized' }, 401);
+
+    const admin = createClient(
+      Deno.env.get('SUPABASE_URL') ?? '',
+      Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') ?? '',
+    );
+
+    const { data: profile, error: profErr } = await admin
+      .from('profiles')
+      .select('stripe_customer_id')
+      .eq('id', user.id)
+      .single();
+    if (profErr) throw profErr;
+
+    const customerId = profile?.stripe_customer_id;
+    if (!customerId) return json({ error: 'No subscription' }, 400);
+
+    const siteUrl = Deno.env.get('SITE_URL') ?? '';
+    const session = await stripe.billingPortal.sessions.create({
+      customer: customerId,
+      return_url: `${siteUrl}/account`,
+    });
+
+    return json({ url: session.url }, 200);
+  } catch (err) {
+    console.error('create-portal-session error:', err);
+    return json({ error: 'Internal error' }, 500);
+  }
+});


### PR DESCRIPTION
The user-facing checkout flow on top of [PROD-104](https://linear.app/bellskill/issue/PROD-104) (checkout session) and [PROD-105](https://linear.app/bellskill/issue/PROD-105) (webhook) — the last Phase-2 piece. Paywall → Stripe Checkout → back into the app with premium active, plus a Customer Portal entry. Web-only (native link-out deferred to PROD-107).

**Gating decision:** the real Subscribe CTA is behind `features.premium`. Production carries **live** Stripe keys, so until launch the paywall keeps the existing **notify-me** CTA; flipping `VITE_FEATURE_PREMIUM=true` at launch turns on real checkout. This PR is safe to merge without charging anyone.

**Changes:**
- **Paywall** (`PaywallPage.tsx`): selectable monthly/yearly cards (yearly preselected) + a single **Subscribe** CTA → `useCreateCheckoutSession` → `window.location` redirect to Stripe Checkout. When `features.premium` is off, the notify-me CTA is unchanged.
- **Return routes** (always routed): `/checkout/success` calls `useEntitlement().refetch()` and **polls through the webhook race** (~2s × 8) with a calm "it'll update shortly" fallback — never an error or trap; `/checkout/cancel` returns to the paywall, no guilt.
- **Account**: "Manage Subscription" (shown when `isPremium`) → new **`create-portal-session`** Edge Function → Stripe Customer Portal, returning to `/account`.
- `useCreatePortalSession` hook; `config.toml` + both CI workflows deploy the portal function. No new secrets (reuses `STRIPE_SECRET_KEY` + `SITE_URL`).

**Testing:**
- Unit: gated CTA (Subscribe vs notify-me by mocking the flag) + plan-selection label; `CheckoutSuccessPage` pending→premium; `CheckoutCancelPage`. **Full suite 256/256**, `tsc` clean.
- `create-portal-session` verified locally: 400 without a Stripe customer; a real `billing.stripe.com` portal URL with one (confirms the Customer Portal is enabled in test mode).
- Checkout-session redirect and webhook premium-flip were already verified in PROD-104/105.

**Manual check before/after merge (DJ, optional):** with `VITE_FEATURE_PREMIUM=true` locally + `stripe listen`, run `npm run dev` → `/paywall` → Subscribe → pay `4242…` → `/checkout/success` flips to premium; cancel path; Account → Manage Subscription round-trip.

**After this merges**, Phase 2 is complete end-to-end. Premium launch is a separate step: trial backfill, `VITE_FEATURE_PREMIUM=true` in prod, and shipping the real gated feature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)