### PR TITLE
feat(active-workout): count each finished side within a rung

### DIFF
--- a/src/api/useInfiniteWorkoutLogs.ts
+++ b/src/api/useInfiniteWorkoutLogs.ts
@@ -44,6 +44,7 @@ const fetchWorkoutLogsPage = async ({
       completedReps: workoutLog.completed_reps,
       completedRounds: workoutLog.completed_rounds,
       completedRungs: workoutLog.completed_rungs,
+      completedSides: workoutLog.completed_sides,
       completedVolume: workoutLog.completed_volume,
       complexSet: workoutLog.complex_set,
       id: workoutLog.id,

--- a/src/api/useLogWorkout.test.ts
+++ b/src/api/useLogWorkout.test.ts
@@ -69,6 +69,7 @@ const logWorkoutInput = {
   completedReps: 5,
   completedRounds: 1,
   completedRungs: 1,
+  completedSides: 2,
   completedVolume: 120,
 };
 
@@ -126,6 +127,30 @@ describe('useLogWorkout — complex_set persistence', () => {
 
     expect(capturedBody).not.toBeNull();
     expect(capturedBody!.complex_set).toBe(false);
+  });
+
+  test('persists completed_sides from the log input', async () => {
+    let capturedBody: Record<string, unknown> | null = null;
+
+    server.use(
+      http.post(WORKOUT_LOGS_URL, async ({ request }) => {
+        capturedBody = (await request.json()) as Record<string, unknown>;
+        return HttpResponse.json([{ id: 1 }]);
+      }),
+    );
+
+    const { result } = renderHook(() => useLogWorkout(), {
+      wrapper: makeWrapper(false),
+    });
+
+    act(() => {
+      result.current.mutate(logWorkoutInput);
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(capturedBody).not.toBeNull();
+    expect(capturedBody!.completed_sides).toBe(logWorkoutInput.completedSides);
   });
 });
 

--- a/src/api/useLogWorkout.ts
+++ b/src/api/useLogWorkout.ts
@@ -11,6 +11,7 @@ interface LogWorkoutInput {
   completedReps: number;
   completedRounds: number;
   completedRungs: number;
+  completedSides: number;
   completedVolume: number;
 }
 
@@ -24,12 +25,14 @@ export const useLogWorkout = () => {
       completedReps,
       completedRounds,
       completedRungs,
+      completedSides,
       completedVolume,
     }: LogWorkoutInput) =>
       logWorkout({
         completedReps,
         completedRounds,
         completedRungs,
+        completedSides,
         completedVolume,
         userId: user.id,
         workoutOptions,
@@ -75,6 +78,7 @@ const logWorkout = async ({
   completedReps,
   completedRounds,
   completedRungs,
+  completedSides,
   completedVolume,
   userId,
   workoutOptions,
@@ -82,6 +86,7 @@ const logWorkout = async ({
   completedReps: number;
   completedRounds: number;
   completedRungs: number;
+  completedSides: number;
   completedVolume: number;
   userId: string;
   workoutOptions: WorkoutOptions;
@@ -121,6 +126,7 @@ const logWorkout = async ({
       completed_reps: completedReps,
       completed_rounds: completedRounds,
       completed_rungs: completedRungs,
+      completed_sides: completedSides,
       completed_volume: completedVolume,
       complex_set: complexSet,
       interval_timer: intervalTimer,

--- a/src/api/useWorkoutLog.ts
+++ b/src/api/useWorkoutLog.ts
@@ -30,6 +30,7 @@ const fetchWorkoutLog = async (id: string): Promise<WorkoutLog> => {
     completedReps: workoutLog.completed_reps,
     completedRounds: workoutLog.completed_rounds,
     completedRungs: workoutLog.completed_rungs,
+    completedSides: workoutLog.completed_sides,
     completedVolume: workoutLog.completed_volume,
     complexSet: workoutLog.complex_set,
     id: workoutLog.id,

--- a/src/api/useWorkoutLogs.ts
+++ b/src/api/useWorkoutLogs.ts
@@ -24,6 +24,7 @@ const fetchWorkoutLogs = async (): Promise<WorkoutLog[]> => {
     completedReps: workoutLog.completed_reps,
     completedRounds: workoutLog.completed_rounds,
     completedRungs: workoutLog.completed_rungs,
+    completedSides: workoutLog.completed_sides,
     completedVolume: workoutLog.completed_volume,
     complexSet: workoutLog.complex_set,
     id: workoutLog.id,

--- a/src/examples/workout-log.examples.ts
+++ b/src/examples/workout-log.examples.ts
@@ -11,6 +11,7 @@ export class ExampleWorkoutLog implements WorkoutLog {
   completed_reps: number;
   completed_rounds: number;
   completed_rungs: number;
+  completed_sides: number | null;
   completed_volume: number | null;
   complex_set: boolean;
   id: number;
@@ -44,6 +45,7 @@ export class ExampleWorkoutLog implements WorkoutLog {
     completed_reps = 0,
     completed_rounds = 0,
     completed_rungs = 0,
+    completed_sides = null,
     completed_volume = 0,
     complex_set = false,
     interval_timer = 0,
@@ -70,6 +72,7 @@ export class ExampleWorkoutLog implements WorkoutLog {
     this.completed_reps = completed_reps;
     this.completed_rounds = completed_rounds;
     this.completed_rungs = completed_rungs;
+    this.completed_sides = completed_sides;
     this.completed_volume = completed_volume;
     this.complex_set = complex_set;
     this.id = id;

--- a/src/pages/ActiveWorkoutPage/ActiveWorkoutPage.test.jsx
+++ b/src/pages/ActiveWorkoutPage/ActiveWorkoutPage.test.jsx
@@ -68,6 +68,7 @@ describe('finishing a workout', () => {
       completedReps: expect.any(Number),
       completedRounds: expect.any(Number),
       completedRungs: expect.any(Number),
+      completedSides: expect.any(Number),
       completedVolume: expect.any(Number),
     });
   });
@@ -86,6 +87,7 @@ describe('finishing a workout', () => {
       completedReps: expect.any(Number),
       completedRounds: expect.any(Number),
       completedRungs: expect.any(Number),
+      completedSides: expect.any(Number),
       completedVolume: expect.any(Number),
     });
   });
@@ -103,6 +105,7 @@ describe('finishing a workout', () => {
       completedReps: 5,
       completedRounds: 1,
       completedRungs: 1,
+      completedSides: expect.any(Number),
       completedVolume: 34,
     });
   });
@@ -140,6 +143,7 @@ describe('integration tests for previous volume persistence', () => {
       completedReps: 5,
       completedRounds: 1,
       completedRungs: 1,
+      completedSides: expect.any(Number),
       completedVolume: 120,
     });
   });
@@ -155,6 +159,7 @@ describe('integration tests for previous volume persistence', () => {
       completedReps: 5,
       completedRounds: 1,
       completedRungs: 1,
+      completedSides: expect.any(Number),
       completedVolume: 120,
     });
   });
@@ -174,6 +179,7 @@ describe('integration tests for previous volume persistence', () => {
       completedReps: 5,
       completedRounds: 1,
       completedRungs: 1,
+      completedSides: expect.any(Number),
       completedVolume: 120, // 120.4 rounds to 120
     });
   });
@@ -209,6 +215,7 @@ describe('volume calculation with kilogram weights', () => {
       completedReps: 5,
       completedRounds: 1,
       completedRungs: 1,
+      completedSides: expect.any(Number),
       completedVolume: 120,
     });
   });
