### PR TITLE
build: serve Storybook at /storybook on Netlify deploy previews

### DIFF
--- a/.github/workflows/storybook-preview-link.yaml
+++ b/.github/workflows/storybook-preview-link.yaml
@@ -1,0 +1,57 @@
+# Comments the live Storybook preview link on each PR.
+#
+# Storybook is built into dist/storybook by the netlify.toml [build] step, so it
+# ships inside the same deploy preview as the app. The deploy-preview URL is
+# deterministic (https://deploy-preview-<PR#>--bellskill.netlify.app), which
+# makes the Storybook link derivable without waiting on Netlify's API. This
+# complements Netlify's own deploy-preview comment rather than replacing it.
+#
+# The comment is posted once and updated in place (matched by a hidden marker),
+# so re-runs never pile up duplicates.
+
+name: Storybook preview link
+
+on:
+  pull_request:
+    types: [opened, reopened]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  comment:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Comment Storybook preview link
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = context.issue.number;
+            const url = `https://deploy-preview-${pr}--bellskill.netlify.app/storybook`;
+            const marker = '<!-- storybook-preview-link -->';
+            const body = `${marker}\n📚 **Storybook preview:** ${url}\n\n` +
+              `Live once this PR's Netlify deploy preview finishes building. ` +
+              `Bundled into the same deploy as the app (served at \`/storybook\`).`;
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: pr,
+            });
+            const existing = comments.find((c) => c.body?.includes(marker));
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: pr,
+                body,
+              });
+            }

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ lerna-debug.log*
 node_modules
 dist
 dist-ssr
+storybook-static
 *.local
 
 # Editor directories and files

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,12 +1,15 @@
 # Netlify configuration.
 #
-# The [build] section below OVERRIDES the build command / publish directory
-# that were previously configured in the Netlify UI. It replicates the app
-# build (`vite build` → dist/) and additionally builds Storybook into
-# dist/storybook, so every deploy serves the app at `/` and a live Storybook
-# at `/storybook` (e.g. https://deploy-preview-<PR#>--bellskill.netlify.app/storybook).
-# Netlify still runs dependency install separately, so `command` only lists the
-# build steps. NODE_VERSION matches .nvmrc (Node 24), the version CI builds on.
+# The [context.deploy-preview] section below scopes a Storybook build to PR
+# deploy previews ONLY. On a preview it OVERRIDES the Netlify UI build command,
+# replicating the app build (`vite build` → dist/) and additionally building
+# Storybook into dist/storybook, so each preview serves the app at `/` and a
+# live Storybook at `/storybook`
+# (e.g. https://deploy-preview-<PR#>--bellskill.netlify.app/storybook).
+# Production build behavior is intentionally unchanged: it keeps the existing
+# Netlify-UI-configured build command and publish dir, so no Storybook is ever
+# built or served on the production site. NODE_VERSION matches .nvmrc (Node 24),
+# the version CI builds on.
 #
 # The rest of this file pins the Supabase connection per deploy context so that:
 #   - production deploys talk to the Bellskill Prod project
@@ -15,12 +18,9 @@
 #     `supabase-preview` GitHub Actions workflow.
 #
 
-[build]
+[context.deploy-preview]
   command = "npm run build && npm run build-storybook -- -o dist/storybook"
   publish = "dist"
-
-[build.environment]
-  NODE_VERSION = "24"
 
 # VITE_SUPABASE_ANON_KEY is a public, RLS-protected key (it ships in the client
 # bundle), so it is safe to commit here.
@@ -34,5 +34,6 @@
   VITE_SUPABASE_ANON_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InluenpxcGFqa2hxanpmdGl5bmZvIiwicm9sZSI6ImFub24iLCJpYXQiOjE2OTA2NjI3NjMsImV4cCI6MjAwNjIzODc2M30.xLRZaFcdp9K2HucbAkJig0GSEfyYsWOYrVOTDIrgK8g"
 
 [context.deploy-preview.environment]
+  NODE_VERSION = "24"
   VITE_SUPABASE_URL = "https://obtrxswejclgxjfyddow.supabase.co"
   VITE_SUPABASE_ANON_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Im9idHJ4c3dlamNsZ3hqZnlkZG93Iiwicm9sZSI6ImFub24iLCJpYXQiOjE2OTk0Nzk2ODQsImV4cCI6MjAxNTA1NTY4NH0.insdjysFDW8dfU-IhgvN-Q3T2fNmeSL2FcejeM2KaGo"

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,12 +1,27 @@
 # Netlify configuration.
 #
-# Build command / publish directory remain configured in the Netlify UI — this
-# file only pins the Supabase connection per deploy context so that:
+# The [build] section below OVERRIDES the build command / publish directory
+# that were previously configured in the Netlify UI. It replicates the app
+# build (`vite build` → dist/) and additionally builds Storybook into
+# dist/storybook, so every deploy serves the app at `/` and a live Storybook
+# at `/storybook` (e.g. https://deploy-preview-<PR#>--bellskill.netlify.app/storybook).
+# Netlify still runs dependency install separately, so `command` only lists the
+# build steps. NODE_VERSION matches .nvmrc (Node 24), the version CI builds on.
+#
+# The rest of this file pins the Supabase connection per deploy context so that:
 #   - production deploys talk to the Bellskill Prod project
 #   - deploy previews (PRs) talk to the Bellskill Dev (staging) project, where
 #     the PR's own migrations + functions are deployed by the
 #     `supabase-preview` GitHub Actions workflow.
 #
+
+[build]
+  command = "npm run build && npm run build-storybook -- -o dist/storybook"
+  publish = "dist"
+
+[build.environment]
+  NODE_VERSION = "24"
+
 # VITE_SUPABASE_ANON_KEY is a public, RLS-protected key (it ships in the client
 # bundle), so it is safe to commit here.
 #

