### PR TITLE
feat(account): owner-only subscription toggle for QA

### DIFF
--- a/.github/workflows/supabase-production.yaml
+++ b/.github/workflows/supabase-production.yaml
@@ -29,3 +29,4 @@ jobs:
       - run: supabase functions deploy create-checkout-session --project-ref $SUPABASE_PROJECT_ID
       - run: supabase functions deploy stripe-webhook --project-ref $SUPABASE_PROJECT_ID
       - run: supabase functions deploy create-portal-session --project-ref $SUPABASE_PROJECT_ID
+      - run: supabase functions deploy set-subscription --project-ref $SUPABASE_PROJECT_ID

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -11,6 +11,7 @@ export * from './useMovements';
 export * from './usePatternDebt';
 export * from './useRecentRepeatableWorkouts';
 export * from './useSelectRPE';
+export * from './useSetSubscription';
 export * from './useUpdateWorkoutNotes';
 export * from './useInfiniteWorkoutLogs';
 export * from './useWorkoutLog';

--- a/src/api/useSetSubscription.ts
+++ b/src/api/useSetSubscription.ts
@@ -1,0 +1,22 @@
+import { useMutation } from 'react-query';
+
+import { supabase } from '../supabaseClient';
+
+export type SubscriptionState = 'free' | 'premium' | 'trialing';
+
+const setSubscription = async (state: SubscriptionState): Promise<void> => {
+  const { error } = await supabase.functions.invoke('set-subscription', {
+    body: { state },
+  });
+
+  if (error) throw error;
+};
+
+/**
+ * Owner-only: flips the current user's subscription state via the
+ * set-subscription Edge Function (free / premium / trialing). Used to QA the
+ * premium vs free surfaces without going through Stripe. The function enforces
+ * the owner check server-side; non-owners get a 403.
+ */
+export const useSetSubscription = () =>
+  useMutation((state: SubscriptionState) => setSubscription(state));

--- a/src/pages/AccountPage/AccountPage.tsx
+++ b/src/pages/AccountPage/AccountPage.tsx
@@ -5,7 +5,11 @@ import {
   useState,
 } from 'react';
 
-import { useCreatePortalSession } from '~/api';
+import {
+  SubscriptionState,
+  useCreatePortalSession,
+  useSetSubscription,
+} from '~/api';
 import { Page, TrialStatusPill } from '~/components';
 import { Button } from '~/components/ui/button';
 import { Input } from '~/components/ui/input';
@@ -20,9 +24,12 @@ import { supabase } from '~/supabaseClient';
 
 export const AccountPage = () => {
   const session = useSession();
-  const { isPremium } = useEntitlement();
+  const { isPremium, isTrialing, refetch: refetchEntitlement } =
+    useEntitlement();
   const { mutate: openPortal, isLoading: portalLoading } =
     useCreatePortalSession();
+  const { mutate: setSubscription, isLoading: settingSubscription } =
+    useSetSubscription();
 
   const [loading, setLoading] = useState<boolean>(true);
   const [username, setUsername] = useState<string>('');
@@ -36,6 +43,18 @@ export const AccountPage = () => {
     setPreviewEnabled(next);
     // Routes are built once from the effective flags, so reload to apply.
     window.location.reload();
+  };
+
+  const currentState: SubscriptionState = isPremium
+    ? 'premium'
+    : isTrialing
+      ? 'trialing'
+      : 'free';
+
+  const handleSetSubscription = (state: SubscriptionState) => {
+    setSubscription(state, {
+      onSuccess: () => refetchEntitlement(),
+    });
   };
 
   const handleManageSubscription = () => {
@@ -136,6 +155,31 @@ export const AccountPage = () => {
               ? 'Disable feature preview'
               : 'Enable feature preview'}
           </Button>
+        </div>
+      )}
+
+      {isOwner(session) && (
+        <div className="flex flex-col gap-1 border-t pt-2">
+          <Label>Subscription (QA)</Label>
+          <p className="text-xs text-muted-foreground">
+            Flip your account between states to test premium vs free surfaces.
+            Owner-only — has no effect for other accounts.
+          </p>
+          <div className="flex gap-1">
+            {(['free', 'premium', 'trialing'] as SubscriptionState[]).map(
+              (state) => (
+                <Button
+                  key={state}
+                  className="flex-1 capitalize"
+                  variant={currentState === state ? 'default' : 'outline'}
+                  disabled={settingSubscription}
+                  onClick={() => handleSetSubscription(state)}
+                >
+                  {state}
+                </Button>
+              ),
+            )}
+          </div>
         </div>
       )}
     </Page>

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -282,6 +282,13 @@ enabled = true
 verify_jwt = true
 import_map = "./functions/recommend-session/deno.json"
 
