### PR TITLE
feat(history): paginate workout history with Load More

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -10,5 +10,6 @@ export * from './useMovements';
 export * from './usePatternDebt';
 export * from './useSelectRPE';
 export * from './useUpdateWorkoutNotes';
+export * from './useInfiniteWorkoutLogs';
 export * from './useWorkoutLog';
 export * from './useWorkoutLogs';

--- a/src/api/useInfiniteWorkoutLogs.ts
+++ b/src/api/useInfiniteWorkoutLogs.ts
@@ -1,0 +1,65 @@
+import { useInfiniteQuery } from 'react-query';
+
+import { QUERIES } from '~/constants';
+import { WorkoutLog } from '~/types';
+
+import { supabase } from '../supabaseClient';
+
+const PAGE_SIZE = 20;
+
+interface WorkoutLogsPage {
+  workoutLogs: WorkoutLog[];
+  nextPage: number | undefined;
+}
+
+export const useInfiniteWorkoutLogs = () =>
+  useInfiniteQuery(QUERIES.WORKOUT_LOGS_INFINITE, fetchWorkoutLogsPage, {
+    getNextPageParam: (lastPage) => lastPage.nextPage,
+  });
+
+const fetchWorkoutLogsPage = async ({
+  pageParam = 1,
+}): Promise<WorkoutLogsPage> => {
+  const from = (pageParam - 1) * PAGE_SIZE;
+  const to = from + PAGE_SIZE - 1;
+
+  const { data, count, error } = await supabase
+    .from('workout_logs')
+    .select('*', { count: 'exact' })
+    .order('started_at', { ascending: false })
+    .range(from, to);
+
+  if (error) {
+    console.error(error);
+    throw error;
+  }
+
+  const totalCount = count ?? 0;
+  const nextPage = to < totalCount - 1 ? pageParam + 1 : undefined;
+
+  return {
+    nextPage,
+    workoutLogs: data.map((workoutLog) => ({
+      completedAt: new Date(workoutLog.completed_at),
+      completedReps: workoutLog.completed_reps,
+      completedRounds: workoutLog.completed_rounds,
+      completedRungs: workoutLog.completed_rungs,
+      completedVolume: workoutLog.completed_volume,
+      complexSet: workoutLog.complex_set,
+      id: workoutLog.id,
+      intervalTimer: workoutLog.interval_timer,
+      movements: workoutLog.movements,
+      restTimer: workoutLog.rest_timer,
+      rpe: workoutLog.rpe,
+      sharedWeightOneUnit: workoutLog.shared_weight_one_unit,
+      sharedWeightOneValue: workoutLog.shared_weight_one_value,
+      sharedWeightTwoUnit: workoutLog.shared_weight_two_unit,
+      sharedWeightTwoValue: workoutLog.shared_weight_two_value,
+      startedAt: new Date(workoutLog.started_at),
+      workoutDetails: workoutLog.workout_details,
+      workoutGoal: workoutLog.workout_goal,
+      workoutGoalUnits: workoutLog.workout_goal_units,
+      workoutNotes: workoutLog.workout_notes,
+    })),
+  };
+};

--- a/src/constants/queries.enum.ts
+++ b/src/constants/queries.enum.ts
@@ -6,4 +6,5 @@ export enum QUERIES {
   USER_MOVEMENTS = 'userMovements',
   WORKOUT_LOG = 'workoutLog',
   WORKOUT_LOGS = 'workoutLogs',
+  WORKOUT_LOGS_INFINITE = 'workoutLogsInfinite',
 }

--- a/src/mocks/mocked-workout-logs.ts
+++ b/src/mocks/mocked-workout-logs.ts
@@ -22,7 +22,32 @@ export const mockedWorkoutLogsGet = http.get(
       return HttpResponse.json([workoutLog]);
     }
 
-    return HttpResponse.json(workoutLogs);
+    // Match the real ordering used by the paginated hook (started_at desc).
+    let logs = workoutLogs;
+    if (url.searchParams.get('order')?.startsWith('started_at')) {
+      logs = [...workoutLogs].sort(
+        (a, b) =>
+          new Date(b.started_at).getTime() - new Date(a.started_at).getTime(),
+      );
+    }
+
+    // Honor Supabase's range-based pagination. supabase-js's `.range()` is sent
+    // as `offset`/`limit` query params, and reads the total count from the
+    // `Content-Range` response header when `{ count: 'exact' }` is requested.
+    const offsetParam = url.searchParams.get('offset');
+    const limitParam = url.searchParams.get('limit');
+    if (offsetParam !== null && limitParam !== null) {
+      const from = Number(offsetParam);
+      const to = from + Number(limitParam) - 1;
+      const page = logs.slice(from, from + Number(limitParam));
+      return HttpResponse.json(page, {
+        headers: {
+          'Content-Range': `${from}-${to}/${logs.length}`,
+        },
+      });
+    }
+
+    return HttpResponse.json(logs);
   },
 );
 

--- a/src/pages/HistoryPage/HistoryPage.test.jsx
+++ b/src/pages/HistoryPage/HistoryPage.test.jsx
@@ -1,5 +1,11 @@
 import { composeStories } from '@storybook/react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { HttpResponse, http } from 'msw';
+
+import { VITE_SUPABASE_URL } from '~/env';
+import { ExampleWorkoutLog } from '~/examples';
+import { server } from '~/mocks/server';
 
 import * as stories from './HistoryPage.stories';
 
