### PR TITLE
feat(programs): next-workout home surfacing (Slice 3, flag-gated)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -114,6 +114,36 @@ pages/
 - Test data lives in `src/examples/` and `src/mocks/mocked-*.ts`.
 - Test files collocate with source: `ComponentName.test.tsx`.
 
+## Program Tracking (behind the `programs` flag)
+
+A sequencing/progress layer over the existing `workout_logs` pipeline. Four
+tables (`programs`, `program_sessions`, `user_programs`,
+`program_session_completions`) plus two SQL functions: `enroll_in_program`
+(copy-on-enroll clone + activate) and `complete_program_session` (record a
+completion/skip, advance, and flip the enrollment to `completed` on the final
+session — atomic). Both are `SECURITY INVOKER` RPCs; progress is fully **derived
+from the completions set**, never a stored cursor.
+
+- **Next session** = lowest-`sequenceIndex` `program_sessions` row with no
+  completion. `useActiveProgram` runs this client-side over the program's ≤~15
+  sessions (a dedicated SQL function buys nothing at that size). It returns the
+  **active _or_ most-recently-completed** enrollment so the "🎉 complete" card
+  still renders after the terminal status flip — consumers that must treat only
+  active enrollments specially (e.g. `ProgramsPage`) guard on
+  `enrollment.status === 'active'`.
+- **Home surfacing:** an active program forces browse mode
+  (`StartWorkoutPage`), rendering `NextProgramWorkoutCard` above the recommended
+  sections. A `programGatePending` flag holds the page in browse until the
+  (async) program query resolves, avoiding a builder→card flash.
+- **Card → start → log seam:** starting a program session threads
+  `{ userProgramId, programSessionId }` through **`ProgramSessionContext`** (a
+  sibling of `WorkoutOptionsProvider` in `App.tsx`), set by `useStartWorkout`
+  and read in `useLogWorkout.onSuccess` to write the completion linked to the new
+  `workout_logs.id`. The linkage is deliberately **NOT** a `workout_logs` column
+  — the completion row is the only new write; the existing log path is untouched.
+- DB behaviors (RLS, the advance/skip/flip RPC, idempotency) are covered by
+  Playwright e2e against the local Supabase (`e2e/program-*.spec.ts`), not MSW.
+
 ## Authentication
 
 - Uses Supabase Auth with both magic links and OTP (one-time passwords)