@@ -226,6 +233,7 @@ describe('volume calculation with kilogram weights', () => {
       completedReps: 5,
       completedRounds: 0,
       completedRungs: 0,
+      completedSides: expect.any(Number),
       completedVolume: 140,
     });
   });
@@ -261,6 +269,7 @@ describe('volume calculation with pound weights', () => {
       completedReps: 5,
       completedRounds: 1,
       completedRungs: 1,
+      completedSides: expect.any(Number),
       completedVolume: expect.any(Number),
     });
 
@@ -300,6 +309,7 @@ describe('volume calculation with mixed weight units', () => {
       completedReps: 5,
       completedRounds: 0,
       completedRungs: 0,
+      completedSides: expect.any(Number),
       completedVolume: expect.any(Number),
     });
 
@@ -321,6 +331,7 @@ describe('volume calculation with mixed weight units', () => {
       completedReps: 5,
       completedRounds: 0,
       completedRungs: 0,
+      completedSides: expect.any(Number),
       completedVolume: expect.any(Number),
     });
 
@@ -361,6 +372,7 @@ describe('volume calculation with one-handed movements', () => {
       completedReps: 5,
       completedRounds: 0,
       completedRungs: 0,
+      completedSides: 1, // finished one side of the one-handed movement
       completedVolume: 80,
     });
   });
