### PR TITLE
fix(programs): list all shared programs, not just one

### DIFF
--- a/src/pages/ProgramsPage/ProgramsPage.test.tsx
+++ b/src/pages/ProgramsPage/ProgramsPage.test.tsx
@@ -41,6 +41,20 @@ const dfw = {
   createdAt: '',
 };
 
+const armor = {
+  id: 'armor-1',
+  ownerId: null,
+  sourceProgramId: null,
+  slug: 'armor-building-complex',
+  title: 'Armor Building Complex',
+  description: null,
+  authorName: 'Dan John',
+  numWeeks: 6,
+  daysPerWeek: 3,
+  isPublic: true,
+  createdAt: '',
+};
+
 const myProgram = {
   id: 'mine-1',
   ownerId: 'user-123',
@@ -115,6 +129,50 @@ describe('ProgramsPage', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Switch program' }));
 
     expect(enrollMutate).toHaveBeenCalledWith('dfw-1', expect.anything());
+  });
+
+  it('renders one card per shared program, each with its own enroll button', () => {
+    mockUsePrograms.mockReturnValue({
+      data: [dfw, armor, myProgram],
+      isLoading: false,
+    });
+
+    renderPage();
+
+    expect(screen.getByText('Dry Fighting Weight')).toBeInTheDocument();
+    expect(screen.getByText('Armor Building Complex')).toBeInTheDocument();
+    expect(screen.getByText('Dan John · 6 weeks · 3/week')).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Start Dry Fighting Weight' }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Start Armor Building Complex' }),
+    ).toBeInTheDocument();
+  });
+
+  it('enrolls in a non-DFW shared program, prompting to switch when another is active', () => {
+    mockUsePrograms.mockReturnValue({
+      data: [dfw, armor, myProgram],
+      isLoading: false,
+    });
+    mockUseActiveProgram.mockReturnValue({
+      data: {
+        enrollment: { programId: 'other-program', status: 'active' },
+        program: { title: 'Other Program' },
+      },
+    });
+
+    renderPage();
+
+    fireEvent.click(screen.getByText('Start Armor Building Complex'));
+
+    // The switch prompt gates the RPC until confirmed.
+    expect(enrollMutate).not.toHaveBeenCalled();
+    expect(screen.getByText('Switch program?')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Switch program' }));
+
+    expect(enrollMutate).toHaveBeenCalledWith('armor-1', expect.anything());
   });
 
   it('creates a program from the inline form and navigates into the builder', () => {

--- a/src/pages/ProgramsPage/ProgramsPage.tsx
+++ b/src/pages/ProgramsPage/ProgramsPage.tsx
@@ -42,9 +42,6 @@ export const ProgramsPage = () => {
 
   const sharedPrograms = programs.filter((p) => p.isPublic);
   const myPrograms = programs.filter((p) => !p.isPublic);
-  const dfw =
-    sharedPrograms.find((p) => p.slug === 'dry-fighting-weight') ??
-    sharedPrograms[0];
 
   const enrollIn = (programId: string) =>
     enroll.mutate(programId, { onSuccess: () => navigate('/') });
@@ -89,26 +86,26 @@ export const ProgramsPage = () => {
 
   return (
     <Page title="Programs">
-      {dfw && (
-        <Card>
+      {sharedPrograms.map((program) => (
+        <Card key={program.id}>
           <CardHeader>
-            <CardTitle>{dfw.title}</CardTitle>
+            <CardTitle>{program.title}</CardTitle>
             <p className="text-xs text-muted-foreground">
-              {dfw.authorName ? `${dfw.authorName} · ` : ''}
-              {dfw.numWeeks} weeks · {dfw.daysPerWeek}/week
+              {program.authorName ? `${program.authorName} · ` : ''}
+              {program.numWeeks} weeks · {program.daysPerWeek}/week
             </p>
           </CardHeader>
           <CardContent>
             <Button
               className="w-full"
-              onClick={() => handleEnroll(dfw.id)}
+              onClick={() => handleEnroll(program.id)}
               disabled={enroll.isLoading}
             >
-              {`Start ${dfw.title}`}
+              {`Start ${program.title}`}
             </Button>
           </CardContent>
         </Card>
-      )}
+      ))}
 
       <div className="flex items-center justify-between">
         <h2 className="text-sm font-semibold">My programs</h2>


### PR DESCRIPTION
## What
`ProgramsPage` now renders one card per shared program instead of a single hardcoded card. Fix is scoped to `ProgramsPage.tsx` and its test.

## Why
PROD-231. `ProgramsPage` already collected every public program into `sharedPrograms`, but only ever rendered one of them (`dfw = sharedPrograms.find(slug === 'dry-fighting-weight') ?? sharedPrograms[0]`). Five new public programs are landing via separate seed migrations (PROD-226..230) and would have been invisible and un-enrollable in the UI without this fix — inert data with no way for a user to see or start them. Captain-approved: render a card per program, reusing the existing layout rather than a new design.

## How tested
- Replaced the single `dfw` card with `sharedPrograms.map((program) => <Card key={program.id}>...)`, mirroring the existing `myPrograms.map` pattern already in the same file. Removed the now-unused `dfw` constant/slug lookup.
- Read `handleEnroll`/`pendingSwitchId`/the switch-confirmation `Dialog` before assuming anything: they were already keyed by `programId`, not "the" DFW program, so they work per shared card with zero changes.
- Extended `ProgramsPage.test.tsx` with a second public fixture and two cases: (1) a card renders per shared program with the correct title/author line/enroll button, (2) enrolling in a non-DFW shared program while another is active is correctly gated behind the switch-confirmation dialog. The existing single-DFW case is preserved unchanged — no regression to today's one-program path.
- `tsc --noEmit` clean, `eslint` clean, full `npm test` green (396 tests), scoped `ProgramsPage.test.tsx` run (5/5 green).
- Rendered the real component with the app's compiled Tailwind CSS and screenshotted two states for visual proof: the shared-program list (3 cards, each with its own author line and Start button) and the switch-confirmation dialog triggered by starting a non-active program. Screenshots below.

## Tradeoffs
None — this is a direct extension of the existing `myPrograms.map` pattern already in the file, not a new design; no alternative approach was considered worth weighing.

- Evidence: ProgramsPage — one card per public program (3 shared programs)
- Evidence: Non-DFW shared program enroll → switch-confirmation dialog

<details>
<summary>Evidence: Rendered ProgramsPage HTML (shared list)</summary>

```text
<!doctype html>
<html><head><meta charset="utf-8">
<link rel="stylesheet" href="app.css">
<style>body{margin:0;padding:24px;max-width:480px;} .evid-label{font:600 13px system-ui;color:#555;margin-bottom:12px;}</style>
</head><body>
<div class="evid-label">ProgramsPage — one card per public program (3 shared programs)</div>
<div class="mx-auto my-2 flex w-full flex-col gap-2 bg-card p-3 max-w-md"><div class="text-xl font-semibold">Programs</div><div class="rounded-md border bg-card text-card-foreground shadow"><div class="flex flex-col gap-y-0.5 p-2"><h3 class="font-semibold leading-none tracking-tight">Dry Fighting Weight</h3><p class="text-xs text-muted-foreground">Geoff Neupert · 5 weeks · 3/week</p></div><div class="p-2 pt-0"><button class="inline-flex items-center rounded-md justify-center whitespace-nowrap font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 bg-primary text-primary-foreground shadow hover:bg-primary/90 h-4 px-2 text-sm w-full">Start Dry Fighting Weight</button></div></div><div class="rounded-md border bg-card text-card-foreground shadow"><div class="flex flex-col gap-y-0.5 p-2"><h3 class="font-semibold leading-none tracking-tight">Armor Building Complex</h3><p class="text-xs text-muted-foreground">Dan John · 6 weeks · 3/week</p></div><div class="p-2 pt-0"><button class="inline-flex items-center rounded-md justify-center whitespace-nowrap font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 bg-primary text-primary-foreground shadow hover:bg-primary/90 h-4 px-2 text-sm w-full">Start Armor Building Complex</button></div></div><div class="rounded-md border bg-card text-card-foreground shadow"><div class="flex flex-col gap-y-0.5 p-2"><h3 class="font-semibold leading-none tracking-tight">Kettlebell Simple &amp; Sinister</h3><p class="text-xs text-muted-foreground">Pavel Tsatsouline · 8 weeks · 4/week</p></div><div class="p-2 pt-0"><button class="inline-flex items-center rounded-md justify-center whitespace-nowrap font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 bg-primary text-primary-foreground shadow hover:bg-primary/90 h-4 px-2 text-sm w-full">Start Kettlebell Simple &amp; Sinister</button></div></div><div class="flex items-center justify-between"><h2 class="text-sm font-semibold">My programs</h2><button class="inline-flex items-center rounded-md justify-center whitespace-nowrap font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 bg-secondary text-secondary-foreground shadow-sm hover:bg-secondary/80 h-3 px-1 text-xs">Create program</button></div><div class="rounded-md border bg-card text-card-foreground shadow"><div class="flex flex-col gap-y-0.5 p-2"><h3 class="font-semibold leading-none tracking-tight flex items-center gap-1"><a class="hover:underline" href="/programs/mine-1">My Program</a></h3><p class="text-xs text-muted-foreground">4 weeks · 3/week</p></div><div class="p-2 pt-0 flex flex-col gap-2"><div class="flex gap-2"><button class="inline-flex items-center rounded-md justify-center whitespace-nowrap font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 bg-secondary text-secondary-foreground shadow-sm hover:bg-secondary/80 h-4 px-2 text-sm flex-1">Add sessions</button><button class="inline-flex items-center rounded-md justify-center whitespace-nowrap font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 bg-primary text-primary-foreground shadow hover:bg-primary/90 h-4 px-2 text-sm flex-1">Start program</button></div><button class="inline-flex items-center rounded-md justify-center whitespace-nowrap font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 hover:text-muted-foreground h-3 px-1 text-xs">View progress</button></div></div></div>
</body></html>
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `vitest run src/pages/ProgramsPage/ProgramsPage.test.tsx` — 5 tests green (multi-card render, non-DFW switch-gating, preserved single-DFW path)
- Rendered the real ProgramsPage with compiled Tailwind CSS via a throwaway evidence test, then screenshotted with chrome-devtools-axi
- programs-list.png — 3 shared cards (Dry Fighting Weight, Armor Building Complex, Kettlebell Simple & Sinister), each with author line + own Start button
- programs-switch-dialog.png — clicking Start Armor Building Complex while DFW is active opens the 'Switch program?' dialog naming the active program

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
