### PR TITLE
feat(programs): seed Dan John's 10,000 Swing Challenge as a shared program

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -151,6 +151,17 @@ session — atomic), and the PROD-219 editing pair `reorder_program_sessions` /
 `delete_program_session`. All are `SECURITY INVOKER` RPCs; progress is fully
 **derived from the completions set**, never a stored cursor.
 
+- **Shared programs (seeded, system-owned):** the public shared programs
+  (`owner_id NULL`, `is_public`) ship as migrations (not `seed.sql`, so they
+  also reach staging/prod) — Dry Fighting Weight
+  (`*_seed_dry_fighting_weight.sql`) and Dan John's 10,000 Swing Challenge
+  (`*_seed_10000_swing_challenge.sql`). Each is idempotent on `slug` and builds
+  every session's `WorkoutOptions` JSONB (shape `Omit<WorkoutOptions,'startedAt'>`,
+  camelCase keys) via a `pg_temp` helper; add another by mirroring one. Seed
+  shape is asserted in `e2e/program-schema.spec.ts`. `ProgramsPage` currently
+  features only a single shared program (`sharedPrograms[0]`, preferring the DFW
+  slug), so a newly seeded program lands in the shared-program data but is not
+  yet surfaced in that UI.
 - **Next session** = lowest-`sequenceIndex` `program_sessions` row with no
   completion. `useActiveProgram` runs this client-side over the program's ≤~15
   sessions (a dedicated SQL function buys nothing at that size). It returns the

--- a/e2e/program-schema.spec.ts
+++ b/e2e/program-schema.spec.ts
@@ -60,12 +60,17 @@ async function signUpThrowawayUser(): Promise<TestUser> {
     `${SUPABASE_URL}/auth/v1/token?grant_type=password`,
     {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json', apikey: SUPABASE_ANON_KEY },
+      headers: {
+        'Content-Type': 'application/json',
+        apikey: SUPABASE_ANON_KEY,
+      },
       body: JSON.stringify({ email, password }),
     },
   );
   if (!signInRes.ok) {
-    throw new Error(`sign-in failed (${signInRes.status}): ${await signInRes.text()}`);
+    throw new Error(
+      `sign-in failed (${signInRes.status}): ${await signInRes.text()}`,
+    );
   }
   const session = (await signInRes.json()) as AuthSession;
   return { token: session.access_token, uid: session.user.id, email };
@@ -106,7 +111,9 @@ async function restJson<T = unknown>(
 ): Promise<T> {
   const res = await rest(method, path, token, opts);
   if (!res.ok) {
-    throw new Error(`${method} ${path} failed (${res.status}): ${await res.text()}`);
+    throw new Error(
+      `${method} ${path} failed (${res.status}): ${await res.text()}`,
+    );
   }
   return res.json() as Promise<T>;
 }