@@ -396,6 +408,7 @@ describe('volume calculation with bodyweight movements', () => {
       completedReps: 5,
       completedRounds: 0,
       completedRungs: 0,
+      completedSides: expect.any(Number),
       completedVolume: 0,
     });
   });
@@ -438,6 +451,7 @@ describe('volume accumulation across multiple rungs', () => {
       completedReps: 6, // 1 + 2 + 3
       completedRounds: 1,
       completedRungs: 3,
+      completedSides: 3, // two-handed: one side per rung across [1, 2, 3]
       completedVolume: 96, // 16 + 32 + 48
     });
   });
@@ -771,6 +785,7 @@ describe('automatic workout completion with volume goals', () => {
       completedReps: 5,
       completedRounds: 1,
       completedRungs: 1,
+      completedSides: expect.any(Number),
       completedVolume: 120,
     });
   });
@@ -786,6 +801,7 @@ describe('automatic workout completion with volume goals', () => {
       completedReps: 5,
       completedRounds: 1,
       completedRungs: 1,
+      completedSides: expect.any(Number),
       completedVolume: 120,
     });
   });
@@ -822,6 +838,7 @@ describe('volume rounding on workout completion', () => {
       completedReps: 5,
       completedRounds: 1,
       completedRungs: 1,
+      completedSides: expect.any(Number),
       completedVolume: 120, // 120.4 rounds down to 120
     });
   });
@@ -840,6 +857,7 @@ describe('volume rounding on workout completion', () => {
       completedReps: 5,
       completedRounds: 1,
       completedRungs: 1,
+      completedSides: expect.any(Number),
       completedVolume: 121, // 120.6 rounds up to 121
     });
   });
@@ -918,6 +936,7 @@ describe('edge case and boundary tests', () => {
         completedReps: 5,
         completedRounds: 1,
         completedRungs: 1,
+        completedSides: expect.any(Number),
         completedVolume: 0,
       });
     });
@@ -941,6 +960,7 @@ describe('edge case and boundary tests', () => {
         completedReps: 15,
         completedRounds: 3,
         completedRungs: 3,
+        completedSides: expect.any(Number),
         completedVolume: 360,
       });
     });
@@ -973,6 +993,7 @@ describe('edge case and boundary tests', () => {
         completedReps: 5,
         completedRounds: 1,
         completedRungs: 1,
+        completedSides: expect.any(Number),
         completedVolume: 123,
       });
     });
@@ -994,6 +1015,7 @@ describe('edge case and boundary tests', () => {
         completedReps: 15,
         completedRounds: 3,
         completedRungs: 3,
+        completedSides: expect.any(Number),
         completedVolume: 369,
       });
     });
@@ -1014,6 +1036,7 @@ describe('edge case and boundary tests', () => {
         completedReps: 10,
         completedRounds: 2,
         completedRungs: 2,
+        completedSides: expect.any(Number),
         completedVolume: 246,
       });
     });
@@ -1052,6 +1075,7 @@ describe('volume calculation for complex mode', () => {
       completedReps: 15,   // 5 + 5 + 5
       completedRounds: 0,  // still in round 1 (only 1 of 5 rungs done)
       completedRungs: 1,
+      completedSides: expect.any(Number),
       completedVolume: 360,
     });
   });
