### PR TITLE
feat(recommender): recommend-session edge function (PROD-87)

### DIFF
--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -276,6 +276,12 @@ enabled = true
 verify_jwt = true
 import_map = "./functions/create-portal-session/deno.json"
 
+# AI Next Session Recommender (PROD-87). Premium-gated; calls the Anthropic API.
+[functions.recommend-session]
+enabled = true
+verify_jwt = true
+import_map = "./functions/recommend-session/deno.json"
+
 [analytics]
 enabled = true
 port = 54327

--- a/supabase/functions/.env.example
+++ b/supabase/functions/.env.example
@@ -13,3 +13,6 @@ SITE_URL=http://localhost:5173
 # stripe-webhook: local signing secret from `stripe listen --forward-to \
 #   http://localhost:54321/functions/v1/stripe-webhook`
 STRIPE_WEBHOOK_SECRET=whsec_xxx
+
+# recommend-session (PROD-87): Anthropic API key for the workout recommender.
+ANTHROPIC_API_KEY=sk-ant-xxx

--- a/supabase/functions/recommend-session/deno.json
+++ b/supabase/functions/recommend-session/deno.json
@@ -1,0 +1,5 @@
+{
+  "imports": {
+    "@supabase/supabase-js": "https://esm.sh/@supabase/supabase-js@2.45.0"
+  }
+}

--- a/supabase/functions/recommend-session/index.ts
+++ b/supabase/functions/recommend-session/index.ts
@@ -1,0 +1,107 @@
+// recommend-session (PROD-87)
+//
+// Authenticated, premium-gated endpoint that generates an LLM workout
+// recommendation. The user is derived from the JWT (never trusted from the body).
+// Mirrors create-checkout-session's auth + service-role pattern. The service role
+// is the SOLE writer of session_recommendations; every attempt (success or error)
+// is logged there for analytics + prompt iteration (PROD-88).
+
+import { createClient } from '@supabase/supabase-js';
+
+import { corsHeaders, handleCors } from '../_shared/cors.ts';
+import { gatherInputs } from './inputs.ts';
+import { generateRecommendation, LLMError } from './llm.ts';
+import { ValidationError } from './validate.ts';
+
+function json(body: unknown, status: number): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+  });
+}
+
+Deno.serve(async (req: Request) => {
+  const preflight = handleCors(req);
+  if (preflight) return preflight;
+
+  if (req.method !== 'POST') return json({ error: 'Method not allowed' }, 405);
+
+  try {
+    const authHeader = req.headers.get('Authorization');
+    if (!authHeader) return json({ error: 'Missing authorization' }, 401);
+
+    // (1) Identity: anon client bound to the caller's JWT.
+    const authClient = createClient(
+      Deno.env.get('SUPABASE_URL') ?? '',
+      Deno.env.get('SUPABASE_ANON_KEY') ?? '',
+      { global: { headers: { Authorization: authHeader } } },
+    );
+    const {
+      data: { user },
+      error: userErr,
+    } = await authClient.auth.getUser();
+    if (userErr || !user) return json({ error: 'Unauthorized' }, 401);
+
+    // (2) Service-role client: premium check + RLS-bypassing reads/writes.
+    const admin = createClient(
+      Deno.env.get('SUPABASE_URL') ?? '',
+      Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') ?? '',
+    );
+
+    // (3) Gate on the single source of truth for entitlement. Free users get a
+    // paywall trigger, not a recommendation.
+    const { data: hasPremium, error: gateErr } = await admin.rpc(
+      'has_premium_access',
+      { user_id: user.id },
+    );
+    if (gateErr) throw gateErr;
+    if (!hasPremium) {
+      return json({ error: 'premium_required', paywall_trigger: true }, 401);
+    }
+
+    // (4) Assemble inputs.
+    const body = await req.json().catch(() => ({}));
+    const inputs = await gatherInputs(admin, user.id, body);
+
+    if (inputs.candidates.length === 0) {
+      // Nothing to recommend from — a user-state issue, not an LLM error, so it
+      // is not logged as a generation attempt.
+      return json({ error: 'no_movements' }, 422);
+    }
+
+    // (5) Generate (with one internal corrective retry), validate, persist.
+    try {
+      const recommendation = await generateRecommendation(inputs);
+
+      const { data: row, error: insErr } = await admin
+        .from('session_recommendations')
+        .insert({
+          user_id: user.id,
+          inputs,
+          output: recommendation,
+          status: 'generated',
+        })
+        .select('id')
+        .single();
+      if (insErr) throw insErr;
+
+      return json({ id: row.id, recommendation }, 200);
+    } catch (genErr) {
+      if (genErr instanceof LLMError || genErr instanceof ValidationError) {
+        // Log the failed attempt for prompt iteration, then surface a 502.
+        await admin.from('session_recommendations').insert({
+          user_id: user.id,
+          inputs,
+          status: 'error',
+          error: genErr.message,
+        });
+        console.error('recommend-session generation error:', genErr);
+        return json({ error: 'recommendation_failed' }, 502);
+      }
+      throw genErr;
+    }
+  } catch (err) {
+    console.error('recommend-session error:', err);
+    return json({ error: 'Internal error' }, 500);
+  }
+});

