### PR TITLE
UI/UX pass: information hierarchy on the four main workout pages

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,17 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "bellskill-dev",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": ["run", "dev"],
+      "port": 5173
+    },
+    {
+      "name": "bellskill-storybook",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": ["run", "storybook"],
+      "port": 6006
+    }
+  ]
+}

--- a/e2e/workout-flow.spec.ts
+++ b/e2e/workout-flow.spec.ts
@@ -220,8 +220,10 @@ test.describe('full workout flow', () => {
     const workoutLogId = parseInt(match![1], 10);
     createdWorkoutLogId = workoutLogId;
 
-    // Confirm the page rendered the completed workout title
-    await expect(page.getByText('Workout Log')).toBeVisible();
+    // Arriving from a finished workout renders the celebratory just-finished
+    // view, which leads with the outcome stats.
+    await expect(page.getByText('Workout complete')).toBeVisible();
+    await expect(page.getByTestId('headline-stats')).toBeVisible();
 
     // ── 9. Verify the database record ─────────────────────────────────────
     const workoutLog = await queryWorkoutLog(workoutLogId, authSession.access_token);

--- a/src/components/MovementAutocomplete/MovementAutocomplete.test.tsx
+++ b/src/components/MovementAutocomplete/MovementAutocomplete.test.tsx
@@ -149,7 +149,7 @@ describe('MovementAutocomplete', () => {
     expect(onWeightModeChange).toHaveBeenCalledWith('1h');
   });
 
-  test('closes dropdown when input loses focus', async () => {
+  test('keeps dropdown open while focus moves to the weight-mode tabs', async () => {
     renderAutocomplete();
 
     const input = screen.getByRole('textbox', { name: 'Movement Input' });
@@ -157,6 +157,24 @@ describe('MovementAutocomplete', () => {
     await userEvent.type(input, 'Swing');
     expect(screen.getByRole('listbox')).toBeInTheDocument();
 
+    // The tabs filter the dropdown's catalog results, so moving focus onto
+    // them must not dismiss the results being filtered.
+    await userEvent.tab();
+    expect(screen.getByRole('tab', { name: 'Two-Hand' })).toHaveFocus();
+    expect(screen.getByRole('listbox')).toBeInTheDocument();
+  });
+
+  test('closes dropdown when focus leaves the picker', async () => {
+    renderAutocomplete();
+
+    const input = screen.getByRole('textbox', { name: 'Movement Input' });
+    await userEvent.click(input);
+    await userEvent.type(input, 'Swing');
+    expect(screen.getByRole('listbox')).toBeInTheDocument();
+
+    // First tab lands on the weight-mode tabs (still inside the picker);
+    // the second leaves the component entirely.
+    await userEvent.tab();
     await userEvent.tab();
     await waitFor(() => {
       expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
@@ -503,8 +521,12 @@ describe('MovementAutocomplete', () => {
       weightModeHint: 'Using shared weight: Two-Hand',
     });
 
-    expect(screen.getByText('Using shared weight: Two-Hand')).toBeInTheDocument();
-    expect(screen.queryByRole('tab', { name: 'Two-Hand' })).not.toBeInTheDocument();
+    expect(
+      screen.getByText('Using shared weight: Two-Hand'),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole('tab', { name: 'Two-Hand' }),
+    ).not.toBeInTheDocument();
   });
 
   test('does not show recent movements when there is no session', async () => {

--- a/src/components/MovementAutocomplete/MovementAutocomplete.tsx
+++ b/src/components/MovementAutocomplete/MovementAutocomplete.tsx
@@ -44,6 +44,7 @@ export const MovementAutocomplete = ({
   const [debouncedSearchQuery, setDebouncedSearchQuery] = useState(value);
   const [isOpen, setIsOpen] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
+  const inputWrapRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     setInputValue(value);
@@ -169,8 +170,10 @@ export const MovementAutocomplete = ({
   };
 
   const handleInputBlur = () => {
+    // The dropdown overlays the weight-mode tabs below the input, so close it
+    // as soon as focus leaves the input area (not just the whole container).
     window.setTimeout(() => {
-      if (!containerRef.current?.contains(document.activeElement)) {
+      if (!inputWrapRef.current?.contains(document.activeElement)) {
         setIsOpen(false);
       }
     }, 0);
@@ -179,115 +182,119 @@ export const MovementAutocomplete = ({
   const showDropdown = isOpen && (hasOptions || showCustomEntry);
   const showSummaryChip = value.length > 0 && weightSummary && !isOpen;
 
+  // The name comes first — you pick the exercise before you pick the grip.
+  // The open dropdown is anchored to the input and overlays the tabs below it.
   return (
-    <div ref={containerRef} className="relative w-full">
-      {showWeightModeTabs && (
-        <WeightModeTabs
-          value={weightMode}
-          onValueChange={handleWeightModeChange}
-          className="mb-1"
+    <div ref={containerRef} className="w-full">
+      <div ref={inputWrapRef} className="relative">
+        <input
+          aria-label="Movement Input"
+          autoComplete="off"
+          className={cn(
+            'flex h-4 w-full rounded-md border border-input bg-transparent px-2 py-1 text-sm ring-offset-background',
+            'file:border-0 file:bg-transparent file:text-sm file:font-medium',
+            'placeholder:text-muted-foreground',
+            'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
+            'disabled:cursor-not-allowed disabled:opacity-50',
+            className,
+          )}
+          value={inputValue}
+          onChange={handleInputChange}
+          onFocus={() => setIsOpen(true)}
+          onBlur={handleInputBlur}
         />
-      )}
 
-      {weightModeHint && (
-        <p className="mb-1 text-xs text-muted-foreground">{weightModeHint}</p>
-      )}
+        {showDropdown && (
+          <ul
+            role="listbox"
+            className="absolute left-0 right-0 top-full z-50 mt-0.5 max-h-[220px] overflow-y-auto rounded-md border border-input bg-background shadow-md"
+          >
+            {filteredRecent.length > 0 && (
+              <>
+                <li className="px-2 py-0.5 text-xs font-medium text-muted-foreground">
+                  Recent
+                </li>
+                {filteredRecent.map((movement) => (
+                  <li
+                    key={movement.id}
+                    role="option"
+                    aria-selected={inputValue === movement.canonicalName}
+                    className="cursor-pointer px-2 py-1 text-sm hover:bg-accent hover:text-accent-foreground"
+                    onMouseDown={(e) => {
+                      e.preventDefault();
+                      handleSelect(
+                        movement.canonicalName,
+                        movement.functionalMovementId,
+                      );
+                    }}
+                  >
+                    {movement.canonicalName}
+                  </li>
+                ))}
+              </>
+            )}
 
-      <input
-        aria-label="Movement Input"
-        autoComplete="off"
-        className={cn(
-          'flex h-4 w-full rounded-md border border-input bg-transparent px-2 py-1 text-sm ring-offset-background',
-          'file:border-0 file:bg-transparent file:text-sm file:font-medium',
-          'placeholder:text-muted-foreground',
-          'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
-          'disabled:cursor-not-allowed disabled:opacity-50',
-          className,
+            {rankedCatalog.length > 0 && (
+              <>
+                <li className="px-2 py-0.5 text-xs font-medium text-muted-foreground">
+                  {catalogSectionLabel}
+                </li>
+                {rankedCatalog.map((movement) => (
+                  <li
+                    key={movement.id}
+                    role="option"
+                    aria-selected={inputValue === movement.name}
+                    className="cursor-pointer px-2 py-1 text-sm hover:bg-accent hover:text-accent-foreground"
+                    onMouseDown={(e) => {
+                      e.preventDefault();
+                      handleSelect(movement.name, movement.id);
+                    }}
+                  >
+                    {movement.name}
+                  </li>
+                ))}
+              </>
+            )}
+
+            {showCatalogEmpty && (
+              <li className="px-2 py-1 text-sm text-muted-foreground">
+                No {WEIGHT_MODE_LABELS[weightMode].toLowerCase()} movements for
+                &ldquo;
+                {inputValue}&rdquo; — try another mode
+              </li>
+            )}
+
+            {showCustomEntry && (
+              <li
+                role="option"
+                aria-selected={false}
+                className="cursor-pointer px-2 py-1 text-sm text-muted-foreground hover:bg-accent hover:text-accent-foreground"
+                onMouseDown={(e) => {
+                  e.preventDefault();
+                  handleCustomEntry();
+                }}
+              >
+                Use &ldquo;{inputValue}&rdquo; as custom movement
+              </li>
+            )}
+          </ul>
         )}
-        value={inputValue}
-        onChange={handleInputChange}
-        onFocus={() => setIsOpen(true)}
-        onBlur={handleInputBlur}
-      />
+      </div>
 
       {showSummaryChip && (
         <p className="mt-1 text-xs text-muted-foreground">{weightSummary}</p>
       )}
 
-      {showDropdown && (
-        <ul
-          role="listbox"
-          className="absolute left-0 right-0 top-full z-50 mt-0.5 max-h-[220px] overflow-y-auto rounded-md border border-input bg-background shadow-md"
-        >
-          {filteredRecent.length > 0 && (
-            <>
-              <li className="px-2 py-0.5 text-xs font-medium text-muted-foreground">
-                Recent
-              </li>
-              {filteredRecent.map((movement) => (
-                <li
-                  key={movement.id}
-                  role="option"
-                  aria-selected={inputValue === movement.canonicalName}
-                  className="cursor-pointer px-2 py-1 text-sm hover:bg-accent hover:text-accent-foreground"
-                  onMouseDown={(e) => {
-                    e.preventDefault();
-                    handleSelect(
-                      movement.canonicalName,
-                      movement.functionalMovementId,
-                    );
-                  }}
-                >
-                  {movement.canonicalName}
-                </li>
-              ))}
-            </>
-          )}
+      {showWeightModeTabs && (
+        <WeightModeTabs
+          value={weightMode}
+          onValueChange={handleWeightModeChange}
+          className="mt-1"
+        />
+      )}
 
-          {rankedCatalog.length > 0 && (
-            <>
-              <li className="px-2 py-0.5 text-xs font-medium text-muted-foreground">
-                {catalogSectionLabel}
-              </li>
-              {rankedCatalog.map((movement) => (
-                <li
-                  key={movement.id}
-                  role="option"
-                  aria-selected={inputValue === movement.name}
-                  className="cursor-pointer px-2 py-1 text-sm hover:bg-accent hover:text-accent-foreground"
-                  onMouseDown={(e) => {
-                    e.preventDefault();
-                    handleSelect(movement.name, movement.id);
-                  }}
-                >
-                  {movement.name}
-                </li>
-              ))}
-            </>
-          )}
-
-          {showCatalogEmpty && (
-            <li className="px-2 py-1 text-sm text-muted-foreground">
-              No {WEIGHT_MODE_LABELS[weightMode].toLowerCase()} movements for
-              &ldquo;
-              {inputValue}&rdquo; — try another mode
-            </li>
-          )}
-
-          {showCustomEntry && (
-            <li
-              role="option"
-              aria-selected={false}
-              className="cursor-pointer px-2 py-1 text-sm text-muted-foreground hover:bg-accent hover:text-accent-foreground"
-              onMouseDown={(e) => {
-                e.preventDefault();
-                handleCustomEntry();
-              }}
-            >
-              Use &ldquo;{inputValue}&rdquo; as custom movement
-            </li>
-          )}
-        </ul>
+      {weightModeHint && (
+        <p className="mt-1 text-xs text-muted-foreground">{weightModeHint}</p>
       )}
     </div>
   );

--- a/src/components/MovementAutocomplete/MovementAutocomplete.tsx
+++ b/src/components/MovementAutocomplete/MovementAutocomplete.tsx
@@ -44,7 +44,6 @@ export const MovementAutocomplete = ({
   const [debouncedSearchQuery, setDebouncedSearchQuery] = useState(value);
   const [isOpen, setIsOpen] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
-  const inputWrapRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     setInputValue(value);
@@ -169,11 +168,13 @@ export const MovementAutocomplete = ({
     persistUserMovement(inputValue, null);
   };
 
-  const handleInputBlur = () => {
-    // The dropdown overlays the weight-mode tabs below the input, so close it
-    // as soon as focus leaves the input area (not just the whole container).
+  // The tabs double as the dropdown's mode filter, so the whole picker is one
+  // focus scope: moving focus to the tabs keeps the dropdown open (refiltered
+  // live); leaving the picker entirely closes it. Attached to the container —
+  // React's onBlur bubbles — so it also fires when focus leaves from the tabs.
+  const handleContainerBlur = () => {
     window.setTimeout(() => {
-      if (!inputWrapRef.current?.contains(document.activeElement)) {
+      if (!containerRef.current?.contains(document.activeElement)) {
         setIsOpen(false);
       }
     }, 0);
@@ -183,103 +184,30 @@ export const MovementAutocomplete = ({
   const showSummaryChip = value.length > 0 && weightSummary && !isOpen;
 
   // The name comes first — you pick the exercise before you pick the grip.
-  // The open dropdown is anchored to the input and overlays the tabs below it.
+  // The open dropdown is anchored to the bottom of the whole picker so the
+  // weight-mode tabs stay visible and clickable while browsing results (they
+  // filter the catalog list).
   return (
-    <div ref={containerRef} className="w-full">
-      <div ref={inputWrapRef} className="relative">
-        <input
-          aria-label="Movement Input"
-          autoComplete="off"
-          className={cn(
-            'flex h-4 w-full rounded-md border border-input bg-transparent px-2 py-1 text-sm ring-offset-background',
-            'file:border-0 file:bg-transparent file:text-sm file:font-medium',
-            'placeholder:text-muted-foreground',
-            'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
-            'disabled:cursor-not-allowed disabled:opacity-50',
-            className,
-          )}
-          value={inputValue}
-          onChange={handleInputChange}
-          onFocus={() => setIsOpen(true)}
-          onBlur={handleInputBlur}
-        />
-
-        {showDropdown && (
-          <ul
-            role="listbox"
-            className="absolute left-0 right-0 top-full z-50 mt-0.5 max-h-[220px] overflow-y-auto rounded-md border border-input bg-background shadow-md"
-          >
-            {filteredRecent.length > 0 && (
-              <>
-                <li className="px-2 py-0.5 text-xs font-medium text-muted-foreground">
-                  Recent
-                </li>
-                {filteredRecent.map((movement) => (
-                  <li
-                    key={movement.id}
-                    role="option"
-                    aria-selected={inputValue === movement.canonicalName}
-                    className="cursor-pointer px-2 py-1 text-sm hover:bg-accent hover:text-accent-foreground"
-                    onMouseDown={(e) => {
-                      e.preventDefault();
-                      handleSelect(
-                        movement.canonicalName,
-                        movement.functionalMovementId,
-                      );
-                    }}
-                  >
-                    {movement.canonicalName}
-                  </li>
-                ))}
-              </>
-            )}
-
-            {rankedCatalog.length > 0 && (
-              <>
-                <li className="px-2 py-0.5 text-xs font-medium text-muted-foreground">
-                  {catalogSectionLabel}
-                </li>
-                {rankedCatalog.map((movement) => (
-                  <li
-                    key={movement.id}
-                    role="option"
-                    aria-selected={inputValue === movement.name}
-                    className="cursor-pointer px-2 py-1 text-sm hover:bg-accent hover:text-accent-foreground"
-                    onMouseDown={(e) => {
-                      e.preventDefault();
-                      handleSelect(movement.name, movement.id);
-                    }}
-                  >
-                    {movement.name}
-                  </li>
-                ))}
-              </>
-            )}
-
-            {showCatalogEmpty && (
-              <li className="px-2 py-1 text-sm text-muted-foreground">
-                No {WEIGHT_MODE_LABELS[weightMode].toLowerCase()} movements for
-                &ldquo;
-                {inputValue}&rdquo; — try another mode
-              </li>
-            )}
-
-            {showCustomEntry && (
-              <li
-                role="option"
-                aria-selected={false}
-                className="cursor-pointer px-2 py-1 text-sm text-muted-foreground hover:bg-accent hover:text-accent-foreground"
-                onMouseDown={(e) => {
-                  e.preventDefault();
-                  handleCustomEntry();
-                }}
-              >
-                Use &ldquo;{inputValue}&rdquo; as custom movement
-              </li>
-            )}
-          </ul>
+    <div
+      ref={containerRef}
+      className="relative w-full"
+      onBlur={handleContainerBlur}
+    >
+      <input
+        aria-label="Movement Input"
+        autoComplete="off"
+        className={cn(
+          'flex h-4 w-full rounded-md border border-input bg-transparent px-2 py-1 text-sm ring-offset-background',
+          'file:border-0 file:bg-transparent file:text-sm file:font-medium',
+          'placeholder:text-muted-foreground',
+          'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
+          'disabled:cursor-not-allowed disabled:opacity-50',
+          className,
         )}
-      </div>
+        value={inputValue}
+        onChange={handleInputChange}
+        onFocus={() => setIsOpen(true)}
+      />
 
       {showSummaryChip && (
         <p className="mt-1 text-xs text-muted-foreground">{weightSummary}</p>
@@ -295,6 +223,82 @@ export const MovementAutocomplete = ({
 
       {weightModeHint && (
         <p className="mt-1 text-xs text-muted-foreground">{weightModeHint}</p>
+      )}
+
+      {showDropdown && (
+        <ul
+          role="listbox"
+          className="absolute left-0 right-0 top-full z-50 mt-0.5 max-h-[220px] overflow-y-auto rounded-md border border-input bg-background shadow-md"
+        >
+          {filteredRecent.length > 0 && (
+            <>
+              <li className="px-2 py-0.5 text-xs font-medium text-muted-foreground">
+                Recent
+              </li>
+              {filteredRecent.map((movement) => (
+                <li
+                  key={movement.id}
+                  role="option"
+                  aria-selected={inputValue === movement.canonicalName}
+                  className="cursor-pointer px-2 py-1 text-sm hover:bg-accent hover:text-accent-foreground"
+                  onMouseDown={(e) => {
+                    e.preventDefault();
+                    handleSelect(
+                      movement.canonicalName,
+                      movement.functionalMovementId,
+                    );
+                  }}
+                >
+                  {movement.canonicalName}
+                </li>
+              ))}
+            </>
+          )}
+
+          {rankedCatalog.length > 0 && (
+            <>
+              <li className="px-2 py-0.5 text-xs font-medium text-muted-foreground">
+                {catalogSectionLabel}
+              </li>
+              {rankedCatalog.map((movement) => (
+                <li
+                  key={movement.id}
+                  role="option"
+                  aria-selected={inputValue === movement.name}
+                  className="cursor-pointer px-2 py-1 text-sm hover:bg-accent hover:text-accent-foreground"
+                  onMouseDown={(e) => {
+                    e.preventDefault();
+                    handleSelect(movement.name, movement.id);
+                  }}
+                >
+                  {movement.name}
+                </li>
+              ))}
+            </>
+          )}
+
+          {showCatalogEmpty && (
+            <li className="px-2 py-1 text-sm text-muted-foreground">
+              No {WEIGHT_MODE_LABELS[weightMode].toLowerCase()} movements for
+              &ldquo;
+              {inputValue}&rdquo; — try another mode
+            </li>
+          )}
+
+          {showCustomEntry && (
+            <li
+              role="option"
+              aria-selected={false}
+              className="cursor-pointer px-2 py-1 text-sm text-muted-foreground hover:bg-accent hover:text-accent-foreground"
+              onMouseDown={(e) => {
+                e.preventDefault();
+                handleCustomEntry();
+              }}
+            >
+              Use &ldquo;{inputValue}&rdquo; as custom movement
+            </li>
+          )}
+        </ul>
       )}
     </div>
   );

--- a/src/components/Page.tsx
+++ b/src/components/Page.tsx
@@ -16,14 +16,11 @@ export const Page = ({
 }: PageProps) => {
   return (
     <div
-      className={clsx(
-        'mx-auto my-2 flex min-w-[390px] flex-col gap-2 bg-card p-3',
-        {
-          // width
-          'max-w-md': width === 'default',
-          'max-w-4xl': width === 'full',
-        },
-      )}
+      className={clsx('mx-auto my-2 flex w-full flex-col gap-2 bg-card p-3', {
+        // width
+        'max-w-md': width === 'default',
+        'max-w-4xl': width === 'full',
+      })}
     >
       {title && <div className="text-xl font-semibold">{title}</div>}
       {children}

--- a/src/pages/ActiveWorkoutPage/ActiveWorkoutPage.test.jsx
+++ b/src/pages/ActiveWorkoutPage/ActiveWorkoutPage.test.jsx
@@ -487,7 +487,7 @@ describe('active workout page (one-handed)', () => {
     render(<OneHanded />);
   });
 
-  test('alternates single weight between right and left side for each rung', async () => {
+  test('alternates the active hand between left and right for each side', async () => {
     const { movements } = workoutOptions;
     const weightValue = movements[0].weightOneValue;
 
@@ -495,55 +495,44 @@ describe('active workout page (one-handed)', () => {
     const rightWeight = screen.getByTestId('right-weight');
     const round = screen.getByTestId('current-round');
 
+    // Both sides show the single bell's weight; the active hand is marked.
     expect(leftWeight).toHaveTextContent(weightValue);
-    expect(rightWeight).not.toHaveTextContent();
-    expect(round).toHaveTextContent('1');
-
-    await clickContinue();
-
-    expect(leftWeight).not.toHaveTextContent();
     expect(rightWeight).toHaveTextContent(weightValue);
+    expect(leftWeight).toHaveAttribute('data-active', 'true');
+    expect(rightWeight).toHaveAttribute('data-active', 'false');
     expect(round).toHaveTextContent('1');
 
     await clickContinue();
 
-    expect(leftWeight).toHaveTextContent(weightValue);
-    expect(rightWeight).not.toHaveTextContent();
+    expect(leftWeight).toHaveAttribute('data-active', 'false');
+    expect(rightWeight).toHaveAttribute('data-active', 'true');
+    expect(round).toHaveTextContent('1');
+
+    await clickContinue();
+
+    expect(leftWeight).toHaveAttribute('data-active', 'true');
+    expect(rightWeight).toHaveAttribute('data-active', 'false');
     expect(round).toHaveTextContent('2');
 
     await clickContinue();
 
-    expect(leftWeight).not.toHaveTextContent();
-    expect(rightWeight).toHaveTextContent(weightValue);
+    expect(leftWeight).toHaveAttribute('data-active', 'false');
+    expect(rightWeight).toHaveAttribute('data-active', 'true');
     expect(round).toHaveTextContent('2');
   });
 
-  test('shows the current side within the rung, advancing per side', async () => {
+  test('shows the active hand and current side, advancing per side', async () => {
     const currentSide = screen.getByTestId('current-side');
 
-    expect(currentSide).toHaveTextContent('Side 1 of 2');
+    expect(currentSide).toHaveTextContent('Left hand · side 1 of 2');
 
     // Finish first side -> advances to second side, same rung
     await clickContinue();
-    expect(currentSide).toHaveTextContent('Side 2 of 2');
+    expect(currentSide).toHaveTextContent('Right hand · side 2 of 2');
 
     // Finish second side -> completes rung, resets to first side
     await clickContinue();
-    expect(currentSide).toHaveTextContent('Side 1 of 2');
-  });
-
-  test('increments the Sides progression counter on each finished side', async () => {
-    const getSides = () => screen.getByText('Sides').parentElement;
-
-    expect(getSides()).toHaveTextContent(/Sides\s*0/);
-
-    // Finish first side (rung not yet complete) -> Sides increments
-    await clickContinue();
-    expect(getSides()).toHaveTextContent(/Sides\s*1/);
-
-    // Finish second side (completes the rung) -> Sides increments again
-    await clickContinue();
-    expect(getSides()).toHaveTextContent(/Sides\s*2/);
+    expect(currentSide).toHaveTextContent('Left hand · side 1 of 2');
   });
 });
 
@@ -1072,8 +1061,8 @@ describe('volume calculation for complex mode', () => {
 
     // 3 movements × 24kg × 5 reps = 360kg
     expect(logWorkout).toHaveBeenCalledWith({
-      completedReps: 15,   // 5 + 5 + 5
-      completedRounds: 0,  // still in round 1 (only 1 of 5 rungs done)
+      completedReps: 15, // 5 + 5 + 5
+      completedRounds: 0, // still in round 1 (only 1 of 5 rungs done)
       completedRungs: 1,
       completedSides: expect.any(Number),
       completedVolume: 360,
@@ -1096,7 +1085,7 @@ describe('volume calculation for complex mode', () => {
 
     // 3 movements × 24kg × (5+4+3+2+1) reps = 3 × 24 × 15 = 1080kg
     expect(logWorkout).toHaveBeenCalledWith({
-      completedReps: 45,   // (5+4+3+2+1) × 3 movements
+      completedReps: 45, // (5+4+3+2+1) × 3 movements
       completedRounds: 1,
       completedRungs: 5,
       completedSides: expect.any(Number),
@@ -1115,8 +1104,8 @@ describe('volume calculation for complex mode', () => {
 
     // 2 movements × (20 + 16)kg × 5 reps = 2 × 36 × 5 = 360kg
     expect(logWorkout).toHaveBeenCalledWith({
-      completedReps: 10,   // 5 + 5
-      completedRounds: 1,  // repScheme [5] has 1 rung — round completes on first press
+      completedReps: 10, // 5 + 5
+      completedRounds: 1, // repScheme [5] has 1 rung — round completes on first press
       completedRungs: 1,
       completedSides: expect.any(Number),
       completedVolume: 360,
@@ -1168,18 +1157,18 @@ describe('active workout page (complex mode)', () => {
   test('advances all movements rung indices simultaneously', async () => {
     // repScheme [5, 4, 3, 2, 1] — rung 0 shows 5 for all movements
     workoutOptions.movements.forEach((movement, index) => {
-      expect(screen.getByTestId(`complex-movement-reps-${index}`)).toHaveTextContent(
-        String(movement.repScheme[0]),
-      );
+      expect(
+        screen.getByTestId(`complex-movement-reps-${index}`),
+      ).toHaveTextContent(String(movement.repScheme[0]));
     });
 
     await clickCompleteSet();
 
     // After first press, all advance to rung 1 → shows 4 for all movements
     workoutOptions.movements.forEach((movement, index) => {
-      expect(screen.getByTestId(`complex-movement-reps-${index}`)).toHaveTextContent(
-        String(movement.repScheme[1]),
-      );
+      expect(
+        screen.getByTestId(`complex-movement-reps-${index}`),
+      ).toHaveTextContent(String(movement.repScheme[1]));
     });
     expect(screen.getByTestId('current-round')).toHaveTextContent('1');
   });
@@ -1196,18 +1185,18 @@ describe('active workout page (complex mode)', () => {
     // Still on round 1 at the last rung
     expect(round).toHaveTextContent('1');
     workoutOptions.movements.forEach((movement, index) => {
-      expect(screen.getByTestId(`complex-movement-reps-${index}`)).toHaveTextContent(
-        String(movement.repScheme[4]),
-      );
+      expect(
+        screen.getByTestId(`complex-movement-reps-${index}`),
+      ).toHaveTextContent(String(movement.repScheme[4]));
     });
 
     await clickCompleteSet(); // completes round — round increments, rung resets
 
     expect(round).toHaveTextContent('2');
     workoutOptions.movements.forEach((movement, index) => {
-      expect(screen.getByTestId(`complex-movement-reps-${index}`)).toHaveTextContent(
-        String(movement.repScheme[0]),
-      );
+      expect(
+        screen.getByTestId(`complex-movement-reps-${index}`),
+      ).toHaveTextContent(String(movement.repScheme[0]));
     });
   });
 });
@@ -1277,8 +1266,12 @@ describe('active workout page (complex mode, different rep schemes)', () => {
     await clickCompleteSet(); // completes round
 
     expect(round).toHaveTextContent('2');
-    expect(screen.getByTestId('complex-movement-reps-0')).toHaveTextContent('5'); // Swing resets
-    expect(screen.getByTestId('complex-movement-reps-1')).toHaveTextContent('3'); // Clean resets
+    expect(screen.getByTestId('complex-movement-reps-0')).toHaveTextContent(
+      '5',
+    ); // Swing resets
+    expect(screen.getByTestId('complex-movement-reps-1')).toHaveTextContent(
+      '3',
+    ); // Clean resets
   });
 });
 

--- a/src/pages/ActiveWorkoutPage/ActiveWorkoutPage.tsx
+++ b/src/pages/ActiveWorkoutPage/ActiveWorkoutPage.tsx
@@ -236,10 +236,7 @@ export const ActiveWorkoutPage = ({
 
   const incrementVolumeComplex = () => {
     const complexVolume = movements.reduce((sum, m) => {
-      const repIdx = Math.min(
-        currentMovementRungIndex,
-        m.repScheme.length - 1,
-      );
+      const repIdx = Math.min(currentMovementRungIndex, m.repScheme.length - 1);
       const reps = m.repScheme[repIdx];
       const weight =
         (m.weightOneUnit === 'pounds'
@@ -432,7 +429,10 @@ export const ActiveWorkoutPage = ({
 
   useEffect(
     function handleFinishWorkout() {
-      if (workoutLogId) navigate(`/history/${workoutLogId}`);
+      if (workoutLogId)
+        navigate(`/history/${workoutLogId}`, {
+          state: { justFinished: true },
+        });
     },
     [workoutLogId],
   );
@@ -507,14 +507,10 @@ export const ActiveWorkoutPage = ({
       <WorkoutSummary
         completedReps={completedReps}
         completedRounds={completedRounds}
-        completedRungs={completedRungs}
-        completedSides={completedSides}
         completedVolume={completedVolume}
         logWorkoutLoading={logWorkoutLoading}
         onClickFinish={handleClickFinish}
         startedAt={startedAt ?? new Date()}
-        workoutGoal={workoutGoal}
-        workoutGoalUnits={workoutGoalUnits}
       />
     </Page>
   );

--- a/src/pages/ActiveWorkoutPage/components/ComplexMovementDisplay.tsx
+++ b/src/pages/ActiveWorkoutPage/components/ComplexMovementDisplay.tsx
@@ -1,9 +1,4 @@
-import {
-  Card,
-  CardContent,
-  CardHeader,
-  CardTitle,
-} from '~/components/ui/card';
+import { Card, CardContent, CardHeader, CardTitle } from '~/components/ui/card';
 import { MovementOptions, WeightUnit } from '~/types';
 import { getWeightUnitLabel } from '~/utils';
 

--- a/src/pages/ActiveWorkoutPage/components/CurrentMovement.tsx
+++ b/src/pages/ActiveWorkoutPage/components/CurrentMovement.tsx
@@ -43,6 +43,49 @@ export const CurrentMovement = ({
 }: CurrentMovementProps) => {
   const isThreeColumn = isOneHanded || rightWeightValue;
 
+  // One-handed work uses a single bell that alternates hands: the page passes
+  // the weight on the active side only. Show it on both sides (dimmed on the
+  // waiting hand) so the empty column doesn't read as a rendering bug.
+  const activeSide = isOneHanded ? (leftWeightValue ? 'left' : 'right') : null;
+  const oneHandedWeightValue = leftWeightValue ?? rightWeightValue;
+  const oneHandedWeightUnit = leftWeightUnit ?? rightWeightUnit;
+
+  // Plain render helper (not a nested component) so React reconciles the
+  // cells in place across renders instead of remounting them.
+  const renderWeightCell = (side: 'left' | 'right') => {
+    const value = isOneHanded
+      ? oneHandedWeightValue
+      : side === 'left'
+        ? leftWeightValue
+        : rightWeightValue;
+    const unit = isOneHanded
+      ? oneHandedWeightUnit
+      : side === 'left'
+        ? leftWeightUnit
+        : rightWeightUnit;
+    const isActive = activeSide === null || activeSide === side;
+
+    if (!value || restRemaining) {
+      return <div data-testid={`${side}-weight`} />;
+    }
+
+    return (
+      <div
+        className={clsx(
+          'flex items-end justify-center gap-1',
+          !isActive && 'opacity-30',
+        )}
+        data-testid={`${side}-weight`}
+        data-active={isActive}
+      >
+        <div className="text-3xl">{Math.round(value)}</div>
+        <div className="text-lg text-muted-foreground">
+          {getWeightUnitLabel(unit)}
+        </div>
+      </div>
+    );
+  };
+
   return (
     <Card>
       <CardHeader>
@@ -76,7 +119,9 @@ export const CurrentMovement = ({
         <div className="flex flex-col gap-1">
           {totalSides > 1 && (
             <CardDescription className="text-center" data-testid="current-side">
-              Side {currentSide} of {totalSides}
+              {activeSide
+                ? `${activeSide === 'left' ? 'Left' : 'Right'} hand · side ${currentSide} of ${totalSides}`
+                : `Side ${currentSide} of ${totalSides}`}
             </CardDescription>
           )}
 
@@ -86,11 +131,23 @@ export const CurrentMovement = ({
               isThreeColumn ? 'grid-cols-3' : 'grid-cols-2',
             )}
           >
-            <CardDescription>
+            <CardDescription
+              className={clsx(
+                activeSide === 'left' && 'font-semibold text-foreground',
+              )}
+            >
               {isThreeColumn ? 'Left' : 'Weight'}
             </CardDescription>
             <CardDescription>Reps</CardDescription>
-            {isThreeColumn && <CardDescription>Right</CardDescription>}
+            {isThreeColumn && (
+              <CardDescription
+                className={clsx(
+                  activeSide === 'right' && 'font-semibold text-foreground',
+                )}
+              >
+                Right
+              </CardDescription>
+            )}
           </div>
 
           <div
@@ -99,18 +156,7 @@ export const CurrentMovement = ({
               isThreeColumn ? 'grid-cols-3' : 'grid-cols-2',
             )}
           >
-            {leftWeightValue && !restRemaining ? (
-              <div className="flex items-end justify-center gap-1">
-                <div className="text-3xl" data-testid="left-weight">
-                  {Math.round(leftWeightValue)}
-                </div>
-                <div className="text-lg text-muted-foreground">
-                  {getWeightUnitLabel(leftWeightUnit)}
-                </div>
-              </div>
-            ) : (
-              <div data-testid="left-weight" />
-            )}
+            {renderWeightCell('left')}
 
             <div
               className="flex items-end justify-center text-3xl"
@@ -119,15 +165,8 @@ export const CurrentMovement = ({
               {restRemaining ? <span className="h-5" /> : repScheme[rungIndex]}
             </div>
 
-            {rightWeightValue && !restRemaining ? (
-              <div className="flex items-end justify-center gap-1">
-                <div className="text-3xl" data-testid="right-weight">
-                  {Math.round(rightWeightValue)}
-                </div>
-                <div className="text-lg text-muted-foreground">
-                  {getWeightUnitLabel(rightWeightUnit)}
-                </div>
-              </div>
+            {isThreeColumn ? (
+              renderWeightCell('right')
             ) : (
               <div data-testid="right-weight" />
             )}

--- a/src/pages/ActiveWorkoutPage/components/ProgressBar.tsx
+++ b/src/pages/ActiveWorkoutPage/components/ProgressBar.tsx
@@ -38,22 +38,24 @@ export const ProgressBar = ({
         })}
         style={{ width: `${completedPercentage}%` }}
       />
-      <div
-        className={clsx(
-          'absolute left-1/2 top-1/2 flex -translate-x-1/2 -translate-y-1/2 items-center gap-0.5 font-mono font-medium text-foreground',
-          {
-            'text-xl': size === 'default',
-            'text-3xl': size === 'large',
-          },
+      <div className="absolute inset-0 flex flex-col items-center justify-center">
+        <div
+          className={clsx(
+            'font-mono font-medium leading-none text-foreground',
+            {
+              'text-xl': size === 'default',
+              'text-3xl': size === 'large',
+            },
+          )}
+        >
+          {value ?? <>&infin;</>}
+        </div>
+        {description && (
+          <span className="text-[10px] uppercase leading-none tracking-wide text-muted-foreground">
+            {description}
+          </span>
         )}
-      >
-        {value ?? <>&infin;</>}
       </div>
-      {description && (
-        <span className="absolute right-0 top-1/2 mr-2 -translate-y-1/2 text-sm uppercase text-muted-foreground">
-          {description}
-        </span>
-      )}
     </div>
   );
 };

--- a/src/pages/ActiveWorkoutPage/components/WorkoutSummary.stories.tsx
+++ b/src/pages/ActiveWorkoutPage/components/WorkoutSummary.stories.tsx
@@ -7,14 +7,10 @@ const meta = {
   args: {
     completedReps: 15,
     completedRounds: 3,
-    completedRungs: 3,
-    completedSides: 6,
     completedVolume: 600,
     logWorkoutLoading: false,
     onClickFinish: () => {},
     startedAt: new Date(),
-    workoutGoal: 30,
-    workoutGoalUnits: 'minutes',
   },
   decorators: [
     (Story) => (
@@ -30,9 +26,10 @@ type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {};
 
-export const Rounds: Story = {
+export const HighVolume: Story = {
   args: {
-    workoutGoal: 10,
-    workoutGoalUnits: 'rounds',
+    completedReps: 120,
+    completedRounds: 12,
+    completedVolume: 4860,
   },
 };

--- a/src/pages/ActiveWorkoutPage/components/WorkoutSummary.tsx
+++ b/src/pages/ActiveWorkoutPage/components/WorkoutSummary.tsx
@@ -3,42 +3,25 @@ import { DateTime } from 'luxon';
 import { useEffect, useState } from 'react';
 
 import { Button } from '~/components/ui/button';
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardFooter,
-  CardHeader,
-  CardTitle,
-} from '~/components/ui/card';
-import { WorkoutGoalUnits } from '~/types';
 
 const TIME_FORMAT = 'm:ss';
 
 interface WorkoutSummaryProps {
   completedReps: number;
   completedRounds: number;
-  completedRungs: number;
-  completedSides: number;
   completedVolume: number;
   logWorkoutLoading: boolean;
   onClickFinish: () => void;
   startedAt: Date;
-  workoutGoal: number;
-  workoutGoalUnits: WorkoutGoalUnits;
 }
 
 export const WorkoutSummary = ({
   completedReps,
   completedRounds,
-  completedRungs,
-  completedSides,
   completedVolume,
   logWorkoutLoading,
   onClickFinish,
   startedAt,
-  workoutGoal,
-  workoutGoalUnits,
 }: WorkoutSummaryProps) => {
   const [formattedElapsed, setFormattedElapsed] = useState(() =>
     getFormattedElapsed(startedAt),
@@ -53,43 +36,27 @@ export const WorkoutSummary = ({
   }, [startedAt]);
 
   return (
-    <Card
-      className="border-transparent bg-accent"
-      data-testid="completed-section"
-    >
-      <CardHeader className="text-center">
-        <CardTitle>Workout Summary</CardTitle>
-        {workoutGoal > 0 && (
-          <CardDescription>
-            Goal: {workoutGoal} {workoutGoalUnits}
-          </CardDescription>
-        )}
-      </CardHeader>
-
-      <CardContent className="flex items-center justify-between gap-2">
+    <div className="flex flex-col gap-2" data-testid="completed-section">
+      <div className="flex items-center justify-between rounded-md bg-accent px-2 py-1 text-accent-foreground">
         <CompletedItem label="Elapsed" value={formattedElapsed} align="left" />
         <CompletedItem label="Rounds" value={completedRounds} />
-        <CompletedItem label="Rungs" value={completedRungs} />
-        <CompletedItem label="Sides" value={completedSides} />
         <CompletedItem label="Reps" value={completedReps} />
         <CompletedItem
           label="Volume"
           value={Math.round(completedVolume)}
           unit="kg"
         />
-      </CardContent>
+      </div>
 
-      <CardFooter className="flex items-center justify-center">
-        <Button
-          disabled={logWorkoutLoading}
-          variant="ghost"
-          onClick={onClickFinish}
-          className="w-full"
-        >
-          Finish workout
-        </Button>
-      </CardFooter>
-    </Card>
+      <Button
+        disabled={logWorkoutLoading}
+        variant="ghost"
+        onClick={onClickFinish}
+        className="w-full text-muted-foreground"
+      >
+        Finish workout
+      </Button>
+    </div>
   );
 };
 
@@ -114,8 +81,13 @@ const CompletedItem = ({
   >
     <div className="text-sm text-muted-foreground">{label}</div>
     <div className="text-lg font-semibold">
-      {value}{' '}
-      <span className="text-sm font-medium text-muted-foreground">{unit}</span>
+      {value}
+      {unit && (
+        <span className="text-sm font-medium text-muted-foreground">
+          {' '}
+          {unit}
+        </span>
+      )}
     </div>
   </div>
 );

--- a/src/pages/CompletedWorkoutPage/CompletedWorkoutPage.stories.jsx
+++ b/src/pages/CompletedWorkoutPage/CompletedWorkoutPage.stories.jsx
@@ -9,8 +9,15 @@ import { CompletedWorkoutPage } from './CompletedWorkoutPage';
 export default {
   component: CompletedWorkoutPage,
   decorators: [
-    (Story) => (
-      <MemoryRouter initialEntries={[`/history/${workoutLogs[0].id}`]}>
+    (Story, { parameters }) => (
+      <MemoryRouter
+        initialEntries={[
+          {
+            pathname: `/history/${workoutLogs[0].id}`,
+            state: parameters.routerState ?? null,
+          },
+        ]}
+      >
         <Routes>
           <Route path="/history/:id" element={<Story />} />
         </Routes>
@@ -32,3 +39,9 @@ export default {
 };
 
 export const Default = {};
+
+export const JustFinished = {
+  parameters: {
+    routerState: { justFinished: true },
+  },
+};

--- a/src/pages/CompletedWorkoutPage/CompletedWorkoutPage.test.jsx
+++ b/src/pages/CompletedWorkoutPage/CompletedWorkoutPage.test.jsx
@@ -6,7 +6,7 @@ import { useDeleteWorkoutLog } from '~/api';
 
 import * as stories from './CompletedWorkoutPage.stories';
 
-const { Default } = composeStories(stories);
+const { Default, JustFinished } = composeStories(stories);
 
 const navigate = vi.fn();
 
@@ -44,6 +44,34 @@ describe('completed workout page', () => {
     render(<Default />);
 
     await screen.findByTestId('workout-history-item');
+  });
+
+  test('leads with the outcome stats of the session', async () => {
+    render(<Default />);
+
+    const headline = await screen.findByTestId('headline-stats');
+    expect(headline).toHaveTextContent('21m');
+    expect(headline).toHaveTextContent('9');
+    expect(headline).toHaveTextContent('54');
+    expect(headline).toHaveTextContent('1000 kg');
+  });
+
+  test('celebrates a just-finished workout and hides Delete', async () => {
+    render(<JustFinished />);
+
+    await screen.findByText('Workout complete');
+    expect(
+      screen.queryByRole('button', { name: /delete/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  test('shows the archival title and Delete when visited from history', async () => {
+    render(<Default />);
+
+    await screen.findByText('Workout Log');
+    expect(
+      await screen.findByRole('button', { name: /delete/i }),
+    ).toBeInTheDocument();
   });
 
   test('renders Complex badge in header when workout is complex', async () => {

--- a/src/pages/CompletedWorkoutPage/CompletedWorkoutPage.tsx
+++ b/src/pages/CompletedWorkoutPage/CompletedWorkoutPage.tsx
@@ -1,6 +1,6 @@
 import { ArrowRightIcon, TrashIcon } from '@heroicons/react/24/outline';
 import { useEffect, useRef } from 'react';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useLocation, useNavigate, useParams } from 'react-router-dom';
 
 import {
   useDeleteWorkoutLog,
@@ -28,11 +28,19 @@ import { workoutLogToWorkoutOptions } from '~/utils';
 
 import { Section } from '../StartWorkoutPage/components';
 import { RPESelector, WorkoutHistoryItem } from './components';
+import { getDuration } from './utils';
 
 export const CompletedWorkoutPage = () => {
   const { id = '' } = useParams<{ id: string }>();
 
   const navigate = useNavigate();
+
+  // The active workout navigates here with `justFinished` so the page can
+  // celebrate the session; visiting from history renders the archival view.
+  const location = useLocation();
+  const justFinished = Boolean(
+    (location.state as { justFinished?: boolean } | null)?.justFinished,
+  );
 
   const [, updateWorkoutOptions] = useWorkoutOptions();
 
@@ -81,7 +89,7 @@ export const CompletedWorkoutPage = () => {
   return (
     <Dialog>
       <Page
-        title="Workout Log"
+        title={justFinished ? 'Workout complete' : 'Workout Log'}
         actions={
           <div className="flex flex-col items-center gap-1">
             <div className="grid grid-cols-3 gap-1">
@@ -101,24 +109,25 @@ export const CompletedWorkoutPage = () => {
                 </Button>
               )}
             </div>
-            <DialogTrigger asChild>
-              <Button
-                variant="ghost"
-                className="flex items-center gap-0.5 text-red-500"
-              >
-                Delete <TrashIcon className="h-2.5 w-2.5" />
-              </Button>
-            </DialogTrigger>
+            {!justFinished && (
+              <DialogTrigger asChild>
+                <Button
+                  variant="ghost"
+                  className="flex items-center gap-0.5 text-red-500"
+                >
+                  Delete <TrashIcon className="h-2.5 w-2.5" />
+                </Button>
+              </DialogTrigger>
+            )}
           </div>
         }
       >
+        <HeadlineStats workoutLog={workoutLog} />
+
+        <RPESelector onSelectRPE={handleSelectRPE} rpeValue={workoutLog.rpe} />
+
         <WorkoutHistoryItem
           completedAt={workoutLog.completedAt}
-          completedReps={workoutLog.completedReps}
-          completedRounds={workoutLog.completedRounds}
-          completedRungs={workoutLog.completedRungs}
-          completedSides={workoutLog.completedSides}
-          completedVolume={workoutLog.completedVolume ?? 0}
           complexSet={workoutLog.complexSet}
           intervalTimer={workoutLog.intervalTimer}
           movementLogs={movementLogs}
@@ -134,8 +143,6 @@ export const CompletedWorkoutPage = () => {
           workoutGoalUnits={workoutLog.workoutGoalUnits}
           workoutLogId={workoutLog.id}
         />
-
-        <RPESelector onSelectRPE={handleSelectRPE} rpeValue={workoutLog.rpe} />
 
         {workoutLog.workoutNotes !== null && (
           <Card>
@@ -186,3 +193,53 @@ export const CompletedWorkoutPage = () => {
     </Dialog>
   );
 };
+
+// The outcome of the session, front and center: what you did, not how it was
+// configured. Volume is omitted for bodyweight-only sessions where it's zero.
+const HeadlineStats = ({ workoutLog }: { workoutLog: WorkoutLog }) => {
+  const duration = getDuration(workoutLog.startedAt, workoutLog.completedAt);
+  const volume = workoutLog.completedVolume ?? 0;
+
+  return (
+    <div
+      className="flex items-center justify-between rounded-md bg-accent px-2 py-1 text-accent-foreground"
+      data-testid="headline-stats"
+    >
+      <HeadlineStat label="Elapsed" value={duration} align="left" />
+      <HeadlineStat label="Rounds" value={workoutLog.completedRounds} />
+      <HeadlineStat label="Reps" value={workoutLog.completedReps} />
+      {volume > 0 && <HeadlineStat label="Volume" value={volume} unit="kg" />}
+    </div>
+  );
+};
+
+const HeadlineStat = ({
+  label,
+  value,
+  unit,
+  align = 'right',
+}: {
+  label: string;
+  value: string | number;
+  unit?: string;
+  align?: 'left' | 'right';
+}) => (
+  <div
+    className={
+      align === 'left'
+        ? 'flex flex-col items-start gap-0.5'
+        : 'flex flex-col items-end gap-0.5'
+    }
+  >
+    <div className="text-sm text-muted-foreground">{label}</div>
+    <div className="text-lg font-semibold">
+      {value}
+      {unit && (
+        <span className="text-sm font-medium text-muted-foreground">
+          {' '}
+          {unit}
+        </span>
+      )}
+    </div>
+  </div>
+);

--- a/src/pages/CompletedWorkoutPage/components/CatalogedBadge.tsx
+++ b/src/pages/CompletedWorkoutPage/components/CatalogedBadge.tsx
@@ -12,9 +12,8 @@ export const CatalogedBadge = ({
   movementLogId,
   workoutLogId,
 }: CatalogedBadgeProps) => {
-  const { mutate: unlinkMovementLog, isLoading } = useUnlinkMovementLog(
-    workoutLogId,
-  );
+  const { mutate: unlinkMovementLog, isLoading } =
+    useUnlinkMovementLog(workoutLogId);
 
   return (
     <Badge

--- a/src/pages/CompletedWorkoutPage/components/LinkMovementDialog.test.tsx
+++ b/src/pages/CompletedWorkoutPage/components/LinkMovementDialog.test.tsx
@@ -120,7 +120,9 @@ describe('LinkMovementDialog', () => {
   test('opens dialog and shows current movement name', async () => {
     renderDialog();
 
-    await userEvent.click(screen.getByRole('button', { name: 'Link' }));
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Match to catalog' }),
+    );
 
     expect(screen.getByRole('dialog')).toBeInTheDocument();
     expect(screen.getByText(/Currently: My Custom Swing/)).toBeInTheDocument();
@@ -162,7 +164,9 @@ describe('LinkMovementDialog', () => {
 
     renderDialog();
 
-    await userEvent.click(screen.getByRole('button', { name: 'Link' }));
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Match to catalog' }),
+    );
 
     const input = screen.getByRole('textbox', { name: 'Movement Input' });
     await userEvent.clear(input);

--- a/src/pages/CompletedWorkoutPage/components/LinkMovementDialog.tsx
+++ b/src/pages/CompletedWorkoutPage/components/LinkMovementDialog.tsx
@@ -117,7 +117,7 @@ export const LinkMovementDialog = ({
     <Dialog open={open} onOpenChange={handleOpenChange}>
       <DialogTrigger asChild>
         <Button variant="ghost" size="sm" className="h-auto shrink-0 px-1 py-0">
-          Link
+          Match to catalog
         </Button>
       </DialogTrigger>
       <DialogContent>

--- a/src/pages/CompletedWorkoutPage/components/WorkoutHistoryItem.stories.tsx
+++ b/src/pages/CompletedWorkoutPage/components/WorkoutHistoryItem.stories.tsx
@@ -31,11 +31,6 @@ const meta = {
   args: {
     workoutLogId: 1,
     completedAt: new Date('2024-01-01T13:15:00'),
-    completedReps: 50,
-    completedRungs: 10,
-    completedRounds: 10,
-    completedSides: 20,
-    completedVolume: 1000,
     intervalTimer: 0,
     movementLogs: [
       {

--- a/src/pages/CompletedWorkoutPage/components/WorkoutHistoryItem.test.jsx
+++ b/src/pages/CompletedWorkoutPage/components/WorkoutHistoryItem.test.jsx
@@ -110,25 +110,11 @@ describe('complex set workouts', () => {
   });
 });
 
-describe('workout summary', () => {
-  test('displays the duration of the workout', async () => {
+describe('unset timers', () => {
+  test('omits interval and rest rows when no timers were set', async () => {
     render(<Default />);
-    expect(screen.getByLabelText('Elapsed')).toHaveTextContent('1h 15m');
-  });
-
-  test('displays number of rounds completed', async () => {
-    render(<Default />);
-    expect(screen.getByLabelText('Rounds')).toHaveTextContent('10');
-  });
-
-  test('displays number of reps completed', async () => {
-    render(<Default />);
-    expect(screen.getByLabelText('Reps')).toHaveTextContent('50');
-  });
-
-  test('displays volume completed in the workout', async () => {
-    render(<Default />);
-    expect(screen.getByLabelText('Volume')).toHaveTextContent('1000 kg');
+    expect(screen.queryByLabelText('Intervals')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('Rest')).not.toBeInTheDocument();
   });
 });
 
@@ -140,7 +126,7 @@ describe('movement linking', () => {
       screen.getByRole('button', { name: 'Unlink from catalog' }),
     ).toBeInTheDocument();
     expect(
-      screen.queryByRole('button', { name: 'Link' }),
+      screen.queryByRole('button', { name: 'Match to catalog' }),
     ).not.toBeInTheDocument();
     expect(
       screen.getByText('Double Kettlebell Push Press'),

--- a/src/pages/CompletedWorkoutPage/components/WorkoutHistoryItem.tsx
+++ b/src/pages/CompletedWorkoutPage/components/WorkoutHistoryItem.tsx
@@ -4,16 +4,13 @@ import {
   Card,
   CardContent,
   CardDescription,
-  CardFooter,
   CardHeader,
   CardTitle,
 } from '~/components/ui/card';
-import { Separator } from '~/components/ui/separator';
 import { MovementLog, WeightUnit } from '~/types';
 
 import {
   getDisplayDate,
-  getDuration,
   getRepSchemeDisplayValue,
   getTimeRange,
   getWeightsDisplayValue,
@@ -24,11 +21,6 @@ import { LinkMovementDialog } from './LinkMovementDialog';
 
 export interface WorkoutHistoryItemProps {
   completedAt: Date;
-  completedReps: number;
-  completedRounds: number;
-  completedRungs: number;
-  completedSides?: number | null;
-  completedVolume: number;
   complexSet?: boolean | null;
   intervalTimer: number;
   movementLogs: MovementLog[];
@@ -47,11 +39,6 @@ export interface WorkoutHistoryItemProps {
 
 export const WorkoutHistoryItem = ({
   completedAt,
-  completedReps,
-  completedRounds,
-  completedRungs,
-  completedSides,
-  completedVolume,
   complexSet,
   intervalTimer,
   movementLogs,
@@ -68,7 +55,6 @@ export const WorkoutHistoryItem = ({
   workoutLogId,
 }: WorkoutHistoryItemProps) => {
   const displayDate = getDisplayDate(completedAt);
-  const duration = getDuration(startedAt, completedAt);
   const timeRange = getTimeRange(startedAt, completedAt);
   const isComplexSet = complexSet === true;
   const sharedWeights = resolveSharedWeights(
@@ -105,18 +91,18 @@ export const WorkoutHistoryItem = ({
                 : `${workoutGoal} ${workoutGoalUnits}`}
           </div>
         </div>
-        <div className="grow text-right">
-          <CardDescription id="intervals">Intervals</CardDescription>
-          <div aria-labelledby="intervals">
-            {intervalTimer > 0 ? `${intervalTimer}s` : 'None'}
+        {intervalTimer > 0 && (
+          <div className="grow text-right">
+            <CardDescription id="intervals">Intervals</CardDescription>
+            <div aria-labelledby="intervals">{`${intervalTimer}s`}</div>
           </div>
-        </div>
-        <div className="grow text-right">
-          <CardDescription id="rest">Rest</CardDescription>
-          <div aria-labelledby="rest">
-            {restTimer > 0 ? `${restTimer}s` : 'None'}
+        )}
+        {restTimer > 0 && (
+          <div className="grow text-right">
+            <CardDescription id="rest">Rest</CardDescription>
+            <div aria-labelledby="rest">{`${restTimer}s`}</div>
           </div>
-        </div>
+        )}
       </CardContent>
 
       {movementLogsLoading ? (
@@ -205,43 +191,6 @@ export const WorkoutHistoryItem = ({
           ))}
         </>
       )}
-
-      <CardContent>
-        <Separator />
-      </CardContent>
-
-      <CardContent>
-        <CardTitle>Workout Summary</CardTitle>
-      </CardContent>
-
-      <CardFooter className="flex gap-2">
-        <div className="grow">
-          <CardDescription id="elapsed">Elapsed</CardDescription>
-          <div aria-labelledby="elapsed">{duration}</div>
-        </div>
-        <div className="grow text-right">
-          <CardDescription id="rounds">Rounds</CardDescription>
-          <div aria-labelledby="rounds">{completedRounds}</div>
-        </div>
-        <div className="grow text-right">
-          <CardDescription id="rungs">Rungs</CardDescription>
-          <div aria-labelledby="rungs">{completedRungs}</div>
-        </div>
-        <div className="grow text-right">
-          <CardDescription id="sides">Sides</CardDescription>
-          <div aria-labelledby="sides">{completedSides ?? 'N/A'}</div>
-        </div>
-        <div className="grow text-right">
-          <CardDescription id="reps">Reps</CardDescription>
-          <div aria-labelledby="reps">{completedReps}</div>
-        </div>
-        <div className="grow text-right">
-          <CardDescription id="volume">Volume</CardDescription>
-          <div aria-labelledby="volume">
-            {completedVolume > 0 ? `${completedVolume} kg` : 'N/A'}
-          </div>
-        </div>
-      </CardFooter>
     </Card>
   );
 };

--- a/src/pages/HistoryPage/HistoryPage.tsx
+++ b/src/pages/HistoryPage/HistoryPage.tsx
@@ -9,6 +9,7 @@ import { Card, CardContent, CardHeader, CardTitle } from '~/components/ui/card';
 import { WorkoutLog } from '~/types';
 
 import { RpeBadge } from '../CompletedWorkoutPage/components';
+import { getDuration } from '../CompletedWorkoutPage/utils';
 
 export const HistoryPage = () => {
   const { data, isLoading, fetchNextPage, hasNextPage, isFetchingNextPage } =
@@ -21,10 +22,24 @@ export const HistoryPage = () => {
 
   return (
     <Page title="Workout History">
+      {!isLoading && workoutLogs.length === 0 && (
+        <Card>
+          <CardContent className="flex flex-col items-center gap-2 p-3 text-center">
+            <div className="text-muted-foreground">
+              Your finished workouts will show up here.
+            </div>
+            <Button asChild>
+              <Link to="/">Start your first workout</Link>
+            </Button>
+          </CardContent>
+        </Card>
+      )}
+
       <div className="flex flex-col gap-4">
-        {workoutWeeks.map(({ weekNumber, workoutDays }) => (
+        {workoutWeeks.map(({ weekKey, weekYear, weekNumber, workoutDays }) => (
           <WorkoutWeekGroup
-            key={weekNumber}
+            key={weekKey}
+            weekYear={weekYear}
             weekNumber={weekNumber}
             workoutDays={workoutDays}
           />
@@ -56,28 +71,33 @@ const WorkoutLogItem = ({ workoutLog }: { workoutLog: WorkoutLog }) => {
     workoutVolume > 0
       ? `${workoutVolume.toFixed(0)} kg`
       : `${workoutLog.completedReps} reps`;
+  const duration = getDuration(workoutLog.startedAt, workoutLog.completedAt);
+
+  // The lifter's own name for the session is the most scannable line; fall
+  // back to the movement list when the workout wasn't named.
+  const title = workoutLog.workoutDetails?.trim() || '';
+  const movementsLine = workoutLog.movements.join(' · ');
 
   return (
     <Link
-      className="flex justify-between rounded-md px-2 py-1 hover:cursor-pointer hover:bg-accent hover:text-accent-foreground"
+      className="flex justify-between gap-1 rounded-md px-2 py-1 hover:cursor-pointer hover:bg-accent hover:text-accent-foreground"
       to={workoutDetailsPath}
     >
-      <div>
-        {workoutLog.movements.map((movement, i) => (
-          <div key={i}>{movement}</div>
-        ))}
-        {workoutLog.workoutDetails && (
-          <div className="text-muted-foreground">
-            {workoutLog.workoutDetails}
-          </div>
+      <div className="min-w-0">
+        <div className="font-medium">{title || movementsLine}</div>
+        {title && (
+          <div className="text-sm text-muted-foreground">{movementsLine}</div>
         )}
       </div>
-      <div className="flex grow items-center justify-end gap-1">
+      <div className="flex shrink-0 items-center justify-end gap-1">
         {workoutLog.complexSet === true && (
           <Badge variant="secondary">Complex</Badge>
         )}
         {workoutLog.rpe !== null && <RpeBadge rpeValue={workoutLog.rpe} />}
-        <div className="text-right">{displayText}</div>
+        <div className="text-right">
+          <div>{displayText}</div>
+          <div className="text-sm text-muted-foreground">{duration}</div>
+        </div>
       </div>
     </Link>
   );
@@ -103,9 +123,11 @@ const WorkoutDayCard = ({
 );
 
 const WorkoutWeekGroup = ({
+  weekYear,
   weekNumber,
   workoutDays,
 }: {
+  weekYear: number;
   weekNumber: number;
   workoutDays: WorkoutDay[];
 }) => {
@@ -124,7 +146,7 @@ const WorkoutWeekGroup = ({
   return (
     <div className="flex flex-col gap-2">
       <div className="flex items-center justify-between gap-1 px-1 text-sm font-medium">
-        <div>Week {weekNumber}</div>
+        <div>{getWeekLabel(weekYear, weekNumber)}</div>
         <div>{displayText}</div>
       </div>
       {workoutDays.map(({ date, workoutLogs }) => (
@@ -138,12 +160,37 @@ const WorkoutWeekGroup = ({
   );
 };
 
+// "Week 27" means nothing to a human — label weeks relative to today, then by
+// date range once they're further back.
+const getWeekLabel = (weekYear: number, weekNumber: number): string => {
+  const now = DateTime.now();
+  if (weekYear === now.weekYear && weekNumber === now.weekNumber) {
+    return 'This week';
+  }
+
+  const lastWeek = now.minus({ weeks: 1 });
+  if (weekYear === lastWeek.weekYear && weekNumber === lastWeek.weekNumber) {
+    return 'Last week';
+  }
+
+  const start = DateTime.fromObject({ weekYear, weekNumber, weekday: 1 });
+  const end = start.plus({ days: 6 });
+  const range =
+    start.month === end.month
+      ? `${start.toFormat('MMM d')} – ${end.toFormat('d')}`
+      : `${start.toFormat('MMM d')} – ${end.toFormat('MMM d')}`;
+
+  return start.year === now.year ? range : `${range}, ${start.year}`;
+};
+
 interface WorkoutDay {
   date: Date;
   workoutLogs: WorkoutLog[];
 }
 
 interface WorkoutWeek {
+  weekKey: string;
+  weekYear: number;
   weekNumber: number;
   workoutDays: WorkoutDay[];
 }
@@ -185,9 +232,14 @@ const groupByWeek = (workoutDays: WorkoutDay[]): WorkoutWeek[] => {
   });
 
   return Object.entries(groupedByWeek)
-    .sort(([a], [b]) => new Date(b).getTime() - new Date(a).getTime())
     .map(([weekKey, workoutDays]) => ({
+      weekKey,
+      weekYear: Number(weekKey.split('-W')[0]),
       weekNumber: Number(weekKey.split('-W')[1]),
       workoutDays,
-    }));
+    }))
+    .sort(
+      (a, b) =>
+        b.workoutDays[0].date.getTime() - a.workoutDays[0].date.getTime(),
+    );
 };

--- a/src/pages/StartWorkoutPage/components/RecommendedWorkoutCard.tsx
+++ b/src/pages/StartWorkoutPage/components/RecommendedWorkoutCard.tsx
@@ -36,7 +36,9 @@ export const RecommendedWorkoutCard = ({
               <span className="text-xs text-muted-foreground">{meta}</span>
             )}
           </div>
-          <span className="text-sm text-muted-foreground">{summary}</span>
+          {summary && (
+            <span className="text-sm text-muted-foreground">{summary}</span>
+          )}
           {subtitle && (
             <span className="text-xs text-muted-foreground">{subtitle}</span>
           )}

--- a/src/pages/StartWorkoutPage/components/RecommendedWorkoutsSection.tsx
+++ b/src/pages/StartWorkoutPage/components/RecommendedWorkoutsSection.tsx
@@ -60,7 +60,7 @@ export const RecommendedWorkoutsSection = ({
               <RecommendedWorkoutCard
                 key={repeat.workoutLogId}
                 title={title}
-                summary={summary}
+                summary={summary === title ? '' : summary}
                 meta={goalLabel(workoutGoal, workoutGoalUnits)}
                 onSelect={() => onSelectRepeat(repeat)}
               />


### PR DESCRIPTION
Implements the highest-leverage recommendations from the design review of the Start, Active, Completed, and History pages: lead with what the lifter needs, cut internal counting jargon, and fix mobile overflow.

**Changes:**
- **Cross-cutting:** removed `min-w-[390px]` from `Page` (horizontal scroll on 375px phones); trimmed user-facing stat rows to Elapsed / Rounds / Reps / Volume — rungs and sides are still logged, just not displayed
- **Active:** progress bar stacks a small label under the time instead of colliding with it ("9:59TIME REMAINING"); one-handed movements show the bell weight on both sides with the active hand highlighted ("Left hand · side 1 of 2") instead of a blank column; the six-column summary card is now a compact single-line strip with Finish visually separated from Continue
- **Completed:** arriving from a finished workout renders a "Workout complete" view — headline outcome stats first, RPE selector second, detail card after, Delete hidden; visiting from history keeps the archival "Workout Log" view with Delete; "Intervals: None" / "Rest: None" rows are omitted; bare "Link" renamed to "Match to catalog"
- **Start:** movement name input now sits above the weight-mode tabs (pick the exercise before the grip); repeat cards no longer render "Pull-Ups / Pull-Ups" when the title equals the movement summary
- **History:** "Week 27" replaced with This week / Last week / date ranges; items lead with the workout's name with movements muted below; per-item duration added; empty state with a "Start your first workout" CTA

**Testing:**
- Full Vitest suite passes (306 tests, including new coverage for headline stats, just-finished vs archive mode, omitted timer rows, and active-hand alternation)
- `npm run compile:ts` clean; `npm run lint` shows only the pre-existing `public/sw.js` error that also fails on main
- Visually verified all changed screens in Storybook at 375px mobile width

🤖 Generated with [Claude Code](https://claude.com/claude-code)