--- a/public/_redirects
+++ b/public/_redirects
@@ -1,3 +1,10 @@
+# Storybook lives as a static build under /storybook. Serve those files as-is
+# and keep them out of the SPA fallback below. Netlify already serves existing
+# static files before applying a non-forced 200 rewrite, but this explicit rule
+# (ahead of the catch-all) documents the intent and 404s unknown /storybook
+# paths instead of quietly rendering the app.
+/storybook/*    /storybook/:splat   200
+
 # SPA fallback: serve index.html for all client-side routes so React Router
 # deep links (e.g. /checkout/success) resolve instead of returning a 404.
 /*    /index.html   200


### PR DESCRIPTION
## What

Serve a live Storybook at `/storybook` inside each PR's Netlify deploy preview, alongside the app at the deploy root, and comment the link on the PR. Scoped to deploy previews only — production is unchanged.

## Why

PROD-222 (https://linear.app/bellskill/issue/PROD-222). Each PR already gets a Netlify deploy preview of the app, but no live Storybook — a reviewer couldn't see a PR's components/stories without checking out the branch and running `storybook dev`. This bundles Storybook into the same preview deploy so it's one click from the PR.

## How tested

- `npm run build-storybook -- -o dist/storybook` builds cleanly; the combined `npm run build && npm run build-storybook -- -o dist/storybook` produces a `dist/` with the app at root and a working `dist/storybook/index.html`.
- `netlify.toml` is valid; the `[context.deploy-preview]` command/publish and the `/storybook/*` redirect (ahead of the SPA catch-all) were reviewed for correctness.
- `npm test`, `npm run compile:ts`, `npm run lint`, and CI (build + integration-tests) all green.
- **Full live-preview verification happens on this PR's Netlify build** — reviewer should confirm `https://deploy-preview-112--bellskill.netlify.app/storybook` renders. The PR-comment workflow posts that link.

## Tradeoffs

- **Subpath of the same deploy over a separate Netlify site.** Serving `/storybook` on the existing preview needs no new Netlify project or credentials; a separate site would be more infrastructure for the same result. The deploy-preview URL is deterministic, so the Storybook link is derivable without waiting on Netlify's API.
- **Scoped to `[context.deploy-preview]`, production build intentionally unchanged.** An earlier revision put the build in a top-level `[build]` that applied to *all* contexts — which would have let a broken story block the production deploy and served Storybook publicly at the production URL. Scoping to the preview context keeps production on its existing Netlify-UI build (no Storybook built or served in prod) and matches the ticket's per-PR scope; production Storybook is explicitly out of scope.
- **`netlify.toml [context.deploy-preview]` overrides the UI build command for previews only.** It replicates the app build (`vite build` → `dist/`) and pins `NODE_VERSION=24` to match `.nvmrc`/CI, so the preview app build stays identical to today's.
## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- ⚠️ `netlify.toml:22` - The [build] command chains `npm run build &amp;&amp; npm run build-storybook` for ALL contexts, so a Storybook build failure (a story that errors at build time) will now fail the app&#39;s deploy — including production deploys off main. Before this change Netlify never built Storybook, so story breakage couldn&#39;t block a deploy. Consider whether coupling deploy reliability to the Storybook build (vs. a separate optional step/site) is the intended tradeoff.
- ℹ️ `netlify.toml:22` - Because [build] applies to context.production too, Storybook is now built and served publicly at bellskill.netlify.app/storybook on the production site, not only on PR deploy previews (the stated goal was per-PR previews). This publicly exposes the full component library, stories, and any mock/fixture data. The netlify.toml comment acknowledges this, but confirm public production exposure is intended.

🔧 Fix: scope Storybook build to deploy-preview context only
1 info still open:
- ℹ️ `.github/workflows/storybook-preview-link.yaml:15` - For PRs opened from a fork, `pull_request`-triggered workflows receive a read-only GITHUB_TOKEN regardless of the `permissions: pull-requests: write` block, so `issues.createComment` would 403 and the Storybook-link comment would silently fail to post. This is fine for same-repo branch PRs (the norm for this solo repo) but would break for any external contributor&#39;s PR. If cross-fork PRs are ever expected, switch to `pull_request_target` (with the usual caution) or accept the missing comment.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>Ran the exact deploy-preview command from netlify.toml: `npm run build &amp;&amp; npm run build-storybook -- -o dist/storybook` with the deploy-preview `VITE_SUPABASE_URL`/`VITE_SUPABASE_ANON_KEY` env vars set — produced dist/ with app index.html at root and working dist/storybook/index.html</code>
- <code>Verified Storybook emits relative asset paths (`href=&#34;./sb-common-assets/...&#34;`) so the /storybook subpath resolves with no base config</code>
- <code>Served dist/ through a Node server emulating public/_redirects rules and curled: `/` (200, title BellSkill), `/storybook/` (200, Storybook title), `/storybook/iframe.html` (200), `/storybook/sb-manager/runtime.js` (200), unknown `/storybook/does-not-exist.html` (404, not app), `/history/some-id` (200 SPA fallback)</code>
- `Captured browser screenshots at http://localhost:8899/ (app login page), /storybook/?path=/story/components-bottomnav--default, and /story/components-weeklybalance--balanced (stories render in the iframe canvas)`
- <code>Validated `.github/workflows/storybook-preview-link.yaml` parses as YAML (triggers opened/reopened, permissions pull-requests: write)</code>
- <code>Simulated the github-script comment logic: confirmed deterministic URL `https://deploy-preview-&lt;PR#&gt;--bellskill.netlify.app/storybook`, create-on-first-run + update-in-place on re-run (no duplicate), and unrelated Netlify comment left intact</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>