--- a/supabase/functions/recommend-session/inputs.ts
+++ b/supabase/functions/recommend-session/inputs.ts
@@ -1,0 +1,112 @@
+// recommend-session (PROD-87): assemble the standalone RecommenderInputs.
+//
+// Uses the service-role client (bypasses RLS) but every query is scoped to the
+// authenticated user_id. pattern_debt / unlocked_weights are stubbed empty here
+// (PROD-75 / PROD-78).
+
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+import type {
+  CandidateMovement,
+  RecommenderInputs,
+  WorkoutHistoryEntry,
+} from './types.ts';
+
+const HISTORY_LIMIT = 5;
+const LB_TO_KG = 0.453592;
+
+function toKg(value: number | null, unit: string | null): number | null {
+  if (value == null) return null;
+  const kg = unit === 'pounds' ? value * LB_TO_KG : value;
+  return Math.round(kg * 2) / 2; // nearest 0.5 kg
+}
+
+function formatGoal(goal: number, units: string): string {
+  return `${goal} ${units}`;
+}
+
+export async function gatherInputs(
+  admin: SupabaseClient,
+  userId: string,
+  body: { readiness?: unknown },
+): Promise<RecommenderInputs> {
+  const readiness =
+    typeof body.readiness === 'string' && body.readiness.trim()
+      ? body.readiness.trim()
+      : null;
+
+  // Candidate movements: the user's own library.
+  const { data: userMovements, error: umErr } = await admin
+    .from('user_movements')
+    .select('id, canonical_name, is_big_6')
+    .eq('user_id', userId);
+  if (umErr) throw umErr;
+
+  const candidates: CandidateMovement[] = (userMovements ?? []).map((m) => ({
+    user_movement_id: m.id,
+    name: m.canonical_name,
+    is_big_6: Boolean(m.is_big_6),
+  }));
+
+  // Persistent training goal.
+  const { data: profile, error: profErr } = await admin
+    .from('profiles')
+    .select('training_goal')
+    .eq('id', userId)
+    .single();
+  if (profErr) throw profErr;
+
+  // Recent workout history.
+  const { data: logs, error: logErr } = await admin
+    .from('workout_logs')
+    .select('id, completed_at, workout_goal, workout_goal_units, rpe')
+    .eq('user_id', userId)
+    .order('completed_at', { ascending: false })
+    .limit(HISTORY_LIMIT);
+  if (logErr) throw logErr;
+
+  const logIds = (logs ?? []).map((l) => l.id);
+  let movementsByLog = new Map<number, WorkoutHistoryEntry['movements']>();
+  if (logIds.length > 0) {
+    const { data: moves, error: mvErr } = await admin
+      .from('movement_logs')
+      .select('workout_log_id, movement_name, rep_scheme, weight_one_value, weight_one_unit')
+      .in('workout_log_id', logIds);
+    if (mvErr) throw mvErr;
+
+    movementsByLog = (moves ?? []).reduce((acc, m) => {
+      const list = acc.get(m.workout_log_id) ?? [];
+      list.push({
+        name: m.movement_name,
+        rep_scheme: m.rep_scheme ?? [],
+        weight_kg: toKg(m.weight_one_value, m.weight_one_unit),
+      });
+      acc.set(m.workout_log_id, list);
+      return acc;
+    }, new Map<number, WorkoutHistoryEntry['movements']>());
+  }
+
+  const recent_history: WorkoutHistoryEntry[] = (logs ?? []).map((l) => ({
+    completed_at: l.completed_at,
+    goal: formatGoal(l.workout_goal, l.workout_goal_units),
+    rpe: l.rpe ?? null,
+    movements: movementsByLog.get(l.id) ?? [],
+  }));
+
+  const days_since_last_workout =
+    logs && logs.length > 0
+      ? Math.floor(
+          (Date.now() - new Date(logs[0].completed_at).getTime()) / 86_400_000,
+        )
+      : null;
+
+  return {
+    training_goal: profile?.training_goal ?? null,
+    readiness,
+    days_since_last_workout,
+    recent_history,
+    candidates,
+    pattern_debt: [],
+    unlocked_weights: {},
+  };
+}

