### PR TITLE
feat(activation): curated first workouts + recent-repeat surface (PROD-159)

### DIFF
--- a/.env.e2e.example
+++ b/.env.e2e.example
@@ -1,0 +1,22 @@
+# Playwright e2e config — copy to .env.e2e and fill in (`.env.e2e` is gitignored).
+# Loaded by playwright.config.ts; the dev server + the test both read these.
+#
+# Targets LOCAL Supabase. Start it first with `supabase start`, then grab the
+# values below from `supabase status` (or `supabase status -o env`).
+
+# IMPORTANT: use the `localhost` hostname (not 127.0.0.1). The test injects the
+# auth session into localStorage under supabase-js's key `sb-<hostname>-auth-token`,
+# so the app and the test must agree on the hostname — `localhost` → `sb-localhost-auth-token`.
+VITE_SUPABASE_URL=http://localhost:54321
+
+# Local anon key from `supabase status` (the local demo key, safe to share).
+VITE_SUPABASE_ANON_KEY=your-local-anon-key
+
+# A confirmed user in local auth. Create one (idempotent) with the service_role
+# key from `supabase status`:
+#   curl -X POST http://localhost:54321/auth/v1/admin/users \
+#     -H "apikey: <SERVICE_ROLE_KEY>" -H "Authorization: Bearer <SERVICE_ROLE_KEY>" \
+#     -H "Content-Type: application/json" \
+#     -d '{"email":"test@example.com","password":"testpassword123","email_confirm":true}'
+TEST_USER_EMAIL=test@example.com
+TEST_USER_PASSWORD=testpassword123

