### PR TITLE
feat(analytics): instrument activation funnel (PROD-157)

### DIFF
--- a/src/api/analytics.test.ts
+++ b/src/api/analytics.test.ts
@@ -1,0 +1,95 @@
+import { http, HttpResponse } from 'msw';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+
+import { VITE_SUPABASE_URL } from '../env';
+import { server } from '~/mocks/server';
+
+import { AnalyticsEvent, trackEvent } from './analytics';
+
+const ANALYTICS_URL = `${VITE_SUPABASE_URL}/rest/v1/analytics_events`;
+
+describe('trackEvent', () => {
+  beforeEach(() => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test('inserts an event row with user_id, event_name, and properties', async () => {
+    let capturedBody: Record<string, unknown> | null = null;
+
+    server.use(
+      http.post(ANALYTICS_URL, async ({ request }) => {
+        capturedBody = (await request.json()) as Record<string, unknown>;
+        return HttpResponse.json([]);
+      }),
+    );
+
+    await trackEvent({
+      event: AnalyticsEvent.WorkoutCompleted,
+      userId: 'user-123',
+      properties: { is_first_workout: true },
+    });
+
+    expect(capturedBody).toEqual({
+      user_id: 'user-123',
+      event_name: 'workout_completed',
+      properties: { is_first_workout: true },
+    });
+  });
+
+  test('defaults properties to an empty object', async () => {
+    let capturedBody: Record<string, unknown> | null = null;
+
+    server.use(
+      http.post(ANALYTICS_URL, async ({ request }) => {
+        capturedBody = (await request.json()) as Record<string, unknown>;
+        return HttpResponse.json([]);
+      }),
+    );
+
+    await trackEvent({
+      event: AnalyticsEvent.FirstSessionStarted,
+      userId: 'user-123',
+    });
+
+    expect(capturedBody).toEqual({
+      user_id: 'user-123',
+      event_name: 'first_session_started',
+      properties: {},
+    });
+  });
+
+  test('no-ops without a userId and issues no request', async () => {
+    const onRequest = vi.fn();
+    server.use(
+      http.post(ANALYTICS_URL, () => {
+        onRequest();
+        return HttpResponse.json([]);
+      }),
+    );
+
+    await expect(
+      trackEvent({ event: AnalyticsEvent.WorkoutStarted, userId: '' }),
+    ).resolves.toBeUndefined();
+
+    expect(onRequest).not.toHaveBeenCalled();
+  });
+
+  test('never throws when the insert fails', async () => {
+    server.use(
+      http.post(ANALYTICS_URL, () =>
+        HttpResponse.json({ message: 'boom' }, { status: 500 }),
+      ),
+    );
+
+    await expect(
+      trackEvent({
+        event: AnalyticsEvent.WorkoutStarted,
+        userId: 'user-123',
+      }),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/src/api/analytics.ts
+++ b/src/api/analytics.ts
@@ -1,0 +1,46 @@
+import { supabase } from '~/supabaseClient';
+
+import type { Json } from '../../types/supabase';
+
+/**
+ * Activation funnel events (PROD-157). `signup_completed` is emitted
+ * server-side by the handle_new_user() trigger; the rest are emitted from the
+ * client via {@link trackEvent}.
+ */
+export enum AnalyticsEvent {
+  SignupCompleted = 'signup_completed',
+  FirstSessionStarted = 'first_session_started',
+  WorkoutStarted = 'workout_started',
+  WorkoutCompleted = 'workout_completed',
+}
+
+interface TrackEventParams {
+  event: AnalyticsEvent;
+  userId: string;
+  properties?: Record<string, Json>;
+}
+
+/**
+ * Append a funnel event to `analytics_events`. Fire-and-forget: analytics must
+ * never break a user flow, so this swallows (and logs) every error and never
+ * throws. Callers may `void trackEvent(...)` without awaiting.
+ */
+export async function trackEvent({
+  event,
+  userId,
+  properties = {},
+}: TrackEventParams): Promise<void> {
+  if (!userId) return;
+
+  try {
+    const { error } = await supabase
+      .from('analytics_events')
+      .insert({ user_id: userId, event_name: event, properties });
+
+    if (error) {
+      console.error(`[analytics] failed to track ${event}`, error);
+    }
+  } catch (err) {
+    console.error(`[analytics] unexpected error tracking ${event}`, err);
+  }
+}

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,3 +1,4 @@
+export * from './analytics';
 export * from './useCreateCheckoutSession';
 export * from './useCreatePortalSession';
 export * from './useDeleteWorkoutLog';

--- a/src/api/useLogWorkout.test.ts
+++ b/src/api/useLogWorkout.test.ts
@@ -17,6 +17,7 @@ import { useLogWorkout } from './useLogWorkout';
 const WORKOUT_LOGS_URL = `${VITE_SUPABASE_URL}/rest/v1/workout_logs`;
 const MOVEMENT_LOGS_URL = `${VITE_SUPABASE_URL}/rest/v1/movement_logs`;
 const USER_MOVEMENTS_URL = `${VITE_SUPABASE_URL}/rest/v1/user_movements`;
+const ANALYTICS_URL = `${VITE_SUPABASE_URL}/rest/v1/analytics_events`;
 
 const mockSession = {
   user: {
@@ -125,5 +126,44 @@ describe('useLogWorkout — complex_set persistence', () => {
 
     expect(capturedBody).not.toBeNull();
     expect(capturedBody!.complex_set).toBe(false);
+  });
+});
+
+describe('useLogWorkout — activation funnel analytics (PROD-157)', () => {
+  beforeEach(() => {
+    server.use(
+      http.get(USER_MOVEMENTS_URL, () => HttpResponse.json([])),
+      http.post(MOVEMENT_LOGS_URL, () => HttpResponse.json([])),
+      http.post(WORKOUT_LOGS_URL, () => HttpResponse.json([{ id: 1 }])),
+    );
+  });
+
+  test('emits is_first_workout: null (not false) when the WORKOUT_LOGS cache is cold', async () => {
+    let analyticsBody: Record<string, unknown> | null = null;
+
+    server.use(
+      http.post(ANALYTICS_URL, async ({ request }) => {
+        analyticsBody = (await request.json()) as Record<string, unknown>;
+        return HttpResponse.json([]);
+      }),
+    );
+
+    // The wrapper's query client never seeds WORKOUT_LOGS, so the cache is cold:
+    // is_first_workout is unknown and must be null rather than a misleading false.
+    const { result } = renderHook(() => useLogWorkout(), {
+      wrapper: makeWrapper(false),
+    });
+
+    act(() => {
+      result.current.mutate(logWorkoutInput);
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    await waitFor(() => expect(analyticsBody).not.toBeNull());
+
+    const properties = analyticsBody!.properties as Record<string, unknown>;
+    expect(analyticsBody!.event_name).toBe('workout_completed');
+    expect(properties.is_first_workout).toBeNull();
+    expect(properties.workout_log_id).toBe(1);
   });
 });

--- a/src/api/useLogWorkout.ts
+++ b/src/api/useLogWorkout.ts
@@ -38,7 +38,9 @@ export const useLogWorkout = () => {
       // Activation funnel (PROD-157). is_first_workout is read from the
       // WORKOUT_LOGS cache, warmed by StartWorkoutPage before the user reaches
       // the active workout; the canonical value is also derivable server-side
-      // from workout_logs (see the user_activation view).
+      // from workout_logs (see the user_activation view). On a cold cache (e.g.
+      // a deep link straight to /active) the value is unknown, so emit null
+      // rather than a misleading `false`.
       const cachedLogs = queryClient.getQueryData<WorkoutLog[]>(
         QUERIES.WORKOUT_LOGS,
       );
@@ -50,8 +52,12 @@ export const useLogWorkout = () => {
         event: AnalyticsEvent.WorkoutCompleted,
         userId: user.id,
         properties: {
+          // Integer PK of the workout_logs row (workout_logs.id), not a UUID.
           workout_log_id: workoutLogId,
-          is_first_workout: cachedLogs?.length === 0,
+          is_first_workout:
+            cachedLogs === undefined ? null : cachedLogs.length === 0,
+          // null when the start time is genuinely unknown (no startedAt on the
+          // options); the DB workout_logs.started_at has its own now() fallback.
           duration_seconds:
             startedAtMs != null
               ? Math.round((completedAt - startedAtMs) / 1000)

--- a/src/api/useLogWorkout.ts
+++ b/src/api/useLogWorkout.ts
@@ -1,9 +1,11 @@
-import { useMutation } from 'react-query';
+import { useMutation, useQueryClient } from 'react-query';
 
+import { QUERIES } from '~/constants';
 import { useSession, useWorkoutOptions } from '~/contexts';
-import { WorkoutOptions } from '~/types';
+import { WorkoutLog, WorkoutOptions } from '~/types';
 
 import { supabase } from '../supabaseClient';
+import { AnalyticsEvent, trackEvent } from './analytics';
 
 interface LogWorkoutInput {
   completedReps: number;
@@ -15,6 +17,7 @@ interface LogWorkoutInput {
 export const useLogWorkout = () => {
   const [workoutOptions] = useWorkoutOptions();
   const { user } = useSession();
+  const queryClient = useQueryClient();
 
   return useMutation({
     mutationFn: ({
@@ -31,6 +34,34 @@ export const useLogWorkout = () => {
         userId: user.id,
         workoutOptions,
       }),
+    onSuccess: (workoutLogId) => {
+      // Activation funnel (PROD-157). is_first_workout is read from the
+      // WORKOUT_LOGS cache, warmed by StartWorkoutPage before the user reaches
+      // the active workout; the canonical value is also derivable server-side
+      // from workout_logs (see the user_activation view).
+      const cachedLogs = queryClient.getQueryData<WorkoutLog[]>(
+        QUERIES.WORKOUT_LOGS,
+      );
+      const completedAt = Date.now();
+      const startedAtMs = workoutOptions.startedAt?.getTime();
+      const signupAtMs = user.created_at ? Date.parse(user.created_at) : NaN;
+
+      void trackEvent({
+        event: AnalyticsEvent.WorkoutCompleted,
+        userId: user.id,
+        properties: {
+          workout_log_id: workoutLogId,
+          is_first_workout: cachedLogs?.length === 0,
+          duration_seconds:
+            startedAtMs != null
+              ? Math.round((completedAt - startedAtMs) / 1000)
+              : null,
+          seconds_since_signup: Number.isNaN(signupAtMs)
+            ? null
+            : Math.round((completedAt - signupAtMs) / 1000),
+        },
+      });
+    },
   });
 };
 

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -12,4 +12,6 @@ export const handlers = [
   http.get(`${VITE_SUPABASE_URL}/rest/v1/movements_catalog`, () => HttpResponse.json([])),
   http.get(`${VITE_SUPABASE_URL}/rest/v1/movements`, () => HttpResponse.json([])),
   http.get(`${VITE_SUPABASE_URL}/rest/v1/user_movements`, () => HttpResponse.json([])),
+  http.post(`${VITE_SUPABASE_URL}/rest/v1/analytics_events`, () => HttpResponse.json([])),
+  http.get(`${VITE_SUPABASE_URL}/rest/v1/analytics_events`, () => HttpResponse.json([])),
 ];

--- a/src/pages/StartWorkoutPage/StartWorkoutPage.tsx
+++ b/src/pages/StartWorkoutPage/StartWorkoutPage.tsx
@@ -58,24 +58,31 @@ export const StartWorkoutPage = () => {
   const [workoutOptions, updateWorkoutOptions] = useWorkoutOptions();
 
   // Activation funnel (PROD-157): a user with zero workout logs is "new".
+  // While the logs query is still loading (workoutLogs === undefined) we don't
+  // yet know, so emit null rather than a misleading `false` for a genuine
+  // first-timer who taps Start before the query resolves.
   const session = useSession();
+  const userId = session?.user?.id;
   const { data: workoutLogs } = useWorkoutLogs();
-  const isFirstWorkout = workoutLogs?.length === 0;
+  const isFirstWorkout =
+    workoutLogs === undefined ? null : workoutLogs.length === 0;
   const firstSessionTracked = useRef(false);
 
   useEffect(
     function trackFirstSession() {
       if (firstSessionTracked.current) return;
-      if (!session?.user || !workoutLogs) return;
+      if (!userId || !workoutLogs) return;
       if (workoutLogs.length > 0) return;
 
       firstSessionTracked.current = true;
       void trackEvent({
         event: AnalyticsEvent.FirstSessionStarted,
-        userId: session.user.id,
+        userId,
       });
     },
-    [session, workoutLogs],
+    // Depend on the stable user id, not the session object (which is replaced on
+    // every token refresh), so this effect doesn't needlessly re-run.
+    [userId, workoutLogs],
   );
 
   const [workoutGoal, setWorkoutGoal] = useState<number>(
@@ -357,10 +364,10 @@ export const StartWorkoutPage = () => {
     };
     updateWorkoutOptions(workoutOptions);
 
-    if (session?.user) {
+    if (userId) {
       void trackEvent({
         event: AnalyticsEvent.WorkoutStarted,
-        userId: session.user.id,
+        userId,
         properties: {
           is_first_workout: isFirstWorkout,
           movement_count: movements.length,

--- a/src/pages/StartWorkoutPage/StartWorkoutPage.tsx
+++ b/src/pages/StartWorkoutPage/StartWorkoutPage.tsx
@@ -1,13 +1,18 @@
 import { XMarkIcon } from '@heroicons/react/24/outline';
-import { useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
+import { AnalyticsEvent, trackEvent, useWorkoutLogs } from '~/api';
 import { Page } from '~/components';
 import { Button } from '~/components/ui/button';
 import { Card } from '~/components/ui/card';
 import { Input } from '~/components/ui/input';
 import { Tabs, TabsList, TabsTrigger } from '~/components/ui/tabs';
-import { DEFAULT_MOVEMENT_OPTIONS, useWorkoutOptions } from '~/contexts';
+import {
+  DEFAULT_MOVEMENT_OPTIONS,
+  useSession,
+  useWorkoutOptions,
+} from '~/contexts';
 import { getWeightsDisplayValue } from '~/pages/CompletedWorkoutPage/utils/displayValues';
 import {
   MovementOptions,
@@ -51,6 +56,27 @@ export const StartWorkoutPage = () => {
   const features = useFeatures();
   const navigate = useNavigate();
   const [workoutOptions, updateWorkoutOptions] = useWorkoutOptions();
+
+  // Activation funnel (PROD-157): a user with zero workout logs is "new".
+  const session = useSession();
+  const { data: workoutLogs } = useWorkoutLogs();
+  const isFirstWorkout = workoutLogs?.length === 0;
+  const firstSessionTracked = useRef(false);
+
+  useEffect(
+    function trackFirstSession() {
+      if (firstSessionTracked.current) return;
+      if (!session?.user || !workoutLogs) return;
+      if (workoutLogs.length > 0) return;
+
+      firstSessionTracked.current = true;
+      void trackEvent({
+        event: AnalyticsEvent.FirstSessionStarted,
+        userId: session.user.id,
+      });
+    },
+    [session, workoutLogs],
+  );
 
   const [workoutGoal, setWorkoutGoal] = useState<number>(
     workoutOptions.workoutGoal,
@@ -330,6 +356,19 @@ export const StartWorkoutPage = () => {
       workoutGoalUnits,
     };
     updateWorkoutOptions(workoutOptions);
+
+    if (session?.user) {
+      void trackEvent({
+        event: AnalyticsEvent.WorkoutStarted,
+        userId: session.user.id,
+        properties: {
+          is_first_workout: isFirstWorkout,
+          movement_count: movements.length,
+          workout_goal_units: workoutGoalUnits,
+        },
+      });
+    }
+
     navigate('active');
   };
 

--- a/supabase/migrations/20260624000001_create_analytics_events.sql
+++ b/supabase/migrations/20260624000001_create_analytics_events.sql
@@ -26,6 +26,17 @@ CREATE INDEX idx_analytics_events_user_created
 CREATE INDEX idx_analytics_events_name_created
   ON public.analytics_events (event_name, created_at DESC);
 
+-- Once-per-user funnel events. signup_completed is emitted exactly-once by the
+-- handle_new_user() trigger, but first_session_started is client-emitted and its
+-- in-memory ref guard resets on unmount/remount, so a re-mounted new user could
+-- insert a second row. This partial unique index is the right-layer backstop: a
+-- duplicate insert hits a unique violation, which trackEvent() swallows
+-- (fire-and-forget). Other events (workout_started/completed) are intentionally
+-- repeatable and excluded.
+CREATE UNIQUE INDEX idx_analytics_events_once_per_user
+  ON public.analytics_events (user_id, event_name)
+  WHERE event_name IN ('signup_completed', 'first_session_started');
+
 ALTER TABLE public.analytics_events ENABLE ROW LEVEL SECURITY;
 
 -- Clients may append their own events and read their own back. No UPDATE/DELETE

--- a/supabase/migrations/20260624000001_create_analytics_events.sql
+++ b/supabase/migrations/20260624000001_create_analytics_events.sql
@@ -1,0 +1,128 @@
+-- Activation funnel instrumentation (PROD-157): measurement backbone for the
+-- Recommended-First-Workout project. We cannot prove an activation lift (or
+-- validate the 79% drop-off claim) without funnel events flowing somewhere we
+-- can query *before* the recommended-first-workout surface ships.
+--
+-- Analytics sink: a first-party `analytics_events` table. The app is already
+-- Supabase-centric with no external analytics dependency, so a queryable table
+-- keeps the funnel self-contained (no new vendor, env var, or network egress)
+-- and lets us derive the two project metrics with plain SQL / the views below.
+
+CREATE TABLE public.analytics_events (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  -- Funnel event name, e.g. signup_completed / first_session_started /
+  -- workout_started / workout_completed. Kept as free TEXT (not an enum) so new
+  -- events can ship without a migration.
+  event_name TEXT NOT NULL,
+  -- Event payload: is_first_workout, elapsed times, movement_count, etc.
+  properties JSONB NOT NULL DEFAULT '{}'::jsonb,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_analytics_events_user_created
+  ON public.analytics_events (user_id, created_at DESC);
+
+CREATE INDEX idx_analytics_events_name_created
+  ON public.analytics_events (event_name, created_at DESC);
+
+ALTER TABLE public.analytics_events ENABLE ROW LEVEL SECURITY;
+
+-- Clients may append their own events and read their own back. No UPDATE/DELETE
+-- policy: events are immutable once written.
+CREATE POLICY "Users can insert own analytics_events" ON public.analytics_events
+  FOR INSERT WITH CHECK ((SELECT auth.uid()) = user_id);
+
+CREATE POLICY "Users can view own analytics_events" ON public.analytics_events
+  FOR SELECT USING ((SELECT auth.uid()) = user_id);
+
+-- Table privileges mirror the rest of the schema: anon gets nothing,
+-- authenticated gets INSERT + SELECT (RLS narrows both to the caller's rows).
+REVOKE ALL ON TABLE public.analytics_events FROM anon;
+REVOKE ALL ON TABLE public.analytics_events FROM authenticated;
+GRANT INSERT, SELECT ON TABLE public.analytics_events TO authenticated;
+
+-- signup_completed is the top of the funnel and must fire exactly once per user
+-- on first successful auth. The auth.users INSERT trigger is the authoritative
+-- place for that (server-side, exactly-once, no client dedup), so extend the
+-- existing handle_new_user() to emit it alongside the profile row.
+CREATE OR REPLACE FUNCTION public.handle_new_user() RETURNS trigger
+    LANGUAGE plpgsql SECURITY DEFINER
+    SET search_path = ''
+    AS $$
+begin
+  insert into public.profiles (id, full_name, avatar_url)
+  values (new.id, new.raw_user_meta_data->>'full_name', new.raw_user_meta_data->>'avatar_url');
+
+  insert into public.analytics_events (user_id, event_name, properties)
+  values (new.id, 'signup_completed', '{}'::jsonb);
+
+  return new;
+end;
+$$;
+
+-- Per-user activation read. Signup time is taken from auth.users.created_at so
+-- the baseline covers every existing user, not just those signed up after this
+-- migration. first_workout_at / the 14-day count are derived from workout_logs
+-- (the canonical record of completed workouts), which also makes is_first_workout
+-- recoverable independent of the client-emitted flag.
+CREATE OR REPLACE VIEW public.user_activation AS
+SELECT
+  u.id AS user_id,
+  u.created_at AS signup_at,
+  fw.first_workout_at,
+  CASE
+    WHEN fw.first_workout_at IS NOT NULL
+    THEN EXTRACT(EPOCH FROM (fw.first_workout_at - u.created_at))::bigint
+  END AS seconds_to_first_workout,
+  -- Leading indicator: first workout completed within 24h of signup.
+  (
+    fw.first_workout_at IS NOT NULL
+    AND fw.first_workout_at <= u.created_at + INTERVAL '24 hours'
+  ) AS activated_24h,
+  COALESCE(w14.workouts_within_14d, 0) AS workouts_within_14d,
+  -- North star leading metric: 3+ workouts within 14 days of signup.
+  (COALESCE(w14.workouts_within_14d, 0) >= 3) AS activated_north_star
+FROM auth.users u
+LEFT JOIN LATERAL (
+  SELECT MIN(wl.completed_at) AS first_workout_at
+  FROM public.workout_logs wl
+  WHERE wl.user_id = u.id
+) fw ON true
+LEFT JOIN LATERAL (
+  SELECT COUNT(*) AS workouts_within_14d
+  FROM public.workout_logs wl
+  WHERE wl.user_id = u.id
+    AND wl.completed_at <= u.created_at + INTERVAL '14 days'
+) w14 ON true;
+
+-- Workspace-wide baseline: signup -> first-workout conversion, the two project
+-- metrics, and time-to-first-workout. Query this once before launch to capture
+-- the before number, then again after to read the lift (blocks PROD-162).
+CREATE OR REPLACE VIEW public.activation_funnel_summary AS
+SELECT
+  COUNT(*) AS total_signups,
+  COUNT(first_workout_at) AS users_with_first_workout,
+  ROUND(
+    COUNT(first_workout_at)::numeric / NULLIF(COUNT(*), 0), 4
+  ) AS signup_to_first_workout_rate,
+  COUNT(*) FILTER (WHERE activated_24h) AS activated_24h_count,
+  ROUND(
+    COUNT(*) FILTER (WHERE activated_24h)::numeric / NULLIF(COUNT(*), 0), 4
+  ) AS activated_24h_rate,
+  COUNT(*) FILTER (WHERE activated_north_star) AS activated_north_star_count,
+  ROUND(
+    COUNT(*) FILTER (WHERE activated_north_star)::numeric / NULLIF(COUNT(*), 0), 4
+  ) AS activated_north_star_rate,
+  ROUND(AVG(seconds_to_first_workout))::bigint AS avg_seconds_to_first_workout,
+  PERCENTILE_CONT(0.5) WITHIN GROUP (
+    ORDER BY seconds_to_first_workout
+  )::bigint AS median_seconds_to_first_workout
+FROM public.user_activation;
+
+-- These views read across all users via auth.users, so they are analyst-only:
+-- queried with the service role (Supabase SQL editor / dashboard), which
+-- bypasses RLS. Deliberately NOT granted to anon/authenticated so they can
+-- never leak other users' activation data to the client.
+REVOKE ALL ON public.user_activation FROM anon, authenticated;
+REVOKE ALL ON public.activation_funnel_summary FROM anon, authenticated;

--- a/types/supabase.ts
+++ b/types/supabase.ts
@@ -9,6 +9,38 @@ export type Json =
 export type Database = {
   public: {
     Tables: {
+      analytics_events: {
+        Row: {
+          created_at: string
+          event_name: string
+          id: string
+          properties: Json
+          user_id: string
+        }
+        Insert: {
+          created_at?: string
+          event_name: string
+          id?: string
+          properties?: Json
+          user_id: string
+        }
+        Update: {
+          created_at?: string
+          event_name?: string
+          id?: string
+          properties?: Json
+          user_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "analytics_events_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "users"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       movement_logs: {
         Row: {
           created_at: string | null


### PR DESCRIPTION
## PROD-157 — Instrument the activation funnel (signup → first workout)

Stands up the measurement backbone for the **Recommended First Workout** project so we can capture a signup → first-workout baseline now and prove an activation lift after launch (blocks PROD-162). Neither project metric was previously measurable:

- **North star (leading):** 3+ workouts within 14 days of signup
- **Leading indicator:** first workout completed within 24h of signup

### Analytics sink
A first-party Supabase **`analytics_events`** table (RLS insert-own / select-own, immutable rows). The app is already Supabase-centric with no analytics vendor, so a queryable table keeps the funnel self-contained — no new dependency, env var, or network egress — and lets us derive both metrics with plain SQL.

### Events tracked
| Event | Where it fires | Properties |
|-------|----------------|------------|
| `signup_completed` | **Server-side** in `handle_new_user()` on `auth.users` INSERT — exactly-once, no client dedup | — |
| `first_session_started` | `StartWorkoutPage` mount when the user has 0 workout logs | — |
| `workout_started` | `StartWorkoutPage` start → active | `is_first_workout`, `movement_count`, `workout_goal_units` |
| `workout_completed` | `useLogWorkout` on success | `is_first_workout`, `duration_seconds`, `seconds_since_signup`, `workout_log_id` |

`trackEvent()` is fire-and-forget and never throws — analytics can't break a user flow. `is_first_workout` is read from the warm `WORKOUT_LOGS` cache and is also recoverable server-side from `workout_logs`.

### Queryable metrics
Two analyst-only views (read across `auth.users`; `REVOKE`d from anon/authenticated, queried via the service role):
- **`user_activation`** — per user: signup time, time-to-first-workout, `activated_24h`, `workouts_within_14d`, `activated_north_star`. Signup time uses `auth.users.created_at` so the baseline covers existing users too.
- **`activation_funnel_summary`** — workspace baseline: total signups, signup→first-workout conversion, the two metric rates, and avg/median time-to-first-workout.

### Verification
- ✅ `npm run compile:ts`, `npm run build`, `npm test` (273 passing, incl. 4 new `analytics.test.ts`)
- ✅ Migration applied end-to-end against a throwaway local Postgres: confirmed the signup trigger emits `signup_completed`, and both views produce correct per-user flags and aggregate rates across sample users.
- ℹ️ `npm run lint` has one **pre-existing** failure in `public/sw.js` (untouched here; the lint script only covers `js,jsx`).

To read the baseline before launch: `SELECT * FROM activation_funnel_summary;`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ce71B5d6T1WVyTcYGSfdvS

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ce71B5d6T1WVyTcYGSfdvS)_