+# Owner-only subscription toggle (QA + friends/family grants). Writes the
+# write-locked subscription columns via the service role.
+[functions.set-subscription]
+enabled = true
+verify_jwt = true
+import_map = "./functions/set-subscription/deno.json"
+
 [analytics]
 enabled = true
 port = 54327

--- a/supabase/functions/.env.example
+++ b/supabase/functions/.env.example
@@ -16,3 +16,9 @@ STRIPE_WEBHOOK_SECRET=whsec_xxx
 
 # recommend-session (PROD-87): Anthropic API key for the workout recommender.
 ANTHROPIC_API_KEY=sk-ant-xxx
+
+# set-subscription (owner-only): comma-separated allowlist of emails permitted
+# to flip subscription state. Optional — defaults to daniel_bowers@icloud.com.
+# Set this as a deployed secret (Edge Functions -> Secrets) rather than relying
+# on the hardcoded fallback.
+OWNER_EMAILS=daniel_bowers@icloud.com

--- a/supabase/functions/set-subscription/deno.json
+++ b/supabase/functions/set-subscription/deno.json
@@ -1,0 +1,5 @@
+{
+  "imports": {
+    "@supabase/supabase-js": "https://esm.sh/@supabase/supabase-js@2.45.0"
+  }
+}

--- a/supabase/functions/set-subscription/index.ts
+++ b/supabase/functions/set-subscription/index.ts
@@ -1,0 +1,126 @@
+// set-subscription (owner-only)
+//
+// Lets an owner flip a user's subscription state (free / premium / trialing).
+// The subscription columns on profiles are write-locked from clients (column-
+// level grants in the entitlement migration), so the only legitimate writer is
+// the service role. This function authenticates the caller, checks they're an
+// owner, then writes via the service role.
+//
+// Primary use: manual QA of premium vs free vs trialing surfaces. Also general
+// enough to grant premium to a specific user (pass targetUserId).
+
+import { createClient } from '@supabase/supabase-js';
+
+import { corsHeaders, handleCors } from '../_shared/cors.ts';
+
+type SubscriptionState = 'free' | 'premium' | 'trialing';
+
+const STATES: readonly SubscriptionState[] = ['free', 'premium', 'trialing'];
+
+const TRIAL_DAYS = 30;
+
+function json(body: unknown, status: number): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+  });
+}
+
+// Server-side owner allowlist. Mirrors src/config/features.ts OWNER_EMAILS, but
+// is the real boundary — the client list is UI-gating only. Configurable via the
+// OWNER_EMAILS env var (comma-separated); falls back to the known owner.
+function ownerEmails(): string[] {
+  const raw = Deno.env.get('OWNER_EMAILS');
+  if (!raw) return ['daniel_bowers@icloud.com'];
+  return raw
+    .split(',')
+    .map((e) => e.trim().toLowerCase())
+    .filter(Boolean);
+}
+
+// Maps a QA state to the subscription columns. Only subscription_tier and
+// trial_ends_at affect entitlement (has_premium_access); subscription_status is
+// cosmetic, set for realism.
+function columnsFor(state: SubscriptionState): Record<string, unknown> {
+  switch (state) {
+    case 'premium':
+      return {
+        subscription_tier: 'premium',
+        trial_ends_at: null,
+        subscription_status: 'active',
+      };
+    case 'trialing':
+      return {
+        subscription_tier: 'free',
+        trial_ends_at: new Date(
+          Date.now() + TRIAL_DAYS * 24 * 60 * 60 * 1000,
+        ).toISOString(),
+        subscription_status: 'trialing',
+      };
+    case 'free':
+      return {
+        subscription_tier: 'free',
+        trial_ends_at: null,
+        subscription_status: null,
+      };
+  }
+}
+
+Deno.serve(async (req: Request) => {
+  const preflight = handleCors(req);
+  if (preflight) return preflight;
+
+  if (req.method !== 'POST') return json({ error: 'Method not allowed' }, 405);
+
+  try {
+    const authHeader = req.headers.get('Authorization');
+    if (!authHeader) return json({ error: 'Missing authorization' }, 401);
+
+    // (1) Identity: anon client bound to the caller's JWT.
+    const authClient = createClient(
+      Deno.env.get('SUPABASE_URL') ?? '',
+      Deno.env.get('SUPABASE_ANON_KEY') ?? '',
+      { global: { headers: { Authorization: authHeader } } },
+    );
+    const {
+      data: { user },
+      error: userErr,
+    } = await authClient.auth.getUser();
+    if (userErr || !user) return json({ error: 'Unauthorized' }, 401);
+
+    // (2) Owner gate — the real boundary for this privileged write.
+    const email = user.email?.toLowerCase();
+    if (!email || !ownerEmails().includes(email)) {
+      return json({ error: 'Forbidden' }, 403);
+    }
+
+    // (3) Validate input.
+    const body = await req.json().catch(() => null);
+    const state = body?.state as SubscriptionState | undefined;
+    if (!state || !STATES.includes(state)) {
+      return json({ error: 'Invalid state' }, 400);
+    }
+    const targetUserId =
+      typeof body?.targetUserId === 'string' && body.targetUserId
+        ? body.targetUserId
+        : user.id;
+
+    // (4) Service-role write — bypasses the column-level write lock.
+    const admin = createClient(
+      Deno.env.get('SUPABASE_URL') ?? '',
+      Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') ?? '',
+    );
+
+    const { error, count } = await admin
+      .from('profiles')
+      .update(columnsFor(state), { count: 'exact' })
+      .eq('id', targetUserId);
+    if (error) throw error;
+    if (!count) return json({ error: 'Profile not found' }, 404);
+
+    return json({ ok: true, state }, 200);
+  } catch (err) {
+    console.error('set-subscription error:', err);
+    return json({ error: 'Internal error' }, 500);
+  }
+});