@@ -133,11 +140,9 @@ async function rpc<T = unknown>(
 
 // Fetch the shared DFW program's id (as any authenticated user).
 async function getDfwProgramId(token: string): Promise<string> {
-  const rows = await restJson<Array<{ id: string; is_public: boolean; owner_id: string | null }>>(
-    'GET',
-    `programs?slug=eq.${DFW_SLUG}&select=id,is_public,owner_id`,
-    token,
-  );
+  const rows = await restJson<
+    Array<{ id: string; is_public: boolean; owner_id: string | null }>
+  >('GET', `programs?slug=eq.${DFW_SLUG}&select=id,is_public,owner_id`, token);
   expect(rows).toHaveLength(1);
   return rows[0].id;
 }
@@ -149,7 +154,13 @@ test.describe('program schema — DFW seed', () => {
     const user = await signUpThrowawayUser();
 
     const programs = await restJson<
-      Array<{ id: string; is_public: boolean; owner_id: string | null; num_weeks: number; days_per_week: number }>
+      Array<{
+        id: string;
+        is_public: boolean;
+        owner_id: string | null;
+        num_weeks: number;
+        days_per_week: number;
+      }>
     >('GET', `programs?slug=eq.${DFW_SLUG}&select=*`, user.token);
 
     expect(programs).toHaveLength(1);
@@ -160,7 +171,10 @@ test.describe('program schema — DFW seed', () => {
     expect(dfw.days_per_week).toBe(3);
 
     const sessions = await restJson<
-      Array<{ sequence_index: number; workout_options: { movements: unknown[] } }>
+      Array<{
+        sequence_index: number;
+        workout_options: { movements: unknown[] };
+      }>
     >(
       'GET',
       `program_sessions?program_id=eq.${dfw.id}&select=sequence_index,workout_options&order=sequence_index.asc`,
@@ -185,7 +199,13 @@ test.describe('program schema — 10,000 Swing Challenge seed', () => {
     const user = await signUpThrowawayUser();
 
     const programs = await restJson<
-      Array<{ id: string; is_public: boolean; owner_id: string | null; num_weeks: number; days_per_week: number }>
+      Array<{
+        id: string;
+        is_public: boolean;
+        owner_id: string | null;
+        num_weeks: number;
+        days_per_week: number;
+      }>
     >('GET', `programs?slug=eq.${SWING10K_SLUG}&select=*`, user.token);
 
     expect(programs).toHaveLength(1);
@@ -256,20 +276,25 @@ test.describe('program schema — 10,000 Swing Challenge seed', () => {
 });
 
 test.describe('program schema — RLS', () => {
-  test('a user cannot read or write another user\'s private program', async () => {
+  test("a user cannot read or write another user's private program", async () => {
     const alice = await signUpThrowawayUser();
     const bob = await signUpThrowawayUser();
 
     // Alice creates a private program she owns.
-    const [program] = await restJson<Array<{ id: string }>>('POST', 'programs', alice.token, {
-      body: {
-        owner_id: alice.uid,
-        title: "Alice's secret program",
-        num_weeks: 1,
-        days_per_week: 1,
+    const [program] = await restJson<Array<{ id: string }>>(
+      'POST',
+      'programs',
+      alice.token,
+      {
+        body: {
+          owner_id: alice.uid,
+          title: "Alice's secret program",
+          num_weeks: 1,
+          days_per_week: 1,
+        },
+        prefer: 'return=representation',
       },
-      prefer: 'return=representation',
-    });
+    );
     expect(program.id).toBeTruthy();
 
     // Bob cannot see it.
@@ -308,10 +333,15 @@ test.describe('program schema — RLS', () => {
 
     // UPDATE is silently scoped out by the RLS USING clause (owner_id is NULL):
     // 0 rows affected, and the shared row is unchanged.
-    const updated = await restJson<Array<unknown>>('PATCH', `programs?id=eq.${dfwId}`, user.token, {
-      body: { title: 'hacked' },
-      prefer: 'return=representation',
-    });
+    const updated = await restJson<Array<unknown>>(
+      'PATCH',
+      `programs?id=eq.${dfwId}`,
+      user.token,
+      {
+        body: { title: 'hacked' },
+        prefer: 'return=representation',
+      },
+    );
     expect(updated).toHaveLength(0);
 
     const stillNamed = await restJson<Array<{ title: string }>>(
@@ -342,10 +372,15 @@ test.describe('program schema — constraints', () => {
     const dfwId = await getDfwProgramId(user.token);
 
     // First active enrollment succeeds.
-    const [first] = await restJson<Array<{ id: string }>>('POST', 'user_programs', user.token, {
-      body: { user_id: user.uid, program_id: dfwId, status: 'active' },
-      prefer: 'return=representation',
-    });
+    const [first] = await restJson<Array<{ id: string }>>(
+      'POST',
+      'user_programs',
+      user.token,
+      {
+        body: { user_id: user.uid, program_id: dfwId, status: 'active' },
+        prefer: 'return=representation',
+      },
+    );
     expect(first.id).toBeTruthy();
 
     // A second active enrollment violates one_active_program_per_user.
@@ -355,10 +390,15 @@ test.describe('program schema — constraints', () => {
     expect(second.status).toBe(409);
 
     // But a non-active enrollment for the same user is fine.
-    const [abandoned] = await restJson<Array<{ id: string }>>('POST', 'user_programs', user.token, {
-      body: { user_id: user.uid, program_id: dfwId, status: 'abandoned' },
-      prefer: 'return=representation',
-    });
+    const [abandoned] = await restJson<Array<{ id: string }>>(
+      'POST',
+      'user_programs',
+      user.token,
+      {
+        body: { user_id: user.uid, program_id: dfwId, status: 'abandoned' },
+        prefer: 'return=representation',
+      },
+    );
     expect(abandoned.id).toBeTruthy();
   });
 
@@ -366,10 +406,15 @@ test.describe('program schema — constraints', () => {
     const user = await signUpThrowawayUser();
     const dfwId = await getDfwProgramId(user.token);
 
-    const [enrollment] = await restJson<Array<{ id: string }>>('POST', 'user_programs', user.token, {
-      body: { user_id: user.uid, program_id: dfwId, status: 'active' },
-      prefer: 'return=representation',
-    });
+    const [enrollment] = await restJson<Array<{ id: string }>>(
+      'POST',
+      'user_programs',
+      user.token,
+      {
+        body: { user_id: user.uid, program_id: dfwId, status: 'active' },
+        prefer: 'return=representation',
+      },
+    );
     const [session] = await restJson<Array<{ id: string }>>(
       'GET',
       `program_sessions?program_id=eq.${dfwId}&select=id&order=sequence_index.asc&limit=1`,
@@ -410,7 +455,12 @@ test.describe('program schema — enroll_in_program (copy-on-enroll)', () => {
 
     // A new user-owned, private clone exists, linked back to the source.
     const clones = await restJson<
-      Array<{ id: string; owner_id: string; is_public: boolean; source_program_id: string }>
+      Array<{
+        id: string;
+        owner_id: string;
+        is_public: boolean;
+        source_program_id: string;
+      }>
     >(
       'GET',
       `programs?source_program_id=eq.${dfwId}&owner_id=eq.${user.uid}&select=id,owner_id,is_public,source_program_id`,
@@ -446,7 +496,9 @@ test.describe('program schema — enroll_in_program (copy-on-enroll)', () => {
     );
 
     // Exactly one active enrollment, pointing at the CLONE (not the shared DFW).
-    const active = await restJson<Array<{ id: string; program_id: string; status: string }>>(
+    const active = await restJson<
+      Array<{ id: string; program_id: string; status: string }>
+    >(
       'GET',
       `user_programs?user_id=eq.${user.uid}&status=eq.active&select=id,program_id,status`,
       user.token,
@@ -461,10 +513,15 @@ test.describe('program schema — enroll_in_program (copy-on-enroll)', () => {
       `program_sessions?program_id=eq.${clone.id}&select=id&order=sequence_index.asc&limit=1`,
       user.token,
     );
-    await restJson('PATCH', `program_sessions?id=eq.${firstClone.id}`, user.token, {
-      body: { title: 'Edited by owner' },
-      prefer: 'return=representation',
-    });
+    await restJson(
+      'PATCH',
+      `program_sessions?id=eq.${firstClone.id}`,
+      user.token,
+      {
+        body: { title: 'Edited by owner' },
+        prefer: 'return=representation',
+      },
+    );
     const dfwFirst = await restJson<Array<{ title: string }>>(
       'GET',
       `program_sessions?program_id=eq.${dfwId}&select=title&order=sequence_index.asc&limit=1`,
@@ -480,9 +537,13 @@ test.describe('program schema — enroll_in_program (copy-on-enroll)', () => {
     const firstEnrollment = await rpc<string>('enroll_in_program', user.token, {
       p_program_id: dfwId,
     });
-    const secondEnrollment = await rpc<string>('enroll_in_program', user.token, {
-      p_program_id: dfwId,
-    });
+    const secondEnrollment = await rpc<string>(
+      'enroll_in_program',
+      user.token,
+      {
+        p_program_id: dfwId,
+      },
+    );
     expect(secondEnrollment).not.toBe(firstEnrollment);
 
     // The first enrollment is now abandoned; exactly one active remains (the new one).

--- a/e2e/program-schema.spec.ts
+++ b/e2e/program-schema.spec.ts
@@ -13,6 +13,8 @@ const SUPABASE_URL = process.env.VITE_SUPABASE_URL!;
 const SUPABASE_ANON_KEY = process.env.VITE_SUPABASE_ANON_KEY!;
 const DFW_SLUG = 'dry-fighting-weight';
 const DFW_SESSION_COUNT = 14;
+const SWING10K_SLUG = '10000-swing-challenge';
+const SWING10K_SESSION_COUNT = 20;
 
 // ── Types ────────────────────────────────────────────────────────────────────
 
@@ -174,6 +176,81 @@ test.describe('program schema — DFW seed', () => {
     for (const s of sessions) {
       expect(Array.isArray(s.workout_options.movements)).toBe(true);
       expect(s.workout_options.movements.length).toBeGreaterThan(0);
+    }
+  });
+});
+
+test.describe('program schema — 10,000 Swing Challenge seed', () => {
+  test('the shared 10k Swing Challenge is present, public, system-owned, with 20 flat sessions', async () => {
+    const user = await signUpThrowawayUser();
+
+    const programs = await restJson<
+      Array<{ id: string; is_public: boolean; owner_id: string | null; num_weeks: number; days_per_week: number }>
+    >('GET', `programs?slug=eq.${SWING10K_SLUG}&select=*`, user.token);
+
+    expect(programs).toHaveLength(1);
+    const challenge = programs[0];
+    expect(challenge.is_public).toBe(true);
+    expect(challenge.owner_id).toBeNull();
+    expect(challenge.num_weeks).toBe(4);
+    expect(challenge.days_per_week).toBe(5);
+
+    const sessions = await restJson<
+      Array<{
+        sequence_index: number;
+        week_number: number;
+        day_number: number;
+        workout_options: {
+          complexSet: boolean;
+          intervalTimer: number;
+          restTimer: number;
+          workoutGoal: number;
+          workoutGoalUnits: string;
+          movements: Array<{
+            movementName: string;
+            repScheme: number[];
+            weightOneUnit: string | null;
+            weightOneValue: number | null;
+            weightTwoUnit: string | null;
+            weightTwoValue: number | null;
+          }>;
+        };
+      }>
+    >(
+      'GET',
+      `program_sessions?program_id=eq.${challenge.id}&select=sequence_index,week_number,day_number,workout_options&order=sequence_index.asc`,
+      user.token,
+    );
+
+    expect(sessions).toHaveLength(SWING10K_SESSION_COUNT);
+    // Contiguous 0..19 order.
+    expect(sessions.map((s) => s.sequence_index)).toEqual(
+      Array.from({ length: SWING10K_SESSION_COUNT }, (_, i) => i),
+    );
+    // 4 weeks x 5 days, laid out in order.
+    expect(sessions.map((s) => [s.week_number, s.day_number])).toEqual(
+      Array.from({ length: SWING10K_SESSION_COUNT }, (_, i) => [
+        Math.floor(i / 5) + 1,
+        (i % 5) + 1,
+      ]),
+    );
+
+    // Every session is the identical 500-swing conditioning target.
+    for (const s of sessions) {
+      const opts = s.workout_options;
+      expect(opts.complexSet).toBe(false);
+      expect(opts.intervalTimer).toBe(0);
+      expect(opts.restTimer).toBe(0);
+      expect(opts.workoutGoal).toBe(5);
+      expect(opts.workoutGoalUnits).toBe('rounds');
+      expect(opts.movements).toHaveLength(1);
+      const [swing] = opts.movements;
+      expect(swing.movementName).toBe('Kettlebell Swing');
+      expect(swing.repScheme).toEqual([10, 15, 25, 50]);
+      expect(swing.weightOneUnit).toBe('kilograms');
+      expect(swing.weightOneValue).toBe(24);
+      expect(swing.weightTwoUnit).toBeNull();
+      expect(swing.weightTwoValue).toBeNull();
     }
   });
 });

--- a/supabase/migrations/20260713181620_seed_10000_swing_challenge.sql
+++ b/supabase/migrations/20260713181620_seed_10000_swing_challenge.sql
@@ -1,0 +1,81 @@
+-- Seed the shared 10,000 Swing Challenge program (Dan John). Public +
+-- system-owned (owner_id NULL, is_public true) so every user sees it and can
+-- one-tap "Start"; enrolling clones it into an editable copy (enroll_in_program).
+-- Idempotent on slug: a re-run (or a fresh env) skips re-seeding sessions.
+--
+-- Runs as the migration role, which bypasses RLS, so the NULL-owner public row
+-- inserts cleanly. This is a MIGRATION (not seed.sql) so it also reaches
+-- staging/production, where seed.sql never runs. Mirrors the DFW seed migration
+-- (20260706170001_seed_dry_fighting_weight.sql) conventions exactly.
+--
+-- 20 trackable sessions (seq 0-19), 4 weeks x 5 days. Every session is identical:
+-- 500 swings as a 100-rep cluster (10/15/25/50) repeated 5 times. The load and
+-- reps are flat for all 4 weeks -- this is a conditioning target, not a strength
+-- progression, so there's no week-to-week variation to encode.
+--
+-- The source prescribes no fixed rest cadence, so intervalTimer/restTimer stay 0
+-- (unused) and the user self-paces -- the same precedent DFW sets for its own
+-- unused-timer sessions. Load is a single 24 kg placeholder (men's standard;
+-- DFW's placeholder-load convention) so the program is runnable out of the box;
+-- the user adjusts load per session in the builder at start time.
+
+-- Session-local helper (pg_temp: auto-dropped at connection end, never persisted
+-- to the committed schema) that builds the WorkoutOptions JSONB for one session.
+-- Shape MUST match Omit<WorkoutOptions,'startedAt'> exactly (camelCase keys).
+CREATE OR REPLACE FUNCTION pg_temp.swing10k_options(p_details TEXT)
+RETURNS JSONB LANGUAGE sql IMMUTABLE AS $$
+  SELECT jsonb_build_object(
+    'complexSet', false,
+    'intervalTimer', 0,
+    'restTimer', 0,
+    'workoutGoal', 5,
+    'workoutGoalUnits', 'rounds',
+    'workoutDetails', p_details,
+    'sharedWeightOneUnit', NULL,
+    'sharedWeightOneValue', NULL,
+    'sharedWeightTwoUnit', NULL,
+    'sharedWeightTwoValue', NULL,
+    'movements', jsonb_build_array(
+      jsonb_build_object(
+        'movementName', 'Kettlebell Swing',
+        'repScheme', to_jsonb(ARRAY[10,15,25,50]::INT[]),
+        'weightOneUnit', 'kilograms', 'weightOneValue', 24,
+        'weightTwoUnit', NULL, 'weightTwoValue', NULL)
+    ));
+$$;
+
+DO $$
+DECLARE
+  v_program_id UUID;
+  v_week INT;
+  v_day INT;
+  v_seq INT := 0;
+BEGIN
+  INSERT INTO programs (owner_id, slug, title, description, author_name, num_weeks, days_per_week, is_public)
+  VALUES (NULL, '10000-swing-challenge',
+          '10,000 Swing Challenge',
+          'Dan John''s 4-week conditioning challenge: 20 sessions of 500 kettlebell '
+          'swings, performed as a 100-rep cluster (10/15/25/50) repeated 5 times.',
+          'Dan John', 4, 5, true)
+  ON CONFLICT (slug) DO NOTHING
+  RETURNING id INTO v_program_id;
+
+  -- If the row already existed, skip re-seeding sessions.
+  IF v_program_id IS NULL THEN
+    RAISE NOTICE '10,000 Swing Challenge program already seeded; skipping sessions.';
+    RETURN;
+  END IF;
+
+  FOR v_week IN 1..4 LOOP
+    FOR v_day IN 1..5 LOOP
+      INSERT INTO program_sessions
+        (program_id, sequence_index, week_number, day_number, title, workout_options)
+      VALUES
+        (v_program_id, v_seq, v_week, v_day,
+         format('Week %s, Day %s', v_week, v_day),
+         pg_temp.swing10k_options(
+           format('Week %s, Day %s - 5 rounds of 10/15/25/50 (500 swings)', v_week, v_day)));
+      v_seq := v_seq + 1;
+    END LOOP;
+  END LOOP;
+END $$;


### PR DESCRIPTION
## What
Adds Dan John's "10,000 Swing Challenge" as a second shared, system-owned program (`owner_id NULL`, `is_public true`) alongside DFW, behind the existing `programs` flag. Seed-data only — no RPC, UI, or type changes.

## Why
PROD-226. DFW is currently the app's only shared program; the research report (`data/research-kb-programs-r3/report.md`) identified 5 free, popular kettlebell programs that fit the existing schema with zero structural gaps, and this is the strongest of the five — a decade-old T-Nation conditioning staple with no compromises needed against `WorkoutOptions`.

A new migration (`20260713181620_seed_10000_swing_challenge.sql`) mirrors the DFW seed's conventions exactly: idempotent on slug, a `pg_temp` helper building each session's `WorkoutOptions` JSONB, one `program_sessions` row per session. The 20 sessions (4 weeks × 5 days) are generated by a nested week/day loop rather than 20 explicit rows, since every session is identical by design — 500 swings as 5 rounds of a 100-rep Kettlebell Swing cluster (`repScheme [10,15,25,50]`) — the source program is a flat conditioning target, not a strength progression.

Known, deliberate out-of-scope item: `ProgramsPage` currently renders only one shared-program card (hardcoded to DFW), so this program lands correctly in the shared-program data layer but isn't yet reachable in the UI. Surfacing it (and four sibling programs landing in parallel) is a separate, coordinated `ProgramsPage` change (PROD-231), intentionally not part of this seed-only task.

## How tested
Because this is seed-data only, the relevant surface is the persisted DB rows the app reads, so I validated there directly rather than through the UI:
- `npx supabase db reset` applied the full migration chain cleanly.
- Applied the migration directly via `psql` and queried `programs`/`program_sessions` for slug `10000-swing-challenge`: program row is system-owned/public, Dan John, 4×5; 20 sessions, `sequence_index` 0–19 contiguous and distinct, laid out 4 weeks × 5 days in order.
- Verified per-session `workout_options` JSONB against the `WorkoutOptions`/`MovementOptions` types, flatness (`count(DISTINCT workout_options - 'workoutDetails') = 1`), idempotency (re-running the migration logs "already seeded; skipping" and leaves exactly 20 rows), and coexistence with DFW and a sibling in-flight program (both public, system-owned, no slug conflict).
- `tsc` clean, lint clean, 394 unit tests green, 8 e2e green locally before the pipeline run.
- The pipeline's own `test` step could not run the new `e2e/program-schema.spec.ts` assertions: the local Supabase container is shared across several parallel worktrees that were mid-`db reset` with different program seeds during this run (observed swapping to sibling programs' data mid-query), so a timed Playwright run would flake on that contention rather than on product behavior. The direct migration-apply + DB-state queries above cover the same assertions deterministically.

## Tradeoffs
Considered writing all 20 sessions as explicit `VALUES` rows, matching DFW's style — DFW does this because its sessions genuinely differ week to week. Went with a generated loop instead since every session here is identical; it's less code and the flatness itself is asserted directly (`distinct_shapes = 1`) rather than left to visual inspection of 20 near-duplicate rows.

<details>
<summary>Evidence: Persisted DB state — program row + 20 sessions (4x5)</summary>

`system_owned=t is_public=t slug=10000-swing-challenge title='10,000 Swing Challenge' author='Dan John' num_weeks=4 days_per_week=5 | sessions=20 min_seq=0 max_seq=19 distinct_seq=20 | 20 rows Week1..4 Day1..5 in order`

```text
### 1. Program row — system-owned (owner_id NULL), public, Dan John, 4x5
 system_owned | is_public |         slug          |         title          | author_name | num_weeks | days_per_week 
--------------+-----------+-----------------------+------------------------+-------------+-----------+---------------
 t            | t         | 10000-swing-challenge | 10,000 Swing Challenge | Dan John    |         4 |             5
(1 row)

### 2. Session count / contiguity — 20 sessions, seq 0..19, all distinct
 sessions | min_seq | max_seq | distinct_seq 
----------+---------+---------+--------------
       20 |       0 |      19 |           20
(1 row)

### 3. All 20 sessions — 4 weeks x 5 days laid out in order
 seq | wk | dy |     title     |                       details                        
-----+----+----+---------------+------------------------------------------------------
   0 |  1 |  1 | Week 1, Day 1 | Week 1, Day 1 - 5 rounds of 10/15/25/50 (500 swings)
   1 |  1 |  2 | Week 1, Day 2 | Week 1, Day 2 - 5 rounds of 10/15/25/50 (500 swings)
   2 |  1 |  3 | Week 1, Day 3 | Week 1, Day 3 - 5 rounds of 10/15/25/50 (500 swings)
   3 |  1 |  4 | Week 1, Day 4 | Week 1, Day 4 - 5 rounds of 10/15/25/50 (500 swings)
   4 |  1 |  5 | Week 1, Day 5 | Week 1, Day 5 - 5 rounds of 10/15/25/50 (500 swings)
   5 |  2 |  1 | Week 2, Day 1 | Week 2, Day 1 - 5 rounds of 10/15/25/50 (500 swings)
   6 |  2 |  2 | Week 2, Day 2 | Week 2, Day 2 - 5 rounds of 10/15/25/50 (500 swings)
   7 |  2 |  3 | Week 2, Day 3 | Week 2, Day 3 - 5 rounds of 10/15/25/50 (500 swings)
   8 |  2 |  4 | Week 2, Day 4 | Week 2, Day 4 - 5 rounds of 10/15/25/50 (500 swings)
   9 |  2 |  5 | Week 2, Day 5 | Week 2, Day 5 - 5 rounds of 10/15/25/50 (500 swings)
  10 |  3 |  1 | Week 3, Day 1 | Week 3, Day 1 - 5 rounds of 10/15/25/50 (500 swings)
  11 |  3 |  2 | Week 3, Day 2 | Week 3, Day 2 - 5 rounds of 10/15/25/50 (500 swings)
  12 |  3 |  3 | Week 3, Day 3 | Week 3, Day 3 - 5 rounds of 10/15/25/50 (500 swings)
  13 |  3 |  4 | Week 3, Day 4 | Week 3, Day 4 - 5 rounds of 10/15/25/50 (500 swings)
  14 |  3 |  5 | Week 3, Day 5 | Week 3, Day 5 - 5 rounds of 10/15/25/50 (500 swings)
  15 |  4 |  1 | Week 4, Day 1 | Week 4, Day 1 - 5 rounds of 10/15/25/50 (500 swings)
  16 |  4 |  2 | Week 4, Day 2 | Week 4, Day 2 - 5 rounds of 10/15/25/50 (500 swings)
  17 |  4 |  3 | Week 4, Day 3 | Week 4, Day 3 - 5 rounds of 10/15/25/50 (500 swings)
  18 |  4 |  4 | Week 4, Day 4 | Week 4, Day 4 - 5 rounds of 10/15/25/50 (500 swings)
  19 |  4 |  5 | Week 4, Day 5 | Week 4, Day 5 - 5 rounds of 10/15/25/50 (500 swings)
(20 rows)
```
</details>
<details>
<summary>Evidence: workout_options JSONB + flatness + idempotency</summary>

`seq0 options: Kettlebell Swing repScheme[10,15,25,50] weightOneUnit=kilograms weightOneValue=24 weightTwo*=null; complexSet=false intervalTimer=0 restTimer=0 workoutGoal=5 workoutGoalUnits=rounds; sharedWeight*=null. distinct_shapes=1. Re-apply -> 'already seeded; skipping', sessions_after_reapply=20`

```text
### workout_options JSONB for session seq=0 (all 20 identical except workoutDetails)
 {                                                                            +
     "movements": [                                                           +
         {                                                                    +
             "repScheme": [                                                   +
                 10,                                                          +
                 15,                                                          +
                 25,                                                          +
                 50                                                           +
             ],                                                               +
             "movementName": "Kettlebell Swing",                              +
             "weightOneUnit": "kilograms",                                    +
             "weightTwoUnit": null,                                           +
             "weightOneValue": 24,                                            +
             "weightTwoValue": null                                           +
         }                                                                    +
     ],                                                                       +
     "restTimer": 0,                                                          +
     "complexSet": false,                                                     +
     "workoutGoal": 5,                                                        +
     "intervalTimer": 0,                                                      +
     "workoutDetails": "Week 1, Day 1 - 5 rounds of 10/15/25/50 (500 swings)",+
     "workoutGoalUnits": "rounds",                                            +
     "sharedWeightOneUnit": null,                                             +
     "sharedWeightTwoUnit": null,                                             +
     "sharedWeightOneValue": null,                                            +
     "sharedWeightTwoValue": null                                             +
 }

### Flatness: distinct workout_options shapes ignoring per-session details (expect 1)
 distinct_shapes 
-----------------
               1
(1 row)

### Idempotency: re-running migration keeps exactly 20 sessions (no dupes)
NOTICE:  10,000 Swing Challenge program already seeded; skipping sessions.
DO
 sessions_after_reapply 
------------------------
                     20
(1 row)
```
</details>
<details>
<summary>Evidence: Shared programs coexist (swing challenge alongside DFW)</summary>

`10000-swing-challenge (20 sessions), dry-fighting-weight (14 sessions), aa-protocol-plan-a (5, sibling worktree) — all system_owned=t is_public=t, distinct slugs, no conflict`

```text
         slug          |         title          | system_owned | is_public | sessions 
-----------------------+------------------------+--------------+-----------+----------
 10000-swing-challenge | 10,000 Swing Challenge | t            | t         |       20
 aa-protocol-plan-a    | A+A Protocol "Plan A"  | t            | t         |        5
 dry-fighting-weight   | Dry Fighting Weight    | t            | t         |       14
(3 rows)
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Test** - 1 info</summary>

- ℹ️ The e2e test e2e/program-schema.spec.ts (the author's new assertions) was not run because the local Supabase container `supabase_db_kettlebells` is a project-scoped resource shared by parallel worktrees that were actively running their own `supabase db reset` cycles during this run (the DB was observed swapping between sibling program sets `armor-building-complex` and `aa-protocol-plan-a`, wiping the swing-challenge seed mid-query). Any timed Playwright run would flake on that contention rather than on product behavior. I instead validated the migration deterministically by applying this worktree's actual migration file and querying the persisted DB state directly.
- `npx supabase db reset` — applied full migration chain incl. `20260713181620_seed_10000_swing_challenge.sql` cleanly
- Applied the migration file directly via `psql < supabase/migrations/20260713181620_seed_10000_swing_challenge.sql` and queried `programs` + `program_sessions` for slug `10000-swing-challenge`
- Verified program row: owner_id NULL (system-owned), is_public true, author 'Dan John', num_weeks 4, days_per_week 5
- Verified 20 sessions, sequence_index 0..19 contiguous & distinct, laid out as 4 weeks x 5 days in order
- Verified per-session workout_options JSONB via jsonb_pretty against Omit<WorkoutOptions,'startedAt'> + MovementOptions type keys
- Verified flatness: `count(DISTINCT workout_options - 'workoutDetails') = 1`
- Verified idempotency: re-applying migration emits 'already seeded; skipping' and leaves exactly 20 sessions
- Verified swing challenge coexists with the shared DFW program (both public, system-owned)

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
