### PR TITLE
fix(types): resolve three tsc errors on main

### DIFF
--- a/src/api/useMovementSearch.ts
+++ b/src/api/useMovementSearch.ts
@@ -42,8 +42,13 @@ const searchMovements = async (
   const { data, error } = await movementsQuery.limit(CATALOG_SEARCH_LIMIT);
 
   if (error) throw error;
-  return (data ?? []).map((movement) => ({
-    id: movement.id,
-    name: movement.name,
-  }));
+  return (data ?? [])
+    .filter(
+      (movement): movement is { id: string; name: string } =>
+        movement.id !== null && movement.name !== null,
+    )
+    .map((movement) => ({
+      id: movement.id,
+      name: movement.name,
+    }));
 };

--- a/src/pages/StartWorkoutPage/StartWorkoutPage.tsx
+++ b/src/pages/StartWorkoutPage/StartWorkoutPage.tsx
@@ -576,7 +576,7 @@ export const StartWorkoutPage = () => {
                       }
                     />
                   }
-                  value={movement.weightOneValue}
+                  value={movement.weightOneValue!}
                   onChange={(value) =>
                     handleChangeWeightOneValue(index, value!)
                   }

--- a/src/utils/resolveAuthSession.test.ts
+++ b/src/utils/resolveAuthSession.test.ts
@@ -23,7 +23,7 @@ const session = {
     id: 'user-123',
     user_metadata: { full_name: 'Test User' },
   },
-} as Session;
+} as unknown as Session;
 
 function mockProfilesTable({
   profile,


### PR DESCRIPTION
Fixes three TypeScript errors that were failing `npm run compile:ts` on `main`.

**Changes:**
- `src/api/useMovementSearch.ts` — the `movements_catalog` `id`/`name` columns are nullable, so filter out rows with null values before mapping; results now satisfy `MovementSearchResult`.
- `src/pages/StartWorkoutPage/StartWorkoutPage.tsx` — add a non-null assertion on `value={movement.weightOneValue}` to match the surrounding `onClickMinus`/`onClickPlus`/`onChange` handlers that already use `weightOneValue!`.
- `src/utils/resolveAuthSession.test.ts` — cast the partial `Session` test fixture through `unknown`, as the compiler suggested, since it intentionally omits token fields.

**Testing:**
- `npm run compile:ts` passes clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)