### PR TITLE
ci: block merges when Supabase types are stale

### DIFF
--- a/.github/workflows/supabase-types-check.yaml
+++ b/.github/workflows/supabase-types-check.yaml
@@ -1,0 +1,53 @@
+name: Validate Supabase Types
+
+# Blocks merges into main when the committed types/supabase.ts is out of sync
+# with the schema in supabase/migrations/**. Spins up the local stack (which
+# applies every migration), regenerates the types with the same `gen:types`
+# script developers run locally, and fails if the working tree changed.
+#
+# Path-filtered: types can only drift from a schema change, so this runs only
+# when a PR touches supabase/** or the generated types file itself.
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - supabase/**
+      - types/supabase.ts
+  workflow_dispatch:
+
+concurrency:
+  group: supabase-types-check-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check-types:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Use Node.js 24.x
+        uses: actions/setup-node@v3
+        with:
+          node-version: 24.x
+          cache: 'npm'
+      - run: npm ci
+
+      - name: Set up Supabase CLI
+        uses: supabase/setup-cli@v1
+        with:
+          version: latest
+
+      - name: Start local Supabase
+        run: supabase start
+
+      - name: Regenerate types from local schema
+        run: npm run gen:types
+
+      - name: Fail if committed types are stale
+        run: |
+          if ! git diff --exit-code -- types/supabase.ts; then
+            echo "::error::types/supabase.ts is out of date. Run 'npm run gen:types' locally and commit the result."
+            exit 1
+          fi


### PR DESCRIPTION
## What
Adds a `Validate Supabase Types` GitHub Actions check that regenerates
`types/supabase.ts` from the local schema on PRs into `main` and fails if the
committed file is out of date.

## Why
`types/supabase.ts` was only kept current by remembering to run `npm run
gen:types` locally after a schema change. When someone forgot, drift slipped in
and had to be fixed in a follow-up PR after merge. This moves the check
pre-merge so the regenerated types land in the same PR as the migration that
changed them.

Fixes PROD-212.

## How tested
- Verified the baseline is in sync: ran `npm run gen:types` against the local
  stack and diffed against the committed `types/supabase.ts` — byte-identical
  (1555 lines, empty diff), so the check starts green.
- Workflow mirrors the existing `integration-tests` job (`supabase/setup-cli` +
  `supabase start`) and reuses the same `gen:types` script devs run locally, so
  there's no local-vs-CI command drift.

## Tradeoffs
- **Path-filtered to `supabase/**` and `types/supabase.ts`** rather than running
  on every PR. Running on all PRs would be more uniform as a required check, but
  types can only drift from a schema change, so the ~1â€“2 min stack spin-up is
  wasted on unrelated PRs. Accepted the narrower trigger.
- **Generate-and-diff** rather than a true `--dry-run` flag (the CLI has none
  that asserts no-change). Same effect: regenerate, then assert the working tree
  is clean.

## Follow-up (not in this PR)
To make a red check actually *block* merges, add "Validate Supabase Types" to
branch protection for `main` (Settings â†’ Branches â†’ require status checks) after
it runs once.

ðŸ¤– Generated with [Claude Code](https://claude.com/claude-code)