--- a/e2e/program-next-workout.spec.ts
+++ b/e2e/program-next-workout.spec.ts
@@ -1,0 +1,319 @@
+import { expect, test } from '@playwright/test';
+
+// Slice 3 backend behavior: the next-unsatisfied-session cursor and the
+// complete_program_session RPC (record completion / skip, advance, and flip the
+// enrollment to `completed` on the final session). These are real-Postgres
+// behaviors, so — like program-schema.spec.ts — this hits the LOCAL Supabase
+// REST/RPC surface directly rather than driving the browser. Auth mirrors
+// program-schema.spec.ts.
+
+const SUPABASE_URL = process.env.VITE_SUPABASE_URL!;
+const SUPABASE_ANON_KEY = process.env.VITE_SUPABASE_ANON_KEY!;
+const DFW_SLUG = 'dry-fighting-weight';
+
+interface TestUser {
+  token: string;
+  uid: string;
+  email: string;
+}
+
+async function signUpThrowawayUser(): Promise<TestUser> {
+  const email = `prognext-${Date.now()}-${Math.floor(Math.random() * 1e9)}@example.com`;
+  const password = 'testpassword123';
+
+  const res = await fetch(`${SUPABASE_URL}/auth/v1/signup`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', apikey: SUPABASE_ANON_KEY },
+    body: JSON.stringify({ email, password }),
+  });
+  if (!res.ok)
+    throw new Error(`signup failed (${res.status}): ${await res.text()}`);
+
+  const body = (await res.json()) as {
+    access_token?: string;
+    user?: { id: string };
+  };
+  if (body.access_token && body.user) {
+    return { token: body.access_token, uid: body.user.id, email };
+  }
+  throw new Error('signup did not return a session');
+}
+
+interface RestOptions {
+  body?: unknown;
+  prefer?: string;
+}
+
+async function rest(
+  method: string,
+  path: string,
+  token: string,
+  opts: RestOptions = {},
+): Promise<Response> {
+  const headers: Record<string, string> = {
+    apikey: SUPABASE_ANON_KEY,
+    Authorization: `Bearer ${token}`,
+  };
+  if (opts.body !== undefined) headers['Content-Type'] = 'application/json';
+  if (opts.prefer) headers['Prefer'] = opts.prefer;
+  return fetch(`${SUPABASE_URL}/rest/v1/${path}`, {
+    method,
+    headers,
+    body: opts.body !== undefined ? JSON.stringify(opts.body) : undefined,
+  });
+}
+
+async function restJson<T = unknown>(
+  method: string,
+  path: string,
+  token: string,
+  opts: RestOptions = {},
+): Promise<T> {
+  const res = await rest(method, path, token, opts);
+  if (!res.ok) {
+    throw new Error(
+      `${method} ${path} failed (${res.status}): ${await res.text()}`,
+    );
+  }
+  return res.json() as Promise<T>;
+}
+
+async function rpc<T = unknown>(
+  fn: string,
+  token: string,
+  args: Record<string, unknown>,
+): Promise<T> {
+  const res = await fetch(`${SUPABASE_URL}/rest/v1/rpc/${fn}`, {
+    method: 'POST',
+    headers: {
+      apikey: SUPABASE_ANON_KEY,
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(args),
+  });
+  if (!res.ok)
+    throw new Error(`rpc ${fn} failed (${res.status}): ${await res.text()}`);
+  return res.json() as Promise<T>;
+}
+
+interface SessionRow {
+  id: string;
+  sequence_index: number;
+}
+
+// Mirror useActiveProgram's client-side cursor: the lowest-sequence session with
+// no completion row yet.
+async function nextSession(
+  token: string,
+  userProgramId: string,
+  programId: string,
+): Promise<SessionRow | null> {
+  const sessions = await restJson<SessionRow[]>(
+    'GET',
+    `program_sessions?program_id=eq.${programId}&select=id,sequence_index&order=sequence_index.asc`,
+    token,
+  );
+  const completions = await restJson<Array<{ program_session_id: string }>>(
+    'GET',
+    `program_session_completions?user_program_id=eq.${userProgramId}&select=program_session_id`,
+    token,
+  );
+  const satisfied = new Set(completions.map((c) => c.program_session_id));
+  return sessions.find((s) => !satisfied.has(s.id)) ?? null;
+}
+
+async function getEnrollment(
+  token: string,
+  userProgramId: string,
+): Promise<{
+  status: string;
+  completed_at: string | null;
+  program_id: string;
+}> {
+  const rows = await restJson<
+    Array<{ status: string; completed_at: string | null; program_id: string }>
+  >(
+    'GET',
+    `user_programs?id=eq.${userProgramId}&select=status,completed_at,program_id`,
+    token,
+  );
+  expect(rows).toHaveLength(1);
+  return rows[0];
+}
+
+// Insert a minimal-but-valid workout_logs row and return its id, so a completion
+// can link to a real log (as it does in the app via useLogWorkout).
+async function insertWorkoutLog(user: TestUser): Promise<number> {
+  const [row] = await restJson<Array<{ id: number }>>(
+    'POST',
+    'workout_logs',
+    user.token,
+    {
+      prefer: 'return=representation',
+      body: {
+        user_id: user.uid,
+        started_at: new Date().toISOString(),
+        movements: ['Clean and Press'],
+        completed_reps: 10,
+        completed_rounds: 1,
+        completed_rungs: 1,
+        workout_goal: 30,
+      },
+    },
+  );
+  return row.id;
+}
+
+test.describe('program next-workout — complete/skip/advance', () => {
+  test('completing a session advances the cursor and links the workout log', async () => {
+    const user = await signUpThrowawayUser();
+    const [dfw] = await restJson<Array<{ id: string }>>(
+      'GET',
+      `programs?slug=eq.${DFW_SLUG}&select=id`,
+      user.token,
+    );
+    const userProgramId = await rpc<string>('enroll_in_program', user.token, {
+      p_program_id: dfw.id,
+    });
+    const { program_id: cloneId } = await getEnrollment(
+      user.token,
+      userProgramId,
+    );
+
+    // Cursor starts at sequence 0.
+    const first = await nextSession(user.token, userProgramId, cloneId);
+    expect(first?.sequence_index).toBe(0);
+
+    // Complete it against a real workout_logs row.
+    const logId = await insertWorkoutLog(user);
+    const doneAll = await rpc<boolean>('complete_program_session', user.token, {
+      p_user_program_id: userProgramId,
+      p_program_session_id: first!.id,
+      p_workout_log_id: logId,
+    });
+    expect(doneAll).toBe(false); // DFW has 14 sessions — not done after one.
+
+    // A completion row exists, linked to the log, status completed.
+    const completions = await restJson<
+      Array<{ workout_log_id: number | null; status: string }>
+    >(
+      'GET',
+      `program_session_completions?user_program_id=eq.${userProgramId}&program_session_id=eq.${first!.id}&select=workout_log_id,status`,
+      user.token,
+    );
+    expect(completions).toHaveLength(1);
+    expect(completions[0].status).toBe('completed');
+    expect(completions[0].workout_log_id).toBe(logId);
+
+    // Cursor advanced to sequence 1.
+    const second = await nextSession(user.token, userProgramId, cloneId);
+    expect(second?.sequence_index).toBe(1);
+  });
+
+  test('skipping writes a skipped completion (no log) and advances', async () => {
+    const user = await signUpThrowawayUser();
+    const [dfw] = await restJson<Array<{ id: string }>>(
+      'GET',
+      `programs?slug=eq.${DFW_SLUG}&select=id`,
+      user.token,
+    );
+    const userProgramId = await rpc<string>('enroll_in_program', user.token, {
+      p_program_id: dfw.id,
+    });
+    const { program_id: cloneId } = await getEnrollment(
+      user.token,
+      userProgramId,
+    );
+
+    const first = await nextSession(user.token, userProgramId, cloneId);
+    await rpc('complete_program_session', user.token, {
+      p_user_program_id: userProgramId,
+      p_program_session_id: first!.id,
+      p_status: 'skipped',
+    });
+
+    const completions = await restJson<
+      Array<{ workout_log_id: number | null; status: string }>
+    >(
+      'GET',
+      `program_session_completions?user_program_id=eq.${userProgramId}&program_session_id=eq.${first!.id}&select=workout_log_id,status`,
+      user.token,
+    );
+    expect(completions[0].status).toBe('skipped');
+    expect(completions[0].workout_log_id).toBeNull();
+
+    const second = await nextSession(user.token, userProgramId, cloneId);
+    expect(second?.sequence_index).toBe(1);
+  });
+
+  test('satisfying every session flips the enrollment to completed', async () => {
+    const user = await signUpThrowawayUser();
+    const [dfw] = await restJson<Array<{ id: string }>>(
+      'GET',
+      `programs?slug=eq.${DFW_SLUG}&select=id`,
+      user.token,
+    );
+    const userProgramId = await rpc<string>('enroll_in_program', user.token, {
+      p_program_id: dfw.id,
+    });
+    const { program_id: cloneId } = await getEnrollment(
+      user.token,
+      userProgramId,
+    );
+
+    // Walk the whole program by skipping every session; the final call returns
+    // true and flips the enrollment.
+    let lastResult = false;
+    for (;;) {
+      const next = await nextSession(user.token, userProgramId, cloneId);
+      if (!next) break;
+      lastResult = await rpc<boolean>('complete_program_session', user.token, {
+        p_user_program_id: userProgramId,
+        p_program_session_id: next.id,
+        p_status: 'skipped',
+      });
+    }
+
+    expect(lastResult).toBe(true);
+    const enrollment = await getEnrollment(user.token, userProgramId);
+    expect(enrollment.status).toBe('completed');
+    expect(enrollment.completed_at).not.toBeNull();
+  });
+
+  test('a duplicate completion is a harmless no-op (idempotent)', async () => {
+    const user = await signUpThrowawayUser();
+    const [dfw] = await restJson<Array<{ id: string }>>(
+      'GET',
+      `programs?slug=eq.${DFW_SLUG}&select=id`,
+      user.token,
+    );
+    const userProgramId = await rpc<string>('enroll_in_program', user.token, {
+      p_program_id: dfw.id,
+    });
+    const { program_id: cloneId } = await getEnrollment(
+      user.token,
+      userProgramId,
+    );
+    const first = await nextSession(user.token, userProgramId, cloneId);
+
+    await rpc('complete_program_session', user.token, {
+      p_user_program_id: userProgramId,
+      p_program_session_id: first!.id,
+      p_status: 'skipped',
+    });
+    // Second call for the same session must not throw or duplicate.
+    await rpc('complete_program_session', user.token, {
+      p_user_program_id: userProgramId,
+      p_program_session_id: first!.id,
+      p_status: 'skipped',
+    });
+
+    const completions = await restJson<Array<unknown>>(
+      'GET',
+      `program_session_completions?user_program_id=eq.${userProgramId}&program_session_id=eq.${first!.id}`,
+      user.token,
+    );
+    expect(completions).toHaveLength(1);
+  });
+});

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -10,6 +10,7 @@ export * from './useMovementLogs';
 export * from './useMovements';
 export * from './usePatternDebt';
 export * from './useActiveProgram';
+export * from './useCompleteProgramSession';
 export * from './useCreateProgram';
 export * from './useDuplicateProgramSession';
 export * from './useEnrollProgram';

--- a/src/api/useActiveProgram.test.ts
+++ b/src/api/useActiveProgram.test.ts
@@ -1,0 +1,177 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { HttpResponse, http } from 'msw';
+import React from 'react';
+import { QueryClient, QueryClientProvider } from 'react-query';
+
+import { SessionProvider } from '~/contexts';
+import { server } from '~/mocks/server';
+
+import { VITE_SUPABASE_URL } from '../env';
+import { useActiveProgram } from './useActiveProgram';
+
+const base = `${VITE_SUPABASE_URL}/rest/v1`;
+
+const mockSession = {
+  user: {
+    id: 'user-123',
+    app_metadata: {},
+    user_metadata: {},
+    created_at: '',
+    aud: '',
+  },
+  access_token: '',
+  refresh_token: '',
+  expires_in: 10000,
+  token_type: '',
+};
+
+const makeWrapper = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return ({ children }: { children: React.ReactNode }) =>
+    React.createElement(
+      QueryClientProvider,
+      { client: queryClient },
+      React.createElement(SessionProvider, { value: mockSession }, children),
+    );
+};
+
+const programRow = {
+  id: 'prog-clone',
+  owner_id: 'user-123',
+  source_program_id: 'dfw',
+  slug: null,
+  title: 'Dry Fighting Weight',
+  description: null,
+  author_name: 'Geoff Neupert',
+  num_weeks: 5,
+  days_per_week: 3,
+  is_public: false,
+  created_at: '',
+};
+
+const sessionRow = (seq: number, week: number, day: number, title: string) => ({
+  id: `ps-${seq}`,
+  program_id: 'prog-clone',
+  sequence_index: seq,
+  week_number: week,
+  day_number: day,
+  title,
+  notes: null,
+  workout_options: {
+    complexSet: false,
+    intervalTimer: 0,
+    movements: [],
+    restTimer: 0,
+    sharedWeightOneUnit: null,
+    sharedWeightOneValue: null,
+    sharedWeightTwoUnit: null,
+    sharedWeightTwoValue: null,
+    workoutDetails: null,
+    workoutGoal: 30,
+    workoutGoalUnits: 'minutes',
+  },
+});
+
+const threeSessions = [
+  sessionRow(0, 1, 1, 'Ladders 1-2-3'),
+  sessionRow(1, 1, 2, 'Sets of 1'),
+  sessionRow(2, 1, 3, 'Sets of 2'),
+];
+
+describe('useActiveProgram', () => {
+  it('derives the next unsatisfied session and progress for an active enrollment', async () => {
+    server.use(
+      http.get(`${base}/user_programs`, () =>
+        HttpResponse.json([
+          {
+            id: 'up-1',
+            user_id: 'user-123',
+            program_id: 'prog-clone',
+            status: 'active',
+            config: {},
+            started_at: '',
+            completed_at: null,
+          },
+        ]),
+      ),
+      http.get(`${base}/programs`, () => HttpResponse.json(programRow)),
+      http.get(`${base}/program_sessions`, () =>
+        HttpResponse.json(threeSessions),
+      ),
+      // Session 0 already done → next is session 1.
+      http.get(`${base}/program_session_completions`, () =>
+        HttpResponse.json([{ program_session_id: 'ps-0' }]),
+      ),
+    );
+
+    const { result } = renderHook(() => useActiveProgram(), {
+      wrapper: makeWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    const data = result.current.data!;
+    expect(data.nextSession?.session.id).toBe('ps-1');
+    expect(data.nextSession?.session.title).toBe('Sets of 1');
+    expect(data.progress).toEqual({
+      completed: 1,
+      total: 3,
+      week: 1,
+      day: 2,
+    });
+    expect(data.isComplete).toBe(false);
+  });
+
+  it('reports the complete state for a finished enrollment (no active)', async () => {
+    server.use(
+      http.get(`${base}/user_programs`, () =>
+        HttpResponse.json([
+          {
+            id: 'up-1',
+            user_id: 'user-123',
+            program_id: 'prog-clone',
+            status: 'completed',
+            config: {},
+            started_at: '',
+            completed_at: '2026-07-06T00:00:00Z',
+          },
+        ]),
+      ),
+      http.get(`${base}/programs`, () => HttpResponse.json(programRow)),
+      http.get(`${base}/program_sessions`, () =>
+        HttpResponse.json(threeSessions),
+      ),
+      http.get(`${base}/program_session_completions`, () =>
+        HttpResponse.json([
+          { program_session_id: 'ps-0' },
+          { program_session_id: 'ps-1' },
+          { program_session_id: 'ps-2' },
+        ]),
+      ),
+    );
+
+    const { result } = renderHook(() => useActiveProgram(), {
+      wrapper: makeWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    const data = result.current.data!;
+    expect(data.nextSession).toBeNull();
+    expect(data.isComplete).toBe(true);
+    expect(data.progress.completed).toBe(3);
+  });
+
+  it('returns null when the user has no active or completed enrollment', async () => {
+    server.use(http.get(`${base}/user_programs`, () => HttpResponse.json([])));
+
+    const { result } = renderHook(() => useActiveProgram(), {
+      wrapper: makeWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toBeNull();
+  });
+});

--- a/src/api/useActiveProgram.ts
+++ b/src/api/useActiveProgram.ts
@@ -2,58 +2,149 @@ import { useQuery } from 'react-query';
 
 import { QUERIES } from '~/constants';
 import { useSession } from '~/contexts';
-import { Program, UserProgram } from '~/types';
+import { Program, ProgramSession, UserProgram, WorkoutOptions } from '~/types';
 
 import { supabase } from '../supabaseClient';
-import { mapProgramRow, mapUserProgramRow } from './program';
+import {
+  mapProgramRow,
+  mapProgramSessionRow,
+  mapUserProgramRow,
+} from './program';
+
+export interface NextProgramSession {
+  session: ProgramSession;
+  /** The stored session options, ready for `loadIntoBuilder` with no mapping. */
+  workoutOptions: Omit<WorkoutOptions, 'startedAt'>;
+}
+
+export interface ProgramProgress {
+  /** Sessions satisfied (completed or skipped). */
+  completed: number;
+  /** Total sessions in the program. */
+  total: number;
+  /** 1-based week of the current session (the next one, or the last when done). */
+  week: number;
+  /** 1-based day of the current session. */
+  day: number;
+}
 
 export interface ActiveProgram {
   enrollment: UserProgram;
   program: Program;
+  /**
+   * The next unsatisfied session (lowest `sequenceIndex` with no completion), or
+   * `null` when every session is satisfied.
+   */
+  nextSession: NextProgramSession | null;
+  progress: ProgramProgress;
+  /** True once every session has a completion (or the enrollment is completed). */
+  isComplete: boolean;
+}
+
+interface UseActiveProgramOptions {
+  /**
+   * Gate the query. Defaults to enabled — pass `false` (e.g. behind the
+   * `programs` flag) so non-program builds fire zero extra requests.
+   */
+  enabled?: boolean;
 }
 
 /**
- * The user's currently active enrollment (there is at most one, enforced by the
- * `one_active_program_per_user` partial unique index), joined to its program.
- * Returns `null` when the user has no active program.
+ * The user's current program: the active enrollment, or — when none is active —
+ * the most recently completed one so the "🎉 complete" card can still render
+ * after the final session flips the enrollment to `completed`. Returns `null`
+ * when the user has neither.
  *
- * Slice 2 uses this only to drive the "switch active program?" prompt on
- * enroll; Slice 3 extends the surface with the next-session lookup.
+ * Beyond the enrollment/program (Slice 2), this derives the Slice-3 next-workout
+ * surface: `nextSession` is the lowest-`sequenceIndex` session with no
+ * completion row (the §3.6 "next unsatisfied session" query, evaluated
+ * client-side over the program's ≤~15 sessions — small enough that a dedicated
+ * SQL function buys nothing over a plain multi-select, and it stays consistent
+ * with the existing enrollment fetch here). Skips get a `skipped` completion, so
+ * they are satisfied and never re-served.
  */
-export const useActiveProgram = () => {
+export const useActiveProgram = (options?: UseActiveProgramOptions) => {
   const session = useSession();
   const userId = session?.user?.id;
 
   return useQuery(
     [QUERIES.ACTIVE_PROGRAM, userId],
     () => fetchActiveProgram(userId!),
-    { enabled: !!userId },
+    { enabled: !!userId && (options?.enabled ?? true) },
   );
 };
 
 const fetchActiveProgram = async (
   userId: string,
 ): Promise<ActiveProgram | null> => {
-  const { data: enrollment, error } = await supabase
+  // Prefer the active enrollment; fall back to the most recently completed one
+  // so the complete state survives the terminal status flip. Abandoned/paused
+  // enrollments never surface here.
+  const { data: enrollments, error } = await supabase
     .from('user_programs')
     .select('*')
     .eq('user_id', userId)
-    .eq('status', 'active')
-    .maybeSingle();
+    .in('status', ['active', 'completed'])
+    .order('completed_at', { ascending: false, nullsFirst: true });
 
   if (error) throw error;
-  if (!enrollment) return null;
 
-  const { data: program, error: programError } = await supabase
-    .from('programs')
-    .select('*')
-    .eq('id', enrollment.program_id)
-    .single();
+  const enrollmentRow =
+    enrollments?.find((row) => row.status === 'active') ?? enrollments?.[0];
+  if (!enrollmentRow) return null;
 
-  if (programError) throw programError;
+  const [programResult, sessionsResult, completionsResult] = await Promise.all([
+    supabase
+      .from('programs')
+      .select('*')
+      .eq('id', enrollmentRow.program_id)
+      .single(),
+    supabase
+      .from('program_sessions')
+      .select('*')
+      .eq('program_id', enrollmentRow.program_id)
+      .order('sequence_index', { ascending: true }),
+    supabase
+      .from('program_session_completions')
+      .select('program_session_id')
+      .eq('user_program_id', enrollmentRow.id),
+  ]);
+
+  if (programResult.error) throw programResult.error;
+  if (sessionsResult.error) throw sessionsResult.error;
+  if (completionsResult.error) throw completionsResult.error;
+
+  const enrollment = mapUserProgramRow(enrollmentRow);
+  const program = mapProgramRow(programResult.data);
+  const sessions = (sessionsResult.data ?? []).map(mapProgramSessionRow);
+  const satisfiedIds = new Set(
+    (completionsResult.data ?? []).map((row) => row.program_session_id),
+  );
+
+  const total = sessions.length;
+  const completed = sessions.filter((s) => satisfiedIds.has(s.id)).length;
+  const nextSessionRow = sessions.find((s) => !satisfiedIds.has(s.id)) ?? null;
+  const isComplete =
+    enrollment.status === 'completed' || nextSessionRow === null;
+
+  // The "current" session for labels: the next unsatisfied one, or the last
+  // session once complete.
+  const labelSession = nextSessionRow ?? sessions[sessions.length - 1] ?? null;
+
+  const nextSession: NextProgramSession | null = nextSessionRow
+    ? { session: nextSessionRow, workoutOptions: nextSessionRow.workoutOptions }
+    : null;
 
   return {
-    enrollment: mapUserProgramRow(enrollment),
-    program: mapProgramRow(program),
+    enrollment,
+    program,
+    nextSession,
+    progress: {
+      completed,
+      total,
+      week: labelSession?.weekNumber ?? 0,
+      day: labelSession?.dayNumber ?? 0,
+    },
+    isComplete,
   };
 };

--- a/src/api/useCompleteProgramSession.test.ts
+++ b/src/api/useCompleteProgramSession.test.ts
@@ -1,0 +1,118 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { HttpResponse, http } from 'msw';
+import React from 'react';
+import { QueryClient, QueryClientProvider } from 'react-query';
+
+import { SessionProvider } from '~/contexts';
+import { server } from '~/mocks/server';
+
+import { VITE_SUPABASE_URL } from '../env';
+import { useCompleteProgramSession } from './useCompleteProgramSession';
+
+const RPC_URL = `${VITE_SUPABASE_URL}/rest/v1/rpc/complete_program_session`;
+
+const mockSession = {
+  user: {
+    id: 'user-123',
+    app_metadata: {},
+    user_metadata: {},
+    created_at: '',
+    aud: '',
+  },
+  access_token: '',
+  refresh_token: '',
+  expires_in: 10000,
+  token_type: '',
+};
+
+const makeWrapper = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return ({ children }: { children: React.ReactNode }) =>
+    React.createElement(
+      QueryClientProvider,
+      { client: queryClient },
+      React.createElement(SessionProvider, { value: mockSession }, children),
+    );
+};
+
+describe('useCompleteProgramSession', () => {
+  it('completes a session with its workout_log_id and resolves the program-complete flag', async () => {
+    let receivedBody: unknown;
+    server.use(
+      http.post(RPC_URL, async ({ request }) => {
+        receivedBody = await request.json();
+        // The RPC returns true when this call finished the whole program.
+        return HttpResponse.json(true);
+      }),
+    );
+
+    const { result } = renderHook(() => useCompleteProgramSession(), {
+      wrapper: makeWrapper(),
+    });
+
+    const done = await result.current.mutateAsync({
+      userProgramId: 'up-1',
+      programSessionId: 'ps-9',
+      workoutLogId: 42,
+    });
+
+    expect(done).toBe(true);
+    expect(receivedBody).toEqual({
+      p_user_program_id: 'up-1',
+      p_program_session_id: 'ps-9',
+      p_workout_log_id: 42,
+      p_status: 'completed',
+    });
+  });
+
+  it('records a skip with no workout_log_id (status skipped)', async () => {
+    let receivedBody: Record<string, unknown> | undefined;
+    server.use(
+      http.post(RPC_URL, async ({ request }) => {
+        receivedBody = (await request.json()) as Record<string, unknown>;
+        return HttpResponse.json(false);
+      }),
+    );
+
+    const { result } = renderHook(() => useCompleteProgramSession(), {
+      wrapper: makeWrapper(),
+    });
+
+    await result.current.mutateAsync({
+      userProgramId: 'up-1',
+      programSessionId: 'ps-9',
+      status: 'skipped',
+    });
+
+    expect(receivedBody).toMatchObject({
+      p_user_program_id: 'up-1',
+      p_program_session_id: 'ps-9',
+      p_status: 'skipped',
+    });
+    // No workout_log_id sent for a skip — the RPC's NULL default applies.
+    expect(receivedBody?.p_workout_log_id).toBeUndefined();
+  });
+
+  it('surfaces RPC errors', async () => {
+    server.use(
+      http.post(RPC_URL, () =>
+        HttpResponse.json({ message: 'boom' }, { status: 400 }),
+      ),
+    );
+
+    const { result } = renderHook(() => useCompleteProgramSession(), {
+      wrapper: makeWrapper(),
+    });
+
+    await expect(
+      result.current.mutateAsync({
+        userProgramId: 'up-1',
+        programSessionId: 'ps-9',
+        workoutLogId: 1,
+      }),
+    ).rejects.toBeTruthy();
+    await waitFor(() => expect(result.current.isError).toBe(true));
+  });
+});

--- a/src/api/useCompleteProgramSession.ts
+++ b/src/api/useCompleteProgramSession.ts
@@ -1,0 +1,54 @@
+import { useMutation, useQueryClient } from 'react-query';
+
+import { QUERIES } from '~/constants';
+import { ProgramSessionCompletionStatus } from '~/types';
+
+import { supabase } from '../supabaseClient';
+
+export interface CompleteProgramSessionInput {
+  userProgramId: string;
+  programSessionId: string;
+  /** The real `workout_logs.id` for a completed session; omit/undefined for a skip. */
+  workoutLogId?: number | null;
+  /** `'completed'` (default) records a done session; `'skipped'` advances the cursor. */
+  status?: ProgramSessionCompletionStatus;
+}
+
+/**
+ * Advances the active program by one session via the Slice-3
+ * `complete_program_session` RPC: records a completion (or a skip) and, when it
+ * satisfies the final session, flips the enrollment to `completed` — all atomic
+ * inside the function. Resolves to `true` when the whole program is now done.
+ *
+ * `useLogWorkout` calls {@link completeProgramSession} directly in its
+ * `onSuccess` (the completed path); this hook drives the card's explicit "Skip".
+ */
+export const completeProgramSession = async ({
+  userProgramId,
+  programSessionId,
+  workoutLogId = null,
+  status = 'completed',
+}: CompleteProgramSessionInput): Promise<boolean> => {
+  const { data, error } = await supabase.rpc('complete_program_session', {
+    p_user_program_id: userProgramId,
+    p_program_session_id: programSessionId,
+    // Omit for a skip so the function's NULL default applies (the generated arg
+    // type is non-nullable `number | undefined`).
+    p_workout_log_id: workoutLogId ?? undefined,
+    p_status: status,
+  });
+
+  if (error) throw error;
+  return Boolean(data);
+};
+
+export const useCompleteProgramSession = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: completeProgramSession,
+    onSuccess: () => {
+      queryClient.invalidateQueries([QUERIES.ACTIVE_PROGRAM]);
+    },
+  });
+};

--- a/src/api/useLogWorkout.ts
+++ b/src/api/useLogWorkout.ts
@@ -1,11 +1,12 @@
 import { useMutation, useQueryClient } from 'react-query';
 
 import { QUERIES } from '~/constants';
-import { useSession, useWorkoutOptions } from '~/contexts';
+import { useProgramSession, useSession, useWorkoutOptions } from '~/contexts';
 import { WorkoutLog, WorkoutOptions } from '~/types';
 
 import { supabase } from '../supabaseClient';
 import { AnalyticsEvent, trackEvent } from './analytics';
+import { completeProgramSession } from './useCompleteProgramSession';
 
 interface LogWorkoutInput {
   completedReps: number;
@@ -18,6 +19,7 @@ interface LogWorkoutInput {
 export const useLogWorkout = () => {
   const [workoutOptions] = useWorkoutOptions();
   const { user } = useSession();
+  const [programSession, setProgramSession] = useProgramSession();
   const queryClient = useQueryClient();
 
   return useMutation({
@@ -38,6 +40,30 @@ export const useLogWorkout = () => {
         workoutOptions,
       }),
     onSuccess: (workoutLogId) => {
+      // Program tracking (Slice 3): if this workout was started from a program
+      // session, advance the program — write a completion linked to the new
+      // workout_logs row (flipping the enrollment to `completed` when it was the
+      // last session, atomically inside the RPC). The completion is a separate
+      // write; the workout_logs insert above is untouched. Fire-and-forget so it
+      // never blocks the normal log/navigation path; clear the pending session
+      // so a subsequent non-program log can't re-attach to it.
+      if (programSession) {
+        const { userProgramId, programSessionId } = programSession;
+        setProgramSession(null);
+        void completeProgramSession({
+          userProgramId,
+          programSessionId,
+          workoutLogId,
+          status: 'completed',
+        })
+          .then(() => {
+            void queryClient.invalidateQueries([QUERIES.ACTIVE_PROGRAM]);
+          })
+          .catch((error) => {
+            console.error('Failed to advance program session', error);
+          });
+      }
+
       // Activation funnel (PROD-157). is_first_workout is read from the
       // WORKOUT_LOGS cache, warmed by StartWorkoutPage before the user reaches
       // the active workout; the canonical value is also derivable server-side

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -4,6 +4,7 @@ import { RouterProvider, createBrowserRouter } from 'react-router-dom';
 
 import { Loading, PWAInstallPrompt, SafeAreaWrapper } from '~/components';
 import { EntitlementProvider } from '~/contexts/EntitlementContext';
+import { ProgramSessionProvider } from '~/contexts/ProgramSessionContext';
 import { WorkoutOptionsProvider } from '~/contexts/WorkoutOptionsContext';
 import { resolveAuthSession } from '~/utils';
 
@@ -45,7 +46,9 @@ export function App() {
         <SessionProvider value={session}>
           <EntitlementProvider>
             <WorkoutOptionsProvider>
-              <RouterProvider router={router} />
+              <ProgramSessionProvider>
+                <RouterProvider router={router} />
+              </ProgramSessionProvider>
             </WorkoutOptionsProvider>
           </EntitlementProvider>
         </SessionProvider>

--- a/src/contexts/ProgramSessionContext.tsx
+++ b/src/contexts/ProgramSessionContext.tsx
@@ -1,0 +1,41 @@
+import { createContext, useContext, useState } from 'react';
+
+/**
+ * Identifies the program session a workout was started from, so the log step can
+ * advance the program on completion. Slice 3: when a workout is started from the
+ * NextProgramWorkoutCard, `useStartWorkout` stashes this here; `useLogWorkout`
+ * reads it in `onSuccess` to write a `program_session_completions` row keyed on
+ * the new `workout_logs.id`. `null` for every non-program start.
+ *
+ * This rides alongside `WorkoutOptionsContext` (App.tsx) rather than on the
+ * committed `WorkoutOptions`, keeping the program linkage out of the
+ * `workout_logs` insert payload entirely.
+ */
+export interface PendingProgramSession {
+  userProgramId: string;
+  programSessionId: string;
+}
+
+// Default to "no pending session" so consumers (and tests/stories that don't
+// wrap in the provider) degrade gracefully: reading yields null and setting is a
+// no-op. The real provider in App.tsx supplies the live state.
+export const ProgramSessionContext = createContext<
+  [
+    PendingProgramSession | null,
+    (session: PendingProgramSession | null) => void,
+  ]
+>([null, () => {}]);
+
+export const ProgramSessionProvider = ({ ...props }) => {
+  const [programSession, setProgramSession] =
+    useState<PendingProgramSession | null>(null);
+
+  return (
+    <ProgramSessionContext.Provider
+      value={[programSession, setProgramSession]}
+      {...props}
+    />
+  );
+};
+
+export const useProgramSession = () => useContext(ProgramSessionContext);

--- a/src/contexts/index.ts
+++ b/src/contexts/index.ts
@@ -1,3 +1,4 @@
 export * from './EntitlementContext';
+export * from './ProgramSessionContext';
 export * from './SessionContext';
 export * from './WorkoutOptionsContext';

--- a/src/hooks/useStartWorkout.ts
+++ b/src/hooks/useStartWorkout.ts
@@ -2,7 +2,12 @@ import { useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 import { AnalyticsEvent, trackEvent } from '~/api';
-import { useSession, useWorkoutOptions } from '~/contexts';
+import {
+  PendingProgramSession,
+  useProgramSession,
+  useSession,
+  useWorkoutOptions,
+} from '~/contexts';
 import { WorkoutOptions } from '~/types';
 
 import type { Json } from '../../types/supabase';
@@ -12,17 +17,23 @@ export type WorkoutStartSource =
   | 'builder'
   | 'curated'
   | 'history_repeat'
-  | 'recommender';
+  | 'recommender'
+  | 'program';
 
 /**
  * Shared "start a workout" action used by the manual builder, curated
- * templates, and history repeats. Stamps `startedAt`, commits the options to
- * context, fires the `workout_started` analytics event (tagged with `source`),
- * and routes into the active workout.
+ * templates, history repeats, and program sessions. Stamps `startedAt`, commits
+ * the options to context, fires the `workout_started` analytics event (tagged
+ * with `source`), and routes into the active workout.
+ *
+ * For a program start (`source === 'program'`) the caller passes `programSession`
+ * so the log step can advance the program on completion; every other start
+ * passes `null`, which clears any stale pending session from a prior start.
  */
 export const useStartWorkout = () => {
   const navigate = useNavigate();
   const [, updateWorkoutOptions] = useWorkoutOptions();
+  const [, setProgramSession] = useProgramSession();
   const session = useSession();
   const userId = session?.user?.id;
 
@@ -31,8 +42,10 @@ export const useStartWorkout = () => {
       options: Omit<WorkoutOptions, 'startedAt'>,
       source: WorkoutStartSource,
       extraProps: Record<string, Json> = {},
+      programSession: PendingProgramSession | null = null,
     ) => {
       updateWorkoutOptions({ ...options, startedAt: new Date() });
+      setProgramSession(programSession);
 
       if (userId) {
         void trackEvent({
@@ -44,6 +57,6 @@ export const useStartWorkout = () => {
 
       navigate('active');
     },
-    [navigate, updateWorkoutOptions, userId],
+    [navigate, updateWorkoutOptions, setProgramSession, userId],
   );
 };

--- a/src/pages/ProgramsPage/ProgramsPage.test.tsx
+++ b/src/pages/ProgramsPage/ProgramsPage.test.tsx
@@ -99,7 +99,7 @@ describe('ProgramsPage', () => {
   it('prompts to switch when a different program is already active, then enrolls on confirm', () => {
     mockUseActiveProgram.mockReturnValue({
       data: {
-        enrollment: { programId: 'other-program' },
+        enrollment: { programId: 'other-program', status: 'active' },
         program: { title: 'Other Program' },
       },
     });

--- a/src/pages/ProgramsPage/ProgramsPage.tsx
+++ b/src/pages/ProgramsPage/ProgramsPage.tsx
@@ -49,8 +49,17 @@ export const ProgramsPage = () => {
   const enrollIn = (programId: string) =>
     enroll.mutate(programId, { onSuccess: () => navigate('/') });
 
+  // Only an *active* enrollment blocks a fresh enroll — a completed program may
+  // still be returned by useActiveProgram (to drive the home "complete" card),
+  // but starting a new program then needs no "switch?" confirmation.
+  const activeEnrollment =
+    activeProgram?.enrollment.status === 'active' ? activeProgram : null;
+
   const handleEnroll = (programId: string) => {
-    if (activeProgram && activeProgram.enrollment.programId !== programId) {
+    if (
+      activeEnrollment &&
+      activeEnrollment.enrollment.programId !== programId
+    ) {
       setPendingSwitchId(programId);
     } else {
       enrollIn(programId);
@@ -76,7 +85,7 @@ export const ProgramsPage = () => {
   };
 
   const isActive = (program: Program) =>
-    activeProgram?.enrollment.programId === program.id;
+    activeEnrollment?.enrollment.programId === program.id;
 
   return (
     <Page title="Programs">
@@ -217,7 +226,7 @@ export const ProgramsPage = () => {
             <DialogTitle>Switch program?</DialogTitle>
             <DialogDescription>
               You already have an active program
-              {activeProgram ? ` (${activeProgram.program.title})` : ''}.
+              {activeEnrollment ? ` (${activeEnrollment.program.title})` : ''}.
               Starting a new one abandons your current progress.
             </DialogDescription>
           </DialogHeader>

--- a/src/pages/StartWorkoutPage/StartWorkoutPage.tsx
+++ b/src/pages/StartWorkoutPage/StartWorkoutPage.tsx
@@ -6,6 +6,8 @@ import {
   AnalyticsEvent,
   RepeatableWorkout,
   trackEvent,
+  useActiveProgram,
+  useCompleteProgramSession,
   useWorkoutLogs,
 } from '~/api';
 import { Page } from '~/components';
@@ -17,6 +19,7 @@ import { CURATED_WORKOUTS_VERSION } from '~/constants';
 import {
   DEFAULT_MOVEMENT_OPTIONS,
   DEFAULT_WORKOUT_OPTIONS,
+  PendingProgramSession,
   useSession,
   useWorkoutOptions,
 } from '~/contexts';
@@ -44,6 +47,7 @@ import {
   ModifyWorkoutButtons,
   MovementAutocomplete,
   MovementsHeader,
+  NextProgramWorkoutCard,
   RecommendSessionSection,
   RecommendedWorkoutsSection,
   Section,
@@ -95,13 +99,34 @@ export const StartWorkoutPage = ({
   const [workoutOptions] = useWorkoutOptions();
   const { curated, recentRepeats } = useRecommendedWorkouts();
 
+  // Program tracking (Slice 3), behind the `programs` flag. The query is gated so
+  // non-program builds fire zero extra requests (zero regression). `data` is
+  // undefined only while the enabled query is still loading, so `programGate-
+  // Pending` reliably holds the page in browse mode until we know whether to
+  // surface the next-workout card — avoiding a builder→card flash on open.
+  const activeProgramQuery = useActiveProgram({ enabled: features.programs });
+  const activeProgram = activeProgramQuery.data ?? null;
+  const hasActiveProgram = Boolean(activeProgram);
+  const programGatePending =
+    features.programs &&
+    !programSaveMode &&
+    activeProgramQuery.data === undefined;
+  const completeProgramSession = useCompleteProgramSession();
+
   // Discovery surfaces are individually flag-gated (PROD-174). With every one
   // off, there's nothing to browse, so the page is the pure custom builder. In
-  // save-session mode the page is always the builder — no browse surfaces.
+  // save-session mode the page is always the builder — no browse surfaces. An
+  // active program forces browse so its next-workout card is the first thing the
+  // user sees on open.
   const showCurated = features.curatedFirstWorkout;
   const showRepeat = features.repeatPrevious;
   const showBrowse =
-    !programSaveMode && (showCurated || showRepeat || features.recommender);
+    !programSaveMode &&
+    (hasActiveProgram ||
+      programGatePending ||
+      showCurated ||
+      showRepeat ||
+      features.recommender);
 
   // When a discovery surface is enabled the page opens in "browse" mode
   // (recommendations + a Build-custom button); selecting one or tapping
@@ -121,6 +146,11 @@ export const StartWorkoutPage = ({
   const [startSourceProps, setStartSourceProps] = useState<
     Record<string, string | number | boolean | null>
   >({});
+  // Program session the builder was loaded from (Slice 3), carried into the log
+  // step so completion advances the program. Cleared whenever a non-program
+  // surface loads the builder, so a stale session never attaches.
+  const [pendingProgramSession, setPendingProgramSession] =
+    useState<PendingProgramSession | null>(null);
 
   // Save-session mode only: the title for the program session being authored.
   const [sessionTitle, setSessionTitle] = useState<string>('');
@@ -151,6 +181,19 @@ export const StartWorkoutPage = ({
     // Depend on the stable user id, not the session object (which is replaced on
     // every token refresh), so this effect doesn't needlessly re-run.
     [userId, workoutLogs],
+  );
+
+  useEffect(
+    function dropIntoBuilderWhenNothingToBrowse() {
+      // The initial `showBuilder` is fixed at mount, before the (async) program
+      // gate resolves. If it resolves to "no program" and there is nothing else
+      // to browse, fall into the builder — matching the non-program default —
+      // so the page never renders blank (neither browse nor builder).
+      if (!programGatePending && !showBrowse && !showBuilder) {
+        setShowBuilder(true);
+      }
+    },
+    [programGatePending, showBrowse, showBuilder],
   );
 
   const [workoutGoal, setWorkoutGoal] = useState<number>(
@@ -436,6 +479,7 @@ export const StartWorkoutPage = ({
       template_id: workout.id,
       curated_version: CURATED_WORKOUTS_VERSION,
     });
+    setPendingProgramSession(null);
     setShowBuilder(true);
   };
 
@@ -443,6 +487,7 @@ export const StartWorkoutPage = ({
     loadIntoBuilder(repeat.workoutOptions);
     setStartSource('history_repeat');
     setStartSourceProps({ workout_log_id: repeat.workoutLogId });
+    setPendingProgramSession(null);
     setShowBuilder(true);
   };
 
@@ -455,6 +500,7 @@ export const StartWorkoutPage = ({
     loadIntoBuilder(recommendationToWorkoutOptions(recommendation));
     setStartSource('recommender');
     setStartSourceProps({ recommendation_id: recommendationId });
+    setPendingProgramSession(null);
     setShowBuilder(true);
   };
 
@@ -462,10 +508,45 @@ export const StartWorkoutPage = ({
     loadIntoBuilder(DEFAULT_WORKOUT_OPTIONS);
     setStartSource('builder');
     setStartSourceProps({});
+    setPendingProgramSession(null);
     setShowBuilder(true);
   };
 
-  const handleBackToRecommendations = () => setShowBuilder(false);
+  // Load the program's next session into the builder for review/edits, tagged so
+  // the eventual start attributes to `program` and the log step advances it.
+  const handleStartProgram = () => {
+    if (!activeProgram?.nextSession) return;
+    const { session } = activeProgram.nextSession;
+    loadIntoBuilder(activeProgram.nextSession.workoutOptions);
+    setStartSource('program');
+    setStartSourceProps({
+      user_program_id: activeProgram.enrollment.id,
+      program_session_id: session.id,
+    });
+    setPendingProgramSession({
+      userProgramId: activeProgram.enrollment.id,
+      programSessionId: session.id,
+    });
+    setShowBuilder(true);
+  };
+
+  // Skip the next session: writes a `skipped` completion (no workout_log), which
+  // advances the cursor to the following session without leaving the home card.
+  const handleSkipProgram = () => {
+    if (!activeProgram?.nextSession || completeProgramSession.isLoading) return;
+    completeProgramSession.mutate({
+      userProgramId: activeProgram.enrollment.id,
+      programSessionId: activeProgram.nextSession.session.id,
+      status: 'skipped',
+    });
+  };
+
+  const handleBackToRecommendations = () => {
+    setStartSource('builder');
+    setStartSourceProps({});
+    setPendingProgramSession(null);
+    setShowBuilder(false);
+  };
 
   const handleClickStart = () => {
     startWorkout(
@@ -489,6 +570,7 @@ export const StartWorkoutPage = ({
         movement_count: movements.length,
         workout_goal_units: workoutGoalUnits,
       },
+      pendingProgramSession,
     );
   };
 
@@ -562,6 +644,18 @@ export const StartWorkoutPage = ({
     >
       {!showBuilder && showBrowse && (
         <>
+          {activeProgram && (
+            <NextProgramWorkoutCard
+              programTitle={activeProgram.program.title}
+              nextSession={activeProgram.nextSession}
+              progress={activeProgram.progress}
+              isComplete={activeProgram.isComplete}
+              onStart={handleStartProgram}
+              onSkip={handleSkipProgram}
+              skipping={completeProgramSession.isLoading}
+            />
+          )}
+
           <RecommendedWorkoutsSection
             curated={showCurated ? curated : []}
             recentRepeats={showRepeat ? recentRepeats : []}

--- a/src/pages/StartWorkoutPage/components/NextProgramWorkoutCard.test.tsx
+++ b/src/pages/StartWorkoutPage/components/NextProgramWorkoutCard.test.tsx
@@ -1,0 +1,123 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { vi } from 'vitest';
+
+import { NextProgramSession, ProgramProgress } from '~/api';
+
+import { NextProgramWorkoutCard } from './NextProgramWorkoutCard';
+
+const nextSession: NextProgramSession = {
+  session: {
+    id: 'ps-8',
+    programId: 'prog-1',
+    sequenceIndex: 7, // 8th session
+    weekNumber: 3,
+    dayNumber: 2,
+    title: 'Ladders 1-2-3-4',
+    notes: null,
+    workoutOptions: {
+      complexSet: false,
+      intervalTimer: 0,
+      movements: [],
+      restTimer: 0,
+      sharedWeightOneUnit: null,
+      sharedWeightOneValue: null,
+      sharedWeightTwoUnit: null,
+      sharedWeightTwoValue: null,
+      workoutDetails: null,
+      workoutGoal: 30,
+      workoutGoalUnits: 'minutes',
+    },
+  },
+  workoutOptions: {
+    complexSet: false,
+    intervalTimer: 0,
+    movements: [],
+    restTimer: 0,
+    sharedWeightOneUnit: null,
+    sharedWeightOneValue: null,
+    sharedWeightTwoUnit: null,
+    sharedWeightTwoValue: null,
+    workoutDetails: null,
+    workoutGoal: 30,
+    workoutGoalUnits: 'minutes',
+  },
+};
+
+const progress: ProgramProgress = {
+  completed: 7,
+  total: 14,
+  week: 3,
+  day: 2,
+};
+
+describe('NextProgramWorkoutCard', () => {
+  it('renders the next session with week/day, session chip, duration and actions', () => {
+    const onStart = vi.fn();
+    const onSkip = vi.fn();
+
+    render(
+      <NextProgramWorkoutCard
+        programTitle="Dry Fighting Weight"
+        nextSession={nextSession}
+        progress={progress}
+        isComplete={false}
+        onStart={onStart}
+        onSkip={onSkip}
+        skipping={false}
+      />,
+    );
+
+    expect(screen.getByText('Dry Fighting Weight')).toBeInTheDocument();
+    expect(screen.getByText('Week 3 · Day 2')).toBeInTheDocument();
+    expect(screen.getByText('Ladders 1-2-3-4')).toBeInTheDocument();
+    // sequenceIndex 7 → "Session 8 of 14".
+    expect(screen.getByText('Session 8 of 14')).toBeInTheDocument();
+    expect(screen.getByText('~30 min')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Start next workout' }));
+    expect(onStart).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Skip' }));
+    expect(onSkip).toHaveBeenCalledTimes(1);
+  });
+
+  it('disables the actions while a skip is in flight', () => {
+    render(
+      <NextProgramWorkoutCard
+        programTitle="Dry Fighting Weight"
+        nextSession={nextSession}
+        progress={progress}
+        isComplete={false}
+        onStart={vi.fn()}
+        onSkip={vi.fn()}
+        skipping
+      />,
+    );
+
+    expect(
+      screen.getByRole('button', { name: 'Start next workout' }),
+    ).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'Skipping…' })).toBeDisabled();
+  });
+
+  it('renders the complete state when the program is finished', () => {
+    render(
+      <NextProgramWorkoutCard
+        programTitle="Dry Fighting Weight"
+        nextSession={null}
+        progress={{ completed: 14, total: 14, week: 5, day: 3 }}
+        isComplete
+        onStart={vi.fn()}
+        onSkip={vi.fn()}
+        skipping={false}
+      />,
+    );
+
+    expect(screen.getByText('🎉 Program complete')).toBeInTheDocument();
+    expect(screen.getByText(/finished all 14 sessions/i)).toBeInTheDocument();
+    // No start/skip actions in the complete state.
+    expect(
+      screen.queryByRole('button', { name: 'Start next workout' }),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/src/pages/StartWorkoutPage/components/NextProgramWorkoutCard.tsx
+++ b/src/pages/StartWorkoutPage/components/NextProgramWorkoutCard.tsx
@@ -1,0 +1,93 @@
+import { NextProgramSession, ProgramProgress } from '~/api';
+import { Button } from '~/components/ui/button';
+import { Card } from '~/components/ui/card';
+import { WorkoutGoalUnits } from '~/types';
+
+export interface NextProgramWorkoutCardProps {
+  /** The active program's title. */
+  programTitle: string;
+  /** The next unsatisfied session, or `null` when the program is complete. */
+  nextSession: NextProgramSession | null;
+  progress: ProgramProgress;
+  isComplete: boolean;
+  /** Load the next session into the builder for review, then start. */
+  onStart: () => void;
+  /** Record a `skipped` completion, advancing the cursor without a workout. */
+  onSkip: () => void;
+  /** Whether a skip is in flight (disables both actions). */
+  skipping: boolean;
+}
+
+const estimatedDuration = (
+  goal: number,
+  units: WorkoutGoalUnits,
+): string | null => {
+  if (units === 'minutes') return `~${goal} min`;
+  if (units === 'rounds') return `${goal} rounds`;
+  return null; // volume goals have no meaningful time estimate here
+};
+
+export const NextProgramWorkoutCard = ({
+  programTitle,
+  nextSession,
+  progress,
+  isComplete,
+  onStart,
+  onSkip,
+  skipping,
+}: NextProgramWorkoutCardProps) => {
+  if (isComplete || !nextSession) {
+    return (
+      <Card className="flex flex-col gap-1 p-2">
+        <span className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+          {programTitle}
+        </span>
+        <span className="text-sm font-semibold">🎉 Program complete</span>
+        <span className="text-sm text-muted-foreground">
+          You finished all {progress.total} sessions. Pick a new program to keep
+          going.
+        </span>
+      </Card>
+    );
+  }
+
+  const { session, workoutOptions } = nextSession;
+  const sessionNumber = session.sequenceIndex + 1;
+  const duration = estimatedDuration(
+    workoutOptions.workoutGoal,
+    workoutOptions.workoutGoalUnits,
+  );
+
+  return (
+    <Card className="flex flex-col gap-1 p-2">
+      <div className="flex items-center justify-between gap-1">
+        <span className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+          {programTitle}
+        </span>
+        <span className="rounded bg-secondary px-0.5 text-xs text-secondary-foreground">
+          Session {sessionNumber} of {progress.total}
+        </span>
+      </div>
+
+      <div className="flex items-baseline gap-1">
+        <span className="text-sm font-semibold leading-none">
+          Week {session.weekNumber} · Day {session.dayNumber}
+        </span>
+        {duration && (
+          <span className="text-xs text-muted-foreground">{duration}</span>
+        )}
+      </div>
+
+      <span className="text-sm text-muted-foreground">{session.title}</span>
+
+      <div className="mt-0.5 flex gap-1">
+        <Button className="flex-1" onClick={onStart} disabled={skipping}>
+          Start next workout
+        </Button>
+        <Button variant="secondary" onClick={onSkip} disabled={skipping}>
+          {skipping ? 'Skipping…' : 'Skip'}
+        </Button>
+      </div>
+    </Card>
+  );
+};

--- a/src/pages/StartWorkoutPage/components/index.ts
+++ b/src/pages/StartWorkoutPage/components/index.ts
@@ -2,6 +2,7 @@ export * from './AddToWorkoutSection';
 export * from './BuildNewWorkoutDivider';
 export * from './ModifyCountButtons';
 export * from './MovementsHeader';
+export * from './NextProgramWorkoutCard';
 export * from './RecommendedWorkoutCard';
 export * from './RecommendedWorkoutsSection';
 export * from './WorkoutAddonToggle';

--- a/supabase/migrations/20260707000000_create_complete_program_session_function.sql
+++ b/supabase/migrations/20260707000000_create_complete_program_session_function.sql
@@ -1,0 +1,87 @@
+-- Program Tracking Slice 3: complete_program_session().
+--
+-- Advances a user's active program by one session: records a completion (or a
+-- skip) and, when that satisfies the final unsatisfied session, flips the
+-- enrollment to 'completed'. Doing the insert + last-session check + status flip
+-- in one plpgsql function makes the advance atomic — a completion never lands
+-- without its terminal status flip, and vice versa.
+--
+--   p_workout_log_id  the real workout_logs.id for a completed session, or NULL
+--                     for a skip (status='skipped').
+--   p_status          'completed' (default) or 'skipped'.
+--
+-- Returns TRUE when this call completed the whole program (all sessions now
+-- satisfied), else FALSE — the client uses it only for messaging; it invalidates
+-- the active-program query either way.
+--
+-- SECURITY INVOKER (house default, cf. enroll_in_program / pattern_debt_window):
+-- every write is permitted by the caller's own RLS — they own the user_programs
+-- row and the completions they insert — so no privilege escalation is needed.
+CREATE OR REPLACE FUNCTION public.complete_program_session(
+  p_user_program_id uuid,
+  p_program_session_id uuid,
+  p_workout_log_id bigint DEFAULT NULL,
+  p_status text DEFAULT 'completed'
+)
+RETURNS boolean
+LANGUAGE plpgsql
+SECURITY INVOKER
+SET search_path = public
+AS $$
+DECLARE
+  v_user_id    uuid := auth.uid();
+  v_program_id uuid;
+  v_total      int;
+  v_satisfied  int;
+  v_all_done   boolean;
+BEGIN
+  IF v_user_id IS NULL THEN
+    RAISE EXCEPTION 'Not authenticated';
+  END IF;
+
+  IF p_status NOT IN ('completed', 'skipped') THEN
+    RAISE EXCEPTION 'Invalid completion status: %', p_status;
+  END IF;
+
+  -- Confirm the enrollment is the caller's own and capture its program (the
+  -- user-owned clone). RLS also guards this, but the explicit check yields a
+  -- clear error and the program_id in one round trip.
+  SELECT program_id INTO v_program_id
+  FROM user_programs
+  WHERE id = p_user_program_id AND user_id = v_user_id;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Enrollment % not found or not owned by caller', p_user_program_id;
+  END IF;
+
+  -- A session is satisfied at most once per enrollment (UNIQUE guard). Make a
+  -- duplicate fire (e.g. a double onSuccess, or a retry) a harmless no-op rather
+  -- than a unique violation.
+  INSERT INTO program_session_completions
+    (user_program_id, program_session_id, user_id, workout_log_id, status)
+  VALUES
+    (p_user_program_id, p_program_session_id, v_user_id, p_workout_log_id, p_status)
+  ON CONFLICT (user_program_id, program_session_id) DO NOTHING;
+
+  -- Is every session in the program now satisfied?
+  SELECT count(*) INTO v_total
+  FROM program_sessions
+  WHERE program_id = v_program_id;
+
+  SELECT count(*) INTO v_satisfied
+  FROM program_session_completions
+  WHERE user_program_id = p_user_program_id;
+
+  v_all_done := v_total > 0 AND v_satisfied >= v_total;
+
+  IF v_all_done THEN
+    UPDATE user_programs
+      SET status = 'completed', completed_at = NOW()
+      WHERE id = p_user_program_id AND status = 'active';
+  END IF;
+
+  RETURN v_all_done;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.complete_program_session(uuid, uuid, bigint, text) FROM public;
+GRANT EXECUTE ON FUNCTION public.complete_program_session(uuid, uuid, bigint, text) TO authenticated;

--- a/types/supabase.ts
+++ b/types/supabase.ts
@@ -847,6 +847,15 @@ export type Database = {
           users_with_first_workout: number
         }[]
       }
+      complete_program_session: {
+        Args: {
+          p_program_session_id: string
+          p_status?: string
+          p_user_program_id: string
+          p_workout_log_id?: number
+        }
+        Returns: boolean
+      }
       enroll_in_program: { Args: { p_program_id: string }; Returns: string }
       has_premium_access: { Args: { user_id: string }; Returns: boolean }
       pattern_debt_window: {


### PR DESCRIPTION
## Intent

Build Slice 3 (PR 3) of the Bellskill program-tracking feature: next-workout home surfacing, all behind the existing `programs` feature flag. Slices 1 (schema + enroll_in_program RPC + seeded DFW) and 2 (programs flag + creation/enrollment UI + Programs nav) are already merged; this builds on them.

Scope delivered: (1) A new complete_program_session SQL migration/RPC (SECURITY INVOKER, mirrors enroll_in_program) that atomically records a completion or skip, checks whether all sessions are satisfied, and flips user_programs.status to 'completed'+completed_at on the last one; idempotent via ON CONFLICT so a duplicate onSuccess is a no-op. Regenerated the repo-root types/supabase.ts. (2) Extended the existing Slice-2 useActiveProgram hook to derive nextSession (lowest-sequence_index session with no completion — the design's §3.6 next-unsatisfied query, done client-side over the ≤~15 sessions because a SQL function buys nothing at that size), progress {completed,total,week,day}, and isComplete. Deliberate decision: it now returns the active-OR-most-recently-completed enrollment (not active-only) so the '🎉 complete' card still renders after the RPC flips status to completed; to keep Slice-2 ProgramsPage correct I guarded its enroll/active-badge logic on enrollment.status==='active' and updated its test mock. (3) NextProgramWorkoutCard at the top of browse mode: program title, 'Week N · Day N · title', 'Session N of M' chip, estimated duration, primary 'Start next workout' + secondary 'Skip', plus a complete state. (4) StartWorkoutPage forces browse mode when an active program exists (added hasActiveProgram || to the showBrowse gate) with a programGatePending guard so the page holds in browse until the async program query resolves, avoiding a builder→card flash; Start loads the session into the builder for review/edit then starts normally; Skip writes a status='skipped' completion. (5) Added 'program' to the WorkoutStartSource union. (6) Program context {user_program_id, program_session_id} threads card→start→log via a NEW ProgramSessionContext (a sibling provider of WorkoutOptionsProvider in App.tsx), set by useStartWorkout and read in useLogWorkout.onSuccess to insert the completion linked to the new workout_logs.id — intentionally NOT a new workout_logs column; the existing log insert path is untouched and the completion is the only added write. ProgramSessionContext has a graceful default value ([null, noop]) so story/test renders without the provider degrade to 'no pending session'.

Edge cases handled per design §5.4: no active program → query gated off by the flag, zero regression, home unchanged; program complete → 🎉 card; skip/rest handled; start-then-bail (no log) leaves the session next-up. Everything is flag-gated (programs, default off) so production users with the flag off see zero change. Did NOT build the Slice-4 progress page. Verified locally: npm run compile:ts and npm run lint clean; npm test 349 pass (9 new: useActiveProgram derivation, useCompleteProgramSession, NextProgramWorkoutCard); npm run test:e2e 12 pass (4 new program-next-workout DB-behavior specs); npx supabase db reset applies the new migration cleanly. Also documented the program-tracking architecture in AGENTS.md.

## What Changed

- Added the `complete_program_session` SQL RPC (SECURITY INVOKER, idempotent via `ON CONFLICT`) that records a completion or skip, advances the enrollment, and flips `user_programs.status` to `completed` on the final session; regenerated repo-root `types/supabase.ts`.
- Extended `useActiveProgram` to derive `nextSession`, `progress`, and `isComplete` client-side and to return the active-or-most-recently-completed enrollment (guarding `ProgramsPage` on `status === 'active'`); added `useCompleteProgramSession`.
- Surfaced `NextProgramWorkoutCard` (next-workout + skip + 🎉 complete states) at the top of browse mode and forced `StartWorkoutPage` into browse when an active program exists, gated by a `programGatePending` guard to avoid a builder→card flash.
- Threaded `{ userProgramId, programSessionId }` from card → start → log via a new `ProgramSessionContext`, written in `useStartWorkout` and read in `useLogWorkout.onSuccess` to insert the linked completion; added `program` to the workout start-source union and documented the architecture in `AGENTS.md`, with new unit and `program-next-workout` e2e coverage.

## Risk Assessment

✅ Low: The change is fully behind the default-off `programs` flag with a clean zero-regression path, an atomic and idempotent RPC, careful async gating, and unit + e2e coverage; only minor, recoverable edge-case concerns remain.

## Testing

Ran the full Vitest suite (349/349, including the 9 new Slice-3 unit tests) and the 4 new program-next-workout Playwright specs against the running local Supabase, which pass and exercise the real `complete_program_session` RPC (advance+link-log, skip, final-session completed flip, idempotency). The e2e run initially failed because the gitignored `.env.e2e` config file was absent locally — a setup gap I fixed by creating it from `.env.e2e.example` with the local Supabase URL/anon key, after which all 4 specs passed. For the UI-facing home-surfacing change I captured reviewer-visible screenshots of the new NextProgramWorkoutCard in its next-workout, in-flight-skip, and program-complete states via a temporary Storybook story rendered headlessly; the story file and all other transient artifacts were removed afterward, leaving the worktree clean and the screenshots in the evidence directory.

- Evidence: NextProgramWorkoutCard — next-workout state (local file: <code>/var/folders/2p/zdp7pmgx05z1k3dd8xyttrv80000gn/T/no-mistakes-evidence/01KWYQQ7EPGGYXCMN92AG6YNMB/NextProgramWorkoutCard-next-workout.png</code>)
- Evidence: NextProgramWorkoutCard — skipping (in-flight, disabled) state (local file: <code>/var/folders/2p/zdp7pmgx05z1k3dd8xyttrv80000gn/T/no-mistakes-evidence/01KWYQQ7EPGGYXCMN92AG6YNMB/NextProgramWorkoutCard-skipping.png</code>)
- Evidence: NextProgramWorkoutCard — program complete state (local file: <code>/var/folders/2p/zdp7pmgx05z1k3dd8xyttrv80000gn/T/no-mistakes-evidence/01KWYQQ7EPGGYXCMN92AG6YNMB/NextProgramWorkoutCard-complete.png</code>)
<details>
<summary>Evidence: program-next-workout e2e run (RPC end-to-end against local Postgres)</summary>

```text
Running 4 tests using 1 worker
✓ completing a session advances the cursor and links the workout log (177ms)
✓ skipping writes a skipped completion (no log) and advances (105ms)
✓ satisfying every session flips the enrollment to completed (155ms)
✓ a duplicate completion is a harmless no-op (idempotent) (83ms)
4 passed (1.5s)
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 3 infos</summary>

- ℹ️ `src/api/useLogWorkout.ts:53` - useLogWorkout.onSuccess fires completeProgramSession as fire-and-forget and clears the pending session context first. On a transient failure the workout is logged but the program does not advance and only console.error surfaces it. This is recoverable (useActiveProgram re-derives from completions, so the same session stays &#39;next-up&#39; and can be redone/skipped), and the fire-and-forget behavior is deliberate — but there is no retry or user-visible signal.
- ℹ️ `src/pages/StartWorkoutPage/StartWorkoutPage.tsx:110` - programGatePending stays true if the active-program query errors (data remains undefined), which keeps showBrowse forced true and prevents the auto-fall-into-builder effect from ever firing. With the programs flag on and no other browse surfaces (curated/repeat/recommender all off), a query error leaves an empty browse view. The &#39;Build custom workout&#39; button still provides an escape hatch, so it degrades rather than locks, but the page never falls into the builder-by-default on error.
- ℹ️ `src/pages/ProgramsPage/ProgramsPage.tsx:31` - ProgramsPage calls useActiveProgram() (enabled defaults true), which now additionally fetches program_sessions and program_session_completions to derive nextSession/progress that ProgramsPage never uses — two extra round trips per visit. Bounded (≤~15 sessions) and the page is nav-gated behind the flag, so low impact, but the derivation work is wasted here.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`npx vitest run` — full suite, 349/349 pass (incl. useActiveProgram.test.ts, useCompleteProgramSession.test.ts, NextProgramWorkoutCard.test.tsx, ProgramsPage.test.tsx)</code>
- <code>Rendered `NextProgramWorkoutCard` in Storybook and screenshotted the next-workout, skipping, and complete states via headless Playwright</code>
- <code>`npx playwright test e2e/program-next-workout.spec.ts` — 4/4 pass against local Supabase (complete/skip/advance, terminal status flip, idempotent duplicate) after fixing the missing `.env.e2e` local setup file</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
