### PR TITLE
feat(programs): surface program mutation errors as a toast

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -167,6 +167,13 @@ session — atomic), and the PROD-219 editing pair `reorder_program_sessions` /
 - DB behaviors (RLS, the advance/skip/flip RPC, idempotency, the reorder/delete
   reindex + constraint-safety) are covered by Playwright e2e against the local
   Supabase (`e2e/program-*.spec.ts`), not MSW.
+- **Error feedback (PROD-220):** program mutations surface failures through one
+  reusable toast — `ToastProvider`/`useToast` (`~/contexts/ToastContext`, mounted
+  app-wide in `App.tsx`; presentational `Toast` in `~/components/ui/toast`). Each
+  program `useMutation` wires the shared `useProgramMutationErrorHandler` as its
+  `onError`; a new program mutation reuses it by adding that `onError`. The
+  behavior is scoped to programs structurally (it is wired only into program
+  hooks), not via a runtime flag check.
 
 ## Authentication
 

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -17,6 +17,7 @@ export * from './useDuplicateProgramSession';
 export * from './useReorderProgramSession';
 export * from './useEnrollProgram';
 export * from './useProgram';
+export * from './useProgramMutationErrorHandler';
 export * from './useProgramProgress';
 export * from './usePrograms';
 export * from './useSaveProgramSession';

--- a/src/api/useCreateProgram.test.ts
+++ b/src/api/useCreateProgram.test.ts
@@ -7,10 +7,10 @@ import { SessionProvider, ToastContext } from '~/contexts';
 import { server } from '~/mocks/server';
 
 import { VITE_SUPABASE_URL } from '../env';
-import { useEnrollProgram } from './useEnrollProgram';
+import { useCreateProgram } from './useCreateProgram';
 import { PROGRAM_MUTATION_ERROR_MESSAGE } from './useProgramMutationErrorHandler';
 
-const RPC_URL = `${VITE_SUPABASE_URL}/rest/v1/rpc/enroll_in_program`;
+const PROGRAMS_URL = `${VITE_SUPABASE_URL}/rest/v1/programs`;
 
 const showToast = vi.fn();
 
@@ -27,6 +27,22 @@ const mockSession = {
   expires_in: 10000,
   token_type: '',
 };
