### PR TITLE
feat(features): owner-only preview override for disabled features

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -7,11 +7,12 @@ import { EntitlementProvider } from '~/contexts/EntitlementContext';
 import { WorkoutOptionsProvider } from '~/contexts/WorkoutOptionsContext';
 import { resolveAuthSession } from '~/utils';
 
+import { getFeatures } from '../config/features';
 import { SessionProvider } from '../contexts';
 import { Signup } from '../pages';
 import { supabase } from '../supabaseClient';
 import '../tailwind.css';
-import { routes } from './routes';
+import { createRoutes } from './routes';
 
 export function App() {
   const [session, setSession] = useState<Session | null | undefined>(undefined);
@@ -30,7 +31,9 @@ export function App() {
     return () => subscription.unsubscribe();
   }, []);
 
-  const router = createBrowserRouter(routes);
+  // Build routes from the session-aware feature flags so that feature-gated
+  // routes become reachable when an owner enables the preview override.
+  const router = createBrowserRouter(createRoutes(getFeatures(session)));
 
   return (
     <SafeAreaWrapper>

--- a/src/app/routes.tsx
+++ b/src/app/routes.tsx
@@ -1,6 +1,6 @@
 import { RouteObject } from 'react-router-dom';
 
-import { features } from '../config/features';
+import { Features, features } from '../config/features';
 import {
   AccountPage,
   ActiveWorkoutPage,
@@ -16,7 +16,12 @@ import {
 } from '../pages';
 import { Root } from './Root';
 
-export const routes: RouteObject[] = [
+/**
+ * Builds the route table for a given set of effective feature flags. Pass the
+ * session-aware flags from `getFeatures(session)` so feature-gated routes
+ * become reachable when an owner enables the preview override.
+ */
+export const createRoutes = (flags: Features = features): RouteObject[] => [
   {
     path: '/',
     element: <Root />,
@@ -53,13 +58,16 @@ export const routes: RouteObject[] = [
         path: 'checkout/cancel',
         element: <CheckoutCancelPage />,
       },
-      ...(features.weeklyBalance
+      ...(flags.weeklyBalance
         ? [{ path: 'balance', element: <WeeklyBalancePage /> }]
         : []),
-      ...(features.explore ? [{ path: 'movements', element: <MovementsPage /> }] : []),
-      ...(features.premium
+      ...(flags.explore ? [{ path: 'movements', element: <MovementsPage /> }] : []),
+      ...(flags.premium
         ? [{ path: 'recommendations', element: <RecommendationsPage /> }]
         : []),
     ],
   },
 ];
+
+/** Default route table built from the static (no-override) feature flags. */
+export const routes: RouteObject[] = createRoutes();

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,7 +1,8 @@
 import { ButtonIcon, SunIcon } from '@radix-ui/react-icons';
 import { NavLink } from 'react-router-dom';
 
-import { features } from '../config/features';
+import { useFeatures } from '~/hooks';
+
 import { supabase } from '../supabaseClient';
 import './Header.styles.css';
 import { Badge } from './ui/badge';
@@ -18,6 +19,7 @@ import {
 import { Separator } from './ui/separator';
 
 export const Header = () => {
+  const features = useFeatures();
   const handleSignOut = () => supabase.auth.signOut();
 
   function handleClickLightDarkMode() {

--- a/src/config/features.ts
+++ b/src/config/features.ts
@@ -1,7 +1,91 @@
-export const features = {
+import { Session } from '@supabase/supabase-js';
+
+export type FeatureName =
+  | 'complexMode'
+  | 'explore'
+  | 'premium'
+  | 'recommender'
+  | 'weeklyBalance';
+
+export type Features = Record<FeatureName, boolean>;
+
+/**
+ * Build-time feature flags — the "real" production state of each flag, driven
+ * by env vars. This is what every user sees by default.
+ */
+const baseFeatures: Features = {
   complexMode: import.meta.env.VITE_FEATURE_COMPLEX_MODE === 'true',
   explore: import.meta.env.VITE_FEATURE_EXPLORE === 'true',
   premium: import.meta.env.VITE_FEATURE_PREMIUM === 'true',
   recommender: import.meta.env.VITE_FEATURE_RECOMMENDER === 'true',
   weeklyBalance: import.meta.env.VITE_FEATURE_WEEKLY_BALANCE === 'true',
-} as const;
+};
+
+/**
+ * Accounts allowed to preview disabled features in production. The preview
+ * override below is only honored for these users, so flipping the localStorage
+ * key does nothing for anyone else.
+ *
+ * NOTE: these flags gate UI/route *visibility* only — they are not a security
+ * boundary. Premium/paid capabilities must still be enforced server-side
+ * (Supabase RLS + Stripe entitlement), so revealing them here cannot grant
+ * paid access.
+ */
+const OWNER_EMAILS = ['daniel_bowers@icloud.com'];
+
+const PREVIEW_STORAGE_KEY = 'bellskill:preview-all-features';
+
+export const isOwner = (session?: Session | null): boolean => {
+  const email = session?.user?.email;
+  return !!email && OWNER_EMAILS.includes(email);
+};
+
+export const isPreviewOverrideEnabled = (): boolean => {
+  try {
+    return localStorage.getItem(PREVIEW_STORAGE_KEY) === 'true';
+  } catch {
+    return false;
+  }
+};
+
+export const setPreviewOverrideEnabled = (enabled: boolean): void => {
+  try {
+    if (enabled) localStorage.setItem(PREVIEW_STORAGE_KEY, 'true');
+    else localStorage.removeItem(PREVIEW_STORAGE_KEY);
+  } catch {
+    /* localStorage unavailable (e.g. private mode) — ignore */
+  }
+};
+
+/**
+ * Whether the current session is actively previewing all features. True only
+ * when an owner has opted in via the preview override.
+ */
+export const isPreviewingAllFeatures = (session?: Session | null): boolean =>
+  isOwner(session) && isPreviewOverrideEnabled();
+
+/**
+ * Effective feature flags for the current session. Returns the base (env)
+ * flags for everyone, except owners who have enabled the preview override —
+ * they get every flag forced on so they can view in-progress features in
+ * production even when those flags are disabled.
+ */
+export const getFeatures = (session?: Session | null): Features => {
+  if (isPreviewingAllFeatures(session)) {
+    return {
+      complexMode: true,
+      explore: true,
+      premium: true,
+      recommender: true,
+      weeklyBalance: true,
+    };
+  }
+  return baseFeatures;
+};
+
+/**
+ * Static, build-time flags (no override). Prefer the `useFeatures()` hook in
+ * components so the owner preview override is respected; this export remains
+ * for non-React / module-load contexts.
+ */
+export const features = baseFeatures;

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,2 +1,3 @@
 export * from './useCountdownTimer';
 export * from './useDebouncedCallback';
+export * from './useFeatures';

--- a/src/hooks/useFeatures.ts
+++ b/src/hooks/useFeatures.ts
@@ -1,0 +1,11 @@
+import { Features, getFeatures } from '~/config/features';
+import { useSession } from '~/contexts';
+
+/**
+ * Returns the effective feature flags for the current session, honoring the
+ * owner-only "preview all features" override (see `~/config/features`).
+ *
+ * Prefer this over importing the static `features` object so that disabled
+ * features become visible when an owner has enabled the preview override.
+ */
+export const useFeatures = (): Features => getFeatures(useSession());

--- a/src/pages/AccountPage/AccountPage.tsx
+++ b/src/pages/AccountPage/AccountPage.tsx
@@ -10,6 +10,11 @@ import { Page, TrialStatusPill } from '~/components';
 import { Button } from '~/components/ui/button';
 import { Input } from '~/components/ui/input';
 import { Label } from '~/components/ui/label';
+import {
+  isOwner,
+  isPreviewOverrideEnabled,
+  setPreviewOverrideEnabled,
+} from '~/config/features';
 import { useEntitlement, useSession } from '~/contexts';
 import { supabase } from '~/supabaseClient';
 
@@ -21,6 +26,17 @@ export const AccountPage = () => {
 
   const [loading, setLoading] = useState<boolean>(true);
   const [username, setUsername] = useState<string>('');
+  const [previewEnabled, setPreviewEnabled] = useState<boolean>(
+    isPreviewOverrideEnabled(),
+  );
+
+  const handleTogglePreview = () => {
+    const next = !previewEnabled;
+    setPreviewOverrideEnabled(next);
+    setPreviewEnabled(next);
+    // Routes are built once from the effective flags, so reload to apply.
+    window.location.reload();
+  };
 
   const handleManageSubscription = () => {
     openPortal(undefined, {
@@ -104,6 +120,21 @@ export const AccountPage = () => {
             loading={portalLoading}
           >
             Manage Subscription
+          </Button>
+        </div>
+      )}
+
+      {isOwner(session) && (
+        <div className="flex flex-col gap-1 border-t pt-2">
+          <Label>Developer</Label>
+          <p className="text-xs text-muted-foreground">
+            Preview every feature in production, even when its flag is disabled.
+            Owner-only — has no effect for other accounts.
+          </p>
+          <Button variant="outline" onClick={handleTogglePreview}>
+            {previewEnabled
+              ? 'Disable feature preview'
+              : 'Enable feature preview'}
           </Button>
         </div>
       )}

--- a/src/pages/PaywallPage/PaywallPage.test.tsx
+++ b/src/pages/PaywallPage/PaywallPage.test.tsx
@@ -2,19 +2,30 @@ import { composeStories } from '@storybook/react';
 import { fireEvent, render, screen } from '@testing-library/react';
 import { vi } from 'vitest';
 
-import { features } from '~/config/features';
-
 import * as stories from './PaywallPage.stories';
 
-// Control the launch flag per test (drives notify-me vs real Subscribe).
-vi.mock('~/config/features', () => ({ features: { premium: false } }));
+// Control the launch flag per test (drives notify-me vs real Subscribe) by
+// mocking the effective-features hook the page reads.
+const { mockUseFeatures } = vi.hoisted(() => ({ mockUseFeatures: vi.fn() }));
+vi.mock('~/hooks', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('~/hooks')>()),
+  useFeatures: mockUseFeatures,
+}));
+
+const setPremium = (premium: boolean) =>
+  mockUseFeatures.mockReturnValue({
+    complexMode: false,
+    explore: false,
+    premium,
+    recommender: false,
+  });
 
 const { Trialing, Expired, Free } = composeStories(stories);
 
 describe('paywall page', () => {
   beforeEach(() => {
     localStorage.clear();
-    (features as { premium: boolean }).premium = false;
+    setPremium(false);
   });
 
   test('trialing variant shows days remaining', () => {
@@ -47,7 +58,7 @@ describe('paywall page', () => {
 
   describe('premium flag ON (launched)', () => {
     beforeEach(() => {
-      (features as { premium: boolean }).premium = true;
+      setPremium(true);
     });
 
     test('shows real Subscribe CTA, not notify-me', () => {

--- a/src/pages/PaywallPage/PaywallPage.tsx
+++ b/src/pages/PaywallPage/PaywallPage.tsx
@@ -7,8 +7,8 @@ import { Page } from '~/components';
 import { Badge } from '~/components/ui/badge';
 import { Button } from '~/components/ui/button';
 import { Card, CardContent } from '~/components/ui/card';
-import { features } from '~/config/features';
 import { useEntitlement } from '~/contexts';
+import { useFeatures } from '~/hooks';
 import { cn } from '~/lib/utils';
 
 const NOTIFY_INTENT_KEY = 'premium_notify_intent';
@@ -94,6 +94,7 @@ const PlanCard = ({
 );
 
 export const PaywallPage = () => {
+  const features = useFeatures();
   const navigate = useNavigate();
   const { isTrialing, trialExpired, trialDaysRemaining } = useEntitlement();
 

--- a/src/pages/StartWorkoutPage/StartWorkoutPage.tsx
+++ b/src/pages/StartWorkoutPage/StartWorkoutPage.tsx
@@ -18,7 +18,7 @@ import {
 } from '~/types';
 import { getWeightTabValue, getWeightUnitLabel, WEIGHT_MODE_LABELS } from '~/utils';
 
-import { features } from '~/config/features';
+import { useFeatures } from '~/hooks';
 
 import {
   AddToWorkoutSection,
@@ -48,6 +48,7 @@ const DEFAULT_MINUTES: number = 10; // minutes
 const DEFAULT_ROUNDS: number = 10; // rounds
 
 export const StartWorkoutPage = () => {
+  const features = useFeatures();
   const navigate = useNavigate();
   const [workoutOptions, updateWorkoutOptions] = useWorkoutOptions();
 


### PR DESCRIPTION
Adds an owner-gated runtime override so disabled feature flags can be previewed in production, without exposing them to other users.

**Changes:**
- `src/config/features.ts`: introduces `getFeatures(session)`, an owner email allowlist, and a `localStorage` preview toggle (`isOwner` / `isPreviewOverrideEnabled` / `setPreviewOverrideEnabled`). When an owner opts in, every flag is forced on; everyone else gets the unchanged env-driven flags. The static `features` export is kept for module-load use.
- `src/hooks/useFeatures.ts` (new): `useFeatures()` returns the session-aware effective flags.
- `src/app/routes.tsx` + `App.tsx`: `routes` becomes `createRoutes(flags)` so feature-gated routes (`balance`, `movements`, `recommendations`) react to the override; `App` builds the router from `getFeatures(session)`.
- `Header.tsx`, `StartWorkoutPage.tsx`, `PaywallPage.tsx`: migrated from the static `features` object to `useFeatures()`.
- `AccountPage.tsx`: adds an owner-only "feature preview" toggle (hidden for non-owners) that flips the override and reloads.
- `PaywallPage.test.tsx`: mock updated to drive the `useFeatures()` hook.

Note: these flags gate UI/route **visibility** only — they are not a security boundary, so previewing premium UI does not grant paid capabilities (those stay enforced server-side via Supabase RLS + Stripe entitlement).

**Testing:**
- `npm run compile:ts` — no new type errors (the 3 reported pre-exist on `main`).
- `npx vitest run` PaywallPage + StartWorkoutPage — 44/44 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)