@@ -1075,6 +1099,7 @@ describe('volume calculation for complex mode', () => {
       completedReps: 45,   // (5+4+3+2+1) × 3 movements
       completedRounds: 1,
       completedRungs: 5,
+      completedSides: expect.any(Number),
       completedVolume: 1080,
     });
   });
@@ -1093,6 +1118,7 @@ describe('volume calculation for complex mode', () => {
       completedReps: 10,   // 5 + 5
       completedRounds: 1,  // repScheme [5] has 1 rung — round completes on first press
       completedRungs: 1,
+      completedSides: expect.any(Number),
       completedVolume: 360,
     });
   });

--- a/src/pages/ActiveWorkoutPage/ActiveWorkoutPage.test.jsx
+++ b/src/pages/ActiveWorkoutPage/ActiveWorkoutPage.test.jsx
@@ -503,6 +503,34 @@ describe('active workout page (one-handed)', () => {
     expect(rightWeight).toHaveTextContent(weightValue);
     expect(round).toHaveTextContent('2');
   });
+
+  test('shows the current side within the rung, advancing per side', async () => {
+    const currentSide = screen.getByTestId('current-side');
+
+    expect(currentSide).toHaveTextContent('Side 1 of 2');
+
+    // Finish first side -> advances to second side, same rung
+    await clickContinue();
+    expect(currentSide).toHaveTextContent('Side 2 of 2');
+
+    // Finish second side -> completes rung, resets to first side
+    await clickContinue();
+    expect(currentSide).toHaveTextContent('Side 1 of 2');
+  });
+
+  test('increments the Sides progression counter on each finished side', async () => {
+    const getSides = () => screen.getByText('Sides').parentElement;
+
+    expect(getSides()).toHaveTextContent(/Sides\s*0/);
+
+    // Finish first side (rung not yet complete) -> Sides increments
+    await clickContinue();
+    expect(getSides()).toHaveTextContent(/Sides\s*1/);
+
+    // Finish second side (completes the rung) -> Sides increments again
+    await clickContinue();
+    expect(getSides()).toHaveTextContent(/Sides\s*2/);
+  });
 });
 
 describe('active workout page (two-handed)', () => {
@@ -535,6 +563,10 @@ describe('active workout page (two-handed)', () => {
     expect(leftWeight).toHaveTextContent(weightValue);
     expect(rightWeight).not.toHaveTextContent();
     expect(round).toHaveTextContent('3');
+  });
+
+  test('does not show a side indicator for single-side movements', () => {
+    expect(screen.queryByTestId('current-side')).toBeNull();
   });
 });
 
@@ -605,6 +637,18 @@ describe('active workout page (mixed weights)', () => {
     expect(leftWeight).toHaveTextContent(primaryWeightValue);
     expect(rightWeight).toHaveTextContent(secondaryWeightValue);
     expect(round).toHaveTextContent('2');
+  });
+
+  test('shows the current side within the rung, advancing per side', async () => {
+    const currentSide = screen.getByTestId('current-side');
+
+    expect(currentSide).toHaveTextContent('Side 1 of 2');
+
+    await clickContinue();
+    expect(currentSide).toHaveTextContent('Side 2 of 2');
+
+    await clickContinue();
+    expect(currentSide).toHaveTextContent('Side 1 of 2');
   });
 });
 

