### PR TITLE
fix(lint): remove unused event parameter in sw.js install handler

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -1,5 +1,5 @@
 // Unregister service worker to clean up old installations
-self.addEventListener('install', function(event) {
+self.addEventListener('install', function() {
   // Skip waiting to activate immediately
   self.skipWaiting();
 });


### PR DESCRIPTION
Fixes the pre-existing `npm run lint` failure so ESLint passes with `--max-warnings 0`.

**Changes:**
- Removed the unused `event` parameter from the service worker `install` handler in `public/sw.js` (it only calls `self.skipWaiting()`), which was failing `no-unused-vars`. The `activate` handler keeps its `event` since it uses `event.waitUntil`.

**Testing:**
- `npm run lint` passes with zero warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)