### PR TITLE
Add Netlify SPA fallback redirect

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -1,0 +1,3 @@
+# SPA fallback: serve index.html for all client-side routes so React Router
+# deep links (e.g. /checkout/success) resolve instead of returning a 404.
+/*    /index.html   200


### PR DESCRIPTION
## Summary
- Adds `public/_redirects` with a Netlify SPA fallback rewrite (`/*  /index.html  200`).
- Fixes 404s on client-side React Router deep links (e.g. `/checkout/success`) when loaded directly, such as Stripe's post-checkout redirect.

## Why
The app uses `createBrowserRouter` (HTML5 history routing), so deep-link paths exist only client-side. Netlify had `public/_headers` but no SPA fallback, so direct loads of any deep link returned a 404. The `200` status makes this a rewrite (not a redirect), preserving the URL and query string so React Router boots and `CheckoutSuccessPage` still receives `session_id`.

## Test plan
- [x] `npm run build` succeeds and copies `_redirects` into `dist/`.
- [ ] After deploy, hard-load `https://dev-kettlebells.netlify.app/checkout/success?session_id=...` and confirm the page renders instead of 404.
- [ ] Spot-check another deep link (e.g. `/account`) via direct load / hard refresh.

Made with [Cursor](https://cursor.com)