--- a/src/pages/ActiveWorkoutPage/ActiveWorkoutPage.tsx
+++ b/src/pages/ActiveWorkoutPage/ActiveWorkoutPage.tsx
@@ -108,6 +108,7 @@ export const ActiveWorkoutPage = ({
   const [completedReps, setCompletedReps] = useState<number>(0);
   const [completedRounds, setCompletedRounds] = useState<number>(0);
   const [completedRungs, setCompletedRungs] = useState<number>(0);
+  const [completedSides, setCompletedSides] = useState<number>(0);
   const [completedVolume, setCompletedVolume] = useState<number>(0);
 
   const [isMirrorSet, setIsMirrorSet] = useState<boolean>(false); // for one-handed movements and mixed weights
@@ -181,6 +182,10 @@ export const ActiveWorkoutPage = ({
   const currentRound = completedRounds + 1;
   const shouldMirrorReps = isOneHanded || isMixedWeights;
 
+  // Sides (within the current rung)
+  const totalSides = shouldMirrorReps ? 2 : 1;
+  const currentSide = isMirrorSet ? 2 : 1; // 1 = first side (left), 2 = second side (right)
+
   // Interval Timer
   const totalIntervalMilliseconds = intervalTimer * 1000;
   const intervalCompletedPercentage =
@@ -220,6 +225,8 @@ export const ActiveWorkoutPage = ({
     );
 
   const incrementRungs = () => setCompletedRungs((prev) => prev + 1);
+
+  const incrementSides = () => setCompletedSides((prev) => prev + 1);
 
   const incrementRounds = () => setCompletedRounds((prev) => prev + 1);
 
@@ -313,6 +320,7 @@ export const ActiveWorkoutPage = ({
 
   const continueWorkout = () => {
     requestWakeLock();
+    incrementSides(); // each continue completes one side of work
     if (complexSet) {
       incrementRepsComplex();
       incrementVolumeComplex();
@@ -456,6 +464,7 @@ export const ActiveWorkoutPage = ({
         <CurrentMovement
           currentMovement={currentMovement}
           currentRound={currentRound}
+          currentSide={currentSide}
           isOneHanded={isOneHanded}
           leftWeightUnit={leftWeightUnit}
           leftWeightValue={leftWeightValue}
@@ -464,6 +473,7 @@ export const ActiveWorkoutPage = ({
           rightWeightUnit={rightWeightUnit}
           rightWeightValue={rightWeightValue}
           rungIndex={currentMovementRungIndex}
+          totalSides={totalSides}
           workoutDetails={workoutDetails}
         />
       )}
@@ -491,6 +501,7 @@ export const ActiveWorkoutPage = ({
         completedReps={completedReps}
         completedRounds={completedRounds}
         completedRungs={completedRungs}
+        completedSides={completedSides}
         completedVolume={completedVolume}
         logWorkoutLoading={logWorkoutLoading}
         onClickFinish={handleClickFinish}

--- a/src/pages/ActiveWorkoutPage/ActiveWorkoutPage.tsx
+++ b/src/pages/ActiveWorkoutPage/ActiveWorkoutPage.tsx
@@ -356,6 +356,7 @@ export const ActiveWorkoutPage = ({
       completedReps,
       completedRounds,
       completedRungs,
+      completedSides,
       completedVolume: Math.round(completedVolume),
     });
   };

--- a/src/pages/ActiveWorkoutPage/components/CurrentMovement.tsx
+++ b/src/pages/ActiveWorkoutPage/components/CurrentMovement.tsx
@@ -13,6 +13,7 @@ import { getWeightUnitLabel } from '~/utils';
 interface CurrentMovementProps {
   currentMovement: MovementOptions;
   currentRound: number;
+  currentSide: number;
   isOneHanded: boolean | null;
   leftWeightUnit: WeightUnit | null;
   leftWeightValue: number | null;
@@ -21,12 +22,14 @@ interface CurrentMovementProps {
   rightWeightUnit: WeightUnit | null;
   rightWeightValue: number | null;
   rungIndex: number;
+  totalSides: number;
   workoutDetails: string | null;
 }
 
 export const CurrentMovement = ({
   currentMovement,
   currentRound,
+  currentSide,
   isOneHanded,
   leftWeightUnit,
   leftWeightValue,
@@ -35,6 +38,7 @@ export const CurrentMovement = ({
   rightWeightUnit,
   rightWeightValue,
   rungIndex,
+  totalSides,
   workoutDetails,
 }: CurrentMovementProps) => {
   const isThreeColumn = isOneHanded || rightWeightValue;
@@ -70,6 +74,12 @@ export const CurrentMovement = ({
 
       <CardContent>
         <div className="flex flex-col gap-1">
+          {totalSides > 1 && (
+            <CardDescription className="text-center" data-testid="current-side">
+              Side {currentSide} of {totalSides}
+            </CardDescription>
+          )}
+
           <div
             className={clsx(
               'grid items-center gap-3 text-center',

--- a/src/pages/ActiveWorkoutPage/components/WorkoutSummary.stories.tsx
+++ b/src/pages/ActiveWorkoutPage/components/WorkoutSummary.stories.tsx
@@ -8,6 +8,7 @@ const meta = {
     completedReps: 15,
     completedRounds: 3,
     completedRungs: 3,
+    completedSides: 6,
     completedVolume: 600,
     logWorkoutLoading: false,
     onClickFinish: () => {},

--- a/src/pages/ActiveWorkoutPage/components/WorkoutSummary.tsx
+++ b/src/pages/ActiveWorkoutPage/components/WorkoutSummary.tsx
@@ -19,6 +19,7 @@ interface WorkoutSummaryProps {
   completedReps: number;
   completedRounds: number;
   completedRungs: number;
+  completedSides: number;
   completedVolume: number;
   logWorkoutLoading: boolean;
   onClickFinish: () => void;
@@ -31,6 +32,7 @@ export const WorkoutSummary = ({
   completedReps,
   completedRounds,
   completedRungs,
+  completedSides,
   completedVolume,
   logWorkoutLoading,
   onClickFinish,
@@ -68,6 +70,7 @@ export const WorkoutSummary = ({
         <CompletedItem label="Elapsed" value={formattedElapsed} align="left" />
         <CompletedItem label="Rounds" value={completedRounds} />
         <CompletedItem label="Rungs" value={completedRungs} />
+        <CompletedItem label="Sides" value={completedSides} />
         <CompletedItem label="Reps" value={completedReps} />
         <CompletedItem
           label="Volume"

--- a/src/pages/CompletedWorkoutPage/CompletedWorkoutPage.tsx
+++ b/src/pages/CompletedWorkoutPage/CompletedWorkoutPage.tsx
@@ -117,6 +117,7 @@ export const CompletedWorkoutPage = () => {
           completedReps={workoutLog.completedReps}
           completedRounds={workoutLog.completedRounds}
           completedRungs={workoutLog.completedRungs}
+          completedSides={workoutLog.completedSides}
           completedVolume={workoutLog.completedVolume ?? 0}
           complexSet={workoutLog.complexSet}
           intervalTimer={workoutLog.intervalTimer}

--- a/src/pages/CompletedWorkoutPage/components/WorkoutHistoryItem.stories.tsx
+++ b/src/pages/CompletedWorkoutPage/components/WorkoutHistoryItem.stories.tsx
@@ -34,6 +34,7 @@ const meta = {
     completedReps: 50,
     completedRungs: 10,
     completedRounds: 10,
+    completedSides: 20,
     completedVolume: 1000,
     intervalTimer: 0,
     movementLogs: [

--- a/src/pages/CompletedWorkoutPage/components/WorkoutHistoryItem.tsx
+++ b/src/pages/CompletedWorkoutPage/components/WorkoutHistoryItem.tsx
@@ -27,6 +27,7 @@ export interface WorkoutHistoryItemProps {
   completedReps: number;
   completedRounds: number;
   completedRungs: number;
+  completedSides?: number | null;
   completedVolume: number;
   complexSet?: boolean | null;
   intervalTimer: number;
@@ -49,6 +50,7 @@ export const WorkoutHistoryItem = ({
   completedReps,
   completedRounds,
   completedRungs,
+  completedSides,
   completedVolume,
   complexSet,
   intervalTimer,
@@ -224,6 +226,10 @@ export const WorkoutHistoryItem = ({
         <div className="grow text-right">
           <CardDescription id="rungs">Rungs</CardDescription>
           <div aria-labelledby="rungs">{completedRungs}</div>
+        </div>
+        <div className="grow text-right">
+          <CardDescription id="sides">Sides</CardDescription>
+          <div aria-labelledby="sides">{completedSides ?? 'N/A'}</div>
         </div>
         <div className="grow text-right">
           <CardDescription id="reps">Reps</CardDescription>

--- a/src/types/workout-log.interface.ts
+++ b/src/types/workout-log.interface.ts
@@ -7,6 +7,7 @@ export interface WorkoutLog {
   completedReps: number;
   completedRounds: number;
   completedRungs: number;
+  completedSides: number | null;
   completedVolume: number | null;
   complexSet: boolean | null;
   id: number;

--- a/src/utils/workoutLogToWorkoutOptions.test.ts
+++ b/src/utils/workoutLogToWorkoutOptions.test.ts
@@ -7,6 +7,7 @@ const baseWorkoutLog = (overrides: Partial<WorkoutLog> = {}): WorkoutLog => ({
   completedReps: 0,
   completedRounds: 5,
   completedRungs: 5,
+  completedSides: null,
   completedVolume: null,
   complexSet: false,
   id: 1,

--- a/supabase/migrations/20260701000000_add_completed_sides_to_workout_logs.sql
+++ b/supabase/migrations/20260701000000_add_completed_sides_to_workout_logs.sql
@@ -1,0 +1,4 @@
+ALTER TABLE workout_logs ADD COLUMN IF NOT EXISTS completed_sides smallint;
+
+COMMENT ON COLUMN workout_logs.completed_sides IS
+  'Number of sides completed across the workout. Each finished side of a one-handed or mixed-weight movement counts once, so a full mirror-set rung contributes two sides. Null for workouts logged before per-side tracking existed.';

--- a/types/supabase.ts
+++ b/types/supabase.ts
@@ -439,6 +439,7 @@ export type Database = {
           completed_reps: number
           completed_rounds: number
           completed_rungs: number
+          completed_sides: number | null
           completed_volume: number | null
           complex_set: boolean
           id: number
@@ -470,6 +471,7 @@ export type Database = {
           completed_reps: number
           completed_rounds: number
           completed_rungs: number
+          completed_sides?: number | null
           completed_volume?: number | null
           complex_set?: boolean
           id?: number
@@ -501,6 +503,7 @@ export type Database = {
           completed_reps?: number
           completed_rounds?: number
           completed_rungs?: number
+          completed_sides?: number | null
           completed_volume?: number | null
           complex_set?: boolean
           id?: number


### PR DESCRIPTION
Adds per-side progression tracking for movements performed one side at a time (one-handed and mixed-weight), and persists the count so side-level progress can be tracked across workouts — not just within a session. A rung stays a full ladder step, so counts are never inflated: a one-handed `[1,2,3]` ladder is **3 rungs** and **6 sides**.

**Changes:**
- **Live feedback:** a session `completedSides` counter increments each time a side is finished (in `continueWorkout`), surfaced as a **"Sides"** stat in the active Workout Summary and a **"Side 1 of 2"** indicator on the current-movement card (shown only for mirror-set movements).
- **Persistence:** new nullable `completed_sides` column on `workout_logs` (migration + regenerated types). It's nullable on purpose — workouts logged before this change read back as `null` (unknown) rather than a misleading `0`.
- **Write path:** `completedSides` flows through the log mutation into the insert.
- **Read path:** mapped back in all three workout-log query hooks and added to the `WorkoutLog` domain type.
- **History display:** a **"Sides"** stat on the completed-workout summary (`N/A` for legacy rows).

**Testing:**
- `npm test` — 307 passed, including new tests for the per-side card indicator, the two-handed no-indicator case, the Sides counter incrementing per side, and `completed_sides` persistence in the log insert. Every `logWorkout` payload assertion updated.
- `npm run compile:ts` — clean. `npm run lint` — clean (except a pre-existing `public/sw.js` error unrelated to this change).
- Staging deploy verified: `completed_sides` (`smallint`, nullable) is live on `workout_logs`.

**Notes for reviewers:**
- Prod is a couple migrations behind, so the next production deploy will apply both `20260630000000` (activation-funnel function) and `20260701000000` (`completed_sides`). Both are additive/safe.
- `completedSides` increments once per "continue" for all movement types, so for two-handed movements it equals completed sets (i.e. rungs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)