+
+const programRow = {
+  id: 'program-1',
+  owner_id: 'user-123',
+  source_program_id: null,
+  slug: null,
+  title: 'My Program',
+  description: null,
+  author_name: null,
+  num_weeks: 4,
+  days_per_week: 3,
+  is_public: false,
+  created_at: '2026-01-01T00:00:00Z',
+};
+
+const input = { title: 'My Program', numWeeks: 4, daysPerWeek: 3 };
 
 const makeWrapper = () => {
   const queryClient = new QueryClient({
@@ -48,59 +64,37 @@ const makeWrapper = () => {
     );
 };
 
-describe('useEnrollProgram', () => {
+describe('useCreateProgram', () => {
   beforeEach(() => showToast.mockClear());
 
-  it('calls the enroll_in_program RPC and resolves with the new enrollment id', async () => {
-    let receivedBody: unknown;
-    server.use(
-      http.post(RPC_URL, async ({ request }) => {
-        receivedBody = await request.json();
-        return HttpResponse.json('new-user-program-id');
-      }),
-    );
+  it('inserts the program and does not toast on success', async () => {
+    server.use(http.post(PROGRAMS_URL, () => HttpResponse.json(programRow)));
 
-    const { result } = renderHook(() => useEnrollProgram(), {
+    const { result } = renderHook(() => useCreateProgram(), {
       wrapper: makeWrapper(),
     });
 
-    const enrolled = await result.current.mutateAsync('program-abc');
+    const created = await result.current.mutateAsync(input);
 
-    expect(enrolled).toBe('new-user-program-id');
-    expect(receivedBody).toEqual({ p_program_id: 'program-abc' });
+    expect(created.id).toBe('program-1');
+    expect(showToast).not.toHaveBeenCalled();
   });
 
-  it('surfaces RPC errors', async () => {
+  it('toasts on failure', async () => {
     server.use(
-      http.post(RPC_URL, () =>
+      http.post(PROGRAMS_URL, () =>
         HttpResponse.json({ message: 'boom' }, { status: 400 }),
       ),
     );
 
-    const { result } = renderHook(() => useEnrollProgram(), {
+    const { result } = renderHook(() => useCreateProgram(), {
       wrapper: makeWrapper(),
     });
 
-    await expect(
-      result.current.mutateAsync('program-abc'),
-    ).rejects.toBeTruthy();
+    await expect(result.current.mutateAsync(input)).rejects.toBeTruthy();
     await waitFor(() => expect(result.current.isError).toBe(true));
     expect(showToast).toHaveBeenCalledWith(PROGRAM_MUTATION_ERROR_MESSAGE, {
       variant: 'destructive',
     });
-  });
-
-  it('does not toast on the happy path', async () => {
-    server.use(
-      http.post(RPC_URL, () => HttpResponse.json('new-user-program-id')),
-    );
-
-    const { result } = renderHook(() => useEnrollProgram(), {
-      wrapper: makeWrapper(),
-    });
-
-    await result.current.mutateAsync('program-abc');
-
-    expect(showToast).not.toHaveBeenCalled();
   });
 });

--- a/src/api/useCreateProgram.ts
+++ b/src/api/useCreateProgram.ts
@@ -6,6 +6,7 @@ import { Program } from '~/types';
 
 import { supabase } from '../supabaseClient';
 import { mapProgramRow } from './program';
+import { useProgramMutationErrorHandler } from './useProgramMutationErrorHandler';
 
 export interface CreateProgramInput {
   title: string;
@@ -20,6 +21,7 @@ export interface CreateProgramInput {
 export const useCreateProgram = () => {
   const session = useSession();
   const queryClient = useQueryClient();
+  const onError = useProgramMutationErrorHandler();
   const userId = session?.user?.id;
 
   return useMutation({
@@ -48,5 +50,6 @@ export const useCreateProgram = () => {
     onSuccess: () => {
       queryClient.invalidateQueries([QUERIES.PROGRAMS]);
     },
+    onError,
   });
 };

--- a/src/api/useDeleteProgramSession.test.ts
+++ b/src/api/useDeleteProgramSession.test.ts
@@ -3,13 +3,16 @@ import { HttpResponse, http } from 'msw';
 import React from 'react';
 import { QueryClient, QueryClientProvider } from 'react-query';
 
-import { SessionProvider } from '~/contexts';
+import { SessionProvider, ToastContext } from '~/contexts';
 import { server } from '~/mocks/server';
 
 import { VITE_SUPABASE_URL } from '../env';
 import { useDeleteProgramSession } from './useDeleteProgramSession';
+import { PROGRAM_MUTATION_ERROR_MESSAGE } from './useProgramMutationErrorHandler';
 
 const RPC_URL = `${VITE_SUPABASE_URL}/rest/v1/rpc/delete_program_session`;
+
+const showToast = vi.fn();
 
 const mockSession = {
   user: {
@@ -33,12 +36,22 @@ const makeWrapper = () => {
     React.createElement(
       QueryClientProvider,
       { client: queryClient },
-      React.createElement(SessionProvider, { value: mockSession }, children),
+      React.createElement(
+        SessionProvider,
+        { value: mockSession },
+        React.createElement(
+          ToastContext.Provider,
+          { value: { showToast } },
+          children,
+        ),
+      ),
     );
 };
 
 describe('useDeleteProgramSession', () => {
-  it('sends only the session id to the RPC (program id is used client-side)', async () => {
+  beforeEach(() => showToast.mockClear());
+
+  it('sends only the session id to the RPC (program id is used client-side) and does not toast on success', async () => {
     let receivedBody: unknown;
     server.use(
       http.post(RPC_URL, async ({ request }) => {
@@ -57,9 +70,10 @@ describe('useDeleteProgramSession', () => {
     });
 
     expect(receivedBody).toEqual({ p_session_id: 's-1' });
+    expect(showToast).not.toHaveBeenCalled();
   });
 
-  it('surfaces RPC errors', async () => {
+  it('surfaces RPC errors and toasts on failure', async () => {
     server.use(
       http.post(RPC_URL, () =>
         HttpResponse.json({ message: 'boom' }, { status: 400 }),
@@ -74,5 +88,8 @@ describe('useDeleteProgramSession', () => {
       result.current.mutateAsync({ sessionId: 's-1', programId: 'prog-1' }),
     ).rejects.toBeTruthy();
     await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(showToast).toHaveBeenCalledWith(PROGRAM_MUTATION_ERROR_MESSAGE, {
+      variant: 'destructive',
+    });
   });
 });

--- a/src/api/useDeleteProgramSession.ts
+++ b/src/api/useDeleteProgramSession.ts
@@ -3,6 +3,7 @@ import { useMutation, useQueryClient } from 'react-query';
 import { QUERIES } from '~/constants';
 
 import { supabase } from '../supabaseClient';
+import { useProgramMutationErrorHandler } from './useProgramMutationErrorHandler';
 
 export interface DeleteProgramSessionInput {
   sessionId: string;
@@ -21,6 +22,7 @@ export interface DeleteProgramSessionInput {
  */
 export const useDeleteProgramSession = () => {
   const queryClient = useQueryClient();
+  const onError = useProgramMutationErrorHandler();
 
   return useMutation({
     mutationFn: async (input: DeleteProgramSessionInput): Promise<void> => {
@@ -35,5 +37,6 @@ export const useDeleteProgramSession = () => {
       queryClient.invalidateQueries([QUERIES.ACTIVE_PROGRAM]);
       queryClient.invalidateQueries([QUERIES.PROGRAM_PROGRESS]);
     },
+    onError,
   });
 };

--- a/src/api/useDuplicateProgramSession.test.ts
+++ b/src/api/useDuplicateProgramSession.test.ts
@@ -1,0 +1,137 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { HttpResponse, http } from 'msw';
+import React from 'react';
+import { QueryClient, QueryClientProvider } from 'react-query';
+
+import { ToastContext } from '~/contexts';
+import { server } from '~/mocks/server';
+import { ProgramSession } from '~/types';
+
+import { VITE_SUPABASE_URL } from '../env';
+import {
+  useDuplicateProgramSession,
+  useDuplicateProgramWeek,
+} from './useDuplicateProgramSession';
+import { PROGRAM_MUTATION_ERROR_MESSAGE } from './useProgramMutationErrorHandler';
+
+const SESSIONS_URL = `${VITE_SUPABASE_URL}/rest/v1/program_sessions`;
+
+const showToast = vi.fn();
+
+const session: ProgramSession = {
+  id: 'session-1',
+  programId: 'program-1',
+  sequenceIndex: 0,
+  weekNumber: 1,
+  dayNumber: 1,
+  title: 'Day 1',
+  workoutOptions: {} as never,
+  notes: null,
+};
+
+const sessionRow = {
+  id: 'session-2',
+  program_id: 'program-1',
+  sequence_index: 1,
+  week_number: 1,
+  day_number: 1,
+  title: 'Day 1',
+  workout_options: {},
+  notes: null,
+  created_at: '2026-01-01T00:00:00Z',
+};
+
+const makeWrapper = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return ({ children }: { children: React.ReactNode }) =>
+    React.createElement(
+      QueryClientProvider,
+      { client: queryClient },
+      React.createElement(
+        ToastContext.Provider,
+        { value: { showToast } },
+        children,
+      ),
+    );
+};
+
+describe('useDuplicateProgramSession', () => {
+  beforeEach(() => showToast.mockClear());
+
+  const input = { session, sequenceIndex: 1, weekNumber: 1, dayNumber: 1 };
+
+  it('duplicates the session and does not toast on success', async () => {
+    server.use(http.post(SESSIONS_URL, () => HttpResponse.json(sessionRow)));
+
+    const { result } = renderHook(() => useDuplicateProgramSession(), {
+      wrapper: makeWrapper(),
+    });
+
+    const copy = await result.current.mutateAsync(input);
+
+    expect(copy.id).toBe('session-2');
+    expect(showToast).not.toHaveBeenCalled();
+  });
+
+  it('toasts on failure', async () => {
+    server.use(
+      http.post(SESSIONS_URL, () =>
+        HttpResponse.json({ message: 'boom' }, { status: 400 }),
+      ),
+    );
+
+    const { result } = renderHook(() => useDuplicateProgramSession(), {
+      wrapper: makeWrapper(),
+    });
+
+    await expect(result.current.mutateAsync(input)).rejects.toBeTruthy();
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(showToast).toHaveBeenCalledWith(PROGRAM_MUTATION_ERROR_MESSAGE, {
+      variant: 'destructive',
+    });
+  });
+});
+
+describe('useDuplicateProgramWeek', () => {
+  beforeEach(() => showToast.mockClear());
+
+  const input = {
+    programId: 'program-1',
+    sessions: [session],
+    newWeekNumber: 2,
+    startSequenceIndex: 1,
+  };
+
+  it('duplicates the week and does not toast on success', async () => {
+    server.use(http.post(SESSIONS_URL, () => HttpResponse.json([sessionRow])));
+
+    const { result } = renderHook(() => useDuplicateProgramWeek(), {
+      wrapper: makeWrapper(),
+    });
+
+    const copies = await result.current.mutateAsync(input);
+
+    expect(copies).toHaveLength(1);
+    expect(showToast).not.toHaveBeenCalled();
+  });
+
+  it('toasts on failure', async () => {
+    server.use(
+      http.post(SESSIONS_URL, () =>
+        HttpResponse.json({ message: 'boom' }, { status: 400 }),
+      ),
+    );
+
+    const { result } = renderHook(() => useDuplicateProgramWeek(), {
+      wrapper: makeWrapper(),
+    });
+
+    await expect(result.current.mutateAsync(input)).rejects.toBeTruthy();
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(showToast).toHaveBeenCalledWith(PROGRAM_MUTATION_ERROR_MESSAGE, {
+      variant: 'destructive',
+    });
+  });
+});

--- a/src/api/useDuplicateProgramSession.ts
+++ b/src/api/useDuplicateProgramSession.ts
@@ -6,6 +6,7 @@ import { ProgramSession } from '~/types';
 import type { Json } from '../../types/supabase';
 import { supabase } from '../supabaseClient';
 import { mapProgramSessionRow } from './program';
+import { useProgramMutationErrorHandler } from './useProgramMutationErrorHandler';
 
 export interface DuplicateProgramSessionInput {
   /** The session to copy. */
@@ -44,6 +45,7 @@ const sessionInsert = (
 /** Copies a single session, appending it to the end of the program. */
 export const useDuplicateProgramSession = () => {
   const queryClient = useQueryClient();
+  const onError = useProgramMutationErrorHandler();
 
   return useMutation({
     mutationFn: async (
@@ -71,6 +73,7 @@ export const useDuplicateProgramSession = () => {
         variables.session.programId,
       ]);
     },
+    onError,
   });
 };
 
@@ -81,6 +84,7 @@ export const useDuplicateProgramSession = () => {
  */
 export const useDuplicateProgramWeek = () => {
   const queryClient = useQueryClient();
+  const onError = useProgramMutationErrorHandler();
 
   return useMutation({
     mutationFn: async (
@@ -106,5 +110,6 @@ export const useDuplicateProgramWeek = () => {
     onSuccess: (_data, variables) => {
       queryClient.invalidateQueries([QUERIES.PROGRAM, variables.programId]);
     },
+    onError,
   });
 };

--- a/src/api/useEnrollProgram.ts
+++ b/src/api/useEnrollProgram.ts
@@ -3,6 +3,7 @@ import { useMutation, useQueryClient } from 'react-query';
 import { QUERIES } from '~/constants';
 
 import { supabase } from '../supabaseClient';
+import { useProgramMutationErrorHandler } from './useProgramMutationErrorHandler';
 
 /**
  * Enrolls the user in a program via the Slice-1 `enroll_in_program` RPC
@@ -15,6 +16,7 @@ import { supabase } from '../supabaseClient';
  */
 export const useEnrollProgram = () => {
   const queryClient = useQueryClient();
+  const onError = useProgramMutationErrorHandler();
 
   return useMutation({
     mutationFn: async (programId: string): Promise<string> => {
@@ -29,5 +31,6 @@ export const useEnrollProgram = () => {
       queryClient.invalidateQueries([QUERIES.ACTIVE_PROGRAM]);
       queryClient.invalidateQueries([QUERIES.PROGRAMS]);
     },
+    onError,
   });
 };

--- a/src/api/useProgramMutationErrorHandler.ts
+++ b/src/api/useProgramMutationErrorHandler.ts
@@ -1,0 +1,26 @@
+import { useToast } from '~/contexts';
+
+/**
+ * The single, human-readable message shown when any program mutation fails.
+ * Kept generic so every program edit surfaces identical feedback.
+ */
+export const PROGRAM_MUTATION_ERROR_MESSAGE =
+  'Something went wrong. Please try again.';
+
+/**
+ * Shared react-query `onError` handler for program mutations. Wiring this into
+ * each program `useMutation` — rather than a bespoke handler per hook — gives
+ * every program edit the same error toast, so a failure (most reachably a
+ * concurrent multi-tab edit hitting the reindex RPC) never fails silently.
+ *
+ * The error-feedback behavior is scoped to the programs feature structurally:
+ * program mutations only run on the (flag-gated) program surfaces, and this
+ * handler is wired only into program mutations, so no non-program flow shows a
+ * toast. A future program mutation reuses it by adding `onError` to its
+ * `useMutation` config.
+ */
+export const useProgramMutationErrorHandler = () => {
+  const { showToast } = useToast();
+  return () =>
+    showToast(PROGRAM_MUTATION_ERROR_MESSAGE, { variant: 'destructive' });
+};

--- a/src/api/useReorderProgramSession.test.ts
+++ b/src/api/useReorderProgramSession.test.ts
@@ -3,13 +3,16 @@ import { HttpResponse, http } from 'msw';
 import React from 'react';
 import { QueryClient, QueryClientProvider } from 'react-query';
 
-import { SessionProvider } from '~/contexts';
+import { SessionProvider, ToastContext } from '~/contexts';
 import { server } from '~/mocks/server';
 
 import { VITE_SUPABASE_URL } from '../env';
+import { PROGRAM_MUTATION_ERROR_MESSAGE } from './useProgramMutationErrorHandler';
 import { useReorderProgramSessions } from './useReorderProgramSession';
 
 const RPC_URL = `${VITE_SUPABASE_URL}/rest/v1/rpc/reorder_program_sessions`;
+
+const showToast = vi.fn();
 
 const mockSession = {
   user: {
@@ -33,12 +36,22 @@ const makeWrapper = () => {
     React.createElement(
       QueryClientProvider,
       { client: queryClient },
-      React.createElement(SessionProvider, { value: mockSession }, children),
+      React.createElement(
+        SessionProvider,
+        { value: mockSession },
+        React.createElement(
+          ToastContext.Provider,
+          { value: { showToast } },
+          children,
+        ),
+      ),
     );
 };
 
 describe('useReorderProgramSessions', () => {
-  it('sends the program id and the full ordered id array to the RPC', async () => {
+  beforeEach(() => showToast.mockClear());
+
+  it('sends the program id and the full ordered id array to the RPC and does not toast on success', async () => {
     let receivedBody: unknown;
     server.use(
       http.post(RPC_URL, async ({ request }) => {
@@ -60,9 +73,10 @@ describe('useReorderProgramSessions', () => {
       p_program_id: 'prog-1',
       p_ordered_ids: ['s-2', 's-0', 's-1'],
     });
+    expect(showToast).not.toHaveBeenCalled();
   });
 
-  it('surfaces RPC errors', async () => {
+  it('surfaces RPC errors and toasts on failure', async () => {
     server.use(
       http.post(RPC_URL, () =>
         HttpResponse.json({ message: 'boom' }, { status: 400 }),
@@ -80,5 +94,8 @@ describe('useReorderProgramSessions', () => {
       }),
     ).rejects.toBeTruthy();
     await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(showToast).toHaveBeenCalledWith(PROGRAM_MUTATION_ERROR_MESSAGE, {
+      variant: 'destructive',
+    });
   });
 });

--- a/src/api/useReorderProgramSession.ts
+++ b/src/api/useReorderProgramSession.ts
@@ -3,6 +3,7 @@ import { useMutation, useQueryClient } from 'react-query';
 import { QUERIES } from '~/constants';
 
 import { supabase } from '../supabaseClient';
+import { useProgramMutationErrorHandler } from './useProgramMutationErrorHandler';
 
 export interface ReorderProgramSessionsInput {
   programId: string;
@@ -26,6 +27,7 @@ export interface ReorderProgramSessionsInput {
  */
 export const useReorderProgramSessions = () => {
   const queryClient = useQueryClient();
+  const onError = useProgramMutationErrorHandler();
 
   return useMutation({
     mutationFn: async (input: ReorderProgramSessionsInput): Promise<void> => {
@@ -40,5 +42,6 @@ export const useReorderProgramSessions = () => {
       queryClient.invalidateQueries([QUERIES.ACTIVE_PROGRAM]);
       queryClient.invalidateQueries([QUERIES.PROGRAM_PROGRESS]);
     },
+    onError,
   });
 };

--- a/src/api/useSaveProgramSession.test.ts
+++ b/src/api/useSaveProgramSession.test.ts
@@ -1,0 +1,87 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { HttpResponse, http } from 'msw';
+import React from 'react';
+import { QueryClient, QueryClientProvider } from 'react-query';
+
+import { ToastContext } from '~/contexts';
+import { server } from '~/mocks/server';
+
+import { VITE_SUPABASE_URL } from '../env';
+import { PROGRAM_MUTATION_ERROR_MESSAGE } from './useProgramMutationErrorHandler';
+import { useSaveProgramSession } from './useSaveProgramSession';
+
+const SESSIONS_URL = `${VITE_SUPABASE_URL}/rest/v1/program_sessions`;
+
+const showToast = vi.fn();
+
+const sessionRow = {
+  id: 'session-1',
+  program_id: 'program-1',
+  sequence_index: 0,
+  week_number: 1,
+  day_number: 1,
+  title: 'Day 1',
+  workout_options: {},
+  notes: null,
+  created_at: '2026-01-01T00:00:00Z',
+};
+
+const input = {
+  programId: 'program-1',
+  sequenceIndex: 0,
+  weekNumber: 1,
+  dayNumber: 1,
+  title: 'Day 1',
+  workoutOptions: {} as never,
+};
+
+const makeWrapper = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return ({ children }: { children: React.ReactNode }) =>
+    React.createElement(
+      QueryClientProvider,
+      { client: queryClient },
+      React.createElement(
+        ToastContext.Provider,
+        { value: { showToast } },
+        children,
+      ),
+    );
+};
+
+describe('useSaveProgramSession', () => {
+  beforeEach(() => showToast.mockClear());
+
+  it('saves the session and does not toast on success', async () => {
+    server.use(http.post(SESSIONS_URL, () => HttpResponse.json(sessionRow)));
+
+    const { result } = renderHook(() => useSaveProgramSession(), {
+      wrapper: makeWrapper(),
+    });
+
+    const saved = await result.current.mutateAsync(input);
+
+    expect(saved.id).toBe('session-1');
+    expect(showToast).not.toHaveBeenCalled();
+  });
+
+  it('toasts on failure', async () => {
+    server.use(
+      http.post(SESSIONS_URL, () =>
+        HttpResponse.json({ message: 'boom' }, { status: 400 }),
+      ),
+    );
+
+    const { result } = renderHook(() => useSaveProgramSession(), {
+      wrapper: makeWrapper(),
+    });
+
+    await expect(result.current.mutateAsync(input)).rejects.toBeTruthy();
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(showToast).toHaveBeenCalledWith(PROGRAM_MUTATION_ERROR_MESSAGE, {
+      variant: 'destructive',
+    });
+  });
+});

--- a/src/api/useSaveProgramSession.ts
+++ b/src/api/useSaveProgramSession.ts
@@ -6,6 +6,7 @@ import { ProgramSession, WorkoutOptions } from '~/types';
 import type { Json } from '../../types/supabase';
 import { supabase } from '../supabaseClient';
 import { mapProgramSessionRow } from './program';
+import { useProgramMutationErrorHandler } from './useProgramMutationErrorHandler';
 
 export interface SaveProgramSessionInput {
   programId: string;
@@ -25,6 +26,7 @@ export interface SaveProgramSessionInput {
  */
 export const useSaveProgramSession = () => {
   const queryClient = useQueryClient();
+  const onError = useProgramMutationErrorHandler();
 
   return useMutation({
     mutationFn: async (
@@ -51,5 +53,6 @@ export const useSaveProgramSession = () => {
       queryClient.invalidateQueries([QUERIES.PROGRAM, variables.programId]);
       queryClient.invalidateQueries([QUERIES.PROGRAMS]);
     },
+    onError,
   });
 };

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -5,6 +5,7 @@ import { RouterProvider, createBrowserRouter } from 'react-router-dom';
 import { Loading, PWAInstallPrompt, SafeAreaWrapper } from '~/components';
 import { EntitlementProvider } from '~/contexts/EntitlementContext';
 import { ProgramSessionProvider } from '~/contexts/ProgramSessionContext';
+import { ToastProvider } from '~/contexts/ToastContext';
 import { WorkoutOptionsProvider } from '~/contexts/WorkoutOptionsContext';
 import { resolveAuthSession } from '~/utils';
 
@@ -47,7 +48,9 @@ export function App() {
           <EntitlementProvider>
             <WorkoutOptionsProvider>
               <ProgramSessionProvider>
-                <RouterProvider router={router} />
+                <ToastProvider>
+                  <RouterProvider router={router} />
+                </ToastProvider>
               </ProgramSessionProvider>
             </WorkoutOptionsProvider>
           </EntitlementProvider>

--- a/src/components/ui/toast.tsx
+++ b/src/components/ui/toast.tsx
@@ -1,0 +1,61 @@
+import * as React from 'react';
+
+import { cn } from '~/lib/utils';
+
+/**
+ * Fixed overlay that stacks active toasts along the bottom of the screen. Inert
+ * (`pointer-events-none`) so it never blocks the page when empty; individual
+ * toasts re-enable pointer events for their dismiss button.
+ */
+const ToastViewport = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn(
+      'pointer-events-none fixed inset-x-0 bottom-0 z-50 flex flex-col items-center gap-1 p-2',
+      className,
+    )}
+    {...props}
+  />
+));
+ToastViewport.displayName = 'ToastViewport';
+
+export interface ToastProps extends React.HTMLAttributes<HTMLDivElement> {
+  variant?: 'default' | 'destructive';
+  onDismiss?: () => void;
+}
+
+/** A single toast card. `destructive` uses the error color tokens. */
+const Toast = React.forwardRef<HTMLDivElement, ToastProps>(
+  ({ className, variant = 'default', onDismiss, children, ...props }, ref) => (
+    <div
+      ref={ref}
+      role="alert"
+      className={cn(
+        'pointer-events-auto flex w-full max-w-sm items-center justify-between gap-2 rounded-md border px-2 py-1.5 text-sm shadow-lg',
+        variant === 'destructive'
+          ? 'border-destructive bg-destructive text-destructive-foreground'
+          : 'border-border bg-background text-foreground',
+        className,
+      )}
+      {...props}
+    >
+      <span>{children}</span>
+      {onDismiss && (
+        <button
+          type="button"
+          onClick={onDismiss}
+          aria-label="Dismiss"
+          className="shrink-0 opacity-80 transition-opacity hover:opacity-100"
+        >
+          ✕
+        </button>
+      )}
+    </div>
+  ),
+);
+Toast.displayName = 'Toast';
+
+export { Toast, ToastViewport };

--- a/src/contexts/ToastContext.test.tsx
+++ b/src/contexts/ToastContext.test.tsx
@@ -1,0 +1,51 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { ToastProvider, useToast } from './ToastContext';
+
+const Trigger = () => {
+  const { showToast } = useToast();
+  return (
+    <button
+      onClick={() =>
+        showToast('Something went wrong.', { variant: 'destructive' })
+      }
+    >
+      fire
+    </button>
+  );
+};
+
+describe('ToastProvider', () => {
+  it('renders the toast message when fired', async () => {
+    const user = userEvent.setup();
+    render(
+      <ToastProvider>
+        <Trigger />
+      </ToastProvider>,
+    );
+
+    expect(screen.queryByText('Something went wrong.')).not.toBeInTheDocument();
+
+    await user.click(screen.getByText('fire'));
+
+    expect(screen.getByRole('alert')).toHaveTextContent(
+      'Something went wrong.',
+    );
+  });
+
+  it('dismisses a toast via its dismiss button', async () => {
+    const user = userEvent.setup();
+    render(
+      <ToastProvider>
+        <Trigger />
+      </ToastProvider>,
+    );
+
+    await user.click(screen.getByText('fire'));
+    expect(screen.getByRole('alert')).toBeInTheDocument();
+
+    await user.click(screen.getByLabelText('Dismiss'));
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+  });
+});

--- a/src/contexts/ToastContext.tsx
+++ b/src/contexts/ToastContext.tsx
@@ -1,0 +1,87 @@
+import {
+  ReactNode,
+  createContext,
+  useCallback,
+  useContext,
+  useRef,
+  useState,
+} from 'react';
+import { createPortal } from 'react-dom';
+
+import { Toast, ToastViewport } from '~/components/ui/toast';
+
+export type ToastVariant = 'default' | 'destructive';
+
+export interface ToastItem {
+  id: number;
+  message: string;
+  variant: ToastVariant;
+}
+
+export interface ShowToastOptions {
+  variant?: ToastVariant;
+  /** Auto-dismiss delay in ms. `0` disables auto-dismiss. */
+  duration?: number;
+}
+
+interface ToastContextValue {
+  showToast: (message: string, options?: ShowToastOptions) => void;
+}
+
+// Default to a no-op so consumers outside the provider (Storybook, isolated
+// component tests) degrade gracefully instead of throwing — mirrors the
+// pattern in ProgramSessionContext.
+export const ToastContext = createContext<ToastContextValue>({
+  showToast: () => {},
+});
+
+const DEFAULT_DURATION = 5000;
+
+/**
+ * App-wide toast host: the single, reusable error/notification mechanism.
+ * Holds the active toast list, exposes `showToast` via context, and portals a
+ * fixed viewport onto `document.body` so toasts overlay every route. Inert
+ * until a toast fires, so mounting it app-wide is free.
+ */
+export const ToastProvider = ({ children }: { children: ReactNode }) => {
+  const [toasts, setToasts] = useState<ToastItem[]>([]);
+  const nextId = useRef(0);
+
+  const dismiss = useCallback((id: number) => {
+    setToasts((current) => current.filter((toast) => toast.id !== id));
+  }, []);
+
+  const showToast = useCallback(
+    (message: string, options?: ShowToastOptions) => {
+      const id = nextId.current++;
+      const variant = options?.variant ?? 'default';
+      setToasts((current) => [...current, { id, message, variant }]);
+
+      const duration = options?.duration ?? DEFAULT_DURATION;
+      if (duration > 0) setTimeout(() => dismiss(id), duration);
+    },
+    [dismiss],
+  );
+
+  return (
+    <ToastContext.Provider value={{ showToast }}>
+      {children}
+      {createPortal(
+        <ToastViewport>
+          {toasts.map((toast) => (
+            <Toast
+              key={toast.id}
+              variant={toast.variant}
+              onDismiss={() => dismiss(toast.id)}
+            >
+              {toast.message}
+            </Toast>
+          ))}
+        </ToastViewport>,
+        document.body,
+      )}
+    </ToastContext.Provider>
+  );
+};
+
+export const useToast = () => useContext(ToastContext);

--- a/src/contexts/index.ts
+++ b/src/contexts/index.ts
@@ -1,4 +1,5 @@
 export * from './EntitlementContext';
 export * from './ProgramSessionContext';
 export * from './SessionContext';
+export * from './ToastContext';
 export * from './WorkoutOptionsContext';


### PR DESCRIPTION
## What

Give every program mutation a consistent error toast on failure, via one reusable `ToastProvider` / `useToast` and a shared `useProgramMutationErrorHandler` wired as the `onError` of each program `useMutation`.

## Why

PROD-220 (https://linear.app/bellskill/issue/PROD-220), a follow-up from the PROD-219 review. The program mutations (create, enroll, save-session, duplicate, reorder, delete) failed silently — on error the action just did nothing, with no feedback. The most reachable failure is a concurrent multi-tab edit hitting the reindex RPC. The app had no toast/error-UX system, so this builds one once and applies it uniformly rather than bolting a one-off onto a single path.

## How tested

- Per-hook unit tests: each program mutation (`useCreateProgram`, `useEnrollProgram`, `useSaveProgramSession`, `useDuplicateProgramSession` + `useDuplicateProgramWeek`, `useReorderProgramSessions`, `useDeleteProgramSession`) fires the toast on a mocked failure and leaves the happy path unchanged.
- `ToastContext` component test: a fired toast renders its visible text.
- `npm test`, `npm run compile:ts`, and `npm run lint` clean; CI green (build + integration-tests).

## Tradeoffs

- **One shared `onError` handler over per-hook bespoke handling.** Wiring the same `useProgramMutationErrorHandler` into each mutation keeps the copy and behavior identical everywhere and makes a future program mutation a one-line addition. The cost is a tiny bit of indirection per hook, worth it for consistency.
- **Custom lightweight toast context over a toast library (e.g. sonner).** A library is less code to write but adds a dependency and its own styling to reconcile with the project's custom Tailwind scale and shadcn components. A small in-repo `ToastProvider` + presentational `Toast` keeps the surface minimal and on-theme.
- **Scoped to programs structurally, not by a runtime flag check.** The provider is mounted app-wide but inert until fired, and the handler is wired only into program mutations (which only run on the already-flag-gated program surfaces) — so no non-program flow shows a toast, without threading a flag through the mechanism.
- **Left `useCompleteProgramSession` (workout-completion / Skip) out of scope.** It is the logging path, not a program-editing mutation, and outside PROD-220's affected-hooks list; wiring it is deferred rather than expanding scope here.
## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Rebase** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ `AGENTS.md` - merge conflict rebasing onto origin/main

🔧 Fix applied.
✅ Re-checked - no issues remain.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ `src/api/useReorderProgramSession.ts:30` - PROD-220&#39;s stated goal is to wire the shared error handler into ALL program mutation hooks so none fail silently, but three program mutations still lack an onError: useReorderProgramSessions (this file, line 30), useDeleteProgramSession (line 25), and useCompleteProgramSession (line 48). This is especially notable because useProgramMutationErrorHandler&#39;s own docstring cites &#34;a concurrent multi-tab edit hitting the reindex RPC&#34; as the most reachable failure — that is precisely the reorder/delete path, yet those hooks are the ones left unwired. The author&#39;s intent note assumed the PROD-219 reorder/delete hooks were parallel work absent from this branch, but they are present in the base commit (2b0143b). A failing reorder/delete/complete therefore still fails silently, contradicting the feature&#39;s purpose. Fix by adding `const onError = useProgramMutationErrorHandler();` and `onError` to each of the three useMutation configs.

🔧 Fix: wire error toast into reorder/delete program mutations
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`npx vitest run src/contexts/ToastContext.test.tsx src/api/useCreateProgram.test.ts src/api/useEnrollProgram.test.ts src/api/useSaveProgramSession.test.ts src/api/useDuplicateProgramSession.test.ts src/api/useDeleteProgramSession.test.ts src/api/useReorderProgramSession.test.ts` — 17 tests pass (toast render/dismiss + per-hook MSW error-path toast assertions and happy-path no-toast assertions)</code>
- `Rendered the real Toast/ToastProvider/useToast components in Storybook (loads the project's tailwind.css) via a temporary story, fired the exact destructive toast a failed program mutation emits, and screenshotted both the live program-failure flow and the default+destructive variant reference`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>

