### PR TITLE
fix(paywall): only promise shipped features in paywall copy

### DIFF
--- a/src/pages/PaywallPage/PaywallPage.test.tsx
+++ b/src/pages/PaywallPage/PaywallPage.test.tsx
@@ -2,22 +2,29 @@ import { composeStories } from '@storybook/react';
 import { fireEvent, render, screen } from '@testing-library/react';
 import { vi } from 'vitest';
 
+import { Features } from '~/config/features';
+
 import * as stories from './PaywallPage.stories';
 
-// Control the launch flag per test (drives notify-me vs real Subscribe) by
-// mocking the effective-features hook the page reads.
+// Control the flags per test (premium drives notify-me vs real Subscribe;
+// weeklyBalance drives the free-forever list) by mocking the
+// effective-features hook the page reads.
 const { mockUseFeatures } = vi.hoisted(() => ({ mockUseFeatures: vi.fn() }));
 vi.mock('~/hooks', async (importOriginal) => ({
   ...(await importOriginal<typeof import('~/hooks')>()),
   useFeatures: mockUseFeatures,
 }));
 
-const setPremium = (premium: boolean) =>
+const setFeatures = (overrides: Partial<Features> = {}) =>
   mockUseFeatures.mockReturnValue({
     complexMode: false,
+    curatedFirstWorkout: false,
     explore: false,
-    premium,
+    premium: false,
     recommender: false,
+    repeatPrevious: false,
+    weeklyBalance: false,
+    ...overrides,
   });
 
 const { Trialing, Expired, Free } = composeStories(stories);
@@ -25,7 +32,7 @@ const { Trialing, Expired, Free } = composeStories(stories);
 describe('paywall page', () => {
   beforeEach(() => {
     localStorage.clear();
-    setPremium(false);
+    setFeatures();
   });
 
   test('trialing variant shows days remaining', () => {
@@ -36,11 +43,41 @@ describe('paywall page', () => {
   test('expired variant reads as the unlock path', () => {
     render(<Expired />);
     expect(screen.getByText('Your trial has ended')).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        'Your workout logging and history are still here. Premium brings back the intelligence layer.',
+      ),
+    ).toBeInTheDocument();
   });
 
   test('free variant shows the generic unlock pitch', () => {
     render(<Free />);
     expect(screen.getByText('Unlock BellSkill Premium')).toBeInTheDocument();
+  });
+
+  test('free-forever list only names shipped features', () => {
+    render(<Free />);
+    expect(
+      screen.getByText('Free forever: Workout logging, Workout history.'),
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/skill tree/i)).not.toBeInTheDocument();
+  });
+
+  test('free-forever list includes weekly balance when flag-enabled', () => {
+    setFeatures({ weeklyBalance: true });
+    render(<Free />);
+    expect(
+      screen.getByText(
+        'Free forever: Workout logging, Workout history, Weekly pattern balance.',
+      ),
+    ).toBeInTheDocument();
+  });
+
+  test('unshipped Tetris programming is framed as upcoming', () => {
+    render(<Free />);
+    expect(
+      screen.getByText('Weekly Tetris programming — coming soon'),
+    ).toBeInTheDocument();
   });
 
   describe('premium flag OFF (pre-launch)', () => {
@@ -58,7 +95,7 @@ describe('paywall page', () => {
 
   describe('premium flag ON (launched)', () => {
     beforeEach(() => {
-      setPremium(true);
+      setFeatures({ premium: true });
     });
 
     test('shows real Subscribe CTA, not notify-me', () => {

--- a/src/pages/PaywallPage/PaywallPage.tsx
+++ b/src/pages/PaywallPage/PaywallPage.tsx
@@ -15,10 +15,8 @@ const NOTIFY_INTENT_KEY = 'premium_notify_intent';
 
 const PREMIUM_FEATURES = [
   'AI session recommendations tuned to your training',
-  'Tetris programming — auto-fitted workouts',
+  'Weekly Tetris programming — coming soon',
 ];
-
-const FREE_FOREVER = ['Workout logging', 'Skill tree', 'Basic analytics'];
 
 interface PaywallHeadline {
   eyebrow: string | null;
@@ -46,7 +44,7 @@ const getHeadline = (
       eyebrow: 'Your trial has ended',
       title: 'Unlock BellSkill Premium',
       subtitle:
-        'Your logging, skill tree, and analytics are still here. Premium brings back the intelligence layer.',
+        'Your workout logging and history are still here. Premium brings back the intelligence layer.',
     };
   }
 
@@ -111,6 +109,12 @@ export const PaywallPage = () => {
 
   const headline = getHeadline(isTrialing, trialExpired, trialDaysRemaining);
 
+  const freeForever = [
+    'Workout logging',
+    'Workout history',
+    ...(features.weeklyBalance ? ['Weekly pattern balance'] : []),
+  ];
+
   const handleSubscribe = () => {
     startCheckout(plan, {
       onSuccess: (url) => {
@@ -147,7 +151,7 @@ export const PaywallPage = () => {
               </div>
             ))}
             <div className="pt-0.5 text-xs text-muted-foreground">
-              Free forever: {FREE_FOREVER.join(', ')}.
+              Free forever: {freeForever.join(', ')}.
             </div>
           </CardContent>
         </Card>


### PR DESCRIPTION
Aligns the paywall copy with what's actually shipped: the free-forever list and trial-expired subtitle promised a Skill Tree that's paused and generic "analytics" that don't exist, and pitched Tetris programming as if it were live.

**Changes:**
- Free-forever list is now `Workout logging, Workout history`, appending `Weekly pattern balance` only when the `weeklyBalance` flag is on (computed from `useFeatures()`, so the owner preview override is honored)
- Premium list reframes "Tetris programming — auto-fitted workouts" as "Weekly Tetris programming — coming soon" (AI session recommendations stay as the live premium pitch)
- Trial-expired subtitle drops its stale "skill tree, and analytics" mention
- Test mock helper widened from `setPremium(bool)` to `setFeatures(Partial<Features>)` covering the full flag shape

**Testing:**
- 4 new assertions: free list names only shipped features (and never "skill tree"), weekly balance appears when flag-enabled, Tetris framed as upcoming, expired subtitle copy
- Full suite: 310 tests / 37 files pass; `eslint` and `tsc --noEmit` clean
- Pre-landing review (checklist + testing/maintainability + adversarial pass): no issues found

## Ship audit
- **Test Coverage:** All changed code paths asserted, including both `weeklyBalance` branches.
- **Pre-Landing Review:** No issues found. Evals skipped (no prompt files). Codex passes skipped (CLI not installed).
- **Scope Check:** CLEAN — intent was paywall copy accuracy; diff touches only `src/pages/PaywallPage/`.
- **Plan Completion:** No plan file detected.
- **Docs:** Current — the only "Skill Tree" doc mention is a roadmap item in AGENT_GUIDELINES.md, unrelated to paywall copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