@@ -38,5 +44,79 @@ describe('workout history page', () => {
     await screen.findByText('50 reps');
     const badges = screen.getAllByText('Complex');
     expect(badges).toHaveLength(1);
+  });
+});
+
+describe('workout history pagination', () => {
+  const PAGE_SIZE = 20;
+
+  // 25 workouts, most-recent first by started_at — spans two pages of 20.
+  const manyWorkoutLogs = Array.from(
+    { length: 25 },
+    (_, i) =>
+      new ExampleWorkoutLog({
+        movements: ['Kettlebell Swing'],
+        started_at: new Date(2025, 0, 25 - i).toISOString(),
+        workout_details: `Session ${i + 1}`,
+      }),
+  );
+
+  beforeEach(() => {
+    server.use(
+      http.get(`${VITE_SUPABASE_URL}/rest/v1/workout_logs`, ({ request }) => {
+        const url = new URL(request.url);
+        const sorted = [...manyWorkoutLogs].sort(
+          (a, b) =>
+            new Date(b.started_at).getTime() - new Date(a.started_at).getTime(),
+        );
+
+        const from = Number(url.searchParams.get('offset') ?? 0);
+        const limit = Number(url.searchParams.get('limit') ?? sorted.length);
+        const to = from + limit - 1;
+        const page = sorted.slice(from, from + limit);
+
+        return HttpResponse.json(page, {
+          headers: { 'Content-Range': `${from}-${to}/${sorted.length}` },
+        });
+      }),
+    );
+
+    render(<Default />);
+  });
+
+  test('renders only the first page of workouts initially', async () => {
+    await screen.findByText('Session 1');
+    expect(screen.queryByText('Session 25')).not.toBeInTheDocument();
+  });
+
+  test('shows a Load More button when more workouts are available', async () => {
+    await screen.findByText('Session 1');
+    expect(
+      screen.getByRole('button', { name: 'Load More' }),
+    ).toBeInTheDocument();
+  });
+
+  test('appends the next page and hides Load More on the last page', async () => {
+    const user = userEvent.setup();
+
+    await screen.findByText('Session 1');
+    await user.click(screen.getByRole('button', { name: 'Load More' }));
+
+    await screen.findByText('Session 25');
+
+    await waitFor(() => {
+      expect(
+        screen.queryByRole('button', { name: 'Load More' }),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  test('loads the configured page size on the first request', async () => {
+    await screen.findByText('Session 1');
+    // Sessions 1-20 are the first page; Session 21 is on the next page.
+    expect(screen.queryByText(`Session ${PAGE_SIZE}`)).toBeInTheDocument();
+    expect(
+      screen.queryByText(`Session ${PAGE_SIZE + 1}`),
+    ).not.toBeInTheDocument();
   });
 });

--- a/src/pages/HistoryPage/HistoryPage.tsx
+++ b/src/pages/HistoryPage/HistoryPage.tsx
@@ -1,16 +1,20 @@
 import { DateTime } from 'luxon';
 import { Link } from 'react-router-dom';
 
-import { useWorkoutLogs } from '~/api';
+import { useInfiniteWorkoutLogs } from '~/api';
 import { Loading, Page } from '~/components';
 import { Badge } from '~/components/ui/badge';
+import { Button } from '~/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '~/components/ui/card';
 import { WorkoutLog } from '~/types';
 
 import { RpeBadge } from '../CompletedWorkoutPage/components';
 
 export const HistoryPage = () => {
-  const { data: workoutLogs, isLoading } = useWorkoutLogs();
+  const { data, isLoading, fetchNextPage, hasNextPage, isFetchingNextPage } =
+    useInfiniteWorkoutLogs();
+
+  const workoutLogs = data?.pages.flatMap((page) => page.workoutLogs) ?? [];
 
   const workoutDays = groupByDate(workoutLogs);
   const workoutWeeks = groupByWeek(workoutDays);
@@ -26,6 +30,19 @@ export const HistoryPage = () => {
           />
         ))}
       </div>
+
+      {hasNextPage && (
+        <div className="mt-4 flex justify-center">
+          <Button
+            variant="outline"
+            loading={isFetchingNextPage}
+            disabled={isFetchingNextPage}
+            onClick={() => fetchNextPage()}
+          >
+            Load More
+          </Button>
+        </div>
+      )}
 
       {isLoading && <Loading />}
     </Page>


### PR DESCRIPTION
Paginate the Workout History page so it loads 20 workouts at a time via a "Load More" button instead of fetching every log in one unbounded query.

**Changes:**
- Add `useInfiniteWorkoutLogs` hook using react-query v3's `useInfiniteQuery` with Supabase `.order('started_at', { ascending: false })` + `.range()` (page size 20), reusing the existing row→`WorkoutLog` mapping and the count/range pattern from `useMovements`
- Refactor `HistoryPage` to flatten loaded pages before the existing week/day grouping and render a "Load More" button gated on `hasNextPage` (with a loading state from `isFetchingNextPage`)
- Leave `useWorkoutLogs` untouched — it's also consumed by `WeeklyBalanceContainer` for its total `workoutLogs?.length` count, so pagination went into a separate hook
- Update the `workout_logs` MSW mock to honor `offset`/`limit` pagination and return `Content-Range` (this postgrest-js version sends `.range()` as query params, not a `Range` header)
- Add new query key `WORKOUT_LOGS_INFINITE`

**Testing:**
- `npm test src/pages/HistoryPage` → 81 passed (existing 7 + 4 new pagination tests: first-page-only, button presence, append + hide on last page, page size)
- `WeeklyBalance` tests still pass (regression check on the untouched hook)
- `compile:ts` introduces zero new type errors (the 3 reported errors pre-exist on `main`, confirmed by stashing)
- Prettier clean on all changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)