### PR TITLE
feat(timers): audible ding + haptic at rest/interval timer end

### DIFF
--- a/src/pages/AccountPage/AccountPage.tsx
+++ b/src/pages/AccountPage/AccountPage.tsx
@@ -21,6 +21,7 @@ import {
 } from '~/config/features';
 import { useEntitlement, useSession } from '~/contexts';
 import { supabase } from '~/supabaseClient';
+import { isSoundEnabled, setSoundEnabled } from '~/utils';
 
 export const AccountPage = () => {
   const session = useSession();
@@ -36,6 +37,15 @@ export const AccountPage = () => {
   const [previewEnabled, setPreviewEnabled] = useState<boolean>(
     isPreviewOverrideEnabled(),
   );
+  const [soundEnabled, setSoundEnabledState] = useState<boolean>(
+    isSoundEnabled(),
+  );
+
+  const handleToggleSound = () => {
+    const next = !soundEnabled;
+    setSoundEnabled(next);
+    setSoundEnabledState(next);
+  };
 
   const handleTogglePreview = () => {
     const next = !previewEnabled;
@@ -129,6 +139,17 @@ export const AccountPage = () => {
           </Button>
         </div>
       </form>
+
+      <div className="flex flex-col gap-1 border-t pt-2">
+        <Label>Sound</Label>
+        <p className="text-xs text-muted-foreground">
+          Play a sound and vibrate when a rest or interval timer ends, so you
+          know it's time for the next set without looking at your screen.
+        </p>
+        <Button variant="outline" onClick={handleToggleSound}>
+          {soundEnabled ? 'Disable timer sounds' : 'Enable timer sounds'}
+        </Button>
+      </div>
 
       {isPremium && (
         <div className="flex flex-col gap-1 border-t pt-2">

--- a/src/pages/ActiveWorkoutPage/ActiveWorkoutPage.tsx
+++ b/src/pages/ActiveWorkoutPage/ActiveWorkoutPage.tsx
@@ -5,6 +5,7 @@ import { useLogWorkout } from '~/api';
 import { Page } from '~/components';
 import { useWorkoutOptions } from '~/contexts';
 import { useCountdownTimer } from '~/hooks';
+import { playDing, playStartCue, unlockAudio } from '~/utils';
 
 import {
   ActiveWorkoutControls,
@@ -300,6 +301,7 @@ export const ActiveWorkoutPage = ({
   };
 
   const finishRest = () => {
+    playDing();
     pauseRestTimer();
     resetRestTimer();
     setIsRestActive(false);
@@ -307,6 +309,7 @@ export const ActiveWorkoutPage = ({
   };
 
   const finishInterval = () => {
+    playDing();
     continueWorkout();
     resetIntervalTimer();
   };
@@ -326,6 +329,7 @@ export const ActiveWorkoutPage = ({
   };
 
   const finishCountdown = () => {
+    playStartCue();
     pauseCountdownTimer();
     setIsCountdownActive(false);
     resetCountdownTimer();
@@ -354,11 +358,13 @@ export const ActiveWorkoutPage = ({
 
   // Event Handlers
   const handleClickContinue = () => {
+    unlockAudio();
     setIsEffectActive(true);
     continueWorkout();
   };
 
   const handleClickStart = () => {
+    unlockAudio();
     startCountdownTimer();
     setIsCountdownActive(true);
   };

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -5,5 +5,7 @@ export * from './patternDebt';
 export * from './rankMovements';
 export * from './resolveAuthSession';
 export * from './resolveSharedWeights';
+export * from './soundPreference';
+export * from './timerSound';
 export * from './weightUnits';
 export * from './workoutLogToWorkoutOptions';

--- a/src/utils/soundPreference.ts
+++ b/src/utils/soundPreference.ts
@@ -1,0 +1,22 @@
+const SOUND_STORAGE_KEY = 'bellskill:sound-enabled';
+
+/**
+ * Whether timer sound effects are enabled. Defaults to ON when the key is
+ * absent — the preference is only "off" when explicitly disabled by the user.
+ */
+export const isSoundEnabled = (): boolean => {
+  try {
+    return localStorage.getItem(SOUND_STORAGE_KEY) !== 'false';
+  } catch {
+    return true;
+  }
+};
+
+export const setSoundEnabled = (enabled: boolean): void => {
+  try {
+    if (enabled) localStorage.removeItem(SOUND_STORAGE_KEY);
+    else localStorage.setItem(SOUND_STORAGE_KEY, 'false');
+  } catch {
+    // ignore — storage unavailable (private mode, etc.)
+  }
+};

--- a/src/utils/timerSound.test.ts
+++ b/src/utils/timerSound.test.ts
@@ -1,0 +1,29 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { setSoundEnabled } from './soundPreference';
+import { playDing, playStartCue, unlockAudio } from './timerSound';
+
+describe('timerSound', () => {
+  afterEach(() => {
+    setSoundEnabled(true);
+    vi.unstubAllGlobals();
+  });
+
+  it('is a safe no-op when Web Audio is unavailable (jsdom)', () => {
+    // jsdom provides no AudioContext, so these must not throw.
+    expect(() => unlockAudio()).not.toThrow();
+    expect(() => playDing()).not.toThrow();
+    expect(() => playStartCue()).not.toThrow();
+  });
+
+  it('does not attempt playback when sound is disabled', () => {
+    const ctor = vi.fn();
+    vi.stubGlobal('AudioContext', ctor);
+
+    setSoundEnabled(false);
+    playDing();
+    playStartCue();
+
+    expect(ctor).not.toHaveBeenCalled();
+  });
+});

--- a/src/utils/timerSound.ts
+++ b/src/utils/timerSound.ts
@@ -1,0 +1,110 @@
+import { isSoundEnabled } from './soundPreference';
+
+/**
+ * Web Audio synthesis for timer cues. No binary asset — the tones are generated
+ * with an oscillator + gain envelope, so they work offline and add no bundle
+ * weight. Every entry point is feature-detected so the module is a safe no-op in
+ * environments without Web Audio (e.g. jsdom during tests).
+ */
+
+type AudioContextConstructor = typeof AudioContext;
+
+const getAudioContextCtor = (): AudioContextConstructor | undefined => {
+  if (typeof window === 'undefined') return undefined;
+  return (
+    window.AudioContext ||
+    (window as unknown as { webkitAudioContext?: AudioContextConstructor })
+      .webkitAudioContext
+  );
+};
+
+let audioContext: AudioContext | null = null;
+
+const getAudioContext = (): AudioContext | null => {
+  if (audioContext) return audioContext;
+  const Ctor = getAudioContextCtor();
+  if (!Ctor) return null;
+  try {
+    audioContext = new Ctor();
+  } catch {
+    audioContext = null;
+  }
+  return audioContext;
+};
+
+/**
+ * Create (if needed) and resume the AudioContext. Must be called from within a
+ * user gesture (e.g. the Start button) so mobile Safari unlocks audio playback.
+ */
+export const unlockAudio = (): void => {
+  const ctx = getAudioContext();
+  if (!ctx) return;
+  if (ctx.state === 'suspended') {
+    void ctx.resume().catch(() => {});
+  }
+};
+
+/** Play a single note with a quick attack + exponential decay envelope. */
+const playTone = (
+  ctx: AudioContext,
+  frequency: number,
+  startAt: number,
+  duration: number,
+): void => {
+  const oscillator = ctx.createOscillator();
+  const gain = ctx.createGain();
+
+  oscillator.type = 'sine';
+  oscillator.frequency.setValueAtTime(frequency, startAt);
+
+  gain.gain.setValueAtTime(0, startAt);
+  gain.gain.linearRampToValueAtTime(0.3, startAt + 0.01);
+  gain.gain.exponentialRampToValueAtTime(0.0001, startAt + duration);
+
+  oscillator.connect(gain);
+  gain.connect(ctx.destination);
+
+  oscillator.start(startAt);
+  oscillator.stop(startAt + duration);
+};
+
+const vibrate = (pattern: number | number[]): void => {
+  try {
+    navigator.vibrate?.(pattern);
+  } catch {
+    // ignore — vibration unsupported
+  }
+};
+
+/**
+ * Two-note "ding" played when a rest or interval timer reaches zero. No-ops when
+ * sound is disabled or Web Audio is unavailable.
+ */
+export const playDing = (): void => {
+  if (!isSoundEnabled()) return;
+  const ctx = getAudioContext();
+  if (!ctx) return;
+  void ctx.resume?.().catch(() => {});
+
+  const now = ctx.currentTime;
+  playTone(ctx, 880, now, 0.28); // A5
+  playTone(ctx, 1318.51, now + 0.13, 0.32); // E6
+
+  vibrate(200);
+};
+
+/**
+ * Distinct higher "go" cue played when the 3-2-1 pre-start countdown finishes,
+ * so it's audibly different from the end-of-timer ding.
+ */
+export const playStartCue = (): void => {
+  if (!isSoundEnabled()) return;
+  const ctx = getAudioContext();
+  if (!ctx) return;
+  void ctx.resume?.().catch(() => {});
+
+  const now = ctx.currentTime;
+  playTone(ctx, 1046.5, now, 0.3); // C6
+
+  vibrate([120, 60, 120]);
+};


### PR DESCRIPTION
Adds an audible "ding" and haptic buzz when a rest or interval timer reaches zero, so lifters know it's time for the next set without looking at their screen — supporting Bellskill's cognitive-offloading goal of externalizing the counting.

**Changes:**
- New `src/utils/timerSound.ts` — Web Audio synthesis (no binary asset, works offline). `playDing()` (two-note bell) at the end of rest/interval timers, and a distinct `playStartCue()` ("go") when the 3-2-1 pre-start countdown finishes. `unlockAudio()` resumes the AudioContext on a user gesture so mobile Safari unlocks playback. Every entry point is feature-detected, so it no-ops safely where Web Audio / `navigator.vibrate` are unavailable.
- New `src/utils/soundPreference.ts` — localStorage-backed `isSoundEnabled` / `setSoundEnabled` (key `bellskill:sound-enabled`, defaults ON), mirroring the existing `config/features.ts` pattern.
- `ActiveWorkoutPage.tsx` — fires `playDing()` in `finishRest`/`finishInterval`, `playStartCue()` in `finishCountdown`, and `unlockAudio()` on the Start/Continue taps.
- `AccountPage.tsx` — an all-users **Sound** toggle following the existing Button-toggle pattern. Disabling it silences both the sound and the vibration.
- New `src/utils/timerSound.test.ts` — asserts the util is a safe no-op in jsdom and when disabled.

**Reviewer notes:**
- Sound + vibration are gated under a single toggle by design; splitting them would be a quick follow-up if desired.
- The 3-2-1 start countdown now also plays a cue, in addition to the rest/interval end ding (confirmed as desired scope).

**Testing:**
- `npm run compile:ts` — clean.
- `npm test` — 69 passing, including all 50 existing ActiveWorkoutPage tests (no regressions) and the new util test.
- `npm run lint` — no new errors (the one remaining error is pre-existing in `public/sw.js`, untouched here).
- Manual device testing (iOS especially, via `npm run dev:host`) still recommended to confirm audible playback, since it can't be verified in CI/jsdom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)