### PR TITLE
fix(test): exclude .claude worktrees from vitest collection

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -10,7 +10,7 @@ export default mergeConfig(
       globals: true,
       environment: 'jsdom',
       setupFiles: './config/vitest.setup.ts',
-      exclude: ['**/node_modules/**', 'e2e/**'],
+      exclude: ['**/node_modules/**', 'e2e/**', '**/.claude/**'],
       // Reduce test output verbosity
       reporters: ['basic'],
       logHeapUsage: false,


### PR DESCRIPTION
Excludes `.claude/**` from vitest test collection so stale agent worktrees no longer break `npm test`.

**Changes:**
- Added `'**/.claude/**'` to `test.exclude` in `vitest.config.ts`. Duplicate test files under `.claude/worktrees/*/src/...` were being collected and failed with `TypeError: Cannot read properties of null (reading 'useContext')` because they loaded a second React instance from the worktree's own `node_modules`.

**Testing:**
- `npx vitest run src/pages/PaywallPage` now collects only the real test file (9 tests pass, no worktree duplicates)
- Full `npx vitest run`: 30 test files, 276 tests, all passing, with no `.claude/worktrees` paths in the collected list

🤖 Generated with [Claude Code](https://claude.com/claude-code)