### PR TITLE
feat(app): add app-level 404 catch-all and route error boundary

### DIFF
--- a/src/app/RouteErrorBoundary.tsx
+++ b/src/app/RouteErrorBoundary.tsx
@@ -1,0 +1,34 @@
+import { useNavigate, useRouteError } from 'react-router-dom';
+
+import { Page } from '~/components';
+import { Button } from '~/components/ui/button';
+
+/**
+ * `errorElement` for the root route. Catches errors thrown while rendering a
+ * route or from a loader/action and renders a friendly fallback in place of the
+ * raw React Router dev error page. Because it replaces the root element, it does
+ * not render the `Root` shell (Header etc.) — it is intentionally self-contained.
+ */
+export const RouteErrorBoundary = () => {
+  const navigate = useNavigate();
+  const error = useRouteError();
+
+  // Surface the underlying error to the console for debugging without exposing
+  // it to the user.
+  console.error('Route error:', error);
+
+  return (
+    <Page title={null}>
+      <div className="flex flex-col items-center gap-2 py-3 text-center">
+        <h1 className="text-xl font-semibold">Something went wrong</h1>
+        <p className="text-sm text-muted-foreground">
+          An unexpected error occurred. Try heading back home and giving it
+          another go.
+        </p>
+        <Button onClick={() => navigate('/')} className="w-full">
+          Back to home
+        </Button>
+      </div>
+    </Page>
+  );
+};