--- a/e2e/workout-flow.spec.ts
+++ b/e2e/workout-flow.spec.ts
@@ -160,11 +160,21 @@ test.describe('full workout flow', () => {
     // ── 2. Load the app ───────────────────────────────────────────────────
     await page.goto('/');
 
-    // Confirm we bypassed the Signup screen and landed on StartWorkoutPage
+    // The Start page now opens in "browse" mode (curated/recent recommendations
+    // + a "Build custom workout" button). Its presence confirms we bypassed the
+    // Signup screen and landed on StartWorkoutPage.
+    const buildCustomButton = page.getByRole('button', {
+      name: 'Build custom workout',
+    });
+    await expect(buildCustomButton).toBeVisible({ timeout: 10_000 });
+
+    // Expand the custom workout builder so the goal/movement controls render.
+    await buildCustomButton.click();
+
     const startWorkoutButton = page.getByRole('button', {
       name: 'Start workout',
     });
-    await expect(startWorkoutButton).toBeVisible({ timeout: 10_000 });
+    await expect(startWorkoutButton).toBeVisible();
 
     // ── 3. Switch goal unit to "Rounds" ───────────────────────────────────
     // Default is "minutes" (10 min). Switching to rounds sets goal to

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -9,6 +9,7 @@ export * from './useLogWorkout';
 export * from './useMovementLogs';
 export * from './useMovements';
 export * from './usePatternDebt';
+export * from './useRecentRepeatableWorkouts';
 export * from './useSelectRPE';
 export * from './useUpdateWorkoutNotes';
 export * from './useInfiniteWorkoutLogs';

--- a/src/api/useRecentRepeatableWorkouts.ts
+++ b/src/api/useRecentRepeatableWorkouts.ts
@@ -1,0 +1,96 @@
+import { useMemo } from 'react';
+import { useQuery } from 'react-query';
+
+import { QUERIES } from '~/constants';
+import { supabase } from '~/supabaseClient';
+import { MovementLog, WorkoutLog, WorkoutOptions } from '~/types';
+import { workoutLogToWorkoutOptions } from '~/utils';
+
+import { useWorkoutLogs } from './useWorkoutLogs';
+
+export const RECENT_REPEAT_LIMIT = 3;
+
+/** A past workout reduced to a one-tap startable session. */
+export interface RepeatableWorkout {
+  workoutLogId: number;
+  workoutLog: WorkoutLog;
+  workoutOptions: Omit<WorkoutOptions, 'startedAt'>;
+}
+
+const fetchMovementLogsByWorkoutIds = async (
+  workoutLogIds: number[],
+): Promise<Record<number, MovementLog[]>> => {
+  if (workoutLogIds.length === 0) return {};
+
+  const { data: rows, error } = await supabase
+    .from('movement_logs')
+    .select('*')
+    .in('workout_log_id', workoutLogIds)
+    .order('id');
+
+  if (error) {
+    console.error(error);
+    throw error;
+  }
+
+  const grouped: Record<number, MovementLog[]> = {};
+  for (const row of rows) {
+    const movementLog: MovementLog = {
+      id: row.id,
+      movementName: row.movement_name,
+      repScheme: row.rep_scheme,
+      userMovementId: row.user_movement_id ?? null,
+      functionalMovementId: null,
+      weightOneUnit: row.weight_one_unit,
+      weightOneValue: row.weight_one_value,
+      weightTwoUnit: row.weight_two_unit,
+      weightTwoValue: row.weight_two_value,
+    };
+    (grouped[row.workout_log_id] ??= []).push(movementLog);
+  }
+  return grouped;
+};
+
+/**
+ * The user's most recent completed workouts, each converted into a one-tap
+ * startable session (via {@link workoutLogToWorkoutOptions}). Empty for users
+ * with no history. Backs the "repeat a recent workout" recommendations that sit
+ * alongside the curated first workouts on the Start page.
+ */
+export const useRecentRepeatableWorkouts = (
+  limit: number = RECENT_REPEAT_LIMIT,
+): { recentRepeats: RepeatableWorkout[]; isLoading: boolean } => {
+  const { data: workoutLogs } = useWorkoutLogs();
+
+  const recentLogs = useMemo(() => {
+    if (!workoutLogs) return [];
+    return [...workoutLogs]
+      .sort((a, b) => b.completedAt.getTime() - a.completedAt.getTime())
+      .slice(0, limit);
+  }, [workoutLogs, limit]);
+
+  const workoutLogIds = recentLogs.map((log) => log.id);
+
+  const { data: grouped, isLoading } = useQuery(
+    [QUERIES.MOVEMENT_LOGS, 'recent', workoutLogIds],
+    () => fetchMovementLogsByWorkoutIds(workoutLogIds),
+    { enabled: workoutLogIds.length > 0 },
+  );
+
+  const recentRepeats = useMemo(() => {
+    if (!grouped) return [];
+    return recentLogs
+      .map((log) => {
+        const movementLogs = grouped[log.id] ?? [];
+        if (movementLogs.length === 0) return null;
+        return {
+          workoutLogId: log.id,
+          workoutLog: log,
+          workoutOptions: workoutLogToWorkoutOptions(log, movementLogs),
+        };
+      })
+      .filter((repeat): repeat is RepeatableWorkout => repeat !== null);
+  }, [recentLogs, grouped]);
+
+  return { recentRepeats, isLoading: workoutLogIds.length > 0 && isLoading };
+};

--- a/src/constants/curatedWorkouts.test.ts
+++ b/src/constants/curatedWorkouts.test.ts
@@ -36,8 +36,26 @@ describe('CURATED_WORKOUTS', () => {
       expect(workout.title.length).toBeGreaterThan(0);
       expect(workout.subtitle.length).toBeGreaterThan(0);
       expect(workout.estimatedMinutes).toBeGreaterThan(0);
+
+      // Notes should be a distinct session label, not the movement name.
+      expect(workoutOptions.workoutDetails?.length ?? 0).toBeGreaterThan(0);
+      expect(workoutOptions.workoutDetails).not.toBe(
+        workoutOptions.movements[0].movementName,
+      );
     },
   );
+
+  test('uses catalog movement names', () => {
+    const byId = Object.fromEntries(CURATED_WORKOUTS.map((w) => [w.id, w]));
+    const nameOf = (id: string) =>
+      byId[id].workoutOptions.movements[0].movementName;
+
+    expect(nameOf('beginner-two-hand-swing')).toBe('Kettlebell Swing');
+    expect(nameOf('beginner-overhead-press')).toBe(
+      'Single Arm Kettlebell Overhead Press',
+    );
+    expect(nameOf('beginner-goblet-squat')).toBe('Kettlebell Goblet Squat');
+  });
 
   test('encodes weight modes the same way the builder would', () => {
     const byId = Object.fromEntries(CURATED_WORKOUTS.map((w) => [w.id, w]));
@@ -82,7 +100,7 @@ describe('CURATED_WORKOUTS', () => {
       sharedWeightOneValue: null,
       sharedWeightTwoUnit: null,
       sharedWeightTwoValue: null,
-      workoutDetails: 'Two-Hand Swing',
+      workoutDetails: 'Beginner: Hinge Foundation',
       workoutGoal: 5,
       workoutGoalUnits: 'rounds',
     });

--- a/src/constants/curatedWorkouts.test.ts
+++ b/src/constants/curatedWorkouts.test.ts
@@ -1,0 +1,90 @@
+import { getWeightTabValue } from '~/utils';
+
+import { CURATED_WORKOUTS, CURATED_WORKOUTS_VERSION } from './curatedWorkouts';
+
+describe('CURATED_WORKOUTS', () => {
+  test('exports a numeric version', () => {
+    expect(typeof CURATED_WORKOUTS_VERSION).toBe('number');
+    expect(CURATED_WORKOUTS_VERSION).toBeGreaterThanOrEqual(1);
+  });
+
+  test('provides 2-3 beginner options with unique ids', () => {
+    expect(CURATED_WORKOUTS.length).toBeGreaterThanOrEqual(2);
+    expect(CURATED_WORKOUTS.length).toBeLessThanOrEqual(3);
+    const ids = CURATED_WORKOUTS.map((workout) => workout.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  test.each(CURATED_WORKOUTS)(
+    '$id is a valid, startable single-bell session',
+    (workout) => {
+      const { workoutOptions } = workout;
+
+      // Beginner-friendly: simple, no complex sets.
+      expect(workoutOptions.complexSet).toBe(false);
+      expect(workoutOptions.sharedWeightOneValue).toBeNull();
+      expect(workoutOptions.intervalTimer).toBe(0);
+      expect(workoutOptions.workoutGoal).toBeGreaterThan(0);
+
+      expect(workoutOptions.movements.length).toBeGreaterThan(0);
+      for (const movement of workoutOptions.movements) {
+        expect(movement.movementName.length).toBeGreaterThan(0);
+        expect(movement.repScheme.length).toBeGreaterThan(0);
+        expect(movement.repScheme.every((reps) => reps > 0)).toBe(true);
+      }
+
+      expect(workout.title.length).toBeGreaterThan(0);
+      expect(workout.subtitle.length).toBeGreaterThan(0);
+      expect(workout.estimatedMinutes).toBeGreaterThan(0);
+    },
+  );
+
+  test('encodes weight modes the same way the builder would', () => {
+    const byId = Object.fromEntries(CURATED_WORKOUTS.map((w) => [w.id, w]));
+
+    expect(
+      getWeightTabValue(
+        byId['beginner-two-hand-swing'].workoutOptions.movements[0],
+      ),
+    ).toBe('2h');
+    expect(
+      getWeightTabValue(
+        byId['beginner-goblet-squat'].workoutOptions.movements[0],
+      ),
+    ).toBe('2h');
+    expect(
+      getWeightTabValue(
+        byId['beginner-overhead-press'].workoutOptions.movements[0],
+      ),
+    ).toBe('1h');
+  });
+
+  test('the swing template equals a hand-built equivalent', () => {
+    const swing = CURATED_WORKOUTS.find(
+      (workout) => workout.id === 'beginner-two-hand-swing',
+    );
+
+    expect(swing?.workoutOptions).toEqual({
+      complexSet: false,
+      intervalTimer: 0,
+      restTimer: 60,
+      movements: [
+        {
+          movementName: 'Kettlebell Swing',
+          repScheme: [10],
+          weightOneUnit: 'kilograms',
+          weightOneValue: 16,
+          weightTwoUnit: null,
+          weightTwoValue: null,
+        },
+      ],
+      sharedWeightOneUnit: null,
+      sharedWeightOneValue: null,
+      sharedWeightTwoUnit: null,
+      sharedWeightTwoValue: null,
+      workoutDetails: 'Two-Hand Swing',
+      workoutGoal: 5,
+      workoutGoalUnits: 'rounds',
+    });
+  });
+});

--- a/src/constants/curatedWorkouts.ts
+++ b/src/constants/curatedWorkouts.ts
@@ -9,7 +9,7 @@ import { CuratedWorkout } from '~/types';
  * Bump CURATED_WORKOUTS_VERSION whenever the content changes so analytics can
  * attribute starts to a known revision.
  */
-export const CURATED_WORKOUTS_VERSION = 1;
+export const CURATED_WORKOUTS_VERSION = 2;
 
 export const CURATED_WORKOUTS: CuratedWorkout[] = [
   {
@@ -35,7 +35,7 @@ export const CURATED_WORKOUTS: CuratedWorkout[] = [
       sharedWeightOneValue: null,
       sharedWeightTwoUnit: null,
       sharedWeightTwoValue: null,
-      workoutDetails: 'Two-Hand Swing',
+      workoutDetails: 'Beginner: Hinge Foundation',
       workoutGoal: 5,
       workoutGoalUnits: 'rounds',
     },
@@ -51,7 +51,7 @@ export const CURATED_WORKOUTS: CuratedWorkout[] = [
       restTimer: 60,
       movements: [
         {
-          movementName: 'Overhead Press',
+          movementName: 'Single Arm Kettlebell Overhead Press',
           repScheme: [5],
           weightOneUnit: 'kilograms',
           weightOneValue: 12,
@@ -64,7 +64,7 @@ export const CURATED_WORKOUTS: CuratedWorkout[] = [
       sharedWeightOneValue: null,
       sharedWeightTwoUnit: null,
       sharedWeightTwoValue: null,
-      workoutDetails: 'Overhead Press',
+      workoutDetails: 'Beginner: Overhead Strength',
       workoutGoal: 5,
       workoutGoalUnits: 'rounds',
     },
@@ -80,7 +80,7 @@ export const CURATED_WORKOUTS: CuratedWorkout[] = [
       restTimer: 60,
       movements: [
         {
-          movementName: 'Goblet Squat',
+          movementName: 'Kettlebell Goblet Squat',
           repScheme: [8],
           weightOneUnit: 'kilograms',
           weightOneValue: 16,
@@ -92,7 +92,7 @@ export const CURATED_WORKOUTS: CuratedWorkout[] = [
       sharedWeightOneValue: null,
       sharedWeightTwoUnit: null,
       sharedWeightTwoValue: null,
-      workoutDetails: 'Goblet Squat',
+      workoutDetails: 'Beginner: Squat Foundation',
       workoutGoal: 5,
       workoutGoalUnits: 'rounds',
     },

--- a/src/constants/curatedWorkouts.ts
+++ b/src/constants/curatedWorkouts.ts
@@ -1,0 +1,100 @@
+import { CuratedWorkout } from '~/types';
+
+/**
+ * Versioned seed of curated beginner workouts (PROD-158 / PROD-159). These are
+ * the one-tap "recommended first workout" options shown to new users in place
+ * of the blank builder. Kept as an in-app constant for v1 — structured so a
+ * Supabase-backed table can replace it later without changing consumers.
+ *
+ * Bump CURATED_WORKOUTS_VERSION whenever the content changes so analytics can
+ * attribute starts to a known revision.
+ */
+export const CURATED_WORKOUTS_VERSION = 1;
+
+export const CURATED_WORKOUTS: CuratedWorkout[] = [
+  {
+    id: 'beginner-two-hand-swing',
+    title: 'Two-Hand Swing',
+    subtitle: 'Power from the hips — 50 swings to learn the hinge.',
+    estimatedMinutes: 10,
+    workoutOptions: {
+      complexSet: false,
+      intervalTimer: 0,
+      restTimer: 60,
+      movements: [
+        {
+          movementName: 'Kettlebell Swing',
+          repScheme: [10],
+          weightOneUnit: 'kilograms',
+          weightOneValue: 16,
+          weightTwoUnit: null,
+          weightTwoValue: null,
+        },
+      ],
+      sharedWeightOneUnit: null,
+      sharedWeightOneValue: null,
+      sharedWeightTwoUnit: null,
+      sharedWeightTwoValue: null,
+      workoutDetails: 'Two-Hand Swing',
+      workoutGoal: 5,
+      workoutGoalUnits: 'rounds',
+    },
+  },
+  {
+    id: 'beginner-overhead-press',
+    title: 'Overhead Press',
+    subtitle: 'Build overhead pressing strength, one arm at a time.',
+    estimatedMinutes: 8,
+    workoutOptions: {
+      complexSet: false,
+      intervalTimer: 0,
+      restTimer: 60,
+      movements: [
+        {
+          movementName: 'Overhead Press',
+          repScheme: [5],
+          weightOneUnit: 'kilograms',
+          weightOneValue: 12,
+          weightTwoUnit: null,
+          // weightTwoValue: 0 encodes a single-arm (1H) hold — see getWeightTabValue.
+          weightTwoValue: 0,
+        },
+      ],
+      sharedWeightOneUnit: null,
+      sharedWeightOneValue: null,
+      sharedWeightTwoUnit: null,
+      sharedWeightTwoValue: null,
+      workoutDetails: 'Overhead Press',
+      workoutGoal: 5,
+      workoutGoalUnits: 'rounds',
+    },
+  },
+  {
+    id: 'beginner-goblet-squat',
+    title: 'Goblet Squat',
+    subtitle: 'Grease the squat holding the bell at your chest.',
+    estimatedMinutes: 8,
+    workoutOptions: {
+      complexSet: false,
+      intervalTimer: 0,
+      restTimer: 60,
+      movements: [
+        {
+          movementName: 'Goblet Squat',
+          repScheme: [8],
+          weightOneUnit: 'kilograms',
+          weightOneValue: 16,
+          weightTwoUnit: null,
+          weightTwoValue: null,
+        },
+      ],
+      sharedWeightOneUnit: null,
+      sharedWeightOneValue: null,
+      sharedWeightTwoUnit: null,
+      sharedWeightTwoValue: null,
+      workoutDetails: 'Goblet Squat',
+      workoutGoal: 5,
+      workoutGoalUnits: 'rounds',
+    },
+  },
+];

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,1 +1,2 @@
+export * from './curatedWorkouts';
 export * from './queries.enum';

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,3 +1,4 @@
 export * from './useCountdownTimer';
 export * from './useDebouncedCallback';
 export * from './useFeatures';
+export * from './useStartWorkout';

--- a/src/hooks/useStartWorkout.ts
+++ b/src/hooks/useStartWorkout.ts
@@ -1,0 +1,45 @@
+import { useCallback } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+import { AnalyticsEvent, trackEvent } from '~/api';
+import { useSession, useWorkoutOptions } from '~/contexts';
+import { WorkoutOptions } from '~/types';
+
+import type { Json } from '../../types/supabase';
+
+/** Where a workout start originated, for activation-funnel attribution. */
+export type WorkoutStartSource = 'builder' | 'curated' | 'history_repeat';
+
+/**
+ * Shared "start a workout" action used by the manual builder, curated
+ * templates, and history repeats. Stamps `startedAt`, commits the options to
+ * context, fires the `workout_started` analytics event (tagged with `source`),
+ * and routes into the active workout.
+ */
+export const useStartWorkout = () => {
+  const navigate = useNavigate();
+  const [, updateWorkoutOptions] = useWorkoutOptions();
+  const session = useSession();
+  const userId = session?.user?.id;
+
+  return useCallback(
+    (
+      options: Omit<WorkoutOptions, 'startedAt'>,
+      source: WorkoutStartSource,
+      extraProps: Record<string, Json> = {},
+    ) => {
+      updateWorkoutOptions({ ...options, startedAt: new Date() });
+
+      if (userId) {
+        void trackEvent({
+          event: AnalyticsEvent.WorkoutStarted,
+          userId,
+          properties: { source, ...extraProps },
+        });
+      }
+
+      navigate('active');
+    },
+    [navigate, updateWorkoutOptions, userId],
+  );
+};

--- a/src/mocks/mocked-movement-logs.ts
+++ b/src/mocks/mocked-movement-logs.ts
@@ -9,8 +9,25 @@ export const mockedMovementLogsGet = http.get(
   MOVEMENT_LOGS_URL,
   ({ request }) => {
     const url = new URL(request.url);
-    const workoutLogId = url.searchParams.get('workout_log_id')?.split('.')[1];
+    const filter = url.searchParams.get('workout_log_id') ?? '';
 
+    // Recent-repeats fetch uses `.in('workout_log_id', [...])`, sent as
+    // `workout_log_id=in.(1,2,3)`. May legitimately match nothing, so don't
+    // throw for this case.
+    if (filter.startsWith('in.')) {
+      const ids = filter
+        .slice('in.'.length)
+        .replace(/[()]/g, '')
+        .split(',')
+        .map(Number)
+        .filter((id) => !Number.isNaN(id));
+      return HttpResponse.json(
+        movementLogs.filter((m) => ids.includes(m.workout_log_id)),
+      );
+    }
+
+    // Single-workout fetch via `.eq('workout_log_id', id)` → `eq.<id>`.
+    const workoutLogId = filter.split('.')[1];
     const filteredMovementLogs = movementLogs.filter(
       (m) => m.workout_log_id === Number(workoutLogId),
     );

--- a/src/pages/CompletedWorkoutPage/CompletedWorkoutPage.test.jsx
+++ b/src/pages/CompletedWorkoutPage/CompletedWorkoutPage.test.jsx
@@ -86,7 +86,9 @@ describe('completed workout page', () => {
         ],
       }),
     );
-    expect(navigate).toHaveBeenCalledWith('/');
+    expect(navigate).toHaveBeenCalledWith('/', {
+      state: { editWorkout: true },
+    });
   });
 
   test('clicking on an RPE value updates the selected value', async () => {

--- a/src/pages/CompletedWorkoutPage/CompletedWorkoutPage.tsx
+++ b/src/pages/CompletedWorkoutPage/CompletedWorkoutPage.tsx
@@ -73,7 +73,9 @@ export const CompletedWorkoutPage = () => {
     // Prefill the builder from the completed workout, then let the user review
     // and adjust before starting (routes to the Start page, not /active).
     updateWorkoutOptions(workoutLogToWorkoutOptions(workoutLog, movementLogs));
-    navigate('/');
+    // Tell the Start page to open the builder (it now defaults to the collapsed
+    // recommendations view) so the prefilled workout is shown for editing.
+    navigate('/', { state: { editWorkout: true } });
   };
 
   return (

--- a/src/pages/CompletedWorkoutPage/CompletedWorkoutPage.tsx
+++ b/src/pages/CompletedWorkoutPage/CompletedWorkoutPage.tsx
@@ -23,11 +23,11 @@ import {
 } from '~/components/ui/dialog';
 import { Textarea } from '~/components/ui/textarea';
 import { useWorkoutOptions } from '~/contexts';
-import { WorkoutGoalUnits, WorkoutLog } from '~/types';
+import { WorkoutLog } from '~/types';
+import { workoutLogToWorkoutOptions } from '~/utils';
 
 import { Section } from '../StartWorkoutPage/components';
 import { RPESelector, WorkoutHistoryItem } from './components';
-import { resolveSharedWeights } from './utils';
 
 export const CompletedWorkoutPage = () => {
   const { id = '' } = useParams<{ id: string }>();
@@ -70,63 +70,9 @@ export const CompletedWorkoutPage = () => {
     updateWorkoutNotes(notesRef.current?.value || null);
 
   const handleClickRepeat = () => {
-    // Calculate actual completed duration in minutes
-    const completedDurationMs =
-      workoutLog.completedAt.getTime() - workoutLog.startedAt.getTime();
-    const completedDurationMinutes = Math.round(completedDurationMs / 60000);
-
-    // Use actual completed values for all unit types
-    const previousMinutes = completedDurationMinutes;
-    const previousRounds = workoutLog.completedRounds ?? 0;
-    const previousVolume =
-      workoutLog.workoutGoalUnits === 'kilograms' && workoutLog.completedVolume
-        ? workoutLog.completedVolume
-        : undefined;
-
-    // Determine workoutGoal and workoutGoalUnits based on original workout
-    let workoutGoal: number = workoutLog.workoutGoal;
-    let workoutGoalUnits: WorkoutGoalUnits = workoutLog.workoutGoalUnits;
-
-    const isComplexSet = workoutLog.complexSet === true;
-    const sharedWeights = resolveSharedWeights(
-      workoutLog.sharedWeightOneValue,
-      workoutLog.sharedWeightOneUnit,
-      workoutLog.sharedWeightTwoValue,
-      workoutLog.sharedWeightTwoUnit,
-      movementLogs,
-    );
-
-    updateWorkoutOptions({
-      complexSet: isComplexSet,
-      intervalTimer: workoutLog.intervalTimer,
-      movements: movementLogs.map((movementLog) => ({
-        movementName: movementLog.movementName,
-        repScheme: movementLog.repScheme,
-        weightOneUnit: isComplexSet
-          ? sharedWeights.weightOneUnit
-          : movementLog.weightOneUnit,
-        weightOneValue: isComplexSet
-          ? sharedWeights.weightOneValue
-          : movementLog.weightOneValue,
-        weightTwoUnit: isComplexSet
-          ? sharedWeights.weightTwoUnit
-          : movementLog.weightTwoUnit,
-        weightTwoValue: isComplexSet
-          ? sharedWeights.weightTwoValue
-          : movementLog.weightTwoValue,
-      })),
-      restTimer: workoutLog.restTimer,
-      sharedWeightOneUnit: isComplexSet ? sharedWeights.weightOneUnit : null,
-      sharedWeightOneValue: isComplexSet ? sharedWeights.weightOneValue : null,
-      sharedWeightTwoUnit: isComplexSet ? sharedWeights.weightTwoUnit : null,
-      sharedWeightTwoValue: isComplexSet ? sharedWeights.weightTwoValue : null,
-      workoutDetails: workoutLog.workoutDetails,
-      workoutGoal,
-      workoutGoalUnits,
-      previousVolume,
-      previousMinutes,
-      previousRounds,
-    });
+    // Prefill the builder from the completed workout, then let the user review
+    // and adjust before starting (routes to the Start page, not /active).
+    updateWorkoutOptions(workoutLogToWorkoutOptions(workoutLog, movementLogs));
     navigate('/');
   };
 

--- a/src/pages/CompletedWorkoutPage/utils/resolveSharedWeights.ts
+++ b/src/pages/CompletedWorkoutPage/utils/resolveSharedWeights.ts
@@ -1,34 +1,5 @@
-import { MovementLog, WeightUnit } from '~/types';
-
-export interface SharedWeights {
-  weightOneUnit: WeightUnit | null;
-  weightOneValue: number | null;
-  weightTwoUnit: WeightUnit | null;
-  weightTwoValue: number | null;
-}
-
-export const resolveSharedWeights = (
-  sharedWeightOneValue: number | null | undefined,
-  sharedWeightOneUnit: WeightUnit | null | undefined,
-  sharedWeightTwoValue: number | null | undefined,
-  sharedWeightTwoUnit: WeightUnit | null | undefined,
-  movementLogs: MovementLog[],
-): SharedWeights => {
-  const fallback = movementLogs[0];
-
-  if (sharedWeightOneValue == null && sharedWeightOneUnit == null) {
-    return {
-      weightOneValue: fallback?.weightOneValue ?? null,
-      weightOneUnit: fallback?.weightOneUnit ?? null,
-      weightTwoValue: fallback?.weightTwoValue ?? null,
-      weightTwoUnit: fallback?.weightTwoUnit ?? null,
-    };
-  }
-
-  return {
-    weightOneValue: sharedWeightOneValue ?? null,
-    weightOneUnit: sharedWeightOneUnit ?? null,
-    weightTwoValue: sharedWeightTwoValue ?? null,
-    weightTwoUnit: sharedWeightTwoUnit ?? null,
-  };
-};
+// resolveSharedWeights now lives in ~/utils so it can be shared by the API
+// layer (recent-workout repeats) without a pages -> utils import cycle. This
+// re-export keeps the existing `./utils` / `../utils/resolveSharedWeights`
+// import paths working for the CompletedWorkoutPage components.
+export * from '~/utils/resolveSharedWeights';

--- a/src/pages/StartWorkoutPage/StartWorkoutPage.recommendations.test.jsx
+++ b/src/pages/StartWorkoutPage/StartWorkoutPage.recommendations.test.jsx
@@ -156,4 +156,60 @@ describe('StartWorkoutPage recommendations', () => {
       expect(screen.getByText('active workout page')).toBeInTheDocument();
     });
   });
+
+  // Regression: the history "Repeat" action prefills context and navigates here
+  // with `editWorkout` nav state; the builder must open directly on that
+  // workout rather than showing the collapsed recommendations.
+  describe('repeat from history (editWorkout nav state)', () => {
+    test('opens the prefilled builder directly, not the recommendations', async () => {
+      const repeated = {
+        ...DEFAULT_WORKOUT_OPTIONS,
+        movements: [
+          {
+            movementName: 'Clean and Press',
+            repScheme: [3],
+            weightOneUnit: 'kilograms',
+            weightOneValue: 20,
+            weightTwoUnit: null,
+            weightTwoValue: null,
+          },
+        ],
+        workoutDetails: 'The Giant 3.0 W1D2',
+      };
+
+      render(
+        <QueryClientProvider client={makeQueryClient()}>
+          <MemoryRouter
+            initialEntries={[{ pathname: '/', state: { editWorkout: true } }]}
+          >
+            <WorkoutOptionsContext.Provider value={[repeated, vi.fn()]}>
+              <Routes>
+                <Route path="/" element={<StartWorkoutPage />} />
+                <Route
+                  path="/active"
+                  element={<div>active workout page</div>}
+                />
+              </Routes>
+            </WorkoutOptionsContext.Provider>
+          </MemoryRouter>
+        </QueryClientProvider>,
+      );
+
+      // Builder is open and prefilled with the repeated workout...
+      expect(await screen.findByLabelText('Movement Input')).toHaveValue(
+        'Clean and Press',
+      );
+
+      // ...and the recommendation browse view is not shown.
+      expect(
+        screen.queryByRole('button', { name: /build custom workout/i }),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByText('Pick up where you left off'),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole('button', { name: 'Two-Hand Swing' }),
+      ).not.toBeInTheDocument();
+    });
+  });
 });

--- a/src/pages/StartWorkoutPage/StartWorkoutPage.recommendations.test.jsx
+++ b/src/pages/StartWorkoutPage/StartWorkoutPage.recommendations.test.jsx
@@ -48,7 +48,7 @@ describe('StartWorkoutPage recommendations', () => {
   describe('new user (no history)', () => {
     beforeEach(returnZeroWorkoutLogs);
 
-    test('shows the curated first workouts and no recent repeats', async () => {
+    test('shows the curated workouts, no recent repeats, and no builder yet', async () => {
       renderPage();
 
       expect(
@@ -60,20 +60,52 @@ describe('StartWorkoutPage recommendations', () => {
       expect(
         screen.getByRole('button', { name: 'Goblet Squat' }),
       ).toBeInTheDocument();
-
       expect(
         screen.getByRole('heading', { name: 'Your recommended first workout' }),
       ).toBeInTheDocument();
       expect(
         screen.queryByText('Pick up where you left off'),
       ).not.toBeInTheDocument();
+
+      // Builder is collapsed until a card or "Build custom workout" is tapped.
+      expect(screen.queryByLabelText('Movement Input')).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole('button', { name: /start workout/i }),
+      ).not.toBeInTheDocument();
     });
 
-    test('one-tap on a curated workout prefills context and enters the active workout', async () => {
+    test('"Build custom workout" reveals an empty builder and hides recommendations', async () => {
+      renderPage();
+
+      await userEvent.click(
+        await screen.findByRole('button', {
+          name: /build custom workout/i,
+        }),
+      );
+
+      expect(screen.getByLabelText('Movement Input')).toHaveValue('');
+      expect(
+        screen.queryByRole('button', { name: 'Two-Hand Swing' }),
+      ).not.toBeInTheDocument();
+    });
+
+    test('tapping a curated workout fills the builder for editing without starting', async () => {
       const { updateWorkoutOptions } = renderPage();
 
       await userEvent.click(
         await screen.findByRole('button', { name: 'Two-Hand Swing' }),
+      );
+
+      // Lands in the builder, prefilled with the catalog movement — not /active.
+      expect(screen.getByLabelText('Movement Input')).toHaveValue(
+        'Kettlebell Swing',
+      );
+      expect(updateWorkoutOptions).not.toHaveBeenCalled();
+      expect(screen.queryByText('active workout page')).not.toBeInTheDocument();
+
+      // The user can then start the (optionally edited) workout.
+      await userEvent.click(
+        screen.getByRole('button', { name: /start workout/i }),
       );
 
       expect(updateWorkoutOptions).toHaveBeenCalledTimes(1);
@@ -89,7 +121,6 @@ describe('StartWorkoutPage recommendations', () => {
     test('shows recent repeats alongside the curated workouts', async () => {
       renderPage();
 
-      // Both surfaces are shown for returning users ("always show both").
       expect(
         await screen.findByText('Pick up where you left off'),
       ).toBeInTheDocument();
@@ -101,12 +132,19 @@ describe('StartWorkoutPage recommendations', () => {
       ).toBeInTheDocument();
     });
 
-    test('one-tap on a recent workout prefills it and enters the active workout', async () => {
+    test('tapping a recent workout fills the builder, then starts on confirm', async () => {
       const { updateWorkoutOptions } = renderPage();
 
       // The most recent logged session in the mock data is a "Pull-Ups" workout.
       await userEvent.click(
         await screen.findByRole('button', { name: 'Pull-Ups' }),
+      );
+
+      expect(screen.getByLabelText('Movement Input')).toHaveValue('Pull-Ups');
+      expect(updateWorkoutOptions).not.toHaveBeenCalled();
+
+      await userEvent.click(
+        screen.getByRole('button', { name: /start workout/i }),
       );
 
       expect(updateWorkoutOptions).toHaveBeenCalledTimes(1);

--- a/src/pages/StartWorkoutPage/StartWorkoutPage.recommendations.test.jsx
+++ b/src/pages/StartWorkoutPage/StartWorkoutPage.recommendations.test.jsx
@@ -1,0 +1,121 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { HttpResponse, http } from 'msw';
+import { QueryClient, QueryClientProvider } from 'react-query';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+
+import { CURATED_WORKOUTS } from '~/constants';
+import { DEFAULT_WORKOUT_OPTIONS, WorkoutOptionsContext } from '~/contexts';
+import { VITE_SUPABASE_URL } from '~/env';
+import { server } from '~/mocks/server';
+
+import { StartWorkoutPage } from './StartWorkoutPage';
+
+const startedAt = new Date('2026-06-25T12:00:00.000Z');
+vi.setSystemTime(startedAt);
+
+const makeQueryClient = () =>
+  new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+
+const renderPage = (updateWorkoutOptions = vi.fn()) => {
+  render(
+    <QueryClientProvider client={makeQueryClient()}>
+      <MemoryRouter initialEntries={['/']}>
+        <WorkoutOptionsContext.Provider
+          value={[DEFAULT_WORKOUT_OPTIONS, updateWorkoutOptions]}
+        >
+          <Routes>
+            <Route path="/" element={<StartWorkoutPage />} />
+            <Route path="/active" element={<div>active workout page</div>} />
+          </Routes>
+        </WorkoutOptionsContext.Provider>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+  return { updateWorkoutOptions };
+};
+
+const returnZeroWorkoutLogs = () =>
+  server.use(
+    http.get(`${VITE_SUPABASE_URL}/rest/v1/workout_logs`, () =>
+      HttpResponse.json([]),
+    ),
+  );
+
+describe('StartWorkoutPage recommendations', () => {
+  describe('new user (no history)', () => {
+    beforeEach(returnZeroWorkoutLogs);
+
+    test('shows the curated first workouts and no recent repeats', async () => {
+      renderPage();
+
+      expect(
+        await screen.findByRole('button', { name: 'Two-Hand Swing' }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole('button', { name: 'Overhead Press' }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole('button', { name: 'Goblet Squat' }),
+      ).toBeInTheDocument();
+
+      expect(
+        screen.getByRole('heading', { name: 'Your recommended first workout' }),
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByText('Pick up where you left off'),
+      ).not.toBeInTheDocument();
+    });
+
+    test('one-tap on a curated workout prefills context and enters the active workout', async () => {
+      const { updateWorkoutOptions } = renderPage();
+
+      await userEvent.click(
+        await screen.findByRole('button', { name: 'Two-Hand Swing' }),
+      );
+
+      expect(updateWorkoutOptions).toHaveBeenCalledTimes(1);
+      expect(updateWorkoutOptions).toHaveBeenCalledWith({
+        ...CURATED_WORKOUTS[0].workoutOptions,
+        startedAt,
+      });
+      expect(screen.getByText('active workout page')).toBeInTheDocument();
+    });
+  });
+
+  describe('returning user (has history)', () => {
+    test('shows recent repeats alongside the curated workouts', async () => {
+      renderPage();
+
+      // Both surfaces are shown for returning users ("always show both").
+      expect(
+        await screen.findByText('Pick up where you left off'),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole('heading', { name: 'Recommended sessions' }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole('button', { name: 'Two-Hand Swing' }),
+      ).toBeInTheDocument();
+    });
+
+    test('one-tap on a recent workout prefills it and enters the active workout', async () => {
+      const { updateWorkoutOptions } = renderPage();
+
+      // The most recent logged session in the mock data is a "Pull-Ups" workout.
+      await userEvent.click(
+        await screen.findByRole('button', { name: 'Pull-Ups' }),
+      );
+
+      expect(updateWorkoutOptions).toHaveBeenCalledTimes(1);
+      const prefilled = updateWorkoutOptions.mock.calls[0][0];
+      expect(prefilled.movements).toEqual([
+        expect.objectContaining({ movementName: 'Pull-Ups' }),
+      ]);
+      expect(prefilled.startedAt).toEqual(startedAt);
+      expect(screen.getByText('active workout page')).toBeInTheDocument();
+    });
+  });
+});

--- a/src/pages/StartWorkoutPage/StartWorkoutPage.test.jsx
+++ b/src/pages/StartWorkoutPage/StartWorkoutPage.test.jsx
@@ -4,7 +4,14 @@ import userEvent from '@testing-library/user-event';
 import { QueryClient, QueryClientProvider } from 'react-query';
 import { MemoryRouter } from 'react-router-dom';
 
-import { DEFAULT_MOVEMENT_OPTIONS, DEFAULT_WORKOUT_OPTIONS, WorkoutOptionsContext } from '~/contexts';
+import {
+  DEFAULT_MOVEMENT_OPTIONS,
+  DEFAULT_WORKOUT_OPTIONS,
+  WorkoutOptionsContext,
+} from '~/contexts';
+
+import { StartWorkoutPage } from './StartWorkoutPage';
+import * as stories from './StartWorkoutPage.stories';
 
 function makeQueryClient() {
   return new QueryClient({
@@ -12,22 +19,27 @@ function makeQueryClient() {
   });
 }
 
-import * as stories from './StartWorkoutPage.stories';
-import { StartWorkoutPage } from './StartWorkoutPage';
-
 const { Default, WithoutPreviousVolume } = composeStories(stories);
 
 const startedAt = new Date();
 vi.setSystemTime(startedAt);
 
+// The builder is now collapsed behind a "Build custom workout" button; reveal
+// it before exercising the builder controls.
+const enterBuildMode = () =>
+  userEvent.click(
+    screen.getByRole('button', { name: /build custom workout/i }),
+  );
+
 describe('start workout page', () => {
   let startWorkout;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     startWorkout = vi.fn();
     Default.parameters.updateWorkoutOptions = startWorkout;
 
     render(<Default />);
+    await enterBuildMode();
   });
 
   test('start button is disabled by default', () => {
@@ -35,12 +47,16 @@ describe('start workout page', () => {
     expect(startButton).toBeDisabled();
   });
 
-  test('renders the "Build new workout" divider label', () => {
-    expect(screen.getByText(/build new workout/i)).toBeInTheDocument();
+  test('shows a back link to recommendations in build mode', () => {
+    expect(
+      screen.getByRole('button', { name: /recommendations/i }),
+    ).toBeInTheDocument();
   });
 
   test('renders the Movements header with count', () => {
-    expect(screen.getByRole('heading', { name: 'Movements' })).toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', { name: 'Movements' }),
+    ).toBeInTheDocument();
     expect(screen.getByLabelText('1 movements')).toBeInTheDocument();
   });
 
@@ -102,7 +118,9 @@ describe('start workout page', () => {
   test('can remove movements', async () => {
     await userEvent.click(screen.getByRole('button', { name: '+ Movement' }));
 
-    const removeButtons = screen.getAllByRole('button', { name: 'Remove movement' });
+    const removeButtons = screen.getAllByRole('button', {
+      name: 'Remove movement',
+    });
     await userEvent.click(removeButtons[0]);
 
     const movementInputs = screen.getAllByLabelText('Movement Input');
@@ -370,7 +388,9 @@ describe('start workout page', () => {
       await userEvent.click(volumeTab);
 
       // Find and click the increment button for the goal
-      const incrementButton = screen.getByRole('button', { name: '+ kilograms' });
+      const incrementButton = screen.getByRole('button', {
+        name: '+ kilograms',
+      });
       await userEvent.click(incrementButton);
 
       const startButton = screen.getByRole('button', { name: /Start/i });
@@ -389,7 +409,9 @@ describe('start workout page', () => {
       await userEvent.click(volumeTab);
 
       // Find and click the decrement button for the goal
-      const decrementButton = screen.getByRole('button', { name: '- kilograms' });
+      const decrementButton = screen.getByRole('button', {
+        name: '- kilograms',
+      });
       await userEvent.click(decrementButton);
 
       const startButton = screen.getByRole('button', { name: /Start/i });
@@ -408,7 +430,9 @@ describe('start workout page', () => {
       await userEvent.click(volumeTab);
 
       // Decrement many times to try to go below 1
-      const decrementButton = screen.getByRole('button', { name: '- kilograms' });
+      const decrementButton = screen.getByRole('button', {
+        name: '- kilograms',
+      });
       for (let i = 0; i < 150; i++) {
         await userEvent.click(decrementButton);
       }
@@ -429,12 +453,13 @@ describe('start workout page', () => {
 describe('start workout page - without previous volume', () => {
   let startWorkoutWithoutPrevious;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     startWorkoutWithoutPrevious = vi.fn();
     WithoutPreviousVolume.parameters.updateWorkoutOptions =
       startWorkoutWithoutPrevious;
 
     render(<WithoutPreviousVolume />);
+    await enterBuildMode();
   });
 
   test('initializes volume goal to default 1000kg when no previous volume exists', async () => {
@@ -461,25 +486,32 @@ describe('start workout page - without previous volume', () => {
 describe('Notes', () => {
   let startWorkout;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     startWorkout = vi.fn();
     Default.parameters.updateWorkoutOptions = startWorkout;
     render(<Default />);
+    await enterBuildMode();
   });
 
   test('clicking Notes toggle on shows the notes section', async () => {
     await userEvent.click(screen.getByRole('button', { name: 'Notes, off' }));
 
     expect(screen.getByRole('heading', { name: 'Notes' })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Notes, on' })).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Notes, on' }),
+    ).toBeInTheDocument();
   });
 
   test('clicking Notes toggle off hides the notes section when input is focused and empty', async () => {
     await userEvent.click(screen.getByRole('button', { name: 'Notes, off' }));
     await userEvent.click(screen.getByRole('button', { name: 'Notes, on' }));
 
-    expect(screen.queryByRole('heading', { name: 'Notes' })).not.toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Notes, off' })).toBeInTheDocument();
+    expect(
+      screen.queryByRole('heading', { name: 'Notes' }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Notes, off' }),
+    ).toBeInTheDocument();
   });
 
   test('clicking Notes toggle off hides the notes section when input has text', async () => {
@@ -487,8 +519,12 @@ describe('Notes', () => {
     await userEvent.keyboard('Heavy day');
     await userEvent.click(screen.getByRole('button', { name: 'Notes, on' }));
 
-    expect(screen.queryByRole('heading', { name: 'Notes' })).not.toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Notes, off' })).toBeInTheDocument();
+    expect(
+      screen.queryByRole('heading', { name: 'Notes' }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Notes, off' }),
+    ).toBeInTheDocument();
   });
 
   test('clicking away from empty notes input keeps the section visible', async () => {
@@ -496,7 +532,9 @@ describe('Notes', () => {
     await userEvent.click(screen.getByLabelText('Movement Input'));
 
     expect(screen.getByRole('heading', { name: 'Notes' })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Notes, on' })).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Notes, on' }),
+    ).toBeInTheDocument();
   });
 
   test('starting a workout with Notes on but empty saves workoutDetails as null', async () => {
@@ -516,27 +554,38 @@ describe('Notes', () => {
 describe('Complex Mode', () => {
   let startWorkout;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     startWorkout = vi.fn();
     Default.parameters.updateWorkoutOptions = startWorkout;
     render(<Default />);
+    await enterBuildMode();
   });
 
   test('Add to workout row includes Complex toggle off by default', () => {
-    expect(screen.getByRole('button', { name: 'Complex, off' })).toBeInTheDocument();
     expect(
-      screen.queryByText('Complete all movements before setting the weight down.'),
+      screen.getByRole('button', { name: 'Complex, off' }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText(
+        'Complete all movements before setting the weight down.',
+      ),
     ).not.toBeInTheDocument();
-    expect(screen.queryByRole('heading', { name: 'Shared Weight' })).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('heading', { name: 'Shared Weight' }),
+    ).not.toBeInTheDocument();
   });
 
   test('selecting Complex reveals shared weight section with all four weight-type options', async () => {
     await userEvent.click(screen.getByRole('button', { name: 'Complex, off' }));
 
     expect(
-      screen.getByText('Complete all movements before setting the weight down.'),
+      screen.getByText(
+        'Complete all movements before setting the weight down.',
+      ),
     ).toBeInTheDocument();
-    expect(screen.getByRole('heading', { name: 'Shared Weight' })).toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', { name: 'Shared Weight' }),
+    ).toBeInTheDocument();
     expect(screen.getByRole('tab', { name: 'Bodyweight' })).toBeInTheDocument();
     expect(screen.getByRole('tab', { name: 'Two-Hand' })).toBeInTheDocument();
     expect(screen.getByRole('tab', { name: 'Single' })).toBeInTheDocument();
@@ -550,16 +599,22 @@ describe('Complex Mode', () => {
     await userEvent.click(screen.getByRole('button', { name: 'Complex, off' }));
 
     expect(screen.queryAllByRole('heading', { name: 'Load' })).toHaveLength(0);
-    expect(screen.getAllByRole('heading', { name: 'Rep Scheme' })).toHaveLength(2);
+    expect(screen.getAllByRole('heading', { name: 'Rep Scheme' })).toHaveLength(
+      2,
+    );
   });
 
   test('toggling Complex off hides shared weight section and restores per-movement weight sections', async () => {
     await userEvent.click(screen.getByRole('button', { name: 'Complex, off' }));
-    expect(screen.getByRole('heading', { name: 'Shared Weight' })).toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', { name: 'Shared Weight' }),
+    ).toBeInTheDocument();
 
     await userEvent.click(screen.getByRole('button', { name: 'Complex, on' }));
 
-    expect(screen.queryByRole('heading', { name: 'Shared Weight' })).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('heading', { name: 'Shared Weight' }),
+    ).not.toBeInTheDocument();
     expect(screen.getByRole('heading', { name: 'Load' })).toBeInTheDocument();
   });
 
@@ -587,7 +642,9 @@ describe('Complex Mode', () => {
     await userEvent.click(screen.getByRole('button', { name: '+ Movement' }));
 
     expect(screen.queryAllByRole('heading', { name: 'Load' })).toHaveLength(0);
-    expect(screen.getByRole('heading', { name: 'Shared Weight' })).toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', { name: 'Shared Weight' }),
+    ).toBeInTheDocument();
   });
 
   test('complex mode toggle is preserved when removing movements', async () => {
@@ -595,11 +652,15 @@ describe('Complex Mode', () => {
     await userEvent.click(screen.getByRole('button', { name: 'Complex, off' }));
     expect(screen.queryAllByRole('heading', { name: 'Load' })).toHaveLength(0);
 
-    const removeButtons = screen.getAllByRole('button', { name: 'Remove movement' });
+    const removeButtons = screen.getAllByRole('button', {
+      name: 'Remove movement',
+    });
     await userEvent.click(removeButtons[0]);
 
     expect(screen.queryAllByRole('heading', { name: 'Load' })).toHaveLength(0);
-    expect(screen.getByRole('heading', { name: 'Shared Weight' })).toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', { name: 'Shared Weight' }),
+    ).toBeInTheDocument();
   });
 });
 
@@ -614,13 +675,16 @@ describe('integration tests for previous volume retrieval', () => {
     render(
       <QueryClientProvider client={makeQueryClient()}>
         <MemoryRouter>
-          <WorkoutOptionsContext.Provider value={[customWorkoutOptions, startWorkout]}>
+          <WorkoutOptionsContext.Provider
+            value={[customWorkoutOptions, startWorkout]}
+          >
             <StartWorkoutPage />
           </WorkoutOptionsContext.Provider>
         </MemoryRouter>
-      </QueryClientProvider>
+      </QueryClientProvider>,
     );
 
+    await enterBuildMode();
     await userEvent.type(
       screen.getByLabelText('Movement Input'),
       'Test Movement',
@@ -651,13 +715,16 @@ describe('integration tests for previous volume retrieval', () => {
     render(
       <QueryClientProvider client={makeQueryClient()}>
         <MemoryRouter>
-          <WorkoutOptionsContext.Provider value={[workoutOptionsAfterCompletion, startWorkout]}>
+          <WorkoutOptionsContext.Provider
+            value={[workoutOptionsAfterCompletion, startWorkout]}
+          >
             <StartWorkoutPage />
           </WorkoutOptionsContext.Provider>
         </MemoryRouter>
-      </QueryClientProvider>
+      </QueryClientProvider>,
     );
 
+    await enterBuildMode();
     await userEvent.type(
       screen.getByLabelText('Movement Input'),
       'Clean and Press',
@@ -691,13 +758,16 @@ describe('integration tests for previous volume retrieval', () => {
     render(
       <QueryClientProvider client={makeQueryClient()}>
         <MemoryRouter>
-          <WorkoutOptionsContext.Provider value={[workoutOptionsWithAllPrevious, startWorkout]}>
+          <WorkoutOptionsContext.Provider
+            value={[workoutOptionsWithAllPrevious, startWorkout]}
+          >
             <StartWorkoutPage />
           </WorkoutOptionsContext.Provider>
         </MemoryRouter>
-      </QueryClientProvider>
+      </QueryClientProvider>,
     );
 
+    await enterBuildMode();
     await userEvent.type(
       screen.getByLabelText('Movement Input'),
       'Test Movement',

--- a/src/pages/StartWorkoutPage/StartWorkoutPage.tsx
+++ b/src/pages/StartWorkoutPage/StartWorkoutPage.tsx
@@ -1,5 +1,6 @@
 import { ArrowLeftIcon, XMarkIcon } from '@heroicons/react/24/outline';
 import { useEffect, useRef, useState } from 'react';
+import { useLocation } from 'react-router-dom';
 
 import {
   AnalyticsEvent,
@@ -72,7 +73,12 @@ export const StartWorkoutPage = () => {
 
   // The page opens in "browse" mode (recommendations + a Build-custom button).
   // Selecting a recommendation or tapping Build-custom switches to the builder.
-  const [showBuilder, setShowBuilder] = useState(false);
+  // The history "Repeat" action prefills context and navigates here with
+  // `editWorkout` so the builder opens directly on the repeated workout.
+  const location = useLocation();
+  const [showBuilder, setShowBuilder] = useState<boolean>(
+    Boolean((location.state as { editWorkout?: boolean } | null)?.editWorkout),
+  );
   // Where the (eventual) start originated, carried through any edits the user
   // makes in the builder so `workout_started` stays attributed to the surface.
   const [startSource, setStartSource] = useState<WorkoutStartSource>('builder');

--- a/src/pages/StartWorkoutPage/StartWorkoutPage.tsx
+++ b/src/pages/StartWorkoutPage/StartWorkoutPage.tsx
@@ -1,41 +1,51 @@
 import { XMarkIcon } from '@heroicons/react/24/outline';
 import { useEffect, useRef, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
 
-import { AnalyticsEvent, trackEvent, useWorkoutLogs } from '~/api';
+import {
+  AnalyticsEvent,
+  RepeatableWorkout,
+  trackEvent,
+  useWorkoutLogs,
+} from '~/api';
 import { Page } from '~/components';
 import { Button } from '~/components/ui/button';
 import { Card } from '~/components/ui/card';
 import { Input } from '~/components/ui/input';
 import { Tabs, TabsList, TabsTrigger } from '~/components/ui/tabs';
+import { CURATED_WORKOUTS_VERSION } from '~/constants';
 import {
   DEFAULT_MOVEMENT_OPTIONS,
   useSession,
   useWorkoutOptions,
 } from '~/contexts';
+import { useFeatures, useStartWorkout } from '~/hooks';
 import { getWeightsDisplayValue } from '~/pages/CompletedWorkoutPage/utils/displayValues';
 import {
+  CuratedWorkout,
   MovementOptions,
   WeightTabValue,
   WeightUnit,
   WorkoutGoalUnits,
-  WorkoutOptions,
 } from '~/types';
-import { getWeightTabValue, getWeightUnitLabel, WEIGHT_MODE_LABELS } from '~/utils';
-
-import { useFeatures } from '~/hooks';
+import {
+  WEIGHT_MODE_LABELS,
+  getWeightTabValue,
+  getWeightUnitLabel,
+} from '~/utils';
 
 import {
   AddToWorkoutSection,
   BuildNewWorkoutDivider,
   ModifyCountButtons,
-  MovementAutocomplete,
   ModifyWorkoutButtons,
+  MovementAutocomplete,
   MovementsHeader,
+  RecommendedWorkoutsSection,
   Section,
   WeightModeTabs,
   WeightUnitTabs,
 } from './components';
+import { useRecommendedWorkouts } from './hooks';
 
 const DEFAULT_INTERVAL_TIMER: number = 30; // seconds
 const DEFAULT_REST_TIMER: number = 30; // seconds
@@ -54,8 +64,9 @@ const DEFAULT_ROUNDS: number = 10; // rounds
 
 export const StartWorkoutPage = () => {
   const features = useFeatures();
-  const navigate = useNavigate();
-  const [workoutOptions, updateWorkoutOptions] = useWorkoutOptions();
+  const startWorkout = useStartWorkout();
+  const [workoutOptions] = useWorkoutOptions();
+  const { curated, recentRepeats } = useRecommendedWorkouts();
 
   // Activation funnel (PROD-157): a user with zero workout logs is "new".
   // While the logs query is still loading (workoutLogs === undefined) we don't
@@ -107,15 +118,13 @@ export const StartWorkoutPage = () => {
   const [sharedWeightOneValue, setSharedWeightOneValue] = useState<
     number | null
   >(workoutOptions.sharedWeightOneValue);
-  const [sharedWeightOneUnit, setSharedWeightOneUnit] = useState<
-    WeightUnit | null
-  >(workoutOptions.sharedWeightOneUnit);
+  const [sharedWeightOneUnit, setSharedWeightOneUnit] =
+    useState<WeightUnit | null>(workoutOptions.sharedWeightOneUnit);
   const [sharedWeightTwoValue, setSharedWeightTwoValue] = useState<
     number | null
   >(workoutOptions.sharedWeightTwoValue);
-  const [sharedWeightTwoUnit, setSharedWeightTwoUnit] = useState<
-    WeightUnit | null
-  >(workoutOptions.sharedWeightTwoUnit);
+  const [sharedWeightTwoUnit, setSharedWeightTwoUnit] =
+    useState<WeightUnit | null>(workoutOptions.sharedWeightTwoUnit);
 
   const detailsRef = useRef<HTMLInputElement>(null);
 
@@ -348,36 +357,41 @@ export const StartWorkoutPage = () => {
     );
 
   const handleClickStart = () => {
-    const workoutOptions: WorkoutOptions = {
-      complexSet,
-      intervalTimer,
-      movements,
-      restTimer,
-      sharedWeightOneUnit,
-      sharedWeightOneValue,
-      sharedWeightTwoUnit,
-      sharedWeightTwoValue,
-      startedAt: new Date(),
-      workoutDetails: workoutDetails?.trim() || null,
-      workoutGoal,
-      workoutGoalUnits,
-    };
-    updateWorkoutOptions(workoutOptions);
-
-    if (userId) {
-      void trackEvent({
-        event: AnalyticsEvent.WorkoutStarted,
-        userId,
-        properties: {
-          is_first_workout: isFirstWorkout,
-          movement_count: movements.length,
-          workout_goal_units: workoutGoalUnits,
-        },
-      });
-    }
-
-    navigate('active');
+    startWorkout(
+      {
+        complexSet,
+        intervalTimer,
+        movements,
+        restTimer,
+        sharedWeightOneUnit,
+        sharedWeightOneValue,
+        sharedWeightTwoUnit,
+        sharedWeightTwoValue,
+        workoutDetails: workoutDetails?.trim() || null,
+        workoutGoal,
+        workoutGoalUnits,
+      },
+      'builder',
+      {
+        is_first_workout: isFirstWorkout,
+        movement_count: movements.length,
+        workout_goal_units: workoutGoalUnits,
+      },
+    );
   };
+
+  const handleStartCurated = (workout: CuratedWorkout) =>
+    startWorkout(workout.workoutOptions, 'curated', {
+      template_id: workout.id,
+      curated_version: CURATED_WORKOUTS_VERSION,
+      is_first_workout: isFirstWorkout,
+    });
+
+  const handleStartRepeat = (repeat: RepeatableWorkout) =>
+    startWorkout(repeat.workoutOptions, 'history_repeat', {
+      workout_log_id: repeat.workoutLogId,
+      is_first_workout: isFirstWorkout,
+    });
 
   const sharedWeightTabValue = getWeightTabValue({
     weightOneValue: sharedWeightOneValue,
@@ -409,6 +423,14 @@ export const StartWorkoutPage = () => {
         </Button>
       }
     >
+      <RecommendedWorkoutsSection
+        curated={curated}
+        recentRepeats={recentRepeats}
+        isFirstWorkout={isFirstWorkout}
+        onStartCurated={handleStartCurated}
+        onStartRepeat={handleStartRepeat}
+      />
+
       <BuildNewWorkoutDivider />
 
       <Card>

--- a/src/pages/StartWorkoutPage/StartWorkoutPage.tsx
+++ b/src/pages/StartWorkoutPage/StartWorkoutPage.tsx
@@ -1,4 +1,4 @@
-import { XMarkIcon } from '@heroicons/react/24/outline';
+import { ArrowLeftIcon, XMarkIcon } from '@heroicons/react/24/outline';
 import { useEffect, useRef, useState } from 'react';
 
 import {
@@ -15,10 +15,12 @@ import { Tabs, TabsList, TabsTrigger } from '~/components/ui/tabs';
 import { CURATED_WORKOUTS_VERSION } from '~/constants';
 import {
   DEFAULT_MOVEMENT_OPTIONS,
+  DEFAULT_WORKOUT_OPTIONS,
   useSession,
   useWorkoutOptions,
 } from '~/contexts';
 import { useFeatures, useStartWorkout } from '~/hooks';
+import type { WorkoutStartSource } from '~/hooks';
 import { getWeightsDisplayValue } from '~/pages/CompletedWorkoutPage/utils/displayValues';
 import {
   CuratedWorkout,
@@ -26,6 +28,7 @@ import {
   WeightTabValue,
   WeightUnit,
   WorkoutGoalUnits,
+  WorkoutOptions,
 } from '~/types';
 import {
   WEIGHT_MODE_LABELS,
@@ -35,7 +38,6 @@ import {
 
 import {
   AddToWorkoutSection,
-  BuildNewWorkoutDivider,
   ModifyCountButtons,
   ModifyWorkoutButtons,
   MovementAutocomplete,
@@ -67,6 +69,16 @@ export const StartWorkoutPage = () => {
   const startWorkout = useStartWorkout();
   const [workoutOptions] = useWorkoutOptions();
   const { curated, recentRepeats } = useRecommendedWorkouts();
+
+  // The page opens in "browse" mode (recommendations + a Build-custom button).
+  // Selecting a recommendation or tapping Build-custom switches to the builder.
+  const [showBuilder, setShowBuilder] = useState(false);
+  // Where the (eventual) start originated, carried through any edits the user
+  // makes in the builder so `workout_started` stays attributed to the surface.
+  const [startSource, setStartSource] = useState<WorkoutStartSource>('builder');
+  const [startSourceProps, setStartSourceProps] = useState<
+    Record<string, string | number | boolean | null>
+  >({});
 
   // Activation funnel (PROD-157): a user with zero workout logs is "new".
   // While the logs query is still loading (workoutLogs === undefined) we don't
@@ -356,6 +368,48 @@ export const StartWorkoutPage = () => {
       ),
     );
 
+  // Fan a set of workout options out to the builder's local state so the user
+  // can review/edit before starting.
+  const loadIntoBuilder = (options: Omit<WorkoutOptions, 'startedAt'>) => {
+    setMovements(options.movements);
+    setWorkoutGoal(options.workoutGoal);
+    setWorkoutGoalUnits(options.workoutGoalUnits);
+    setWorkoutDetails(options.workoutDetails);
+    setIntervalTimer(options.intervalTimer);
+    setRestTimer(options.restTimer);
+    setComplexSet(options.complexSet);
+    setSharedWeightOneValue(options.sharedWeightOneValue);
+    setSharedWeightOneUnit(options.sharedWeightOneUnit);
+    setSharedWeightTwoValue(options.sharedWeightTwoValue);
+    setSharedWeightTwoUnit(options.sharedWeightTwoUnit);
+  };
+
+  const handleSelectCurated = (workout: CuratedWorkout) => {
+    loadIntoBuilder(workout.workoutOptions);
+    setStartSource('curated');
+    setStartSourceProps({
+      template_id: workout.id,
+      curated_version: CURATED_WORKOUTS_VERSION,
+    });
+    setShowBuilder(true);
+  };
+
+  const handleSelectRepeat = (repeat: RepeatableWorkout) => {
+    loadIntoBuilder(repeat.workoutOptions);
+    setStartSource('history_repeat');
+    setStartSourceProps({ workout_log_id: repeat.workoutLogId });
+    setShowBuilder(true);
+  };
+
+  const handleClickBuildCustom = () => {
+    loadIntoBuilder(DEFAULT_WORKOUT_OPTIONS);
+    setStartSource('builder');
+    setStartSourceProps({});
+    setShowBuilder(true);
+  };
+
+  const handleBackToRecommendations = () => setShowBuilder(false);
+
   const handleClickStart = () => {
     startWorkout(
       {
@@ -371,27 +425,15 @@ export const StartWorkoutPage = () => {
         workoutGoal,
         workoutGoalUnits,
       },
-      'builder',
+      startSource,
       {
+        ...startSourceProps,
         is_first_workout: isFirstWorkout,
         movement_count: movements.length,
         workout_goal_units: workoutGoalUnits,
       },
     );
   };
-
-  const handleStartCurated = (workout: CuratedWorkout) =>
-    startWorkout(workout.workoutOptions, 'curated', {
-      template_id: workout.id,
-      curated_version: CURATED_WORKOUTS_VERSION,
-      is_first_workout: isFirstWorkout,
-    });
-
-  const handleStartRepeat = (repeat: RepeatableWorkout) =>
-    startWorkout(repeat.workoutOptions, 'history_repeat', {
-      workout_log_id: repeat.workoutLogId,
-      is_first_workout: isFirstWorkout,
-    });
 
   const sharedWeightTabValue = getWeightTabValue({
     weightOneValue: sharedWeightOneValue,
@@ -413,323 +455,353 @@ export const StartWorkoutPage = () => {
   return (
     <Page
       actions={
-        <Button
-          className="w-full"
-          size="lg"
-          onClick={handleClickStart}
-          disabled={startDisabled}
-        >
-          Start workout
-        </Button>
+        showBuilder ? (
+          <Button
+            className="w-full"
+            size="lg"
+            onClick={handleClickStart}
+            disabled={startDisabled}
+          >
+            Start workout
+          </Button>
+        ) : undefined
       }
     >
-      <RecommendedWorkoutsSection
-        curated={curated}
-        recentRepeats={recentRepeats}
-        isFirstWorkout={isFirstWorkout}
-        onStartCurated={handleStartCurated}
-        onStartRepeat={handleStartRepeat}
-      />
-
-      <BuildNewWorkoutDivider />
-
-      <Card>
-        <Section
-          title="Goal"
-          actions={
-            <Tabs
-              value={workoutGoalUnits}
-              onValueChange={handleChangeWorkoutGoalUnits}
-            >
-              <TabsList>
-                <TabsTrigger size="sm" value="minutes">
-                  Time
-                </TabsTrigger>
-                <TabsTrigger size="sm" value="rounds">
-                  Rounds
-                </TabsTrigger>
-                <TabsTrigger size="sm" value="kilograms">
-                  Volume
-                </TabsTrigger>
-              </TabsList>
-            </Tabs>
-          }
-        >
-          <ModifyCountButtons
-            onClickMinus={handleDecrementGoalValue}
-            onClickPlus={handleIncrementGoalValue}
-            onChange={setWorkoutGoal}
-            unit={workoutGoalUnits}
-            value={workoutGoal}
+      {!showBuilder && (
+        <>
+          <RecommendedWorkoutsSection
+            curated={curated}
+            recentRepeats={recentRepeats}
+            isFirstWorkout={isFirstWorkout}
+            onSelectCurated={handleSelectCurated}
+            onSelectRepeat={handleSelectRepeat}
           />
-        </Section>
-      </Card>
 
-      <AddToWorkoutSection
-        complexSet={complexSet}
-        hasNotes={workoutDetails !== null}
-        hasInterval={intervalTimer > 0}
-        hasRest={restTimer > 0}
-        showComplex={features.complexMode}
-        onToggleComplex={handleToggleComplex}
-        onToggleInterval={handleToggleInterval}
-        onToggleNotes={handleToggleNotes}
-        onToggleRest={handleToggleRest}
-      />
-
-      {features.complexMode && complexSet && (
-        <Card>
-          <Section title="Shared Weight">
-            <p className="text-xs text-muted-foreground">
-              Complete all movements before setting the weight down.
-            </p>
-            <WeightModeTabs
-              value={sharedWeightTabValue}
-              onValueChange={handleChangeSharedWeightTab}
-            />
-            {sharedWeightOneValue !== null && (
-              <ModifyCountButtons
-                onClickMinus={() =>
-                  handleChangeSharedWeightOneValue(sharedWeightOneValue - 1)
-                }
-                onClickPlus={() =>
-                  handleChangeSharedWeightOneValue(sharedWeightOneValue + 1)
-                }
-                unit={getWeightUnitLabel(sharedWeightOneUnit)}
-                unitTabs={
-                  <WeightUnitTabs
-                    value={sharedWeightOneUnit}
-                    onChange={handleChangeSharedWeightOneUnit}
-                  />
-                }
-                value={sharedWeightOneValue}
-                onChange={(value) => handleChangeSharedWeightOneValue(value!)}
-              />
-            )}
-            {sharedWeightTwoValue !== null && sharedWeightTwoValue > 0 && (
-              <ModifyCountButtons
-                onClickMinus={() =>
-                  handleChangeSharedWeightTwoValue(sharedWeightTwoValue - 1)
-                }
-                onClickPlus={() =>
-                  handleChangeSharedWeightTwoValue(sharedWeightTwoValue + 1)
-                }
-                unit={getWeightUnitLabel(sharedWeightTwoUnit)}
-                unitTabs={
-                  <WeightUnitTabs
-                    value={sharedWeightTwoUnit}
-                    onChange={handleChangeSharedWeightTwoUnit}
-                  />
-                }
-                value={sharedWeightTwoValue}
-                onChange={(value) => handleChangeSharedWeightTwoValue(value)}
-              />
-            )}
-          </Section>
-        </Card>
+          <Button
+            variant="secondary"
+            className="w-full"
+            onClick={handleClickBuildCustom}
+          >
+            Build custom workout
+          </Button>
+        </>
       )}
 
-      {workoutDetails !== null && (
-        <Card>
-          <Section title="Notes">
-            <Input
-              autoFocus
-              className="w-full"
-              defaultValue={workoutDetails}
-              onBlur={handleBlurDetails}
-              ref={detailsRef}
-            />
-          </Section>
-        </Card>
-      )}
+      {showBuilder && (
+        <>
+          <button
+            type="button"
+            onClick={handleBackToRecommendations}
+            className="flex items-center gap-0.5 self-start text-xs font-medium text-muted-foreground"
+          >
+            <ArrowLeftIcon className="h-2 w-2" aria-hidden="true" />
+            Recommendations
+          </button>
 
-      {intervalTimer > 0 && (
-        <Card>
-          <Section title="Interval Timer">
-            <ModifyCountButtons
-              onClickMinus={handleDecrementInterval}
-              onClickPlus={handleIncrementInterval}
-              unit="sec"
-              value={intervalTimer}
-              onChange={setIntervalTimer}
-            />
-          </Section>
-        </Card>
-      )}
-
-      {restTimer > 0 && (
-        <Card>
-          <Section title="Rest Timer">
-            <ModifyCountButtons
-              onClickMinus={handleDecrementRest}
-              onClickPlus={handleIncrementRest}
-              unit="sec"
-              value={restTimer}
-              onChange={setRestTimer}
-            />
-          </Section>
-        </Card>
-      )}
-
-      <MovementsHeader count={movements.length} />
-
-      {movements.map((movement, index) => {
-        const weightTabValue = getWeightTabValue(movement);
-        const activeWeightMode: WeightTabValue = complexSet
-          ? sharedWeightTabValue
-          : weightTabValue;
-        const weightSummary =
-          movement.movementName.length > 0
-            ? getWeightsDisplayValue(
-                movement.weightOneValue,
-                movement.weightOneUnit,
-                movement.weightTwoValue,
-                movement.weightTwoUnit,
-              )
-            : null;
-
-        return (
-          <Card key={index}>
+          <Card>
             <Section
-              title={`Movement #${index + 1}`}
+              title="Goal"
               actions={
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  aria-label="Remove movement"
-                  onClick={() => handleClickRemoveMovement(index)}
+                <Tabs
+                  value={workoutGoalUnits}
+                  onValueChange={handleChangeWorkoutGoalUnits}
                 >
-                  <XMarkIcon className="h-2.5 w-2.5" />
-                </Button>
+                  <TabsList>
+                    <TabsTrigger size="sm" value="minutes">
+                      Time
+                    </TabsTrigger>
+                    <TabsTrigger size="sm" value="rounds">
+                      Rounds
+                    </TabsTrigger>
+                    <TabsTrigger size="sm" value="kilograms">
+                      Volume
+                    </TabsTrigger>
+                  </TabsList>
+                </Tabs>
               }
             >
-              <MovementAutocomplete
-                value={movement.movementName}
-                onChange={(name) => handleChangeMovementName(index, name)}
-                weightMode={activeWeightMode}
-                onWeightModeChange={(mode) =>
-                  complexSet
-                    ? handleChangeSharedWeightTab(mode)
-                    : handleChangeWeightTab(index, mode)
-                }
-                showWeightModeTabs={!complexSet}
-                weightModeHint={
-                  complexSet
-                    ? `Using shared weight: ${WEIGHT_MODE_LABELS[sharedWeightTabValue]}`
-                    : null
-                }
-                weightSummary={weightSummary}
+              <ModifyCountButtons
+                onClickMinus={handleDecrementGoalValue}
+                onClickPlus={handleIncrementGoalValue}
+                onChange={setWorkoutGoal}
+                unit={workoutGoalUnits}
+                value={workoutGoal}
               />
             </Section>
-            {!complexSet && weightTabValue !== 'none' && (
-              <Section title="Load">
-                <ModifyCountButtons
-                  onClickMinus={() =>
-                    handleChangeWeightOneValue(
-                      index,
-                      movement.weightOneValue! - 1,
-                    )
-                  }
-                  onClickPlus={() =>
-                    handleChangeWeightOneValue(
-                      index,
-                      movement.weightOneValue! + 1,
-                    )
-                  }
-                  unit={getWeightUnitLabel(movement.weightOneUnit)}
-                  unitTabs={
-                    <WeightUnitTabs
-                      value={movement.weightOneUnit}
-                      onChange={(value) =>
-                        handleChangeWeightOneUnit(index, value)
-                      }
-                    />
-                  }
-                  value={movement.weightOneValue!}
-                  onChange={(value) =>
-                    handleChangeWeightOneValue(index, value!)
-                  }
+          </Card>
+
+          <AddToWorkoutSection
+            complexSet={complexSet}
+            hasNotes={workoutDetails !== null}
+            hasInterval={intervalTimer > 0}
+            hasRest={restTimer > 0}
+            showComplex={features.complexMode}
+            onToggleComplex={handleToggleComplex}
+            onToggleInterval={handleToggleInterval}
+            onToggleNotes={handleToggleNotes}
+            onToggleRest={handleToggleRest}
+          />
+
+          {features.complexMode && complexSet && (
+            <Card>
+              <Section title="Shared Weight">
+                <p className="text-xs text-muted-foreground">
+                  Complete all movements before setting the weight down.
+                </p>
+                <WeightModeTabs
+                  value={sharedWeightTabValue}
+                  onValueChange={handleChangeSharedWeightTab}
                 />
-                {movement.weightTwoValue !== null &&
-                  movement.weightTwoValue > 0 && (
+                {sharedWeightOneValue !== null && (
+                  <ModifyCountButtons
+                    onClickMinus={() =>
+                      handleChangeSharedWeightOneValue(sharedWeightOneValue - 1)
+                    }
+                    onClickPlus={() =>
+                      handleChangeSharedWeightOneValue(sharedWeightOneValue + 1)
+                    }
+                    unit={getWeightUnitLabel(sharedWeightOneUnit)}
+                    unitTabs={
+                      <WeightUnitTabs
+                        value={sharedWeightOneUnit}
+                        onChange={handleChangeSharedWeightOneUnit}
+                      />
+                    }
+                    value={sharedWeightOneValue}
+                    onChange={(value) =>
+                      handleChangeSharedWeightOneValue(value!)
+                    }
+                  />
+                )}
+                {sharedWeightTwoValue !== null && sharedWeightTwoValue > 0 && (
+                  <ModifyCountButtons
+                    onClickMinus={() =>
+                      handleChangeSharedWeightTwoValue(sharedWeightTwoValue - 1)
+                    }
+                    onClickPlus={() =>
+                      handleChangeSharedWeightTwoValue(sharedWeightTwoValue + 1)
+                    }
+                    unit={getWeightUnitLabel(sharedWeightTwoUnit)}
+                    unitTabs={
+                      <WeightUnitTabs
+                        value={sharedWeightTwoUnit}
+                        onChange={handleChangeSharedWeightTwoUnit}
+                      />
+                    }
+                    value={sharedWeightTwoValue}
+                    onChange={(value) =>
+                      handleChangeSharedWeightTwoValue(value)
+                    }
+                  />
+                )}
+              </Section>
+            </Card>
+          )}
+
+          {workoutDetails !== null && (
+            <Card>
+              <Section title="Notes">
+                <Input
+                  autoFocus
+                  className="w-full"
+                  defaultValue={workoutDetails}
+                  onBlur={handleBlurDetails}
+                  ref={detailsRef}
+                />
+              </Section>
+            </Card>
+          )}
+
+          {intervalTimer > 0 && (
+            <Card>
+              <Section title="Interval Timer">
+                <ModifyCountButtons
+                  onClickMinus={handleDecrementInterval}
+                  onClickPlus={handleIncrementInterval}
+                  unit="sec"
+                  value={intervalTimer}
+                  onChange={setIntervalTimer}
+                />
+              </Section>
+            </Card>
+          )}
+
+          {restTimer > 0 && (
+            <Card>
+              <Section title="Rest Timer">
+                <ModifyCountButtons
+                  onClickMinus={handleDecrementRest}
+                  onClickPlus={handleIncrementRest}
+                  unit="sec"
+                  value={restTimer}
+                  onChange={setRestTimer}
+                />
+              </Section>
+            </Card>
+          )}
+
+          <MovementsHeader count={movements.length} />
+
+          {movements.map((movement, index) => {
+            const weightTabValue = getWeightTabValue(movement);
+            const activeWeightMode: WeightTabValue = complexSet
+              ? sharedWeightTabValue
+              : weightTabValue;
+            const weightSummary =
+              movement.movementName.length > 0
+                ? getWeightsDisplayValue(
+                    movement.weightOneValue,
+                    movement.weightOneUnit,
+                    movement.weightTwoValue,
+                    movement.weightTwoUnit,
+                  )
+                : null;
+
+            return (
+              <Card key={index}>
+                <Section
+                  title={`Movement #${index + 1}`}
+                  actions={
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      aria-label="Remove movement"
+                      onClick={() => handleClickRemoveMovement(index)}
+                    >
+                      <XMarkIcon className="h-2.5 w-2.5" />
+                    </Button>
+                  }
+                >
+                  <MovementAutocomplete
+                    value={movement.movementName}
+                    onChange={(name) => handleChangeMovementName(index, name)}
+                    weightMode={activeWeightMode}
+                    onWeightModeChange={(mode) =>
+                      complexSet
+                        ? handleChangeSharedWeightTab(mode)
+                        : handleChangeWeightTab(index, mode)
+                    }
+                    showWeightModeTabs={!complexSet}
+                    weightModeHint={
+                      complexSet
+                        ? `Using shared weight: ${WEIGHT_MODE_LABELS[sharedWeightTabValue]}`
+                        : null
+                    }
+                    weightSummary={weightSummary}
+                  />
+                </Section>
+                {!complexSet && weightTabValue !== 'none' && (
+                  <Section title="Load">
                     <ModifyCountButtons
                       onClickMinus={() =>
-                        handleChangeWeightTwoValue(
+                        handleChangeWeightOneValue(
                           index,
-                          movement.weightTwoValue! - 1,
+                          movement.weightOneValue! - 1,
                         )
                       }
                       onClickPlus={() =>
-                        handleChangeWeightTwoValue(
+                        handleChangeWeightOneValue(
                           index,
-                          movement.weightTwoValue! + 1,
+                          movement.weightOneValue! + 1,
                         )
                       }
-                      unit={getWeightUnitLabel(movement.weightTwoUnit)}
+                      unit={getWeightUnitLabel(movement.weightOneUnit)}
                       unitTabs={
                         <WeightUnitTabs
-                          value={movement.weightTwoUnit}
+                          value={movement.weightOneUnit}
                           onChange={(value) =>
-                            handleChangeWeightTwoUnit(index, value)
+                            handleChangeWeightOneUnit(index, value)
                           }
                         />
                       }
-                      value={movement.weightTwoValue}
+                      value={movement.weightOneValue!}
                       onChange={(value) =>
-                        handleChangeWeightTwoValue(index, value)
+                        handleChangeWeightOneValue(index, value!)
                       }
                     />
-                  )}
-              </Section>
-            )}
-            <Section
-              title="Rep Scheme"
-              actions={
-                <ModifyWorkoutButtons
-                  count={movement.repScheme.length}
-                  label="Rung"
-                  onClickMinus={() => handleClickMinusRung(index)}
-                  onClickPlus={() => handleClickPlusRung(index)}
-                />
-              }
-            >
-              {movement.repScheme.map((_, rungIndex) => (
-                <ModifyCountButtons
-                  key={rungIndex}
-                  value={movement.repScheme[rungIndex]}
-                  onChange={(value) =>
-                    handleChangeRepScheme(index, rungIndex, value)
+                    {movement.weightTwoValue !== null &&
+                      movement.weightTwoValue > 0 && (
+                        <ModifyCountButtons
+                          onClickMinus={() =>
+                            handleChangeWeightTwoValue(
+                              index,
+                              movement.weightTwoValue! - 1,
+                            )
+                          }
+                          onClickPlus={() =>
+                            handleChangeWeightTwoValue(
+                              index,
+                              movement.weightTwoValue! + 1,
+                            )
+                          }
+                          unit={getWeightUnitLabel(movement.weightTwoUnit)}
+                          unitTabs={
+                            <WeightUnitTabs
+                              value={movement.weightTwoUnit}
+                              onChange={(value) =>
+                                handleChangeWeightTwoUnit(index, value)
+                              }
+                            />
+                          }
+                          value={movement.weightTwoValue}
+                          onChange={(value) =>
+                            handleChangeWeightTwoValue(index, value)
+                          }
+                        />
+                      )}
+                  </Section>
+                )}
+                <Section
+                  title="Rep Scheme"
+                  actions={
+                    <ModifyWorkoutButtons
+                      count={movement.repScheme.length}
+                      label="Rung"
+                      onClickMinus={() => handleClickMinusRung(index)}
+                      onClickPlus={() => handleClickPlusRung(index)}
+                    />
                   }
-                  onClickMinus={() =>
-                    handleChangeRepScheme(
-                      index,
-                      rungIndex,
-                      movement.repScheme[rungIndex] - 1,
-                    )
-                  }
-                  onClickPlus={() =>
-                    handleChangeRepScheme(
-                      index,
-                      rungIndex,
-                      movement.repScheme[rungIndex] + 1,
-                    )
-                  }
-                  unit="reps"
-                />
-              ))}
-            </Section>
-          </Card>
-        );
-      })}
+                >
+                  {movement.repScheme.map((_, rungIndex) => (
+                    <ModifyCountButtons
+                      key={rungIndex}
+                      value={movement.repScheme[rungIndex]}
+                      onChange={(value) =>
+                        handleChangeRepScheme(index, rungIndex, value)
+                      }
+                      onClickMinus={() =>
+                        handleChangeRepScheme(
+                          index,
+                          rungIndex,
+                          movement.repScheme[rungIndex] - 1,
+                        )
+                      }
+                      onClickPlus={() =>
+                        handleChangeRepScheme(
+                          index,
+                          rungIndex,
+                          movement.repScheme[rungIndex] + 1,
+                        )
+                      }
+                      unit="reps"
+                    />
+                  ))}
+                </Section>
+              </Card>
+            );
+          })}
 
-      <Button variant="secondary" onClick={handleClickAddMovement}>
-        + Movement
-      </Button>
+          <Button variant="secondary" onClick={handleClickAddMovement}>
+            + Movement
+          </Button>
 
-      {isDifferentRepSchemes && (
-        <div className="text-sm text-red-500">
-          Rep schemes must contain the same number of rungs for each movement.
-        </div>
+          {isDifferentRepSchemes && (
+            <div className="text-sm text-red-500">
+              Rep schemes must contain the same number of rungs for each
+              movement.
+            </div>
+          )}
+        </>
       )}
     </Page>
   );

--- a/src/pages/StartWorkoutPage/components/RecommendedWorkoutCard.tsx
+++ b/src/pages/StartWorkoutPage/components/RecommendedWorkoutCard.tsx
@@ -10,7 +10,8 @@ export interface RecommendedWorkoutCardProps {
   summary: string;
   /** Short metadata, e.g. "5 rounds · ~10 min". */
   meta?: string;
-  onStart: () => void;
+  /** Opens the workout in the builder for review/edits before starting. */
+  onSelect: () => void;
 }
 
 export const RecommendedWorkoutCard = ({
@@ -18,14 +19,14 @@ export const RecommendedWorkoutCard = ({
   subtitle,
   summary,
   meta,
-  onStart,
+  onSelect,
 }: RecommendedWorkoutCardProps) => {
   return (
     <Card>
       <button
         type="button"
         aria-label={title}
-        onClick={onStart}
+        onClick={onSelect}
         className="flex w-full items-center justify-between gap-2 p-2 text-left"
       >
         <div className="flex flex-col gap-0.5">

--- a/src/pages/StartWorkoutPage/components/RecommendedWorkoutCard.tsx
+++ b/src/pages/StartWorkoutPage/components/RecommendedWorkoutCard.tsx
@@ -1,0 +1,50 @@
+import { ArrowRightIcon } from '@heroicons/react/24/outline';
+
+import { Card } from '~/components/ui/card';
+
+export interface RecommendedWorkoutCardProps {
+  title: string;
+  /** The "why" line — shown for curated workouts. */
+  subtitle?: string;
+  /** Movements summary, e.g. "Kettlebell Swing". */
+  summary: string;
+  /** Short metadata, e.g. "5 rounds · ~10 min". */
+  meta?: string;
+  onStart: () => void;
+}
+
+export const RecommendedWorkoutCard = ({
+  title,
+  subtitle,
+  summary,
+  meta,
+  onStart,
+}: RecommendedWorkoutCardProps) => {
+  return (
+    <Card>
+      <button
+        type="button"
+        aria-label={title}
+        onClick={onStart}
+        className="flex w-full items-center justify-between gap-2 p-2 text-left"
+      >
+        <div className="flex flex-col gap-0.5">
+          <div className="flex items-baseline gap-1">
+            <span className="text-sm font-semibold leading-none">{title}</span>
+            {meta && (
+              <span className="text-xs text-muted-foreground">{meta}</span>
+            )}
+          </div>
+          <span className="text-sm text-muted-foreground">{summary}</span>
+          {subtitle && (
+            <span className="text-xs text-muted-foreground">{subtitle}</span>
+          )}
+        </div>
+        <ArrowRightIcon
+          className="h-2.5 w-2.5 shrink-0 text-muted-foreground"
+          aria-hidden="true"
+        />
+      </button>
+    </Card>
+  );
+};

--- a/src/pages/StartWorkoutPage/components/RecommendedWorkoutsSection.tsx
+++ b/src/pages/StartWorkoutPage/components/RecommendedWorkoutsSection.tsx
@@ -1,0 +1,90 @@
+import { RepeatableWorkout } from '~/api';
+import { CuratedWorkout, MovementOptions, WorkoutGoalUnits } from '~/types';
+
+import { RecommendedWorkoutCard } from './RecommendedWorkoutCard';
+
+export interface RecommendedWorkoutsSectionProps {
+  curated: CuratedWorkout[];
+  recentRepeats: RepeatableWorkout[];
+  /** null while the logs query is still resolving. */
+  isFirstWorkout: boolean | null;
+  onStartCurated: (curated: CuratedWorkout) => void;
+  onStartRepeat: (repeat: RepeatableWorkout) => void;
+}
+
+const goalLabel = (goal: number, units: WorkoutGoalUnits) => {
+  if (units === 'minutes') return `${goal} min`;
+  if (units === 'rounds') return `${goal} rounds`;
+  return `${goal} kg`;
+};
+
+const movementsSummary = (movements: MovementOptions[]) =>
+  movements
+    .map((movement) => movement.movementName)
+    .filter((name) => name.length > 0)
+    .join(' · ');
+
+const SectionLabel = ({ children }: { children: string }) => (
+  <h2 className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+    {children}
+  </h2>
+);
+
+export const RecommendedWorkoutsSection = ({
+  curated,
+  recentRepeats,
+  isFirstWorkout,
+  onStartCurated,
+  onStartRepeat,
+}: RecommendedWorkoutsSectionProps) => {
+  const curatedHeading =
+    isFirstWorkout === true
+      ? 'Your recommended first workout'
+      : 'Recommended sessions';
+
+  return (
+    <div className="flex flex-col gap-2">
+      {recentRepeats.length > 0 && (
+        <div className="flex flex-col gap-1">
+          <SectionLabel>Pick up where you left off</SectionLabel>
+          {recentRepeats.map((repeat) => {
+            const { movements, workoutGoal, workoutGoalUnits } =
+              repeat.workoutOptions;
+            const summary = movementsSummary(movements);
+            const title =
+              repeat.workoutLog.workoutDetails?.trim() ||
+              summary ||
+              'Recent workout';
+            return (
+              <RecommendedWorkoutCard
+                key={repeat.workoutLogId}
+                title={title}
+                summary={summary}
+                meta={goalLabel(workoutGoal, workoutGoalUnits)}
+                onStart={() => onStartRepeat(repeat)}
+              />
+            );
+          })}
+        </div>
+      )}
+
+      <div className="flex flex-col gap-1">
+        <SectionLabel>{curatedHeading}</SectionLabel>
+        {curated.map((workout) => {
+          const { movements, workoutGoal, workoutGoalUnits } =
+            workout.workoutOptions;
+          return (
+            <RecommendedWorkoutCard
+              key={workout.id}
+              title={workout.title}
+              subtitle={workout.subtitle}
+              summary={movementsSummary(movements)}
+              meta={`${goalLabel(workoutGoal, workoutGoalUnits)} · ~${workout.estimatedMinutes} min`}
+              onStart={() => onStartCurated(workout)}
+            />
+          );
+        })}
+      </div>
+    </div>
+  );
+};

--- a/src/pages/StartWorkoutPage/components/RecommendedWorkoutsSection.tsx
+++ b/src/pages/StartWorkoutPage/components/RecommendedWorkoutsSection.tsx
@@ -8,8 +8,9 @@ export interface RecommendedWorkoutsSectionProps {
   recentRepeats: RepeatableWorkout[];
   /** null while the logs query is still resolving. */
   isFirstWorkout: boolean | null;
-  onStartCurated: (curated: CuratedWorkout) => void;
-  onStartRepeat: (repeat: RepeatableWorkout) => void;
+  /** Opens the workout in the builder for review/edits before starting. */
+  onSelectCurated: (curated: CuratedWorkout) => void;
+  onSelectRepeat: (repeat: RepeatableWorkout) => void;
 }
 
 const goalLabel = (goal: number, units: WorkoutGoalUnits) => {
@@ -34,8 +35,8 @@ export const RecommendedWorkoutsSection = ({
   curated,
   recentRepeats,
   isFirstWorkout,
-  onStartCurated,
-  onStartRepeat,
+  onSelectCurated,
+  onSelectRepeat,
 }: RecommendedWorkoutsSectionProps) => {
   const curatedHeading =
     isFirstWorkout === true
@@ -61,7 +62,7 @@ export const RecommendedWorkoutsSection = ({
                 title={title}
                 summary={summary}
                 meta={goalLabel(workoutGoal, workoutGoalUnits)}
-                onStart={() => onStartRepeat(repeat)}
+                onSelect={() => onSelectRepeat(repeat)}
               />
             );
           })}
@@ -80,7 +81,7 @@ export const RecommendedWorkoutsSection = ({
               subtitle={workout.subtitle}
               summary={movementsSummary(movements)}
               meta={`${goalLabel(workoutGoal, workoutGoalUnits)} · ~${workout.estimatedMinutes} min`}
-              onStart={() => onStartCurated(workout)}
+              onSelect={() => onSelectCurated(workout)}
             />
           );
         })}

--- a/src/pages/StartWorkoutPage/components/index.ts
+++ b/src/pages/StartWorkoutPage/components/index.ts
@@ -2,6 +2,8 @@ export * from './AddToWorkoutSection';
 export * from './BuildNewWorkoutDivider';
 export * from './ModifyCountButtons';
 export * from './MovementsHeader';
+export * from './RecommendedWorkoutCard';
+export * from './RecommendedWorkoutsSection';
 export * from './WorkoutAddonToggle';
 export * from './MovementAutocomplete';
 export * from './ModifyWorkoutButtons';

--- a/src/pages/StartWorkoutPage/hooks/index.ts
+++ b/src/pages/StartWorkoutPage/hooks/index.ts
@@ -1,0 +1,1 @@
+export * from './useRecommendedWorkouts';

--- a/src/pages/StartWorkoutPage/hooks/useRecommendedWorkouts.ts
+++ b/src/pages/StartWorkoutPage/hooks/useRecommendedWorkouts.ts
@@ -1,0 +1,17 @@
+import { RepeatableWorkout, useRecentRepeatableWorkouts } from '~/api';
+import { CURATED_WORKOUTS } from '~/constants';
+import { CuratedWorkout } from '~/types';
+
+/**
+ * The recommendations shown above the workout builder on the Start page:
+ * always the curated first workouts, plus repeats of the user's most recent
+ * sessions once they have history ("always show both").
+ */
+export const useRecommendedWorkouts = (): {
+  curated: CuratedWorkout[];
+  recentRepeats: RepeatableWorkout[];
+  isLoading: boolean;
+} => {
+  const { recentRepeats, isLoading } = useRecentRepeatableWorkouts();
+  return { curated: CURATED_WORKOUTS, recentRepeats, isLoading };
+};

--- a/src/types/curated-workout.interface.ts
+++ b/src/types/curated-workout.interface.ts
@@ -1,0 +1,18 @@
+import { WorkoutOptions } from './workout-options.interface';
+
+/**
+ * A pre-built, one-tap startable workout. Decoupled from the UI so the same
+ * templates can later feed the skill tree / weekly Tetris plan. `workoutOptions`
+ * matches the runtime {@link WorkoutOptions} shape minus `startedAt`, which is
+ * stamped when the workout actually starts.
+ */
+export interface CuratedWorkout {
+  /** Stable slug, e.g. 'beginner-two-hand-swing'. */
+  id: string;
+  title: string;
+  /** The "why" — a short reason this is a good session, shown on the card. */
+  subtitle: string;
+  /** Rough duration in minutes, for "how long will this take" legibility. */
+  estimatedMinutes: number;
+  workoutOptions: Omit<WorkoutOptions, 'startedAt'>;
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,3 +1,4 @@
+export * from './curated-workout.interface';
 export * from './difficultyLevel.type';
 export * from './equipment.type';
 export * from './movement-log.interface';

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -4,4 +4,6 @@ export * from './ordinalSuffixOf';
 export * from './patternDebt';
 export * from './rankMovements';
 export * from './resolveAuthSession';
+export * from './resolveSharedWeights';
 export * from './weightUnits';
+export * from './workoutLogToWorkoutOptions';

--- a/src/utils/resolveSharedWeights.ts
+++ b/src/utils/resolveSharedWeights.ts
@@ -1,0 +1,34 @@
+import { MovementLog, WeightUnit } from '~/types';
+
+export interface SharedWeights {
+  weightOneUnit: WeightUnit | null;
+  weightOneValue: number | null;
+  weightTwoUnit: WeightUnit | null;
+  weightTwoValue: number | null;
+}
+
+export const resolveSharedWeights = (
+  sharedWeightOneValue: number | null | undefined,
+  sharedWeightOneUnit: WeightUnit | null | undefined,
+  sharedWeightTwoValue: number | null | undefined,
+  sharedWeightTwoUnit: WeightUnit | null | undefined,
+  movementLogs: MovementLog[],
+): SharedWeights => {
+  const fallback = movementLogs[0];
+
+  if (sharedWeightOneValue == null && sharedWeightOneUnit == null) {
+    return {
+      weightOneValue: fallback?.weightOneValue ?? null,
+      weightOneUnit: fallback?.weightOneUnit ?? null,
+      weightTwoValue: fallback?.weightTwoValue ?? null,
+      weightTwoUnit: fallback?.weightTwoUnit ?? null,
+    };
+  }
+
+  return {
+    weightOneValue: sharedWeightOneValue ?? null,
+    weightOneUnit: sharedWeightOneUnit ?? null,
+    weightTwoValue: sharedWeightTwoValue ?? null,
+    weightTwoUnit: sharedWeightTwoUnit ?? null,
+  };
+};

--- a/src/utils/workoutLogToWorkoutOptions.test.ts
+++ b/src/utils/workoutLogToWorkoutOptions.test.ts
@@ -1,0 +1,119 @@
+import { MovementLog, WorkoutLog } from '~/types';
+
+import { workoutLogToWorkoutOptions } from './workoutLogToWorkoutOptions';
+
+const baseWorkoutLog = (overrides: Partial<WorkoutLog> = {}): WorkoutLog => ({
+  completedAt: new Date('2026-01-01T10:10:00.000Z'),
+  completedReps: 0,
+  completedRounds: 5,
+  completedRungs: 5,
+  completedVolume: null,
+  complexSet: false,
+  id: 1,
+  intervalTimer: 0,
+  movements: [],
+  restTimer: 60,
+  rpe: null,
+  sharedWeightOneUnit: null,
+  sharedWeightOneValue: null,
+  sharedWeightTwoUnit: null,
+  sharedWeightTwoValue: null,
+  startedAt: new Date('2026-01-01T10:00:00.000Z'),
+  workoutDetails: 'Morning swings',
+  workoutGoal: 5,
+  workoutGoalUnits: 'rounds',
+  workoutNotes: null,
+  ...overrides,
+});
+
+const movementLog = (overrides: Partial<MovementLog> = {}): MovementLog => ({
+  id: 1,
+  movementName: 'Kettlebell Swing',
+  repScheme: [10],
+  userMovementId: null,
+  functionalMovementId: null,
+  weightOneUnit: 'kilograms',
+  weightOneValue: 16,
+  weightTwoUnit: null,
+  weightTwoValue: null,
+  ...overrides,
+});
+
+describe('workoutLogToWorkoutOptions', () => {
+  test('maps a non-complex workout, using per-movement weights', () => {
+    const result = workoutLogToWorkoutOptions(baseWorkoutLog(), [
+      movementLog(),
+    ]);
+
+    expect(result).toEqual({
+      complexSet: false,
+      intervalTimer: 0,
+      restTimer: 60,
+      movements: [
+        {
+          movementName: 'Kettlebell Swing',
+          repScheme: [10],
+          weightOneUnit: 'kilograms',
+          weightOneValue: 16,
+          weightTwoUnit: null,
+          weightTwoValue: null,
+        },
+      ],
+      sharedWeightOneUnit: null,
+      sharedWeightOneValue: null,
+      sharedWeightTwoUnit: null,
+      sharedWeightTwoValue: null,
+      workoutDetails: 'Morning swings',
+      workoutGoal: 5,
+      workoutGoalUnits: 'rounds',
+      previousVolume: undefined,
+      previousMinutes: 10,
+      previousRounds: 5,
+    });
+  });
+
+  test('omits startedAt so the caller can stamp it at start time', () => {
+    const result = workoutLogToWorkoutOptions(baseWorkoutLog(), [
+      movementLog(),
+    ]);
+    expect('startedAt' in result).toBe(false);
+  });
+
+  test('carries previousVolume only for kilogram-goal workouts', () => {
+    const result = workoutLogToWorkoutOptions(
+      baseWorkoutLog({ workoutGoalUnits: 'kilograms', completedVolume: 800 }),
+      [movementLog()],
+    );
+    expect(result.previousVolume).toBe(800);
+    expect(result.workoutGoalUnits).toBe('kilograms');
+  });
+
+  test('applies shared weights to every movement for complex workouts', () => {
+    const result = workoutLogToWorkoutOptions(
+      baseWorkoutLog({
+        complexSet: true,
+        sharedWeightOneUnit: 'kilograms',
+        sharedWeightOneValue: 24,
+      }),
+      [
+        movementLog({ movementName: 'Clean', weightOneValue: 16 }),
+        movementLog({ id: 2, movementName: 'Front Squat', weightOneValue: 16 }),
+      ],
+    );
+
+    expect(result.complexSet).toBe(true);
+    expect(result.sharedWeightOneValue).toBe(24);
+    expect(result.movements).toEqual([
+      expect.objectContaining({
+        movementName: 'Clean',
+        weightOneValue: 24,
+        weightOneUnit: 'kilograms',
+      }),
+      expect.objectContaining({
+        movementName: 'Front Squat',
+        weightOneValue: 24,
+        weightOneUnit: 'kilograms',
+      }),
+    ]);
+  });
+});

--- a/src/utils/workoutLogToWorkoutOptions.ts
+++ b/src/utils/workoutLogToWorkoutOptions.ts
@@ -1,0 +1,67 @@
+import { MovementLog, WorkoutLog, WorkoutOptions } from '~/types';
+
+import { resolveSharedWeights } from './resolveSharedWeights';
+
+/**
+ * Convert a completed {@link WorkoutLog} (plus its per-movement
+ * {@link MovementLog}s) back into the {@link WorkoutOptions} shape so it can be
+ * repeated. Carries forward the actual completed duration / rounds / volume as
+ * the `previous*` hints used by the Start Workout builder.
+ *
+ * `startedAt` is intentionally omitted — the caller stamps it when the workout
+ * actually starts.
+ */
+export const workoutLogToWorkoutOptions = (
+  workoutLog: WorkoutLog,
+  movementLogs: MovementLog[],
+): Omit<WorkoutOptions, 'startedAt'> => {
+  const completedDurationMs =
+    workoutLog.completedAt.getTime() - workoutLog.startedAt.getTime();
+  const previousMinutes = Math.round(completedDurationMs / 60000);
+  const previousRounds = workoutLog.completedRounds ?? 0;
+  const previousVolume =
+    workoutLog.workoutGoalUnits === 'kilograms' && workoutLog.completedVolume
+      ? workoutLog.completedVolume
+      : undefined;
+
+  const isComplexSet = workoutLog.complexSet === true;
+  const sharedWeights = resolveSharedWeights(
+    workoutLog.sharedWeightOneValue,
+    workoutLog.sharedWeightOneUnit,
+    workoutLog.sharedWeightTwoValue,
+    workoutLog.sharedWeightTwoUnit,
+    movementLogs,
+  );
+
+  return {
+    complexSet: isComplexSet,
+    intervalTimer: workoutLog.intervalTimer,
+    movements: movementLogs.map((movementLog) => ({
+      movementName: movementLog.movementName,
+      repScheme: movementLog.repScheme,
+      weightOneUnit: isComplexSet
+        ? sharedWeights.weightOneUnit
+        : movementLog.weightOneUnit,
+      weightOneValue: isComplexSet
+        ? sharedWeights.weightOneValue
+        : movementLog.weightOneValue,
+      weightTwoUnit: isComplexSet
+        ? sharedWeights.weightTwoUnit
+        : movementLog.weightTwoUnit,
+      weightTwoValue: isComplexSet
+        ? sharedWeights.weightTwoValue
+        : movementLog.weightTwoValue,
+    })),
+    restTimer: workoutLog.restTimer,
+    sharedWeightOneUnit: isComplexSet ? sharedWeights.weightOneUnit : null,
+    sharedWeightOneValue: isComplexSet ? sharedWeights.weightOneValue : null,
+    sharedWeightTwoUnit: isComplexSet ? sharedWeights.weightTwoUnit : null,
+    sharedWeightTwoValue: isComplexSet ? sharedWeights.weightTwoValue : null,
+    workoutDetails: workoutLog.workoutDetails,
+    workoutGoal: workoutLog.workoutGoal,
+    workoutGoalUnits: workoutLog.workoutGoalUnits,
+    previousVolume,
+    previousMinutes,
+    previousRounds,
+  };
+};


### PR DESCRIPTION
One-tap recommended workouts replace the blank builder for new users, and recent-workout repeats show alongside them for returning users — the first user-facing change in the Activation project (PROD-159, with PROD-158 content and the PROD-160 surface folded in).

**Changes:**
- Add `CuratedWorkout` type + versioned in-app seed of 3 beginner single-bell sessions (Two-Hand Swing 16 kg 5×10, Overhead Press 12 kg 1H 5×5, Goblet Squat 16 kg 5×8)
- Add `useStartWorkout`: shared prefill-context + `workout_started` (tagged with a `source`: builder/curated/history_repeat) + `navigate('active')`; the builder, curated cards, and repeats all use it
- Extract `workoutLogToWorkoutOptions` from `CompletedWorkoutPage.handleClickRepeat`; relocate `resolveSharedWeights` to `~/utils` (re-exported from the page for back-compat)
- Add `useRecentRepeatableWorkouts` (most recent N workouts → one-tap startable options, single batched movement-logs query)
- Render `RecommendedWorkoutsSection` above the builder on `StartWorkoutPage`: new users see curated only ("Your recommended first workout"); returning users see recent repeats ("Pick up where you left off") **and** curated
- Extend the MSW movement-logs handler to support the `in.(...)` filter

**Testing:**
- `compile:ts` clean; full suite green (293 tests, +15)
- New unit tests: prefill mapping (PROD-159 acceptance) + curated content / weight-mode encoding
- New page tests render `StartWorkoutPage` through MSW: new vs returning user, and one-tap navigating into `/active` with the session prefilled
- Not yet verified in the running app — movement names (`Overhead Press`, `Goblet Squat`) log fine as free strings but should be confirmed to resolve to `movements_catalog` records for movement-linking

🤖 Generated with [Claude Code](https://claude.com/claude-code)