--- a/supabase/functions/recommend-session/llm.ts
+++ b/supabase/functions/recommend-session/llm.ts
@@ -1,0 +1,138 @@
+// recommend-session (PROD-87): the LLM provider boundary.
+//
+// This is the ONLY module that talks to a specific LLM provider. Everything else
+// works in terms of RecommenderInputs -> Recommendation. To swap providers later
+// (per the project goal), reimplement generateRecommendation here and leave the
+// rest of the function untouched.
+//
+// We call the Anthropic Messages API over raw fetch rather than @anthropic-ai/sdk:
+// the SDK's esm.sh type graph fails to bootstrap in the Supabase edge runtime, and
+// a single structured-outputs call needs no SDK surface.
+
+import {
+  buildCorrectionPrompt,
+  buildSystemPrompt,
+  buildUserPrompt,
+} from './prompt.ts';
+import type { Recommendation, RecommenderInputs } from './types.ts';
+import { RECOMMENDATION_SCHEMA } from './types.ts';
+import { ValidationError, validateRecommendation } from './validate.ts';
+
+const API_URL = 'https://api.anthropic.com/v1/messages';
+const ANTHROPIC_VERSION = '2023-06-01';
+const MODEL = 'claude-sonnet-4-6';
+const MAX_TOKENS = 2048;
+
+/** Transport/parse-level failure (API down, bad JSON) — distinct from ValidationError. */
+export class LLMError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'LLMError';
+  }
+}
+
+interface Message {
+  role: 'user' | 'assistant';
+  content: string;
+}
+
+interface AnthropicResponse {
+  content?: Array<{ type: string; text?: string }>;
+}
+
+/**
+ * Generate a validated recommendation. Calls the model, validates the output,
+ * and retries once with a correction if validation fails. Throws LLMError on a
+ * transport/parse failure and ValidationError if the retry also fails.
+ */
+export async function generateRecommendation(
+  inputs: RecommenderInputs,
+): Promise<Recommendation> {
+  const apiKey = Deno.env.get('ANTHROPIC_API_KEY');
+  if (!apiKey) throw new LLMError('ANTHROPIC_API_KEY is not configured');
+
+  const candidateIds = new Set(
+    inputs.candidates.map((c) => c.user_movement_id),
+  );
+  const system = buildSystemPrompt();
+  const messages: Message[] = [
+    { role: 'user', content: buildUserPrompt(inputs) },
+  ];
+
+  // First attempt, then one corrective retry on validation failure.
+  for (let attempt = 0; attempt < 2; attempt++) {
+    const rec = await callModel(apiKey, system, messages);
+    try {
+      validateRecommendation(rec, candidateIds);
+      return rec;
+    } catch (err) {
+      if (!(err instanceof ValidationError) || attempt === 1) throw err;
+      // Feed the failure back and let the model fix it.
+      messages.push({ role: 'assistant', content: JSON.stringify(rec) });
+      messages.push({
+        role: 'user',
+        content: buildCorrectionPrompt(err.reasons),
+      });
+    }
+  }
+
+  // Unreachable: the loop either returns or throws.
+  throw new LLMError('recommendation generation exhausted retries');
+}
+
+async function callModel(
+  apiKey: string,
+  system: string,
+  messages: Message[],
+): Promise<Recommendation> {
+  let res: Response;
+  try {
+    res = await fetch(API_URL, {
+      method: 'POST',
+      headers: {
+        'x-api-key': apiKey,
+        'anthropic-version': ANTHROPIC_VERSION,
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        model: MODEL,
+        max_tokens: MAX_TOKENS,
+        thinking: { type: 'disabled' },
+        output_config: {
+          effort: 'low',
+          format: { type: 'json_schema', schema: RECOMMENDATION_SCHEMA },
+        },
+        system,
+        messages,
+      }),
+    });
+  } catch (err) {
+    throw new LLMError(
+      `Anthropic request failed: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+
+  if (!res.ok) {
+    const detail = await res.text().catch(() => '');
+    throw new LLMError(`Anthropic API ${res.status}: ${detail.slice(0, 300)}`);
+  }
+
+  let payload: AnthropicResponse;
+  try {
+    payload = (await res.json()) as AnthropicResponse;
+  } catch {
+    throw new LLMError('Anthropic returned a non-JSON response');
+  }
+
+  const text = (payload.content ?? [])
+    .map((block) => (block.type === 'text' ? (block.text ?? '') : ''))
+    .join('')
+    .trim();
+  if (!text) throw new LLMError('model returned no text content');
+
+  try {
+    return JSON.parse(text) as Recommendation;
+  } catch {
+    throw new LLMError('model returned invalid JSON');
+  }
+}

--- a/supabase/functions/recommend-session/prompt.ts
+++ b/supabase/functions/recommend-session/prompt.ts
@@ -1,0 +1,72 @@
+// recommend-session (PROD-87): prompt construction.
+//
+// Kept separate from transport (llm.ts) so prompt quality can be iterated in
+// PROD-88 without touching the API plumbing.
+
+import type { RecommenderInputs } from './types.ts';
+
+export function buildSystemPrompt(): string {
+  return [
+    'You are an expert kettlebell programming coach. You know the Big 6 (swing,',
+    'clean, press, snatch, squat, get-up) and common protocols (Simple & Sinister,',
+    'Rite of Passage). You design a single, focused next training session.',
+    '',
+    'Rules:',
+    "- Choose movements ONLY from the candidate list. Use each block's exact",
+    '  user_movement_id from that list — never invent an id or a movement.',
+    '- Size the session to the time the lifter has and how they say they feel',
+    '  today. When they are tired, sore, or short on time, scale volume down.',
+    '- Prescribe weights in kilograms (whole or half kg) and rep schemes as a list',
+    '  of positive integers (one entry per rung/set).',
+    '- Give a short, concrete rationale a thoughtful coach would give — tie it to',
+    '  their goal, recent history, and readiness. Avoid generic filler.',
+  ].join('\n');
+}
+
+export function buildUserPrompt(inputs: RecommenderInputs): string {
+  const candidateLines = inputs.candidates
+    .map(
+      (c) =>
+        `- ${c.name}${c.is_big_6 ? ' (Big 6)' : ''} [user_movement_id: ${c.user_movement_id}]`,
+    )
+    .join('\n');
+
+  const historyLines = inputs.recent_history.length
+    ? inputs.recent_history
+        .map((w) => {
+          const moves = w.movements
+            .map(
+              (m) =>
+                `${m.name} ${m.rep_scheme.join('/')}${m.weight_kg ? ` @ ${m.weight_kg}kg` : ''}`,
+            )
+            .join('; ');
+          return `- ${w.completed_at.slice(0, 10)} · goal ${w.goal}${w.rpe ? ` · RPE ${w.rpe}` : ''} · ${moves}`;
+        })
+        .join('\n')
+    : '- (no recent workouts logged)';
+
+  return [
+    `Training goal: ${inputs.training_goal ?? '(none provided)'}`,
+    `How they feel today: ${inputs.readiness ?? '(not provided)'}`,
+    `Days since last workout: ${inputs.days_since_last_workout ?? '(unknown)'}`,
+    '',
+    'Recent workouts (most recent first):',
+    historyLines,
+    '',
+    'Candidate movements (choose only from these):',
+    candidateLines,
+    '',
+    'Recommend their next session now.',
+  ].join('\n');
+}
+
+/** Appended on a retry when the first attempt failed validation. */
+export function buildCorrectionPrompt(reasons: string[]): string {
+  return [
+    'Your previous response was rejected for these reasons:',
+    ...reasons.map((r) => `- ${r}`),
+    '',
+    'Produce a corrected recommendation that uses only candidate user_movement_ids',
+    'and positive integer reps and weights.',
+  ].join('\n');
+}

--- a/supabase/functions/recommend-session/types.ts
+++ b/supabase/functions/recommend-session/types.ts
@@ -1,0 +1,97 @@
+// recommend-session (PROD-87): shared types + the structured-output JSON schema.
+//
+// RecommenderInputs is the typed snapshot fed to the LLM and persisted verbatim
+// into session_recommendations.inputs. pattern_debt / unlocked_weights are present
+// but empty stubs for now (PROD-75 / PROD-78 deferred) so they can be populated
+// later without reshaping the prompt or the table.
+
+/** One movement in the user's library — the candidate set the LLM may choose from. */
+export interface CandidateMovement {
+  user_movement_id: string;
+  name: string;
+  is_big_6: boolean;
+}
+
+/** A compact summary of one past workout, for history context. */
+export interface WorkoutHistoryEntry {
+  completed_at: string;
+  goal: string; // e.g. "20 minutes", "5 rounds", "1000 kg"
+  rpe: string | null;
+  movements: Array<{
+    name: string;
+    rep_scheme: number[];
+    weight_kg: number | null;
+  }>;
+}
+
+/** Everything the recommender reasons over. Snapshotted into inputs JSONB. */
+export interface RecommenderInputs {
+  training_goal: string | null;
+  readiness: string | null;
+  days_since_last_workout: number | null;
+  recent_history: WorkoutHistoryEntry[];
+  candidates: CandidateMovement[];
+  // Reserved, populated later (PROD-75 / PROD-78). Kept in the snapshot so the
+  // prompt and the logged inputs are forward-compatible.
+  pattern_debt: never[];
+  unlocked_weights: Record<string, never>;
+}
+
+/** One block of the recommended session. Maps onto the app's MovementOptions. */
+export interface RecommendationBlock {
+  user_movement_id: string;
+  movement_name: string;
+  weight_kg: number;
+  rep_scheme: number[];
+  notes: string;
+}
+
+/** The validated LLM output. Persisted into session_recommendations.output. */
+export interface Recommendation {
+  rationale: string;
+  duration_minutes: number;
+  format: 'EMOM' | 'AMRAP' | 'Circuit' | 'Ladder' | 'Straight Sets';
+  confidence: 'high' | 'medium' | 'low';
+  blocks: RecommendationBlock[];
+}
+
+// JSON schema for Anthropic structured outputs (output_config.format). Structured
+// outputs forbid numeric min/max and string length constraints and require every
+// object to set additionalProperties:false with all properties in `required` — so
+// value-range sanity (positive weights/reps, ids in the candidate set) is enforced
+// separately in validate.ts, not here.
+export const RECOMMENDATION_SCHEMA = {
+  type: 'object',
+  additionalProperties: false,
+  properties: {
+    rationale: { type: 'string' },
+    duration_minutes: { type: 'integer' },
+    format: {
+      type: 'string',
+      enum: ['EMOM', 'AMRAP', 'Circuit', 'Ladder', 'Straight Sets'],
+    },
+    confidence: { type: 'string', enum: ['high', 'medium', 'low'] },
+    blocks: {
+      type: 'array',
+      items: {
+        type: 'object',
+        additionalProperties: false,
+        properties: {
+          user_movement_id: { type: 'string' },
+          movement_name: { type: 'string' },
+          weight_kg: { type: 'number' },
+          rep_scheme: { type: 'array', items: { type: 'integer' } },
+          notes: { type: 'string' },
+        },
+        required: [
+          'user_movement_id',
+          'movement_name',
+          'weight_kg',
+          'rep_scheme',
+          'notes',
+        ],
+      },
+    },
+  },
+  required: ['rationale', 'duration_minutes', 'format', 'confidence', 'blocks'],
+} as const;

--- a/supabase/functions/recommend-session/validate.ts
+++ b/supabase/functions/recommend-session/validate.ts
@@ -1,0 +1,58 @@
+// recommend-session (PROD-87): validation of the LLM output.
+//
+// Structured outputs guarantee the JSON *shape*; this enforces the *semantics*
+// the schema can't express — movement ids must be real candidates, and reps and
+// weights must be sane. A failure here drives the single retry in llm.ts.
+
+import type { Recommendation } from './types.ts';
+
+export class ValidationError extends Error {
+  reasons: string[];
+  constructor(reasons: string[]) {
+    super(`Recommendation failed validation: ${reasons.join('; ')}`);
+    this.name = 'ValidationError';
+    this.reasons = reasons;
+  }
+}
+
+const MAX_WEIGHT_KG = 100; // generous ceiling; guards against absurd hallucinations
+const MAX_REP = 100;
+
+export function validateRecommendation(
+  rec: Recommendation,
+  candidateIds: Set<string>,
+): void {
+  const reasons: string[] = [];
+
+  if (rec.blocks.length === 0) {
+    reasons.push('the session has no movement blocks');
+  }
+
+  for (const [i, block] of rec.blocks.entries()) {
+    const where = `block ${i + 1} (${block.movement_name})`;
+
+    if (!candidateIds.has(block.user_movement_id)) {
+      reasons.push(
+        `${where} uses user_movement_id "${block.user_movement_id}", which is not in the candidate list`,
+      );
+    }
+
+    if (!Number.isFinite(block.weight_kg) || block.weight_kg <= 0) {
+      reasons.push(`${where} has a non-positive weight`);
+    } else if (block.weight_kg > MAX_WEIGHT_KG) {
+      reasons.push(`${where} has an implausible weight (${block.weight_kg} kg)`);
+    }
+
+    if (block.rep_scheme.length === 0) {
+      reasons.push(`${where} has an empty rep scheme`);
+    } else if (
+      block.rep_scheme.some(
+        (r) => !Number.isInteger(r) || r <= 0 || r > MAX_REP,
+      )
+    ) {
+      reasons.push(`${where} has invalid rep counts`);
+    }
+  }
+
+  if (reasons.length > 0) throw new ValidationError(reasons);
+}


### PR DESCRIPTION
Adds the `recommend-session` Edge Function — the keystone of the AI Next Session Recommender ([PROD-85](https://linear.app/bellskill/issue/PROD-85)). Premium users get an LLM-generated, validated workout proposal; free users get a paywall trigger.

**Changes:**
- New `supabase/functions/recommend-session/`: JWT auth → `has_premium_access` gate (401 + `paywall_trigger` for free users) → gather standalone inputs (history, `training_goal`, daily readiness, candidate `user_movements`) → Anthropic Messages API with structured outputs (`claude-sonnet-4-6`) → semantic validation with one corrective retry → persist every attempt (success + error) to `session_recommendations`.
- LLM call isolated behind `llm.ts` (raw `fetch`) so the provider is swappable per the project goal; `pattern_debt` / `unlocked_weights` stubbed for PROD-75/78.
- Registered `[functions.recommend-session]` (`verify_jwt = true`) in `config.toml`; documented `ANTHROPIC_API_KEY` in `.env.example`.

**Testing:**
- `deno check` + `deno lint` clean.
- Local end-to-end against the running stack with a real key:
  - Free user → `401 { paywall_trigger: true }`
  - Premium user → `200` validated recommendation; `status='generated'` row with `inputs`+`output`
  - LLM failure (bad key) → `502` + `status='error'` row with the API error logged
- Warm latency ~10s locally (above the 8s target) — model-bound; prompt/output/`effort` tuning is PROD-88.

**Not customer-facing yet (intentional):** the deploy workflows list functions by name and `recommend-session` is not among them, so merging does **not** deploy it. Even if deployed, `has_premium_access` returns false for all prod users today (tier defaults to `free`, no active trials, premium not launched). Shipping later = add a `supabase functions deploy recommend-session` step **and** set the `ANTHROPIC_API_KEY` production secret.

**Note:** uses raw `fetch` rather than `@anthropic-ai/sdk` — the SDK's esm.sh type graph fails to bootstrap in the Supabase edge runtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)