--- a/src/app/routes.test.tsx
+++ b/src/app/routes.test.tsx
@@ -61,7 +61,9 @@ describe('createRoutes catch-all', () => {
 describe('RouteErrorBoundary', () => {
   it('renders a friendly fallback when a route throws', () => {
     // Swallow React Router's expected error-boundary console output.
-    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const consoleError = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
 
     const Boom = () => {
       throw new Error('kaboom');

--- a/src/app/routes.test.tsx
+++ b/src/app/routes.test.tsx
@@ -1,0 +1,84 @@
+import { render, screen } from '@testing-library/react';
+import { RouterProvider, createMemoryRouter } from 'react-router-dom';
+import { vi } from 'vitest';
+
+import { Features } from '~/config/features';
+
+import { RouteErrorBoundary } from './RouteErrorBoundary';
+import { createRoutes } from './routes';
+
+const flagsOff: Features = {
+  bottomNav: false,
+  complexMode: false,
+  curatedFirstWorkout: false,
+  explore: false,
+  premium: false,
+  programs: false,
+  recommender: false,
+  repeatPrevious: false,
+  weeklyBalance: false,
+};
+
+const renderAt = (path: string, flags: Features = flagsOff) => {
+  const router = createMemoryRouter(createRoutes(flags), {
+    initialEntries: [path],
+  });
+  return render(<RouterProvider router={router} />);
+};
+
+describe('createRoutes catch-all', () => {
+  it('renders the not-found page for a genuinely unmatched path', () => {
+    renderAt('/this-route-does-not-exist');
+
+    expect(screen.getByText('Page not found')).toBeInTheDocument();
+    // Never the raw React Router dev fallback.
+    expect(screen.queryByText(/Unexpected Application Error/i)).toBeNull();
+  });
+
+  it('renders the not-found page for a feature-gated route whose flag is off', () => {
+    renderAt('/programs', { ...flagsOff, programs: false });
+
+    expect(screen.getByText('Page not found')).toBeInTheDocument();
+  });
+
+  it('does not shadow a real matched route', () => {
+    // A genuine always-on route still resolves to its own page rather than the
+    // catch-all, proving the `*` route sits after the concrete routes.
+    renderAt('/checkout/cancel');
+
+    expect(screen.getByText('Checkout canceled')).toBeInTheDocument();
+    expect(screen.queryByText('Page not found')).toBeNull();
+  });
+
+  it('wires an errorElement on the root route regardless of flags', () => {
+    expect(createRoutes(flagsOff)[0].errorElement).toBeTruthy();
+    expect(
+      createRoutes({ ...flagsOff, programs: true })[0].errorElement,
+    ).toBeTruthy();
+  });
+});
+
+describe('RouteErrorBoundary', () => {
+  it('renders a friendly fallback when a route throws', () => {
+    // Swallow React Router's expected error-boundary console output.
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const Boom = () => {
+      throw new Error('kaboom');
+    };
+    const router = createMemoryRouter([
+      {
+        path: '/',
+        element: <Boom />,
+        errorElement: <RouteErrorBoundary />,
+      },
+    ]);
+    render(<RouterProvider router={router} />);
+
+    expect(screen.getByText('Something went wrong')).toBeInTheDocument();
+    // Never the raw React Router dev fallback.
+    expect(screen.queryByText(/Unexpected Application Error/i)).toBeNull();
+
+    consoleError.mockRestore();
+  });
+});

--- a/src/app/routes.tsx
+++ b/src/app/routes.tsx
@@ -18,8 +18,8 @@ import {
   StartWorkoutPage,
   WeeklyBalancePage,
 } from '../pages';
-import { RouteErrorBoundary } from './RouteErrorBoundary';
 import { Root } from './Root';
+import { RouteErrorBoundary } from './RouteErrorBoundary';
 
 /**
  * Builds the route table for a given set of effective feature flags. Pass the

--- a/src/app/routes.tsx
+++ b/src/app/routes.tsx
@@ -9,6 +9,7 @@ import {
   CompletedWorkoutPage,
   HistoryPage,
   MovementsPage,
+  NotFoundPage,
   PaywallPage,
   ProgramProgressPage,
   ProgramSessionBuilderPage,
@@ -17,6 +18,7 @@ import {
   StartWorkoutPage,
   WeeklyBalancePage,
 } from '../pages';
+import { RouteErrorBoundary } from './RouteErrorBoundary';
 import { Root } from './Root';
 
 /**
@@ -28,6 +30,7 @@ export const createRoutes = (flags: Features = features): RouteObject[] => [
   {
     path: '/',
     element: <Root />,
+    errorElement: <RouteErrorBoundary />,
     children: [
       {
         path: '',
@@ -80,6 +83,13 @@ export const createRoutes = (flags: Features = features): RouteObject[] => [
             },
           ]
         : []),
+      // Catch-all for any unmatched path — including feature-gated routes whose
+      // flag is off (e.g. `/programs` when `programs` is disabled). Kept outside
+      // every `flags.*` spread so it is always present regardless of flags.
+      {
+        path: '*',
+        element: <NotFoundPage />,
+      },
     ],
   },
 ];

--- a/src/pages/NotFoundPage/NotFoundPage.tsx
+++ b/src/pages/NotFoundPage/NotFoundPage.tsx
@@ -1,0 +1,23 @@
+import { useNavigate } from 'react-router-dom';
+
+import { Page } from '~/components';
+import { Button } from '~/components/ui/button';
+
+export const NotFoundPage = () => {
+  const navigate = useNavigate();
+
+  return (
+    <Page title={null}>
+      <div className="flex flex-col items-center gap-2 py-3 text-center">
+        <h1 className="text-xl font-semibold">Page not found</h1>
+        <p className="text-sm text-muted-foreground">
+          We couldn't find that page. It may have moved, or the link may be out
+          of date.
+        </p>
+        <Button onClick={() => navigate('/')} className="w-full">
+          Back to home
+        </Button>
+      </div>
+    </Page>
+  );
+};

--- a/src/pages/NotFoundPage/index.ts
+++ b/src/pages/NotFoundPage/index.ts
@@ -1,0 +1,1 @@
+export * from './NotFoundPage';

--- a/src/pages/index.ts
+++ b/src/pages/index.ts
@@ -5,6 +5,7 @@ export * from './CheckoutSuccessPage';
 export * from './CompletedWorkoutPage';
 export * from './HistoryPage';
 export * from './MovementsPage';
+export * from './NotFoundPage';
 export * from './PaywallPage';
 export * from './ProgramProgressPage';
 export * from './ProgramSessionBuilderPage';


### PR DESCRIPTION
## What

Add an app-level catch-all route and a root `errorElement` so unmatched paths and unexpected render/loader errors show friendly in-app pages instead of React Router's raw dev error page.

## Why

PROD-221 (https://linear.app/bellskill/issue/PROD-221). The app registered no `errorElement` and no catch-all, so any unmatched path rendered React Router's raw fallback ("Unexpected Application Error! / 404 Not Found / 💿 Hey developer 👋"). Two real triggers: a bad URL, and a feature-gated route whose flag is off (e.g. `/programs` when `programs` is off, reachable from a stale bookmark or shared preview link). Found during the DFW QA pass (PROD-179).

## How tested

- `src/app/routes.test.tsx`: an unmatched path (`/this-route-does-not-exist`) renders the NotFoundPage and never the raw fallback; `/programs` with `programs` off renders the NotFoundPage; a concrete always-on route (`/checkout/cancel`) is not shadowed by the catch-all; the root `errorElement` is present regardless of flags; and `RouteErrorBoundary` renders its friendly fallback when a route throws.
- `npm test` (364), `npm run compile:ts`, and `npm run lint` all clean.

## Tradeoffs

- **Catch-all `*` as a child of the root route** (rendering inside the `Root` shell, so the 404 keeps the Header/nav) plus a **root `errorElement`** that is intentionally self-contained (it replaces the root element, so it does not render the shell). Two mechanisms because they cover different failures: `*` handles no-match, `errorElement` handles thrown/loader errors. Considered a single top-level error boundary for both; kept them separate so a plain 404 stays inside the familiar app shell rather than looking like a crash.
- **Kept the catch-all outside every `flags.*` spread** so it is always present regardless of feature flags — a flag-off route falls through to the friendly 404 rather than a missing-route error.
- Purely additive (no existing routes or behavior changed); not gated on any feature flag, by design.
## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`npx vitest run src/app/routes.test.tsx` — all 5 tests pass: unmatched path → NotFoundPage (not raw dev fallback), /programs with programs flag off → NotFoundPage, /checkout/cancel still resolves (catch-all doesn&#39;t shadow), errorElement wired on root regardless of flags, and a thrown route renders the RouteErrorBoundary fallback</code>
- <code>Rendered the real `NotFoundPage` and `RouteErrorBoundary` in a headless Chrome via a temporary Vite entry (real components + tailwind.css), driving the catch-all at `/this-route-does-not-exist` and a throwing route through `errorElement`, then captured a full-page screenshot</code>
- `Confirmed rendered copy via DOM: 'Page not found' + 'We couldn't find that page…' + 'Back to home', and 'Something went wrong' + 'An unexpected error occurred…' + 'Back to home'`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>

