### PR TITLE
chore: trim narration comments, favor self-documenting code

### DIFF
--- a/src/components/PWAInstallPrompt/PWAInstallPrompt.stories.tsx
+++ b/src/components/PWAInstallPrompt/PWAInstallPrompt.stories.tsx
@@ -3,7 +3,6 @@ import { useEffect } from 'react';
 
 import { PWAInstallPrompt } from './PWAInstallPrompt';
 
-// Mock the beforeinstallprompt event
 const mockBeforeInstallPrompt = () => {
   const event = new Event('beforeinstallprompt') as any;
   event.platforms = ['web'];
@@ -12,13 +11,11 @@ const mockBeforeInstallPrompt = () => {
   return event;
 };
 
-// Mock localStorage
 const mockLocalStorage = {
   getItem: (key: string) => null,
   setItem: (key: string, value: string) => {},
 };
 
-// Mock window.matchMedia
 const mockMatchMedia = (matches: boolean) => {
   Object.defineProperty(window, 'matchMedia', {
     writable: true,
@@ -35,7 +32,6 @@ const mockMatchMedia = (matches: boolean) => {
   });
 };
 
-// Mock navigator.userAgent
 const mockUserAgent = (userAgent: string) => {
   Object.defineProperty(navigator, 'userAgent', {
     value: userAgent,
@@ -43,7 +39,6 @@ const mockUserAgent = (userAgent: string) => {
   });
 };
 
-// Mock navigator.standalone
 const mockStandalone = (standalone: boolean) => {
   Object.defineProperty(navigator, 'standalone', {
     value: standalone,
@@ -51,7 +46,6 @@ const mockStandalone = (standalone: boolean) => {
   });
 };
 
-// Mock document.referrer
 const mockReferrer = (referrer: string) => {
   Object.defineProperty(document, 'referrer', {
     value: referrer,
@@ -67,7 +61,6 @@ const meta = {
   decorators: [
     (Story: any) => {
       useEffect(() => {
-        // Reset mocks before each story
         mockMatchMedia(false);
         mockUserAgent(
           'Mozilla/5.0 (iPhone; CPU iPhone OS 14_0 like Mac OS X) AppleWebKit/605.1.15',
@@ -75,7 +68,6 @@ const meta = {
         mockStandalone(false);
         mockReferrer('https://example.com');
 
-        // Mock localStorage
         Object.defineProperty(window, 'localStorage', {
           value: mockLocalStorage,
           writable: true,
@@ -94,7 +86,6 @@ export const Default: Story = {
   decorators: [
     (Story: any) => {
       useEffect(() => {
-        // Trigger the beforeinstallprompt event after component mounts
         setTimeout(() => {
           const event = mockBeforeInstallPrompt();
           window.dispatchEvent(event);

--- a/src/components/PWAInstallPrompt/PWAInstallPrompt.test.tsx
+++ b/src/components/PWAInstallPrompt/PWAInstallPrompt.test.tsx
@@ -6,7 +6,6 @@ import * as stories from './PWAInstallPrompt.stories';
 
 const { Default } = composeStories(stories);
 
-// Mock the beforeinstallprompt event (using Vitest for tests)
 const mockBeforeInstallPrompt = () => {
   const event = new Event('beforeinstallprompt') as any;
   event.platforms = ['web'];
@@ -15,13 +14,11 @@ const mockBeforeInstallPrompt = () => {
   return event;
 };
 
-// Mock localStorage (using Vitest for tests)
 const mockLocalStorage = {
   getItem: vi.fn((key: string) => null),
   setItem: vi.fn((key: string, value: string) => {}),
 };
 
-// Mock window.matchMedia (using Vitest for tests)
 const mockMatchMedia = (matches: boolean) => {
   Object.defineProperty(window, 'matchMedia', {
     writable: true,
@@ -38,7 +35,6 @@ const mockMatchMedia = (matches: boolean) => {
   });
 };
 
-// Mock navigator.userAgent
 const mockUserAgent = (userAgent: string) => {
   Object.defineProperty(navigator, 'userAgent', {
     value: userAgent,
@@ -46,7 +42,6 @@ const mockUserAgent = (userAgent: string) => {
   });
 };
 
-// Mock navigator.standalone
 const mockStandalone = (standalone: boolean) => {
   Object.defineProperty(navigator, 'standalone', {
     value: standalone,
@@ -54,7 +49,6 @@ const mockStandalone = (standalone: boolean) => {
   });
 };
 
-// Mock document.referrer
 const mockReferrer = (referrer: string) => {
   Object.defineProperty(document, 'referrer', {
     value: referrer,
@@ -62,12 +56,9 @@ const mockReferrer = (referrer: string) => {
   });
 };
 
-// Setup all mocks before tests run
 const setupMocks = () => {
-  // Reset mocks
   vi.clearAllMocks();
 
-  // Setup default mocks
   mockMatchMedia(false);
   mockUserAgent(
     'Mozilla/5.0 (iPhone; CPU iPhone OS 14_0 like Mac OS X) AppleWebKit/605.1.15',
@@ -75,7 +66,6 @@ const setupMocks = () => {
   mockStandalone(false);
   mockReferrer('https://example.com');
 
-  // Mock localStorage
   Object.defineProperty(window, 'localStorage', {
     value: mockLocalStorage,
     writable: true,
@@ -88,7 +78,6 @@ describe('PWAInstallPrompt', () => {
   });
 
   afterEach(() => {
-    // Clean up event listeners
     window.removeEventListener('beforeinstallprompt', vi.fn());
   });
 
@@ -184,11 +173,9 @@ describe('PWAInstallPrompt', () => {
         expect(screen.getByText('Install BellSkill')).toBeTruthy();
       });
 
-      // Simulate the beforeinstallprompt event
       const event = mockBeforeInstallPrompt();
       window.dispatchEvent(event);
 
-      // The component should still be visible after the event
       expect(screen.getByText('Install BellSkill')).toBeTruthy();
     });
   });
@@ -251,7 +238,6 @@ describe('PWAInstallPrompt', () => {
         expect(screen.getByText('Install BellSkill')).toBeTruthy();
       });
 
-      // Check that the share icon is present (it should be rendered as an SVG)
       const shareIcon = document.querySelector('svg');
       expect(shareIcon).toBeTruthy();
     });

--- a/src/components/PWAInstallPrompt/PWAInstallPrompt.tsx
+++ b/src/components/PWAInstallPrompt/PWAInstallPrompt.tsx
@@ -23,7 +23,6 @@ export function PWAInstallPrompt() {
   const [isMobile, setIsMobile] = useState(false);
 
   useEffect(() => {
-    // Check if app is already installed (running in standalone mode)
     const isStandaloneMode =
       window.matchMedia('(display-mode: standalone)').matches ||
       (window.navigator as any).standalone ||
@@ -31,20 +30,17 @@ export function PWAInstallPrompt() {
 
     setIsStandalone(isStandaloneMode);
 
-    // Check if device is mobile
     const isMobileDevice =
       /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(
         navigator.userAgent,
       );
     setIsMobile(isMobileDevice);
 
-    // Check if user has already dismissed the prompt
     const hasBeenDismissed = localStorage.getItem('pwa-install-dismissed');
     const dismissedTime = hasBeenDismissed ? parseInt(hasBeenDismissed) : 0;
     const daysSinceDismissed =
       (Date.now() - dismissedTime) / (1000 * 60 * 60 * 24);
 
-    // Show prompt if: mobile device, not standalone, not recently dismissed
     if (
       isMobileDevice &&
       !isStandaloneMode &&
@@ -53,7 +49,6 @@ export function PWAInstallPrompt() {
       setShowPrompt(true);
     }
 
-    // Listen for the beforeinstallprompt event
     const handleBeforeInstallPrompt = (e: Event) => {
       e.preventDefault();
       setDeferredPrompt(e as BeforeInstallPromptEvent);
@@ -80,7 +75,7 @@ export function PWAInstallPrompt() {
 
       setDeferredPrompt(null);
     } else {
-      // Fallback for iOS Safari and other browsers
+      // iOS Safari never fires beforeinstallprompt, so there's no native prompt
       showInstallInstructions();
     }
   };
@@ -108,7 +103,6 @@ export function PWAInstallPrompt() {
     localStorage.setItem('pwa-install-dismissed', Date.now().toString());
   };
 
-  // Don't show if not mobile, already installed, or user dismissed
   if (!showPrompt || !isMobile || isStandalone) {
     return null;
   }

--- a/src/components/Page.tsx
+++ b/src/components/Page.tsx
@@ -17,7 +17,6 @@ export const Page = ({
   return (
     <div
       className={clsx('mx-auto my-2 flex w-full flex-col gap-2 bg-card p-3', {
-        // width
         'max-w-md': width === 'default',
         'max-w-4xl': width === 'full',
       })}

--- a/src/components/ui/otp-input.tsx
+++ b/src/components/ui/otp-input.tsx
@@ -19,7 +19,6 @@ const OtpInput = React.forwardRef<HTMLDivElement, OtpInputProps>(
     const inputRefs = React.useRef<(HTMLInputElement | null)[]>([]);
 
     const handleChange = (index: number, inputValue: string) => {
-      // Only allow single digit
       const digit = inputValue.replace(/\D/g, '').slice(-1);
 
       const newValue = value.split('');
@@ -28,12 +27,10 @@ const OtpInput = React.forwardRef<HTMLDivElement, OtpInputProps>(
 
       onChange(updatedValue);
 
-      // Move to next input if digit was entered
       if (digit && index < length - 1) {
         inputRefs.current[index + 1]?.focus();
       }
 
-      // Call onComplete if all digits are filled
       if (updatedValue.length === length && onComplete) {
         onComplete(updatedValue);
       }
@@ -44,7 +41,6 @@ const OtpInput = React.forwardRef<HTMLDivElement, OtpInputProps>(
       e: React.KeyboardEvent<HTMLInputElement>,
     ) => {
       if (e.key === 'Backspace' && !value[index] && index > 0) {
-        // Move to previous input on backspace if current is empty
         inputRefs.current[index - 1]?.focus();
       } else if (e.key === 'ArrowLeft' && index > 0) {
         inputRefs.current[index - 1]?.focus();
@@ -59,7 +55,6 @@ const OtpInput = React.forwardRef<HTMLDivElement, OtpInputProps>(
       const newValue = pastedData.slice(0, length);
       onChange(newValue);
 
-      // Focus the last filled input or the first empty one
       const focusIndex = Math.min(newValue.length, length - 1);
       setTimeout(() => {
         inputRefs.current[focusIndex]?.focus();

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -11,12 +11,12 @@ async function enableMocking() {
 
   const { worker } = await import('./mocks/browser');
 
-  // `worker.start()` returns a Promise that resolves
-  // once the Service Worker is up and ready to intercept requests.
+  // Resolves once the mock Service Worker is intercepting requests.
   return worker.start();
 }
 
-// Clean up any existing service workers
+// Stale service workers from earlier builds 404 on sw.js; unregister them
+// and clear their caches.
 if ('serviceWorker' in navigator) {
   navigator.serviceWorker.getRegistrations().then(function(registrations) {
     for(let registration of registrations) {
@@ -28,7 +28,6 @@ if ('serviceWorker' in navigator) {
     console.log('Service worker unregistration failed: ', err);
   });
 
-  // Clear all caches
   if ('caches' in window) {
     caches.keys().then(function(cacheNames) {
       cacheNames.forEach(function(cacheName) {

--- a/src/pages/ActiveWorkoutPage/ActiveWorkoutPage.tsx
+++ b/src/pages/ActiveWorkoutPage/ActiveWorkoutPage.tsx
@@ -117,12 +117,10 @@ export const ActiveWorkoutPage = ({
   const [isRestActive, setIsRestActive] = useState<boolean>(false);
   const [isCountdownActive, setIsCountdownActive] = useState<boolean>(false);
 
-  // Movements
   const lastMovementIndex = movements.length - 1;
   const isLastMovement = currentMovementIndex === lastMovementIndex;
   const currentMovement = movements[currentMovementIndex];
 
-  // Weights
   const primaryWeightSide = isMirrorSet ? 'right' : 'left'; // todo: make primary weight side configurable
 
   const primaryWeightUnit = currentMovement.weightOneUnit;
@@ -173,28 +171,23 @@ export const ActiveWorkoutPage = ({
         ? null
         : secondaryWeightValue;
 
-  // Rungs
   const currentMovementRungs = currentMovement.repScheme.length;
   const isLastRung = currentMovementRungIndex === currentMovementRungs - 1;
   const currentRungVolume =
     currentTotalWeight * currentMovement.repScheme[currentMovementRungIndex];
 
-  // Rounds
   const currentRound = completedRounds + 1;
   const shouldMirrorReps = isOneHanded || isMixedWeights;
 
-  // Sides (within the current rung)
   const totalSides = shouldMirrorReps ? 2 : 1;
   const currentSide = isMirrorSet ? 2 : 1; // 1 = first side (left), 2 = second side (right)
 
-  // Interval Timer
   const totalIntervalMilliseconds = intervalTimer * 1000;
   const intervalCompletedPercentage =
     ((totalIntervalMilliseconds - intervalRemainingMilliseconds) /
       totalIntervalMilliseconds) *
     100;
 
-  // Rest Timer
   const totalRestMilliseconds = restTimer * 1000;
   const restCompletedPercentage =
     ((totalRestMilliseconds - restRemainingMilliseconds) /
@@ -206,7 +199,6 @@ export const ActiveWorkoutPage = ({
     ? Math.max(...movements.map((m) => m.repScheme.length))
     : currentMovementRungs;
 
-  // Helper Functions
   const incrementReps = () =>
     setCompletedReps(
       (prev) => prev + currentMovement.repScheme[currentMovementRungIndex],
@@ -362,7 +354,6 @@ export const ActiveWorkoutPage = ({
     });
   };
 
-  // Event Handlers
   const handleClickContinue = () => {
     unlockAudio();
     setIsEffectActive(true);

--- a/src/pages/ActiveWorkoutPage/components/WorkoutProgress.test.tsx
+++ b/src/pages/ActiveWorkoutPage/components/WorkoutProgress.test.tsx
@@ -24,35 +24,30 @@ describe('WorkoutProgress - volume goals', () => {
     test('displays 100% remaining when no volume completed (0%)', () => {
       render(<VolumeGoalNoProgress />);
 
-      // 0% complete means 100% remaining
       expect(screen.getByText('100%')).toBeInTheDocument();
     });
 
     test('displays 75% remaining when 25% complete', () => {
       render(<VolumeGoal25PercentComplete />);
 
-      // 25% complete means 75% remaining
       expect(screen.getByText('75%')).toBeInTheDocument();
     });
 
     test('displays 50% remaining when 50% complete', () => {
       render(<VolumeGoal50PercentComplete />);
 
-      // 50% complete means 50% remaining
       expect(screen.getByText('50%')).toBeInTheDocument();
     });
 
     test('displays 25% remaining when 75% complete', () => {
       render(<VolumeGoal75PercentComplete />);
 
-      // 75% complete means 25% remaining
       expect(screen.getByText('25%')).toBeInTheDocument();
     });
 
     test('displays 0% remaining when 100% complete', () => {
       render(<VolumeGoal100PercentComplete />);
 
-      // 100% complete means 0% remaining
       expect(screen.getByText('0%')).toBeInTheDocument();
     });
   });
@@ -83,10 +78,8 @@ describe('WorkoutProgress - volume goals', () => {
     test('displays no progress information when workoutGoal is 0', () => {
       render(<VolumeGoalZero />);
 
-      // When goal is 0, no value or description should be displayed
       expect(screen.queryByText('volume remaining')).not.toBeInTheDocument();
 
-      // The infinity symbol should be displayed instead
       const progressBar = screen.getByText('∞');
       expect(progressBar).toBeInTheDocument();
     });
@@ -94,7 +87,6 @@ describe('WorkoutProgress - volume goals', () => {
     test('does not display percentage when workoutGoal is 0', () => {
       render(<VolumeGoalZero />);
 
-      // Should not display any percentage values
       expect(screen.queryByText(/\d+%/)).not.toBeInTheDocument();
     });
   });
@@ -103,21 +95,18 @@ describe('WorkoutProgress - volume goals', () => {
     test('displays 0% remaining when completedVolume exceeds workoutGoal', () => {
       render(<VolumeGoalExceeded />);
 
-      // When completed > goal, remaining should be capped at 0%
       expect(screen.getByText('0%')).toBeInTheDocument();
     });
 
     test('displays 0% remaining when completedVolume significantly exceeds workoutGoal', () => {
       render(<VolumeGoalSignificantlyExceeded />);
 
-      // Even with large excess, remaining should be 0%
       expect(screen.getByText('0%')).toBeInTheDocument();
     });
 
     test('never displays negative percentage', () => {
       render(<VolumeGoalExceeded />);
 
-      // Verify no negative values are displayed
       const text = screen.getByText('0%');
       expect(text).toBeInTheDocument();
       expect(screen.queryByText(/-\d+%/)).not.toBeInTheDocument();
@@ -128,21 +117,18 @@ describe('WorkoutProgress - volume goals', () => {
     test('handles large volume values correctly (10000kg goal)', () => {
       render(<VolumeGoalLargeValues />);
 
-      // 1200 / 10000 = 12% complete, so 88% remaining
       expect(screen.getByText('88%')).toBeInTheDocument();
     });
 
     test('calculates percentage correctly with large completed volume', () => {
       render(<VolumeGoalLargeValuesHalfway />);
 
-      // 7500 / 10000 = 75% complete, so 25% remaining
       expect(screen.getByText('25%')).toBeInTheDocument();
     });
 
     test('handles very large values without overflow', () => {
       render(<VolumeGoalVeryLargeValues />);
 
-      // 50000 / 100000 = 50% complete, so 50% remaining
       expect(screen.getByText('50%')).toBeInTheDocument();
     });
   });

--- a/src/pages/CompletedWorkoutPage/CompletedWorkoutPage.tsx
+++ b/src/pages/CompletedWorkoutPage/CompletedWorkoutPage.tsx
@@ -78,11 +78,9 @@ export const CompletedWorkoutPage = () => {
     updateWorkoutNotes(notesRef.current?.value || null);
 
   const handleClickRepeat = () => {
-    // Prefill the builder from the completed workout, then let the user review
-    // and adjust before starting (routes to the Start page, not /active).
+    // Prefill the builder (not /active) so the user can review and adjust
+    // before starting; `editWorkout` makes the Start page skip browse mode.
     updateWorkoutOptions(workoutLogToWorkoutOptions(workoutLog, movementLogs));
-    // Tell the Start page to open the builder (it now defaults to the collapsed
-    // recommendations view) so the prefilled workout is shown for editing.
     navigate('/', { state: { editWorkout: true } });
   };
 

--- a/src/pages/CompletedWorkoutPage/utils/resolveSharedWeights.ts
+++ b/src/pages/CompletedWorkoutPage/utils/resolveSharedWeights.ts
@@ -1,5 +1,3 @@
-// resolveSharedWeights now lives in ~/utils so it can be shared by the API
-// layer (recent-workout repeats) without a pages -> utils import cycle. This
-// re-export keeps the existing `./utils` / `../utils/resolveSharedWeights`
-// import paths working for the CompletedWorkoutPage components.
+// Re-export: the implementation lives in ~/utils so the API layer can use it
+// without a pages -> utils import cycle.
 export * from '~/utils/resolveSharedWeights';

--- a/src/pages/StartWorkoutPage/StartWorkoutPage.tsx
+++ b/src/pages/StartWorkoutPage/StartWorkoutPage.tsx
@@ -96,29 +96,21 @@ export const StartWorkoutPage = ({
   programSaveMode,
 }: StartWorkoutPageProps = {}) => {
   const features = useFeatures();
-  // Discovery surfaces (curated / repeat / recommender) migrated onto the
-  // runtime feature-flag mechanism (PROD-175). Resolved once at app init
-  // (`FeatureFlagsGate` in `~/app/App.tsx`, gated behind its own splash)
-  // before this page ever mounts, so `useFeatureFlags()` here just reads the
-  // already-settled, cached result (`staleTime: Infinity`) — no pending state
-  // to gate on. Defaults to all-OFF (pure builder) on error or until
-  // deliberately toggled, so production behavior is unchanged.
+  // Runtime flags (PROD-175) settle at app init (`FeatureFlagsGate`) before
+  // this page mounts, so there's no pending state to gate on; they default to
+  // all-OFF (pure builder) on error.
   const { features: experimentFeatures } = useFeatureFlags();
   const navigate = useNavigate();
   const startWorkout = useStartWorkout();
   const [workoutOptions] = useWorkoutOptions();
   const { curated, recentRepeats } = useRecommendedWorkouts();
 
-  // Program tracking (Slice 3), behind the `programs` flag. The query is gated so
-  // non-program builds fire zero extra requests (zero regression). `data` is
-  // undefined only while the enabled query is still loading, so `programGate-
-  // Pending` reliably holds the page in browse mode until we know whether to
-  // surface the next-workout card — avoiding a builder→card flash on open.
-  // A terminal error also settles the gate (`!isError`): this query has no
-  // `placeholderData`, so `data` stays undefined after a failed fetch — without
-  // the `isError` escape a program-enabled session would be stranded on the
-  // blocking skeleton forever. On error we fall through to the safe default
-  // (no active program → builder).
+  // Program tracking, behind the `programs` flag (query gated so non-program
+  // builds fire zero requests). `programGatePending` holds the page in browse
+  // mode until the query settles, avoiding a builder→card flash on open. The
+  // `!isError` escape matters: `data` stays undefined after a failed fetch (no
+  // `placeholderData`), so without it an error would strand the page on the
+  // blocking skeleton instead of falling through to the builder.
   const activeProgramQuery = useActiveProgram({ enabled: features.programs });
   const activeProgram = activeProgramQuery.data ?? null;
   const hasActiveProgram = Boolean(activeProgram);
@@ -129,11 +121,9 @@ export const StartWorkoutPage = ({
     !activeProgramQuery.isError;
   const completeProgramSession = useCompleteProgramSession();
 
-  // Discovery surfaces are individually flag-gated (PROD-174). With every one
-  // off, there's nothing to browse, so the page is the pure custom builder. In
-  // save-session mode the page is always the builder — no browse surfaces. An
-  // active program forces browse so its next-workout card is the first thing the
-  // user sees on open.
+  // Discovery surfaces are individually flag-gated (PROD-174); with all of
+  // them off the page is the pure custom builder. Save-session mode never
+  // browses; an active program forces browse so its card is seen first.
   const showCurated = experimentFeatures.curatedFirstWorkout;
   const showRepeat = experimentFeatures.repeatPrevious;
   const showBrowse =
@@ -144,25 +134,19 @@ export const StartWorkoutPage = ({
       showRepeat ||
       experimentFeatures.recommender);
 
-  // When a discovery surface is enabled the page opens in "browse" mode
-  // (recommendations + a Build-custom button); selecting one or tapping
-  // Build-custom switches to the builder. With nothing to browse, or when the
-  // history "Repeat" action navigates here with `editWorkout`, the builder
-  // opens directly.
+  // Browse mode shows recommendations plus a Build-custom button; the builder
+  // opens directly when there's nothing to browse or when history's "Repeat"
+  // navigates here with `editWorkout`.
   const location = useLocation();
   const editWorkout = Boolean(
     (location.state as { editWorkout?: boolean } | null)?.editWorkout,
   );
-  // `showBrowse` is forced true while `programGatePending` is still resolving
-  // (see above), so committing to a mode from that still-forced value at
-  // mount would strand a program-enabled session in the builder until a
-  // correction effect fires post-paint — a visible flash. Instead we render
-  // neither surface until the gate settles (below) and derive the mode fresh
-  // each render from the now-final `showBrowse`, so there's never a stale
-  // value to correct. `builderOverride` is `null` until the user explicitly
-  // switches modes (Build custom, selecting a recommendation, Back to
-  // recommendations); once set, it wins over the derived default. Save mode
-  // has no browse surface to race against, so it's excluded from the gate.
+  // Committing to a mode at mount would use the still-forced `showBrowse` and
+  // need a post-paint correction (a visible flash), so render neither surface
+  // until the gate settles and derive the mode fresh each render.
+  // `builderOverride` is null until the user explicitly switches modes, then
+  // wins over the derived default. Save mode has no browse surface to race
+  // against, so it's excluded from the gate.
   const [builderOverride, setBuilderOverride] = useState<boolean | null>(null);
   const showBuilder = builderOverride ?? (editWorkout || !showBrowse);
   const gatesPending = !programSaveMode && programGatePending && !editWorkout;


### PR DESCRIPTION
## What
Removes comments that only restate the line below them (`// Check if device is mobile`, `// Mock localStorage`, section banners like `// Weights`) and tightens several verbose why-comments down to the load-bearing constraint, across 11 files. Fixes one outdated comment in `main.tsx` while touching it.

## Why
New project convention: favor self-documenting code over explanatory comments, keeping only genuine "why" context (constraints, workarounds, domain rules). See the updated comment-style guidance in the global CLAUDE.md.

## How tested
- `npm run compile:ts` — clean
- `npm test` — 394 tests passing (59 files)
- `npx prettier --check` on changed files — clean except `main.tsx`, which was already failing on `main` before this change (unrelated, left alone)

## Tradeoffs
Left the recent feature code (`useLogWorkout`, `patternDebt`, `ProgramSessionBuilderPage`, `MovementAutocomplete`, the contexts) untouched — those comments explain real constraints (flag-gating rationale, race conditions, RLS/constraint traps) rather than narrating the code, so they stay.