### PR DESCRIPTION
Adds an owner-only **Subscription (QA)** toggle to the Account page so premium vs free vs trialing surfaces can be QA'd manually, without going through Stripe checkout. Also general enough to grant premium to any user by id (friends/family), since the subscription columns are write-locked from clients and need a service-role write.

**Changes:**
- New `set-subscription` edge function: authenticates the caller, enforces a **server-side** owner-email allowlist (`OWNER_EMAILS` env var, falling back to the owner email), then writes `subscription_tier` / `trial_ends_at` / `subscription_status` via the service role. Accepts an optional `targetUserId` (defaults to caller).
- State mapping mirrors `has_premium_access`: Premium → `tier=premium`; Trialing → `tier=free` + `trial_ends_at=now()+30d`; Free → `tier=free`, `trial_ends_at=null`.
- Registers the function in `config.toml` (`verify_jwt = true`) and the production deploy workflow.
- New `useSetSubscription` react-query hook, exported from `~/api`.
- Owner-only toggle UI on `AccountPage` (Free / Premium / Trialing buttons, current state highlighted); refetches entitlement on success so premium surfaces update live.
- Documents `OWNER_EMAILS` in `supabase/functions/.env.example`.

**Reviewer notes:**
- The client `isOwner` check is UI-gating only; the real boundary is the server-side owner allowlist inside the edge function.
- For production, set `OWNER_EMAILS` as a deployed secret (Edge Functions → Secrets) rather than relying on the hardcoded fallback.
- These subscription columns are normally writable only by the Stripe webhook; this function is the deliberate owner-gated exception.

**Testing:**
- `npm run compile:ts` clean
- Full vitest suite: 296 tests passing (`AccountPage.test` uses a non-owner session, so the new section stays hidden)

🤖 Generated with [Claude Code](https://claude.com/claude-code)