### PR TITLE
feat(programs): add program progress views (Slice 4)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -141,6 +141,15 @@ from the completions set**, never a stored cursor.
   and read in `useLogWorkout.onSuccess` to write the completion linked to the new
   `workout_logs.id`. The linkage is deliberately **NOT** a `workout_logs` column
   — the completion row is the only new write; the existing log path is untouched.
+- **Progress view (Slice 4):** `ProgramProgressPage` at `programs/:id` renders
+  the program's sessions grouped by week as done ✓ / skipped ⊘ / upcoming chips,
+  plus an "N of M sessions" / "Week X of Y" summary. State is derived by
+  `useProgramProgress(programId)` **entirely** from the enrollment's
+  `program_session_completions` joined to `program_sessions` — nothing from
+  `workout_logs`. Completed chips link to `/history/<workout_log_id>` (the
+  completion row carries the log id), reusing `CompletedWorkoutPage` verbatim.
+  Entry points: each `ProgramsPage` "My programs" card and the home
+  `NextProgramWorkoutCard` (`onViewProgress`).
 - DB behaviors (RLS, the advance/skip/flip RPC, idempotency) are covered by
   Playwright e2e against the local Supabase (`e2e/program-*.spec.ts`), not MSW.
 

--- a/e2e/program-progress.spec.ts
+++ b/e2e/program-progress.spec.ts
@@ -1,0 +1,188 @@
+import { expect, test } from '@playwright/test';
+
+// Slice 4 read contract: the progress page derives done / skipped / upcoming
+// state (and the history link) entirely from the `program_session_completions`
+// set joined to `program_sessions` — nothing from `workout_logs`. This asserts
+// the exact REST shape `useProgramProgress` consumes against the LOCAL Supabase,
+// mirroring program-next-workout.spec.ts (real-Postgres behavior, no browser).
+
+const SUPABASE_URL = process.env.VITE_SUPABASE_URL!;
+const SUPABASE_ANON_KEY = process.env.VITE_SUPABASE_ANON_KEY!;
+const DFW_SLUG = 'dry-fighting-weight';
+
+interface TestUser {
+  token: string;
+  uid: string;
+  email: string;
+}
+
+async function signUpThrowawayUser(): Promise<TestUser> {
+  const email = `progview-${Date.now()}-${Math.floor(Math.random() * 1e9)}@example.com`;
+  const password = 'testpassword123';
+
+  const res = await fetch(`${SUPABASE_URL}/auth/v1/signup`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', apikey: SUPABASE_ANON_KEY },
+    body: JSON.stringify({ email, password }),
+  });
+  if (!res.ok)
+    throw new Error(`signup failed (${res.status}): ${await res.text()}`);
+
+  const body = (await res.json()) as {
+    access_token?: string;
+    user?: { id: string };
+  };
+  if (body.access_token && body.user) {
+    return { token: body.access_token, uid: body.user.id, email };
+  }
+  throw new Error('signup did not return a session');
+}
+
+interface RestOptions {
+  body?: unknown;
+  prefer?: string;
+}
+
+async function restJson<T = unknown>(
+  method: string,
+  path: string,
+  token: string,
+  opts: RestOptions = {},
+): Promise<T> {
+  const headers: Record<string, string> = {
+    apikey: SUPABASE_ANON_KEY,
+    Authorization: `Bearer ${token}`,
+  };
+  if (opts.body !== undefined) headers['Content-Type'] = 'application/json';
+  if (opts.prefer) headers['Prefer'] = opts.prefer;
+  const res = await fetch(`${SUPABASE_URL}/rest/v1/${path}`, {
+    method,
+    headers,
+    body: opts.body !== undefined ? JSON.stringify(opts.body) : undefined,
+  });
+  if (!res.ok) {
+    throw new Error(
+      `${method} ${path} failed (${res.status}): ${await res.text()}`,
+    );
+  }
+  return res.json() as Promise<T>;
+}
+
+async function rpc<T = unknown>(
+  fn: string,
+  token: string,
+  args: Record<string, unknown>,
+): Promise<T> {
+  const res = await fetch(`${SUPABASE_URL}/rest/v1/rpc/${fn}`, {
+    method: 'POST',
+    headers: {
+      apikey: SUPABASE_ANON_KEY,
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(args),
+  });
+  if (!res.ok)
+    throw new Error(`rpc ${fn} failed (${res.status}): ${await res.text()}`);
+  return res.json() as Promise<T>;
+}
+
+async function insertWorkoutLog(user: TestUser): Promise<number> {
+  const [row] = await restJson<Array<{ id: number }>>(
+    'POST',
+    'workout_logs',
+    user.token,
+    {
+      prefer: 'return=representation',
+      body: {
+        user_id: user.uid,
+        started_at: new Date().toISOString(),
+        movements: ['Clean and Press'],
+        completed_reps: 10,
+        completed_rounds: 1,
+        completed_rungs: 1,
+        workout_goal: 30,
+      },
+    },
+  );
+  return row.id;
+}
+
+type SessionState = 'done' | 'skipped' | 'upcoming';
+
+test.describe('program progress — derived view', () => {
+  test('completions map sessions to done/skipped/upcoming with the log link', async () => {
+    const user = await signUpThrowawayUser();
+    const [dfw] = await restJson<Array<{ id: string }>>(
+      'GET',
+      `programs?slug=eq.${DFW_SLUG}&select=id`,
+      user.token,
+    );
+    const userProgramId = await rpc<string>('enroll_in_program', user.token, {
+      p_program_id: dfw.id,
+    });
+    const [{ program_id: cloneId }] = await restJson<
+      Array<{ program_id: string }>
+    >(
+      'GET',
+      `user_programs?id=eq.${userProgramId}&select=program_id`,
+      user.token,
+    );
+
+    // Ordered sessions — exactly what the hook fetches.
+    const sessions = await restJson<
+      Array<{ id: string; sequence_index: number; week_number: number }>
+    >(
+      'GET',
+      `program_sessions?program_id=eq.${cloneId}&select=id,sequence_index,week_number&order=sequence_index.asc`,
+      user.token,
+    );
+    expect(sessions.length).toBeGreaterThanOrEqual(3);
+
+    // Complete session 0 against a real log; skip session 1; leave the rest.
+    const logId = await insertWorkoutLog(user);
+    await rpc('complete_program_session', user.token, {
+      p_user_program_id: userProgramId,
+      p_program_session_id: sessions[0].id,
+      p_workout_log_id: logId,
+    });
+    await rpc('complete_program_session', user.token, {
+      p_user_program_id: userProgramId,
+      p_program_session_id: sessions[1].id,
+      p_status: 'skipped',
+    });
+
+    // The completion set the page derives progress from.
+    const completions = await restJson<
+      Array<{
+        program_session_id: string;
+        status: string;
+        workout_log_id: number | null;
+      }>
+    >(
+      'GET',
+      `program_session_completions?user_program_id=eq.${userProgramId}&select=program_session_id,status,workout_log_id`,
+      user.token,
+    );
+    const byId = new Map(completions.map((c) => [c.program_session_id, c]));
+
+    const derive = (
+      id: string,
+    ): { state: SessionState; logId: number | null } => {
+      const c = byId.get(id);
+      if (!c) return { state: 'upcoming', logId: null };
+      return {
+        state: c.status === 'skipped' ? 'skipped' : 'done',
+        logId: c.status === 'skipped' ? null : c.workout_log_id,
+      };
+    };
+
+    expect(derive(sessions[0].id)).toEqual({ state: 'done', logId });
+    expect(derive(sessions[1].id)).toEqual({ state: 'skipped', logId: null });
+    expect(derive(sessions[2].id)).toEqual({ state: 'upcoming', logId: null });
+
+    // "N of M sessions": 2 satisfied of all sessions.
+    const satisfied = sessions.filter((s) => byId.has(s.id)).length;
+    expect(satisfied).toBe(2);
+  });
+});

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -15,6 +15,7 @@ export * from './useCreateProgram';
 export * from './useDuplicateProgramSession';
 export * from './useEnrollProgram';
 export * from './useProgram';
+export * from './useProgramProgress';
 export * from './usePrograms';
 export * from './useSaveProgramSession';
 export * from './useRecentRepeatableWorkouts';

--- a/src/api/program.ts
+++ b/src/api/program.ts
@@ -1,6 +1,8 @@
 import {
   Program,
   ProgramSession,
+  ProgramSessionCompletion,
+  ProgramSessionCompletionStatus,
   UserProgram,
   UserProgramStatus,
   WorkoutOptions,
@@ -12,6 +14,8 @@ type ProgramRow = Database['public']['Tables']['programs']['Row'];
 type ProgramSessionRow =
   Database['public']['Tables']['program_sessions']['Row'];
 type UserProgramRow = Database['public']['Tables']['user_programs']['Row'];
+type ProgramSessionCompletionRow =
+  Database['public']['Tables']['program_session_completions']['Row'];
 
 /** camelCase mapper for a raw `programs` row. */
 export const mapProgramRow = (row: ProgramRow): Program => ({
@@ -47,6 +51,19 @@ export const mapProgramSessionRow = (
     'startedAt'
   >,
   notes: row.notes,
+});
+
+/** camelCase mapper for a raw `program_session_completions` row. */
+export const mapProgramSessionCompletionRow = (
+  row: ProgramSessionCompletionRow,
+): ProgramSessionCompletion => ({
+  id: row.id,
+  userProgramId: row.user_program_id,
+  programSessionId: row.program_session_id,
+  userId: row.user_id,
+  workoutLogId: row.workout_log_id,
+  status: row.status as ProgramSessionCompletionStatus,
+  completedAt: row.completed_at,
 });
 
 /** camelCase mapper for a raw `user_programs` enrollment row. */

--- a/src/api/useProgramProgress.test.ts
+++ b/src/api/useProgramProgress.test.ts
@@ -1,0 +1,226 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { HttpResponse, http } from 'msw';
+import React from 'react';
+import { QueryClient, QueryClientProvider } from 'react-query';
+
+import { SessionProvider } from '~/contexts';
+import { server } from '~/mocks/server';
+
+import { VITE_SUPABASE_URL } from '../env';
+import { useProgramProgress } from './useProgramProgress';
+
+const base = `${VITE_SUPABASE_URL}/rest/v1`;
+
+const mockSession = {
+  user: {
+    id: 'user-123',
+    app_metadata: {},
+    user_metadata: {},
+    created_at: '',
+    aud: '',
+  },
+  access_token: '',
+  refresh_token: '',
+  expires_in: 10000,
+  token_type: '',
+};
+
+const makeWrapper = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return ({ children }: { children: React.ReactNode }) =>
+    React.createElement(
+      QueryClientProvider,
+      { client: queryClient },
+      React.createElement(SessionProvider, { value: mockSession }, children),
+    );
+};
+
+const programRow = {
+  id: 'prog-clone',
+  owner_id: 'user-123',
+  source_program_id: 'dfw',
+  slug: null,
+  title: 'Dry Fighting Weight',
+  description: null,
+  author_name: 'Geoff Neupert',
+  num_weeks: 2,
+  days_per_week: 2,
+  is_public: false,
+  created_at: '',
+};
+
+const sessionRow = (seq: number, week: number, day: number, title: string) => ({
+  id: `ps-${seq}`,
+  program_id: 'prog-clone',
+  sequence_index: seq,
+  week_number: week,
+  day_number: day,
+  title,
+  notes: null,
+  workout_options: {
+    complexSet: false,
+    intervalTimer: 0,
+    movements: [],
+    restTimer: 0,
+    sharedWeightOneUnit: null,
+    sharedWeightOneValue: null,
+    sharedWeightTwoUnit: null,
+    sharedWeightTwoValue: null,
+    workoutDetails: null,
+    workoutGoal: 30,
+    workoutGoalUnits: 'minutes',
+  },
+});
+
+// Two weeks × two days = four sessions.
+const fourSessions = [
+  sessionRow(0, 1, 1, 'W1D1'),
+  sessionRow(1, 1, 2, 'W1D2'),
+  sessionRow(2, 2, 1, 'W2D1'),
+  sessionRow(3, 2, 2, 'W2D2'),
+];
+
+const enrollmentRow = {
+  id: 'up-1',
+  user_id: 'user-123',
+  program_id: 'prog-clone',
+  status: 'active',
+  config: {},
+  started_at: '',
+  completed_at: null,
+};
+
+describe('useProgramProgress', () => {
+  it('derives done/skipped/upcoming states, counts, and week grouping', async () => {
+    server.use(
+      http.get(`${base}/programs`, () => HttpResponse.json(programRow)),
+      http.get(`${base}/program_sessions`, () =>
+        HttpResponse.json(fourSessions),
+      ),
+      http.get(`${base}/user_programs`, () =>
+        HttpResponse.json([enrollmentRow]),
+      ),
+      // Session 0 completed (links to log 42), session 1 skipped, sessions 2-3 upcoming.
+      http.get(`${base}/program_session_completions`, () =>
+        HttpResponse.json([
+          {
+            id: 'c-0',
+            user_program_id: 'up-1',
+            program_session_id: 'ps-0',
+            user_id: 'user-123',
+            workout_log_id: 42,
+            status: 'completed',
+            completed_at: '2026-07-01T00:00:00Z',
+          },
+          {
+            id: 'c-1',
+            user_program_id: 'up-1',
+            program_session_id: 'ps-1',
+            user_id: 'user-123',
+            workout_log_id: null,
+            status: 'skipped',
+            completed_at: '2026-07-02T00:00:00Z',
+          },
+        ]),
+      ),
+    );
+
+    const { result } = renderHook(() => useProgramProgress('prog-clone'), {
+      wrapper: makeWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    const data = result.current.data!;
+
+    expect(data.completedCount).toBe(2);
+    expect(data.totalCount).toBe(4);
+    expect(data.totalWeeks).toBe(2);
+    // Next unsatisfied session is W2D1 → current week 2.
+    expect(data.currentWeek).toBe(2);
+    expect(data.isComplete).toBe(false);
+
+    expect(data.weeks).toHaveLength(2);
+    expect(data.weeks[0].weekNumber).toBe(1);
+    expect(data.weeks[1].weekNumber).toBe(2);
+
+    const [done, skipped] = data.weeks[0].sessions;
+    expect(done.state).toBe('done');
+    expect(done.workoutLogId).toBe(42);
+    expect(skipped.state).toBe('skipped');
+    expect(skipped.workoutLogId).toBeNull();
+
+    expect(data.weeks[1].sessions.map((s) => s.state)).toEqual([
+      'upcoming',
+      'upcoming',
+    ]);
+  });
+
+  it('reports every session upcoming when the user has no enrollment', async () => {
+    server.use(
+      http.get(`${base}/programs`, () => HttpResponse.json(programRow)),
+      http.get(`${base}/program_sessions`, () =>
+        HttpResponse.json(fourSessions),
+      ),
+      http.get(`${base}/user_programs`, () => HttpResponse.json([])),
+    );
+
+    const { result } = renderHook(() => useProgramProgress('prog-clone'), {
+      wrapper: makeWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    const data = result.current.data!;
+
+    expect(data.enrollment).toBeNull();
+    expect(data.completedCount).toBe(0);
+    expect(data.totalCount).toBe(4);
+    expect(data.currentWeek).toBe(1);
+    expect(data.isComplete).toBe(false);
+    expect(
+      data.weeks
+        .flatMap((w) => w.sessions)
+        .every((s) => s.state === 'upcoming'),
+    ).toBe(true);
+  });
+
+  it('is complete once every session is satisfied', async () => {
+    server.use(
+      http.get(`${base}/programs`, () => HttpResponse.json(programRow)),
+      http.get(`${base}/program_sessions`, () =>
+        HttpResponse.json(fourSessions),
+      ),
+      http.get(`${base}/user_programs`, () =>
+        HttpResponse.json([
+          { ...enrollmentRow, status: 'completed', completed_at: '2026-07-06' },
+        ]),
+      ),
+      http.get(`${base}/program_session_completions`, () =>
+        HttpResponse.json(
+          fourSessions.map((s, i) => ({
+            id: `c-${i}`,
+            user_program_id: 'up-1',
+            program_session_id: s.id,
+            user_id: 'user-123',
+            workout_log_id: i,
+            status: 'completed',
+            completed_at: '2026-07-06T00:00:00Z',
+          })),
+        ),
+      ),
+    );
+
+    const { result } = renderHook(() => useProgramProgress('prog-clone'), {
+      wrapper: makeWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    const data = result.current.data!;
+
+    expect(data.completedCount).toBe(4);
+    expect(data.isComplete).toBe(true);
+    // No upcoming session → current week falls back to the last week.
+    expect(data.currentWeek).toBe(2);
+  });
+});

--- a/src/api/useProgramProgress.ts
+++ b/src/api/useProgramProgress.ts
@@ -1,0 +1,198 @@
+import { useQuery } from 'react-query';
+
+import { QUERIES } from '~/constants';
+import { useSession } from '~/contexts';
+import { Program, ProgramSession, UserProgram } from '~/types';
+
+import { supabase } from '../supabaseClient';
+import {
+  mapProgramRow,
+  mapProgramSessionCompletionRow,
+  mapProgramSessionRow,
+  mapUserProgramRow,
+} from './program';
+
+/** Per-session progress state within an enrollment. */
+export type SessionState = 'done' | 'skipped' | 'upcoming';
+
+export interface SessionProgress {
+  session: ProgramSession;
+  state: SessionState;
+  /**
+   * The logged `workout_logs.id` for a `done` session — the link target for the
+   * history view. `null` for skipped or upcoming sessions.
+   */
+  workoutLogId: number | null;
+}
+
+export interface WeekProgress {
+  weekNumber: number;
+  sessions: SessionProgress[];
+}
+
+export interface ProgramProgressResult {
+  program: Program;
+  /**
+   * The user's enrollment in this program, or `null` when they have never
+   * enrolled (every session then reads as `upcoming`).
+   */
+  enrollment: UserProgram | null;
+  /** Sessions grouped by week, each in program order. */
+  weeks: WeekProgress[];
+  /** Satisfied sessions (done + skipped) — the "N" in "N of M". */
+  completedCount: number;
+  /** Total sessions in the program — the "M" in "N of M". */
+  totalCount: number;
+  /** 1-based week of the next unsatisfied session, or the last week once complete. */
+  currentWeek: number;
+  /** Total weeks in the program — the "Y" in "Week X of Y". */
+  totalWeeks: number;
+  /** True once every session has a completion (or the enrollment is completed). */
+  isComplete: boolean;
+}
+
+interface UseProgramProgressOptions {
+  /**
+   * Gate the query. Defaults to enabled — pass `false` (e.g. behind the
+   * `programs` flag) so non-program builds fire zero extra requests.
+   */
+  enabled?: boolean;
+}
+
+/**
+ * Progress for a single program: its sessions grouped by week, each tagged
+ * done / skipped / upcoming, plus the counts that drive the "N of M sessions"
+ * and "Week X of Y" summary. Progress is derived **entirely** from the
+ * `program_session_completions` set for the user's enrollment joined to
+ * `program_sessions` — nothing is duplicated from `workout_logs`. Completed
+ * sessions carry their `workoutLogId` so the page can link each into
+ * `/history/<id>`.
+ *
+ * `programId` is a program row id (the user's own clone, as listed in
+ * `ProgramsPage`). The matching enrollment is resolved as the active one, or —
+ * failing that — the most recent, mirroring {@link useActiveProgram}.
+ */
+export const useProgramProgress = (
+  programId?: string,
+  options?: UseProgramProgressOptions,
+) => {
+  const session = useSession();
+  const userId = session?.user?.id;
+
+  return useQuery(
+    [QUERIES.PROGRAM_PROGRESS, programId, userId],
+    () => fetchProgramProgress(programId!, userId!),
+    { enabled: !!programId && !!userId && (options?.enabled ?? true) },
+  );
+};
+
+const fetchProgramProgress = async (
+  programId: string,
+  userId: string,
+): Promise<ProgramProgressResult> => {
+  const [programResult, sessionsResult, enrollmentsResult] = await Promise.all([
+    supabase.from('programs').select('*').eq('id', programId).single(),
+    supabase
+      .from('program_sessions')
+      .select('*')
+      .eq('program_id', programId)
+      .order('sequence_index', { ascending: true }),
+    // The user's enrollments in this program. Prefer the active one; fall back
+    // to the most recently completed/abandoned so progress still renders after
+    // the terminal status flip.
+    supabase
+      .from('user_programs')
+      .select('*')
+      .eq('user_id', userId)
+      .eq('program_id', programId)
+      .order('completed_at', { ascending: false, nullsFirst: true }),
+  ]);
+
+  if (programResult.error) throw programResult.error;
+  if (sessionsResult.error) throw sessionsResult.error;
+  if (enrollmentsResult.error) throw enrollmentsResult.error;
+
+  const program = mapProgramRow(programResult.data);
+  const sessions = (sessionsResult.data ?? []).map(mapProgramSessionRow);
+
+  const enrollmentRow =
+    enrollmentsResult.data?.find((row) => row.status === 'active') ??
+    enrollmentsResult.data?.[0] ??
+    null;
+  const enrollment = enrollmentRow ? mapUserProgramRow(enrollmentRow) : null;
+
+  // Completions only exist once enrolled; skip the fetch otherwise.
+  const completions = enrollmentRow
+    ? await fetchCompletions(enrollmentRow.id)
+    : [];
+  const completionBySessionId = new Map(
+    completions.map((c) => [c.programSessionId, c]),
+  );
+
+  const sessionProgress: SessionProgress[] = sessions.map((s) => {
+    const completion = completionBySessionId.get(s.id);
+    const state: SessionState = completion
+      ? completion.status === 'skipped'
+        ? 'skipped'
+        : 'done'
+      : 'upcoming';
+    return {
+      session: s,
+      state,
+      workoutLogId: state === 'done' ? completion!.workoutLogId : null,
+    };
+  });
+
+  const weeks = groupByWeek(sessionProgress);
+
+  const completedCount = sessionProgress.filter(
+    (s) => s.state !== 'upcoming',
+  ).length;
+  const totalCount = sessions.length;
+  const nextUpcoming = sessionProgress.find((s) => s.state === 'upcoming');
+  const currentWeek =
+    nextUpcoming?.session.weekNumber ??
+    sessions[sessions.length - 1]?.weekNumber ??
+    0;
+  const totalWeeks = Math.max(
+    program.numWeeks,
+    ...sessions.map((s) => s.weekNumber),
+    0,
+  );
+  const isComplete =
+    enrollment?.status === 'completed' ||
+    (totalCount > 0 && completedCount === totalCount);
+
+  return {
+    program,
+    enrollment,
+    weeks,
+    completedCount,
+    totalCount,
+    currentWeek,
+    totalWeeks,
+    isComplete,
+  };
+};
+
+const fetchCompletions = async (userProgramId: string) => {
+  const { data, error } = await supabase
+    .from('program_session_completions')
+    .select('*')
+    .eq('user_program_id', userProgramId);
+
+  if (error) throw error;
+  return (data ?? []).map(mapProgramSessionCompletionRow);
+};
+
+/** Group progress rows into ordered weeks, preserving session order. */
+const groupByWeek = (sessions: SessionProgress[]): WeekProgress[] => {
+  const groups: WeekProgress[] = [];
+  for (const item of sessions) {
+    const week = item.session.weekNumber;
+    const group = groups.find((g) => g.weekNumber === week);
+    if (group) group.sessions.push(item);
+    else groups.push({ weekNumber: week, sessions: [item] });
+  }
+  return groups;
+};

--- a/src/api/useProgramProgress.ts
+++ b/src/api/useProgramProgress.ts
@@ -105,7 +105,7 @@ const fetchProgramProgress = async (
       .select('*')
       .eq('user_id', userId)
       .eq('program_id', programId)
-      .order('completed_at', { ascending: false, nullsFirst: true }),
+      .order('completed_at', { ascending: false, nullsFirst: false }),
   ]);
 
   if (programResult.error) throw programResult.error;

--- a/src/app/routes.tsx
+++ b/src/app/routes.tsx
@@ -10,6 +10,7 @@ import {
   HistoryPage,
   MovementsPage,
   PaywallPage,
+  ProgramProgressPage,
   ProgramSessionBuilderPage,
   ProgramsPage,
   RecommendationsPage,
@@ -72,6 +73,7 @@ export const createRoutes = (flags: Features = features): RouteObject[] => [
       ...(flags.programs
         ? [
             { path: 'programs', element: <ProgramsPage /> },
+            { path: 'programs/:id', element: <ProgramProgressPage /> },
             {
               path: 'programs/:id/sessions/new',
               element: <ProgramSessionBuilderPage />,

--- a/src/constants/queries.enum.ts
+++ b/src/constants/queries.enum.ts
@@ -5,6 +5,7 @@ export enum QUERIES {
   MOVEMENTS = 'movements',
   PATTERN_DEBT = 'patternDebt',
   PROGRAM = 'program',
+  PROGRAM_PROGRESS = 'programProgress',
   PROGRAMS = 'programs',
   USER_MOVEMENTS = 'userMovements',
   WORKOUT_LOG = 'workoutLog',

--- a/src/pages/ProgramProgressPage/ProgramProgressPage.test.tsx
+++ b/src/pages/ProgramProgressPage/ProgramProgressPage.test.tsx
@@ -1,0 +1,132 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { vi } from 'vitest';
+
+import { ProgramProgressPage } from './ProgramProgressPage';
+
+const { mockUseProgramProgress } = vi.hoisted(() => ({
+  mockUseProgramProgress: vi.fn(),
+}));
+
+vi.mock('~/api', () => ({
+  useProgramProgress: mockUseProgramProgress,
+}));
+
+const session = (seq: number, week: number, day: number, title: string) => ({
+  id: `ps-${seq}`,
+  programId: 'prog-1',
+  sequenceIndex: seq,
+  weekNumber: week,
+  dayNumber: day,
+  title,
+  notes: null,
+  workoutOptions: {} as never,
+});
+
+const progressData = {
+  program: { id: 'prog-1', title: 'Dry Fighting Weight', numWeeks: 2 },
+  enrollment: { id: 'up-1', status: 'active' },
+  weeks: [
+    {
+      weekNumber: 1,
+      sessions: [
+        { session: session(0, 1, 1, 'W1D1'), state: 'done', workoutLogId: 42 },
+        {
+          session: session(1, 1, 2, 'W1D2'),
+          state: 'skipped',
+          workoutLogId: null,
+        },
+      ],
+    },
+    {
+      weekNumber: 2,
+      sessions: [
+        {
+          session: session(2, 2, 1, 'W2D1'),
+          state: 'upcoming',
+          workoutLogId: null,
+        },
+      ],
+    },
+  ],
+  completedCount: 2,
+  totalCount: 3,
+  currentWeek: 2,
+  totalWeeks: 2,
+  isComplete: false,
+};
+
+const renderPage = () =>
+  render(
+    <MemoryRouter initialEntries={['/programs/prog-1']}>
+      <Routes>
+        <Route path="/programs/:id" element={<ProgramProgressPage />} />
+        <Route path="/history/:logId" element={<div>history detail</div>} />
+        <Route path="/programs" element={<div>programs list</div>} />
+      </Routes>
+    </MemoryRouter>,
+  );
+
+describe('ProgramProgressPage', () => {
+  beforeEach(() => {
+    mockUseProgramProgress.mockReset();
+  });
+
+  it('renders the summary, week groups, and session states', () => {
+    mockUseProgramProgress.mockReturnValue({
+      data: progressData,
+      isLoading: false,
+      isError: false,
+    });
+
+    renderPage();
+
+    expect(screen.getByText('Dry Fighting Weight')).toBeInTheDocument();
+    expect(screen.getByText('2 of 3 sessions')).toBeInTheDocument();
+    expect(screen.getByText('Week 2 of 2')).toBeInTheDocument();
+    expect(screen.getByText('Week 1')).toBeInTheDocument();
+    expect(screen.getByText('Week 2')).toBeInTheDocument();
+    expect(screen.getByText('W1D1')).toBeInTheDocument();
+  });
+
+  it('links a completed session chip to its logged workout', () => {
+    mockUseProgramProgress.mockReturnValue({
+      data: progressData,
+      isLoading: false,
+      isError: false,
+    });
+
+    renderPage();
+
+    const doneChip = screen.getByText('W1D1').closest('a');
+    expect(doneChip).toHaveAttribute('href', '/history/42');
+
+    // Skipped and upcoming sessions are not links.
+    expect(screen.getByText('W1D2').closest('a')).toBeNull();
+    expect(screen.getByText('W2D1').closest('a')).toBeNull();
+  });
+
+  it('shows the complete state when the program is finished', () => {
+    mockUseProgramProgress.mockReturnValue({
+      data: { ...progressData, isComplete: true },
+      isLoading: false,
+      isError: false,
+    });
+
+    renderPage();
+
+    expect(screen.getByText('🎉 Program complete')).toBeInTheDocument();
+  });
+
+  it('renders a not-found state on error', () => {
+    mockUseProgramProgress.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isError: true,
+    });
+
+    renderPage();
+
+    expect(screen.getByText('Program not found.')).toBeInTheDocument();
+  });
+});

--- a/src/pages/ProgramProgressPage/ProgramProgressPage.tsx
+++ b/src/pages/ProgramProgressPage/ProgramProgressPage.tsx
@@ -1,0 +1,154 @@
+import { Link, useNavigate, useParams } from 'react-router-dom';
+
+import {
+  SessionProgress,
+  SessionState,
+  WeekProgress,
+  useProgramProgress,
+} from '~/api';
+import { Page } from '~/components';
+import { Button } from '~/components/ui/button';
+import { Card, CardContent } from '~/components/ui/card';
+import { cn } from '~/lib/utils';
+
+/** Glyph + label + chip styling for each session state. */
+const STATE_META: Record<SessionState, { icon: string; className: string }> = {
+  done: {
+    icon: '✓',
+    className:
+      'border-primary bg-primary/10 text-foreground hover:bg-primary/20',
+  },
+  skipped: {
+    icon: '⊘',
+    className: 'border-dashed border-muted-foreground/40 text-muted-foreground',
+  },
+  upcoming: {
+    icon: '',
+    className: 'border-border text-muted-foreground',
+  },
+};
+
+export const ProgramProgressPage = () => {
+  const { id } = useParams<{ id: string }>();
+  const navigate = useNavigate();
+  const { data, isLoading, isError } = useProgramProgress(id);
+
+  if (isLoading) {
+    return (
+      <Page title="Program progress">
+        <p className="text-sm text-muted-foreground">Loading progress…</p>
+      </Page>
+    );
+  }
+
+  if (isError || !data) {
+    return (
+      <Page title="Program progress">
+        <p className="text-sm text-muted-foreground">Program not found.</p>
+        <Button variant="secondary" onClick={() => navigate('/programs')}>
+          Back to programs
+        </Button>
+      </Page>
+    );
+  }
+
+  const {
+    program,
+    weeks,
+    completedCount,
+    totalCount,
+    currentWeek,
+    totalWeeks,
+    isComplete,
+  } = data;
+
+  const percent =
+    totalCount > 0 ? Math.round((completedCount / totalCount) * 100) : 0;
+
+  return (
+    <Page title={program.title}>
+      <Link
+        to="/programs"
+        className="self-start text-xs font-medium text-muted-foreground"
+      >
+        ← Programs
+      </Link>
+
+      <Card>
+        <CardContent className="flex flex-col gap-1 pt-2">
+          <div className="flex items-baseline justify-between text-sm font-medium">
+            <span>
+              {isComplete
+                ? '🎉 Program complete'
+                : `Week ${currentWeek} of ${totalWeeks}`}
+            </span>
+            <span className="text-muted-foreground">
+              {completedCount} of {totalCount} sessions
+            </span>
+          </div>
+          <div
+            className="h-0.5 w-full overflow-hidden rounded-full bg-secondary"
+            role="progressbar"
+            aria-valuenow={completedCount}
+            aria-valuemin={0}
+            aria-valuemax={totalCount}
+          >
+            <div
+              className="h-full rounded-full bg-primary transition-all"
+              style={{ width: `${percent}%` }}
+            />
+          </div>
+        </CardContent>
+      </Card>
+
+      {weeks.map((week) => (
+        <WeekRow key={week.weekNumber} week={week} />
+      ))}
+    </Page>
+  );
+};
+
+const WeekRow = ({ week }: { week: WeekProgress }) => (
+  <div className="flex flex-col gap-0.5">
+    <span className="text-xs font-medium text-muted-foreground">
+      Week {week.weekNumber}
+    </span>
+    <div className="flex flex-wrap gap-1">
+      {week.sessions.map((item) => (
+        <SessionChip key={item.session.id} item={item} />
+      ))}
+    </div>
+  </div>
+);
+
+const SessionChip = ({ item }: { item: SessionProgress }) => {
+  const { session, state, workoutLogId } = item;
+  const meta = STATE_META[state];
+
+  const label = (
+    <>
+      {meta.icon && <span aria-hidden>{meta.icon}</span>}
+      <span className="font-medium">Day {session.dayNumber}</span>
+      <span className="truncate opacity-80">{session.title}</span>
+    </>
+  );
+
+  const baseClassName = cn(
+    'flex max-w-full items-center gap-0.5 rounded-md border px-1 py-0.5 text-xs',
+    meta.className,
+  );
+
+  // Completed sessions link to their logged workout; skipped/upcoming are static.
+  if (state === 'done' && workoutLogId !== null) {
+    return (
+      <Link
+        to={`/history/${workoutLogId}`}
+        className={cn(baseClassName, 'hover:cursor-pointer')}
+      >
+        {label}
+      </Link>
+    );
+  }
+
+  return <div className={baseClassName}>{label}</div>;
+};

--- a/src/pages/ProgramProgressPage/index.ts
+++ b/src/pages/ProgramProgressPage/index.ts
@@ -1,0 +1,1 @@
+export * from './ProgramProgressPage';

--- a/src/pages/ProgramsPage/ProgramsPage.tsx
+++ b/src/pages/ProgramsPage/ProgramsPage.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 
 import {
   useActiveProgram,
@@ -185,7 +185,9 @@ export const ProgramsPage = () => {
         <Card key={program.id}>
           <CardHeader>
             <CardTitle className="flex items-center gap-1">
-              {program.title}
+              <Link to={`/programs/${program.id}`} className="hover:underline">
+                {program.title}
+              </Link>
               {isActive(program) && (
                 <span className="rounded bg-primary px-0.5 text-xs text-primary-foreground">
                   Active
@@ -196,20 +198,29 @@ export const ProgramsPage = () => {
               {program.numWeeks} weeks · {program.daysPerWeek}/week
             </p>
           </CardHeader>
-          <CardContent className="flex gap-2">
+          <CardContent className="flex flex-col gap-2">
+            <div className="flex gap-2">
+              <Button
+                variant="secondary"
+                className="flex-1"
+                onClick={() => navigate(`/programs/${program.id}/sessions/new`)}
+              >
+                Add sessions
+              </Button>
+              <Button
+                className="flex-1"
+                onClick={() => handleEnroll(program.id)}
+                disabled={enroll.isLoading || isActive(program)}
+              >
+                {isActive(program) ? 'Enrolled' : 'Start program'}
+              </Button>
+            </div>
             <Button
-              variant="secondary"
-              className="flex-1"
-              onClick={() => navigate(`/programs/${program.id}/sessions/new`)}
+              variant="ghost"
+              size="sm"
+              onClick={() => navigate(`/programs/${program.id}`)}
             >
-              Add sessions
-            </Button>
-            <Button
-              className="flex-1"
-              onClick={() => handleEnroll(program.id)}
-              disabled={enroll.isLoading || isActive(program)}
-            >
-              {isActive(program) ? 'Enrolled' : 'Start program'}
+              View progress
             </Button>
           </CardContent>
         </Card>

--- a/src/pages/StartWorkoutPage/StartWorkoutPage.tsx
+++ b/src/pages/StartWorkoutPage/StartWorkoutPage.tsx
@@ -1,6 +1,6 @@
 import { ArrowLeftIcon, XMarkIcon } from '@heroicons/react/24/outline';
 import { ReactNode, useEffect, useRef, useState } from 'react';
-import { useLocation } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 
 import {
   AnalyticsEvent,
@@ -95,6 +95,7 @@ export const StartWorkoutPage = ({
   programSaveMode,
 }: StartWorkoutPageProps = {}) => {
   const features = useFeatures();
+  const navigate = useNavigate();
   const startWorkout = useStartWorkout();
   const [workoutOptions] = useWorkoutOptions();
   const { curated, recentRepeats } = useRecommendedWorkouts();
@@ -653,6 +654,9 @@ export const StartWorkoutPage = ({
               onStart={handleStartProgram}
               onSkip={handleSkipProgram}
               skipping={completeProgramSession.isLoading}
+              onViewProgress={() =>
+                navigate(`/programs/${activeProgram.program.id}`)
+              }
             />
           )}
 

--- a/src/pages/StartWorkoutPage/components/NextProgramWorkoutCard.tsx
+++ b/src/pages/StartWorkoutPage/components/NextProgramWorkoutCard.tsx
@@ -16,6 +16,8 @@ export interface NextProgramWorkoutCardProps {
   onSkip: () => void;
   /** Whether a skip is in flight (disables both actions). */
   skipping: boolean;
+  /** Open the program's progress page. Omitted → the link is not rendered. */
+  onViewProgress?: () => void;
 }
 
 const estimatedDuration = (
@@ -35,7 +37,18 @@ export const NextProgramWorkoutCard = ({
   onStart,
   onSkip,
   skipping,
+  onViewProgress,
 }: NextProgramWorkoutCardProps) => {
+  const viewProgressLink = onViewProgress && (
+    <button
+      type="button"
+      onClick={onViewProgress}
+      className="self-start text-xs font-medium text-muted-foreground hover:underline"
+    >
+      View progress →
+    </button>
+  );
+
   if (isComplete || !nextSession) {
     return (
       <Card className="flex flex-col gap-1 p-2">
@@ -47,6 +60,7 @@ export const NextProgramWorkoutCard = ({
           You finished all {progress.total} sessions. Pick a new program to keep
           going.
         </span>
+        {viewProgressLink}
       </Card>
     );
   }
@@ -88,6 +102,8 @@ export const NextProgramWorkoutCard = ({
           {skipping ? 'Skipping…' : 'Skip'}
         </Button>
       </div>
+
+      {viewProgressLink}
     </Card>
   );
 };

--- a/src/pages/index.ts
+++ b/src/pages/index.ts
@@ -6,6 +6,7 @@ export * from './CompletedWorkoutPage';
 export * from './HistoryPage';
 export * from './MovementsPage';
 export * from './PaywallPage';
+export * from './ProgramProgressPage';
 export * from './ProgramSessionBuilderPage';
 export * from './ProgramsPage';
 export * from './RecommendationsPage';


### PR DESCRIPTION
## Intent

Build Slice 4 (final slice) of the Bellskill program-tracking feature: progress views, entirely behind the existing `programs` feature flag (zero change when off). Slices 1-3 (schema+RPCs+seeded DFW; creation/enrollment UI; next-workout home surfacing + complete/advance) are already merged; this builds on them.

Scope delivered:
- ProgramProgressPage at the flag-gated route programs/:id (added in createRoutes only under flags.programs): shows the program title, an 'N of M sessions' progress bar + 'Week X of Y' summary (with a complete state), and sessions grouped by week rendered as chips showing done/skipped/upcoming state.
- Completed session chips link to /history/<workout_log_id>, reusing CompletedWorkoutPage verbatim (the completion row carries the workout_log_id; deliberately NOT a workout_logs column).
- Progress derived ENTIRELY from program_session_completions joined to program_sessions — nothing duplicated from workout_logs. New useProgramProgress(programId) hook follows the existing react-query + supabase.from(...) patterns, with a QUERIES.PROGRAM_PROGRESS key. Added a program_session_completions camelCase mapper to program.ts.
- Entry points wired from the existing Programs UI: each ProgramsPage 'My programs' card (title link + a 'View progress' button) and the home NextProgramWorkoutCard (new optional onViewProgress callback, rendered in both active and complete states).
- Adherence stats are explicitly deferred (not built), per the plan.

Design decisions/tradeoffs: A dedicated useProgramProgress hook (rather than extending useActiveProgram) because the progress page needs per-session state AND each completed session's workoutLogId for the history link, which useActiveProgram does not expose. Given a program id, the matching enrollment is resolved as the active one else the most recent (mirroring useActiveProgram) so progress still renders after the terminal completed status flip. No schema change was needed (Slice 1's four tables cover it). The progress-bar uses a plain div (no shadcn Progress component exists in the repo). Chip icons use ✓/⊘ glyphs. totalWeeks = max(program.numWeeks, max session week); currentWeek = week of next unsatisfied session, else last session's week.

Testing done: compile:ts, lint, prettier --check all clean; npm test 356 unit tests pass (incl. new useProgramProgress + ProgramProgressPage tests, and existing ProgramsPage/NextProgramWorkoutCard tests unaffected); npm run test:e2e 13 pass including a new e2e/program-progress.spec.ts locking the completions read contract. Flag-off is regression-free: the route and the hook only mount under the programs gate. Also updated the checked-in AGENTS.md/CLAUDE.md Program Tracking section to document the Slice 4 surface.

## What Changed

- Added a flag-gated `ProgramProgressPage` at `programs/:id` (registered in `createRoutes` only under `flags.programs`) showing the program title, an "N of M sessions" progress bar with a "Week X of Y" summary and complete state, and sessions grouped by week rendered as done ✓ / skipped ⊘ / upcoming chips; completed chips link to `/history/<workout_log_id>`, reusing `CompletedWorkoutPage`.
- Introduced a `useProgramProgress(programId)` react-query hook (new `QUERIES.PROGRAM_PROGRESS` key) that derives all state from `program_session_completions` joined to `program_sessions`, resolving the enrollment as the active one else the most recent — plus a `program_session_completions` camelCase mapper in `program.ts`. A follow-up commit fixed the enrollment fallback to prefer a `completed` enrollment over an abandoned one with a null `completed_at`.
- Wired entry points from the existing Programs UI: each `ProgramsPage` "My programs" card (title link + "View progress" button) and the home `NextProgramWorkoutCard` (new optional `onViewProgress` callback in both active and complete states). Documented the Slice 4 surface in `AGENTS.md`/`CLAUDE.md` and added a `program-progress` e2e spec locking the completions read contract.

## Risk Assessment

✅ Low: Well-bounded, entirely flag-gated additive slice with derived-only progress logic; the one prior finding is already fixed and no new material issues surfaced.

## Testing

Installed deps (worktree had none), ran the new/affected unit suites and the e2e REST-contract spec (all green), then drove the real app with the programs flag on against local Supabase — seeding a real enrollment via the RPCs — to capture reviewer-visible screenshots of the progress page in both partial and complete states, the "View progress" entry point, and a click-through proving done-chip→/history/CompletedWorkoutPage navigation. Everything behaves as the intent describes; no issues found. Worktree left clean (transient .env.e2e and playwright output removed).

- Evidence: Progress page — partial (Week 1 of 5, 2 of 14, done/skipped/upcoming chips) (local file: <code>/var/folders/2p/zdp7pmgx05z1k3dd8xyttrv80000gn/T/no-mistakes-evidence/01KWZ9852T4PY37CWWR02B9AME/progress-partial.png</code>)
- Evidence: Progress page — complete state (🎉 Program complete, 14 of 14, renders after terminal status flip) (local file: <code>/var/folders/2p/zdp7pmgx05z1k3dd8xyttrv80000gn/T/no-mistakes-evidence/01KWZ9852T4PY37CWWR02B9AME/progress-complete.png</code>)
- Evidence: Programs list — &#39;View progress&#39; entry point on the My programs card (local file: <code>/var/folders/2p/zdp7pmgx05z1k3dd8xyttrv80000gn/T/no-mistakes-evidence/01KWZ9852T4PY37CWWR02B9AME/programs-list.png</code>)
- Evidence: Done chip → /history/18 renders CompletedWorkoutPage (completion→log seam) (local file: <code>/var/folders/2p/zdp7pmgx05z1k3dd8xyttrv80000gn/T/no-mistakes-evidence/01KWZ9852T4PY37CWWR02B9AME/done-chip-to-history.png</code>)
<details>
<summary>Evidence: Navigation seam verification (console transcript)</summary>

```text
after View progress click, url = /programs/5cebde8c-183f-47ed-a83e-0440615af3c5
after done-chip click, url = /history/18 (chip href was /history/18)
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ `src/api/useProgramProgress.ts:112` - The enrollment query pulls all statuses (no status filter, unlike useActiveProgram) and falls back to data[0] from `order(&#39;completed_at&#39;, desc, nullsFirst: true)`. Abandoned/paused enrollments keep completed_at=null (only the terminal flip sets it), so they always outrank a `completed` enrollment in the fallback. For an own program (enroll_in_program does not clone, so re-enrolling adds user_programs rows), a user with both a completed and a later abandoned enrollment would see the abandoned enrollment&#39;s empty progress (&#39;0 of M&#39;) instead of the completed one. Consider `nullsFirst: false` or filtering statuses like useActiveProgram. Edge-case (DFW clone flow has one enrollment per clone and is unaffected), and untested.

🔧 Fix: fix program-progress enrollment fallback to prefer completed over null-dated
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`vitest run src/api/useProgramProgress.test.ts src/pages/ProgramProgressPage/ProgramProgressPage.test.tsx` — new hook + page unit tests (7 pass)</code>
- <code>`vitest run src/pages/ProgramsPage src/pages/StartWorkoutPage/components/NextProgramWorkoutCard.test.tsx` — entry-point tests (6 pass)</code>
- <code>`playwright test e2e/program-progress.spec.ts` — completions→done/skipped/upcoming REST contract against local Supabase (1 pass)</code>
- `Manual browser capture: seeded DFW enrollment via enroll_in_program + complete_program_session RPCs, injected auth, navigated /programs/:id with VITE_FEATURE_PROGRAMS=true; screenshotted partial + complete progress states and the Programs list entry point`
- `Clicked 'View progress' (→ /programs/:id) and a done chip (→ /history/18 rendering CompletedWorkoutPage) to verify both navigation seams`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
