### PR TITLE
feat(programs): seed StrongFirst Snatch Test Training Plan

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -190,8 +190,9 @@ session — atomic), and the PROD-219 editing pair `reorder_program_sessions` /
   `NextProgramWorkoutCard` (`onViewProgress`).
 - **Reorder / delete (PROD-219, owner-editable programs only):** the builder
   save-mode surface (`ProgramSessionBuilderPage`) shows up/down + Delete controls
-  per session, gated on `program.ownerId === session.user.id` so the read-only
-  shared DFW is never editable. Both persist through RPCs
+  per session, gated on `program.ownerId === session.user.id` so read-only
+  shared programs (DFW, the StrongFirst Snatch Test plan — both system-owned,
+  seeded via idempotent migrations) are never editable. Both persist through RPCs
   (`useReorderProgramSessions` / `useDeleteProgramSession`) because
   `UNIQUE (program_id, sequence_index)` is **NOT deferrable** — a naive
   client-side permutation transiently duplicates an index and 409s. Each RPC

--- a/e2e/program-schema.spec.ts
+++ b/e2e/program-schema.spec.ts
@@ -376,10 +376,12 @@ test.describe('program schema — StrongFirst Snatch Test seed', () => {
       expect(o.complexSet).toBe(false);
       expect(o.intervalTimer).toBe(0);
       expect(o.workoutGoalUnits).toBe('rounds');
-      // Single bell: no second weight anywhere.
+      // Single bell in Single/'1h' mode: weightTwoValue is 0 (not null), which
+      // makes the runtime mirror each rung per hand. repScheme is the per-hand
+      // count [10]; each mirrored set is 10/hand x 2 = 20 reps.
       for (const m of o.movements) {
-        expect(m.weightTwoValue).toBeNull();
-        expect(m.repScheme).toEqual([20]);
+        expect(m.weightTwoValue).toBe(0);
+        expect(m.repScheme).toEqual([10]);
       }
 
       if (s.week_number <= 7) {

--- a/e2e/program-schema.spec.ts
+++ b/e2e/program-schema.spec.ts
@@ -15,6 +15,8 @@ const DFW_SLUG = 'dry-fighting-weight';
 const DFW_SESSION_COUNT = 14;
 const SWING10K_SLUG = '10000-swing-challenge';
 const SWING10K_SESSION_COUNT = 20;
+const SNATCH_SLUG = 'strongfirst-snatch-test-plan';
+const SNATCH_SESSION_COUNT = 30; // 10 weeks x 3 days
 
 // ── Types ────────────────────────────────────────────────────────────────────
 
@@ -272,6 +274,139 @@ test.describe('program schema — 10,000 Swing Challenge seed', () => {
       expect(swing.weightTwoUnit).toBeNull();
       expect(swing.weightTwoValue).toBeNull();
     }
+  });
+});
+
+test.describe('program schema — StrongFirst Snatch Test seed', () => {
+  interface SnatchMovement {
+    movementName: string;
+    repScheme: number[];
+    weightOneValue: number | null;
+    weightTwoValue: number | null;
+  }
+  interface SnatchSession {
+    sequence_index: number;
+    week_number: number;
+    day_number: number;
+    workout_options: {
+      complexSet: boolean;
+      intervalTimer: number;
+      restTimer: number;
+      workoutGoal: number;
+      workoutGoalUnits: string;
+      movements: SnatchMovement[];
+    };
+  }
+
+  test('the shared Snatch Test plan is present, public, system-owned, with 30 ordered sessions', async () => {
+    const user = await signUpThrowawayUser();
+
+    const programs = await restJson<
+      Array<{ id: string; is_public: boolean; owner_id: string | null; num_weeks: number; days_per_week: number; author_name: string }>
+    >('GET', `programs?slug=eq.${SNATCH_SLUG}&select=*`, user.token);
+
+    expect(programs).toHaveLength(1);
+    const plan = programs[0];
+    expect(plan.is_public).toBe(true);
+    expect(plan.owner_id).toBeNull();
+    expect(plan.num_weeks).toBe(10);
+    expect(plan.days_per_week).toBe(3);
+    expect(plan.author_name).toBe('Dr. Michael Hartle (StrongFirst)');
+
+    const sessions = await restJson<SnatchSession[]>(
+      'GET',
+      `program_sessions?program_id=eq.${plan.id}&select=sequence_index,week_number,day_number,workout_options&order=sequence_index.asc`,
+      user.token,
+    );
+
+    expect(sessions).toHaveLength(SNATCH_SESSION_COUNT);
+    // Contiguous 0..29 order.
+    expect(sessions.map((s) => s.sequence_index)).toEqual(
+      Array.from({ length: SNATCH_SESSION_COUNT }, (_, i) => i),
+    );
+  });
+
+  // The defining feature of this plan: rest interval shrinks week over week.
+  test('restTimer strictly decreases week over week', async () => {
+    const user = await signUpThrowawayUser();
+    const [plan] = await restJson<Array<{ id: string }>>(
+      'GET',
+      `programs?slug=eq.${SNATCH_SLUG}&select=id`,
+      user.token,
+    );
+    const sessions = await restJson<SnatchSession[]>(
+      'GET',
+      `program_sessions?program_id=eq.${plan.id}&select=week_number,workout_options&order=sequence_index.asc`,
+      user.token,
+    );
+
+    // One restTimer per week (every session in a week shares it).
+    const restByWeek = new Map<number, number>();
+    for (const s of sessions) {
+      const rest = s.workout_options.restTimer;
+      const seen = restByWeek.get(s.week_number);
+      if (seen === undefined) restByWeek.set(s.week_number, rest);
+      else expect(rest).toBe(seen); // uniform within the week
+    }
+
+    const weeks = [...restByWeek.keys()].sort((a, b) => a - b);
+    expect(weeks).toEqual(Array.from({ length: 10 }, (_, i) => i + 1));
+    const rests = weeks.map((w) => restByWeek.get(w)!);
+    expect(rests).toEqual([45, 40, 35, 30, 25, 20, 15, 12, 10, 8]);
+    for (let i = 1; i < rests.length; i++) {
+      expect(rests[i]).toBeLessThan(rests[i - 1]);
+    }
+  });
+
+  test('session shape matches the plan: build weeks alternate swing/snatch, test weeks are snatch-only 100 reps', async () => {
+    const user = await signUpThrowawayUser();
+    const [plan] = await restJson<Array<{ id: string }>>(
+      'GET',
+      `programs?slug=eq.${SNATCH_SLUG}&select=id`,
+      user.token,
+    );
+    const sessions = await restJson<SnatchSession[]>(
+      'GET',
+      `program_sessions?program_id=eq.${plan.id}&select=sequence_index,week_number,day_number,workout_options&order=sequence_index.asc`,
+      user.token,
+    );
+
+    for (const s of sessions) {
+      const o = s.workout_options;
+      expect(o.complexSet).toBe(false);
+      expect(o.intervalTimer).toBe(0);
+      expect(o.workoutGoalUnits).toBe('rounds');
+      // Single bell: no second weight anywhere.
+      for (const m of o.movements) {
+        expect(m.weightTwoValue).toBeNull();
+        expect(m.repScheme).toEqual([20]);
+      }
+
+      if (s.week_number <= 7) {
+        // Build weeks: 6 sets alternating one-arm swing/snatch = 3 rounds x 2 movements.
+        expect(o.workoutGoal).toBe(3);
+        expect(o.movements.map((m) => m.movementName)).toEqual([
+          'One-Arm Kettlebell Swing',
+          'One-Arm Kettlebell Snatch',
+        ]);
+      } else {
+        // Test weeks (8-10): the 100-snatch rehearsal = 5 rounds x 20 reps, snatch only.
+        expect(o.workoutGoal).toBe(5);
+        expect(o.movements.map((m) => m.movementName)).toEqual([
+          'One-Arm Kettlebell Snatch',
+        ]);
+      }
+    }
+
+    // Heavy/medium/light bell rotates by day across the build weeks (placeholder loads).
+    const buildByDay = new Map<number, Set<number>>();
+    for (const s of sessions.filter((x) => x.week_number <= 7)) {
+      const w = s.workout_options.movements[0].weightOneValue!;
+      (buildByDay.get(s.day_number) ?? buildByDay.set(s.day_number, new Set()).get(s.day_number)!).add(w);
+    }
+    expect([...buildByDay.get(1)!]).toEqual([28]);
+    expect([...buildByDay.get(2)!]).toEqual([24]);
+    expect([...buildByDay.get(3)!]).toEqual([20]);
   });
 });
 

--- a/e2e/program-schema.spec.ts
+++ b/e2e/program-schema.spec.ts
@@ -302,7 +302,14 @@ test.describe('program schema — StrongFirst Snatch Test seed', () => {
     const user = await signUpThrowawayUser();
 
     const programs = await restJson<
-      Array<{ id: string; is_public: boolean; owner_id: string | null; num_weeks: number; days_per_week: number; author_name: string }>
+      Array<{
+        id: string;
+        is_public: boolean;
+        owner_id: string | null;
+        num_weeks: number;
+        days_per_week: number;
+        author_name: string;
+      }>
     >('GET', `programs?slug=eq.${SNATCH_SLUG}&select=*`, user.token);
 
     expect(programs).toHaveLength(1);
@@ -404,7 +411,10 @@ test.describe('program schema — StrongFirst Snatch Test seed', () => {
     const buildByDay = new Map<number, Set<number>>();
     for (const s of sessions.filter((x) => x.week_number <= 7)) {
       const w = s.workout_options.movements[0].weightOneValue!;
-      (buildByDay.get(s.day_number) ?? buildByDay.set(s.day_number, new Set()).get(s.day_number)!).add(w);
+      (
+        buildByDay.get(s.day_number) ??
+        buildByDay.set(s.day_number, new Set()).get(s.day_number)!
+      ).add(w);
     }
     expect([...buildByDay.get(1)!]).toEqual([28]);
     expect([...buildByDay.get(2)!]).toEqual([24]);

--- a/supabase/migrations/20260713181831_seed_strongfirst_snatch_test_plan.sql
+++ b/supabase/migrations/20260713181831_seed_strongfirst_snatch_test_plan.sql
@@ -21,25 +21,30 @@
 --
 --   * Weeks 1-7 ("build"): 6 sets alternating One-Arm Swing / One-Arm Snatch,
 --     20 reps/set. Modeled as two movements (complexSet:false, so they alternate
---     rung-by-rung exactly like DFW's press/squat pairing), each repScheme [20],
---     with `workoutGoalUnits:'rounds'`, `workoutGoal:3` -- 3 rounds x 2 movements
+--     rung-by-rung exactly like DFW's press/squat pairing), each repScheme [10]
+--     (the PER-HAND rep count; see mirroring note below), with
+--     `workoutGoalUnits:'rounds'`, `workoutGoal:3` -- 3 rounds x 2 movements
 --     = the 6 alternating sets. (One round = one swing set + one snatch set.)
 --
 --   * Weeks 8-10 ("test prep + test week"): the 100-snatch test simulation,
 --     5 sets of 20 = 100 reps, snatch only. Modeled as a single One-Arm Snatch
---     movement, repScheme [20], `workoutGoal:5` rounds (single-movement round =
---     one set, so 5 rounds = 5 sets = 100 reps).
+--     movement, repScheme [10] (per-hand; mirrored to 20/set), `workoutGoal:5`
+--     rounds (single-movement round = one set, so 5 rounds = 5 sets x 20 = 100).
 --
 --   * Bell rotation heavy/medium/light is one weight per movement per session
 --     (no in-session variation), so it's encoded as `weightOneValue` varying by
 --     DAY across each week: Day1 28 kg (heavy) / Day2 24 kg (medium) / Day3
 --     20 kg (light). These are PLACEHOLDERS around the 24 kg test standard; the
 --     user overrides load per session in the builder, exactly like DFW's loads.
---     One-Arm movements are single-bell, so weightTwo is NULL throughout.
+--     One-Arm movements are single-bell: weightOneValue is the load and
+--     weightTwoValue is 0 (not NULL) throughout -- 0 is the Single/'1h' weight
+--     mode the runtime keys off (getWeightTabValue / isOneHanded).
 --
---   * One-Arm movements are mirrored (per-hand) by the runtime, so "20 reps/set"
---     is tracked per hand; the source's "100 total reps" is the per-side target.
---     `workoutDetails` notes this on each session.
+--   * Because weightTwoValue=0 puts these one-arm movements in Single/'1h' mode,
+--     the runtime MIRRORS each rung per hand. So the stored repScheme [10] is the
+--     per-hand count and each set is 10/hand x 2 = 20 reps; the weeks 8-10 test is
+--     5 sets x 20 = 100 total, matching the source exactly. `workoutDetails`
+--     spells out the "(10 per hand)" split on each session.
 --
 -- 30 trackable sessions (seq 0-29 = 10 weeks x 3 days). num_weeks=10 /
 -- days_per_week=3.
@@ -66,14 +71,14 @@ RETURNS JSONB LANGUAGE sql IMMUTABLE AS $$
     'movements', jsonb_build_array(
       jsonb_build_object(
         'movementName', 'One-Arm Kettlebell Swing',
-        'repScheme', to_jsonb(ARRAY[20]::INT[]),
+        'repScheme', to_jsonb(ARRAY[10]::INT[]),
         'weightOneUnit', 'kilograms', 'weightOneValue', p_weight,
-        'weightTwoUnit', NULL, 'weightTwoValue', NULL),
+        'weightTwoUnit', NULL, 'weightTwoValue', 0),
       jsonb_build_object(
         'movementName', 'One-Arm Kettlebell Snatch',
-        'repScheme', to_jsonb(ARRAY[20]::INT[]),
+        'repScheme', to_jsonb(ARRAY[10]::INT[]),
         'weightOneUnit', 'kilograms', 'weightOneValue', p_weight,
-        'weightTwoUnit', NULL, 'weightTwoValue', NULL)
+        'weightTwoUnit', NULL, 'weightTwoValue', 0)
     ));
 $$;
 
@@ -95,9 +100,9 @@ RETURNS JSONB LANGUAGE sql IMMUTABLE AS $$
     'movements', jsonb_build_array(
       jsonb_build_object(
         'movementName', 'One-Arm Kettlebell Snatch',
-        'repScheme', to_jsonb(ARRAY[20]::INT[]),
+        'repScheme', to_jsonb(ARRAY[10]::INT[]),
         'weightOneUnit', 'kilograms', 'weightOneValue', p_weight,
-        'weightTwoUnit', NULL, 'weightTwoValue', NULL)
+        'weightTwoUnit', NULL, 'weightTwoValue', 0)
     ));
 $$;
 
@@ -127,34 +132,34 @@ BEGIN
   INSERT INTO program_sessions
     (program_id, sequence_index, week_number, day_number, title, workout_options)
   VALUES
-    (v_program_id,  0,  1, 1, 'Heavy - swing/snatch',  pg_temp.snatch_build_options(45, 28, 'Snatch Test W1D1 - Heavy - 6 sets alternating one-arm swing/snatch, 20 reps/set (per hand), rest 45s. Load is a placeholder; adjust in the builder.')),
-    (v_program_id,  1,  1, 2, 'Medium - swing/snatch', pg_temp.snatch_build_options(45, 24, 'Snatch Test W1D2 - Medium - 6 sets alternating one-arm swing/snatch, 20 reps/set (per hand), rest 45s.')),
-    (v_program_id,  2,  1, 3, 'Light - swing/snatch',  pg_temp.snatch_build_options(45, 20, 'Snatch Test W1D3 - Light - 6 sets alternating one-arm swing/snatch, 20 reps/set (per hand), rest 45s.')),
-    (v_program_id,  3,  2, 1, 'Heavy - swing/snatch',  pg_temp.snatch_build_options(40, 28, 'Snatch Test W2D1 - Heavy - 6 sets alternating one-arm swing/snatch, 20 reps/set (per hand), rest 40s.')),
-    (v_program_id,  4,  2, 2, 'Medium - swing/snatch', pg_temp.snatch_build_options(40, 24, 'Snatch Test W2D2 - Medium - 6 sets alternating one-arm swing/snatch, 20 reps/set (per hand), rest 40s.')),
-    (v_program_id,  5,  2, 3, 'Light - swing/snatch',  pg_temp.snatch_build_options(40, 20, 'Snatch Test W2D3 - Light - 6 sets alternating one-arm swing/snatch, 20 reps/set (per hand), rest 40s.')),
-    (v_program_id,  6,  3, 1, 'Heavy - swing/snatch',  pg_temp.snatch_build_options(35, 28, 'Snatch Test W3D1 - Heavy - 6 sets alternating one-arm swing/snatch, 20 reps/set (per hand), rest 35s.')),
-    (v_program_id,  7,  3, 2, 'Medium - swing/snatch', pg_temp.snatch_build_options(35, 24, 'Snatch Test W3D2 - Medium - 6 sets alternating one-arm swing/snatch, 20 reps/set (per hand), rest 35s.')),
-    (v_program_id,  8,  3, 3, 'Light - swing/snatch',  pg_temp.snatch_build_options(35, 20, 'Snatch Test W3D3 - Light - 6 sets alternating one-arm swing/snatch, 20 reps/set (per hand), rest 35s.')),
-    (v_program_id,  9,  4, 1, 'Heavy - swing/snatch',  pg_temp.snatch_build_options(30, 28, 'Snatch Test W4D1 - Heavy - 6 sets alternating one-arm swing/snatch, 20 reps/set (per hand), rest 30s.')),
-    (v_program_id, 10,  4, 2, 'Medium - swing/snatch', pg_temp.snatch_build_options(30, 24, 'Snatch Test W4D2 - Medium - 6 sets alternating one-arm swing/snatch, 20 reps/set (per hand), rest 30s.')),
-    (v_program_id, 11,  4, 3, 'Light - swing/snatch',  pg_temp.snatch_build_options(30, 20, 'Snatch Test W4D3 - Light - 6 sets alternating one-arm swing/snatch, 20 reps/set (per hand), rest 30s.')),
-    (v_program_id, 12,  5, 1, 'Heavy - swing/snatch',  pg_temp.snatch_build_options(25, 28, 'Snatch Test W5D1 - Heavy - 6 sets alternating one-arm swing/snatch, 20 reps/set (per hand), rest 25s.')),
-    (v_program_id, 13,  5, 2, 'Medium - swing/snatch', pg_temp.snatch_build_options(25, 24, 'Snatch Test W5D2 - Medium - 6 sets alternating one-arm swing/snatch, 20 reps/set (per hand), rest 25s.')),
-    (v_program_id, 14,  5, 3, 'Light - swing/snatch',  pg_temp.snatch_build_options(25, 20, 'Snatch Test W5D3 - Light - 6 sets alternating one-arm swing/snatch, 20 reps/set (per hand), rest 25s.')),
-    (v_program_id, 15,  6, 1, 'Heavy - swing/snatch',  pg_temp.snatch_build_options(20, 28, 'Snatch Test W6D1 - Heavy - 6 sets alternating one-arm swing/snatch, 20 reps/set (per hand), rest 20s.')),
-    (v_program_id, 16,  6, 2, 'Medium - swing/snatch', pg_temp.snatch_build_options(20, 24, 'Snatch Test W6D2 - Medium - 6 sets alternating one-arm swing/snatch, 20 reps/set (per hand), rest 20s.')),
-    (v_program_id, 17,  6, 3, 'Light - swing/snatch',  pg_temp.snatch_build_options(20, 20, 'Snatch Test W6D3 - Light - 6 sets alternating one-arm swing/snatch, 20 reps/set (per hand), rest 20s.')),
-    (v_program_id, 18,  7, 1, 'Heavy - swing/snatch',  pg_temp.snatch_build_options(15, 28, 'Snatch Test W7D1 - Heavy - 6 sets alternating one-arm swing/snatch, 20 reps/set (per hand), rest 15s.')),
-    (v_program_id, 19,  7, 2, 'Medium - swing/snatch', pg_temp.snatch_build_options(15, 24, 'Snatch Test W7D2 - Medium - 6 sets alternating one-arm swing/snatch, 20 reps/set (per hand), rest 15s.')),
-    (v_program_id, 20,  7, 3, 'Light - swing/snatch',  pg_temp.snatch_build_options(15, 20, 'Snatch Test W7D3 - Light - 6 sets alternating one-arm swing/snatch, 20 reps/set (per hand), rest 15s.')),
-    (v_program_id, 21,  8, 1, 'Test prep - 100 snatches', pg_temp.snatch_test_options(12, 28, 'Snatch Test W8D1 - Heavy - 100-snatch rehearsal: 5 sets of 20 (per hand), rest 12s. Load is a placeholder; the 24 kg (men) / 16 kg (women) test bell is the standard.')),
-    (v_program_id, 22,  8, 2, 'Test prep - 100 snatches', pg_temp.snatch_test_options(12, 24, 'Snatch Test W8D2 - Medium - 100-snatch rehearsal: 5 sets of 20 (per hand), rest 12s.')),
-    (v_program_id, 23,  8, 3, 'Test prep - 100 snatches', pg_temp.snatch_test_options(12, 20, 'Snatch Test W8D3 - Light - 100-snatch rehearsal: 5 sets of 20 (per hand), rest 12s.')),
-    (v_program_id, 24,  9, 1, 'Test prep - 100 snatches', pg_temp.snatch_test_options(10, 28, 'Snatch Test W9D1 - Heavy - 100-snatch rehearsal: 5 sets of 20 (per hand), rest 10s.')),
-    (v_program_id, 25,  9, 2, 'Test prep - 100 snatches', pg_temp.snatch_test_options(10, 24, 'Snatch Test W9D2 - Medium - 100-snatch rehearsal: 5 sets of 20 (per hand), rest 10s.')),
-    (v_program_id, 26,  9, 3, 'Test prep - 100 snatches', pg_temp.snatch_test_options(10, 20, 'Snatch Test W9D3 - Light - 100-snatch rehearsal: 5 sets of 20 (per hand), rest 10s.')),
-    (v_program_id, 27, 10, 1, 'Test week - 100 snatches', pg_temp.snatch_test_options(8, 24, 'Snatch Test W10D1 - Test week - 100 snatches with the test bell (24 kg men / 16 kg women). 5 sets of 20 (per hand), minimal rest 8s; on test day the standard is 100 reps in 5 minutes.')),
-    (v_program_id, 28, 10, 2, 'Test week - practice',     pg_temp.snatch_test_options(8, 20, 'Snatch Test W10D2 - Test week - light practice: 5 sets of 20 (per hand), rest 8s.')),
-    (v_program_id, 29, 10, 3, 'Test week - the test',     pg_temp.snatch_test_options(8, 24, 'Snatch Test W10D3 - THE TEST - 100 snatches, test bell, as few sets as possible in 5 minutes. Modeled as 5 sets of 20 (per hand); rest 8s is a placeholder for a continuous effort.'));
+    (v_program_id,  0,  1, 1, 'Heavy - swing/snatch',  pg_temp.snatch_build_options(45, 28, 'Snatch Test W1D1 - Heavy - 6 sets alternating one-arm swing/snatch, 20 reps/set (10 per hand), rest 45s. Load is a placeholder; adjust in the builder.')),
+    (v_program_id,  1,  1, 2, 'Medium - swing/snatch', pg_temp.snatch_build_options(45, 24, 'Snatch Test W1D2 - Medium - 6 sets alternating one-arm swing/snatch, 20 reps/set (10 per hand), rest 45s.')),
+    (v_program_id,  2,  1, 3, 'Light - swing/snatch',  pg_temp.snatch_build_options(45, 20, 'Snatch Test W1D3 - Light - 6 sets alternating one-arm swing/snatch, 20 reps/set (10 per hand), rest 45s.')),
+    (v_program_id,  3,  2, 1, 'Heavy - swing/snatch',  pg_temp.snatch_build_options(40, 28, 'Snatch Test W2D1 - Heavy - 6 sets alternating one-arm swing/snatch, 20 reps/set (10 per hand), rest 40s.')),
+    (v_program_id,  4,  2, 2, 'Medium - swing/snatch', pg_temp.snatch_build_options(40, 24, 'Snatch Test W2D2 - Medium - 6 sets alternating one-arm swing/snatch, 20 reps/set (10 per hand), rest 40s.')),
+    (v_program_id,  5,  2, 3, 'Light - swing/snatch',  pg_temp.snatch_build_options(40, 20, 'Snatch Test W2D3 - Light - 6 sets alternating one-arm swing/snatch, 20 reps/set (10 per hand), rest 40s.')),
+    (v_program_id,  6,  3, 1, 'Heavy - swing/snatch',  pg_temp.snatch_build_options(35, 28, 'Snatch Test W3D1 - Heavy - 6 sets alternating one-arm swing/snatch, 20 reps/set (10 per hand), rest 35s.')),
+    (v_program_id,  7,  3, 2, 'Medium - swing/snatch', pg_temp.snatch_build_options(35, 24, 'Snatch Test W3D2 - Medium - 6 sets alternating one-arm swing/snatch, 20 reps/set (10 per hand), rest 35s.')),
+    (v_program_id,  8,  3, 3, 'Light - swing/snatch',  pg_temp.snatch_build_options(35, 20, 'Snatch Test W3D3 - Light - 6 sets alternating one-arm swing/snatch, 20 reps/set (10 per hand), rest 35s.')),
+    (v_program_id,  9,  4, 1, 'Heavy - swing/snatch',  pg_temp.snatch_build_options(30, 28, 'Snatch Test W4D1 - Heavy - 6 sets alternating one-arm swing/snatch, 20 reps/set (10 per hand), rest 30s.')),
+    (v_program_id, 10,  4, 2, 'Medium - swing/snatch', pg_temp.snatch_build_options(30, 24, 'Snatch Test W4D2 - Medium - 6 sets alternating one-arm swing/snatch, 20 reps/set (10 per hand), rest 30s.')),
+    (v_program_id, 11,  4, 3, 'Light - swing/snatch',  pg_temp.snatch_build_options(30, 20, 'Snatch Test W4D3 - Light - 6 sets alternating one-arm swing/snatch, 20 reps/set (10 per hand), rest 30s.')),
+    (v_program_id, 12,  5, 1, 'Heavy - swing/snatch',  pg_temp.snatch_build_options(25, 28, 'Snatch Test W5D1 - Heavy - 6 sets alternating one-arm swing/snatch, 20 reps/set (10 per hand), rest 25s.')),
+    (v_program_id, 13,  5, 2, 'Medium - swing/snatch', pg_temp.snatch_build_options(25, 24, 'Snatch Test W5D2 - Medium - 6 sets alternating one-arm swing/snatch, 20 reps/set (10 per hand), rest 25s.')),
+    (v_program_id, 14,  5, 3, 'Light - swing/snatch',  pg_temp.snatch_build_options(25, 20, 'Snatch Test W5D3 - Light - 6 sets alternating one-arm swing/snatch, 20 reps/set (10 per hand), rest 25s.')),
+    (v_program_id, 15,  6, 1, 'Heavy - swing/snatch',  pg_temp.snatch_build_options(20, 28, 'Snatch Test W6D1 - Heavy - 6 sets alternating one-arm swing/snatch, 20 reps/set (10 per hand), rest 20s.')),
+    (v_program_id, 16,  6, 2, 'Medium - swing/snatch', pg_temp.snatch_build_options(20, 24, 'Snatch Test W6D2 - Medium - 6 sets alternating one-arm swing/snatch, 20 reps/set (10 per hand), rest 20s.')),
+    (v_program_id, 17,  6, 3, 'Light - swing/snatch',  pg_temp.snatch_build_options(20, 20, 'Snatch Test W6D3 - Light - 6 sets alternating one-arm swing/snatch, 20 reps/set (10 per hand), rest 20s.')),
+    (v_program_id, 18,  7, 1, 'Heavy - swing/snatch',  pg_temp.snatch_build_options(15, 28, 'Snatch Test W7D1 - Heavy - 6 sets alternating one-arm swing/snatch, 20 reps/set (10 per hand), rest 15s.')),
+    (v_program_id, 19,  7, 2, 'Medium - swing/snatch', pg_temp.snatch_build_options(15, 24, 'Snatch Test W7D2 - Medium - 6 sets alternating one-arm swing/snatch, 20 reps/set (10 per hand), rest 15s.')),
+    (v_program_id, 20,  7, 3, 'Light - swing/snatch',  pg_temp.snatch_build_options(15, 20, 'Snatch Test W7D3 - Light - 6 sets alternating one-arm swing/snatch, 20 reps/set (10 per hand), rest 15s.')),
+    (v_program_id, 21,  8, 1, 'Test prep - 100 snatches', pg_temp.snatch_test_options(12, 28, 'Snatch Test W8D1 - Heavy - 100-snatch rehearsal: 5 sets of 20 (10 per hand) = 100 total, rest 12s. Load is a placeholder; the 24 kg (men) / 16 kg (women) test bell is the standard.')),
+    (v_program_id, 22,  8, 2, 'Test prep - 100 snatches', pg_temp.snatch_test_options(12, 24, 'Snatch Test W8D2 - Medium - 100-snatch rehearsal: 5 sets of 20 (10 per hand) = 100 total, rest 12s.')),
+    (v_program_id, 23,  8, 3, 'Test prep - 100 snatches', pg_temp.snatch_test_options(12, 20, 'Snatch Test W8D3 - Light - 100-snatch rehearsal: 5 sets of 20 (10 per hand) = 100 total, rest 12s.')),
+    (v_program_id, 24,  9, 1, 'Test prep - 100 snatches', pg_temp.snatch_test_options(10, 28, 'Snatch Test W9D1 - Heavy - 100-snatch rehearsal: 5 sets of 20 (10 per hand) = 100 total, rest 10s.')),
+    (v_program_id, 25,  9, 2, 'Test prep - 100 snatches', pg_temp.snatch_test_options(10, 24, 'Snatch Test W9D2 - Medium - 100-snatch rehearsal: 5 sets of 20 (10 per hand) = 100 total, rest 10s.')),
+    (v_program_id, 26,  9, 3, 'Test prep - 100 snatches', pg_temp.snatch_test_options(10, 20, 'Snatch Test W9D3 - Light - 100-snatch rehearsal: 5 sets of 20 (10 per hand) = 100 total, rest 10s.')),
+    (v_program_id, 27, 10, 1, 'Test week - 100 snatches', pg_temp.snatch_test_options(8, 24, 'Snatch Test W10D1 - Test week - 100 snatches with the test bell (24 kg men / 16 kg women). 5 sets of 20 (10 per hand) = 100 total, minimal rest 8s; on test day the standard is 100 reps in 5 minutes.')),
+    (v_program_id, 28, 10, 2, 'Test week - practice',     pg_temp.snatch_test_options(8, 20, 'Snatch Test W10D2 - Test week - light practice: 5 sets of 20 (10 per hand) = 100 total, rest 8s.')),
+    (v_program_id, 29, 10, 3, 'Test week - the test',     pg_temp.snatch_test_options(8, 24, 'Snatch Test W10D3 - THE TEST - 100 snatches, test bell, as few sets as possible in 5 minutes. Modeled as 5 sets of 20 (10 per hand) = 100 total; rest 8s is a placeholder for a continuous effort.'));
 END $$;

--- a/supabase/migrations/20260713181831_seed_strongfirst_snatch_test_plan.sql
+++ b/supabase/migrations/20260713181831_seed_strongfirst_snatch_test_plan.sql
@@ -1,0 +1,160 @@
+-- Seed the shared StrongFirst Snatch Test Training Plan (Dr. Michael Hartle).
+-- Public + system-owned (owner_id NULL, is_public true) so every user sees it
+-- and can one-tap "Start"; enrolling clones it into an editable copy
+-- (enroll_in_program). Idempotent on slug: a re-run (or fresh env) skips
+-- re-seeding sessions. This is a MIGRATION (not seed.sql) so it also reaches
+-- staging/production, where seed.sql never runs. Surfaced only behind the
+-- `programs` feature flag, like DFW.
+--
+-- Source: https://www.strongfirst.com/snatch-test-training-plan/ — the official
+-- free plan for StrongFirst's own snatch-test certification. 10 weeks, 3x/wk.
+--
+-- MODELING DECISIONS (this plan is an approximation of prose programming, same
+-- as DFW's autoregulated days — the calls below are the product-review-worthy
+-- ones):
+--
+--   * The plan's defining feature is REST SHRINKING WEEK OVER WEEK. That maps
+--     directly onto `restTimer` varying session-to-session: every session in a
+--     given week shares one restTimer, and it decreases strictly each week
+--     (45s -> 8s across the 10 weeks). This is the whole reason the plan was
+--     picked; the e2e spec asserts the monotonic decrease.
+--
+--   * Weeks 1-7 ("build"): 6 sets alternating One-Arm Swing / One-Arm Snatch,
+--     20 reps/set. Modeled as two movements (complexSet:false, so they alternate
+--     rung-by-rung exactly like DFW's press/squat pairing), each repScheme [20],
+--     with `workoutGoalUnits:'rounds'`, `workoutGoal:3` -- 3 rounds x 2 movements
+--     = the 6 alternating sets. (One round = one swing set + one snatch set.)
+--
+--   * Weeks 8-10 ("test prep + test week"): the 100-snatch test simulation,
+--     5 sets of 20 = 100 reps, snatch only. Modeled as a single One-Arm Snatch
+--     movement, repScheme [20], `workoutGoal:5` rounds (single-movement round =
+--     one set, so 5 rounds = 5 sets = 100 reps).
+--
+--   * Bell rotation heavy/medium/light is one weight per movement per session
+--     (no in-session variation), so it's encoded as `weightOneValue` varying by
+--     DAY across each week: Day1 28 kg (heavy) / Day2 24 kg (medium) / Day3
+--     20 kg (light). These are PLACEHOLDERS around the 24 kg test standard; the
+--     user overrides load per session in the builder, exactly like DFW's loads.
+--     One-Arm movements are single-bell, so weightTwo is NULL throughout.
+--
+--   * One-Arm movements are mirrored (per-hand) by the runtime, so "20 reps/set"
+--     is tracked per hand; the source's "100 total reps" is the per-side target.
+--     `workoutDetails` notes this on each session.
+--
+-- 30 trackable sessions (seq 0-29 = 10 weeks x 3 days). num_weeks=10 /
+-- days_per_week=3.
+
+-- Session-local helpers (pg_temp: auto-dropped at connection end, never
+-- persisted to the committed schema) that build the WorkoutOptions JSONB.
+-- Shape MUST match Omit<WorkoutOptions,'startedAt'> exactly (camelCase keys).
+
+-- Weeks 1-7 build session: One-Arm Swing + One-Arm Snatch alternating,
+-- 6 sets (3 rounds) of 20 reps, single bell, rest shrinking by week.
+CREATE OR REPLACE FUNCTION pg_temp.snatch_build_options(p_rest INT, p_weight INT, p_details TEXT)
+RETURNS JSONB LANGUAGE sql IMMUTABLE AS $$
+  SELECT jsonb_build_object(
+    'complexSet', false,
+    'intervalTimer', 0,
+    'restTimer', p_rest,
+    'workoutGoal', 3,
+    'workoutGoalUnits', 'rounds',
+    'workoutDetails', p_details,
+    'sharedWeightOneUnit', NULL,
+    'sharedWeightOneValue', NULL,
+    'sharedWeightTwoUnit', NULL,
+    'sharedWeightTwoValue', NULL,
+    'movements', jsonb_build_array(
+      jsonb_build_object(
+        'movementName', 'One-Arm Kettlebell Swing',
+        'repScheme', to_jsonb(ARRAY[20]::INT[]),
+        'weightOneUnit', 'kilograms', 'weightOneValue', p_weight,
+        'weightTwoUnit', NULL, 'weightTwoValue', NULL),
+      jsonb_build_object(
+        'movementName', 'One-Arm Kettlebell Snatch',
+        'repScheme', to_jsonb(ARRAY[20]::INT[]),
+        'weightOneUnit', 'kilograms', 'weightOneValue', p_weight,
+        'weightTwoUnit', NULL, 'weightTwoValue', NULL)
+    ));
+$$;
+
+-- Weeks 8-10 test-prep session: One-Arm Snatch only, 5 sets (5 rounds) of 20 =
+-- 100 reps, single bell, rest shrinking by week.
+CREATE OR REPLACE FUNCTION pg_temp.snatch_test_options(p_rest INT, p_weight INT, p_details TEXT)
+RETURNS JSONB LANGUAGE sql IMMUTABLE AS $$
+  SELECT jsonb_build_object(
+    'complexSet', false,
+    'intervalTimer', 0,
+    'restTimer', p_rest,
+    'workoutGoal', 5,
+    'workoutGoalUnits', 'rounds',
+    'workoutDetails', p_details,
+    'sharedWeightOneUnit', NULL,
+    'sharedWeightOneValue', NULL,
+    'sharedWeightTwoUnit', NULL,
+    'sharedWeightTwoValue', NULL,
+    'movements', jsonb_build_array(
+      jsonb_build_object(
+        'movementName', 'One-Arm Kettlebell Snatch',
+        'repScheme', to_jsonb(ARRAY[20]::INT[]),
+        'weightOneUnit', 'kilograms', 'weightOneValue', p_weight,
+        'weightTwoUnit', NULL, 'weightTwoValue', NULL)
+    ));
+$$;
+
+DO $$
+DECLARE
+  v_program_id UUID;
+BEGIN
+  INSERT INTO programs (owner_id, slug, title, description, author_name, num_weeks, days_per_week, is_public)
+  VALUES (NULL, 'strongfirst-snatch-test-plan',
+          'StrongFirst Snatch Test Training Plan',
+          'A 10-week single-kettlebell plan to pass the StrongFirst snatch test. '
+          'Weeks 1-7 alternate one-arm swings and snatches for 6 sets of 20 with '
+          'rest shrinking every week; weeks 8-10 rehearse the 100-rep snatch test.',
+          'Dr. Michael Hartle (StrongFirst)', 10, 3, true)
+  ON CONFLICT (slug) DO NOTHING
+  RETURNING id INTO v_program_id;
+
+  -- If the row already existed, skip re-seeding sessions.
+  IF v_program_id IS NULL THEN
+    RAISE NOTICE 'Snatch Test program already seeded; skipping sessions.';
+    RETURN;
+  END IF;
+
+  -- Rest shrinks strictly week over week (the defining feature). Weight rotates
+  -- heavy(28)/medium(24)/light(20) by day within each week. Weeks 1-7 build
+  -- (swing+snatch); weeks 8-10 rehearse the 100-snatch test (snatch only).
+  INSERT INTO program_sessions
+    (program_id, sequence_index, week_number, day_number, title, workout_options)
+  VALUES
+    (v_program_id,  0,  1, 1, 'Heavy - swing/snatch',  pg_temp.snatch_build_options(45, 28, 'Snatch Test W1D1 - Heavy - 6 sets alternating one-arm swing/snatch, 20 reps/set (per hand), rest 45s. Load is a placeholder; adjust in the builder.')),
+    (v_program_id,  1,  1, 2, 'Medium - swing/snatch', pg_temp.snatch_build_options(45, 24, 'Snatch Test W1D2 - Medium - 6 sets alternating one-arm swing/snatch, 20 reps/set (per hand), rest 45s.')),
+    (v_program_id,  2,  1, 3, 'Light - swing/snatch',  pg_temp.snatch_build_options(45, 20, 'Snatch Test W1D3 - Light - 6 sets alternating one-arm swing/snatch, 20 reps/set (per hand), rest 45s.')),
+    (v_program_id,  3,  2, 1, 'Heavy - swing/snatch',  pg_temp.snatch_build_options(40, 28, 'Snatch Test W2D1 - Heavy - 6 sets alternating one-arm swing/snatch, 20 reps/set (per hand), rest 40s.')),
+    (v_program_id,  4,  2, 2, 'Medium - swing/snatch', pg_temp.snatch_build_options(40, 24, 'Snatch Test W2D2 - Medium - 6 sets alternating one-arm swing/snatch, 20 reps/set (per hand), rest 40s.')),
+    (v_program_id,  5,  2, 3, 'Light - swing/snatch',  pg_temp.snatch_build_options(40, 20, 'Snatch Test W2D3 - Light - 6 sets alternating one-arm swing/snatch, 20 reps/set (per hand), rest 40s.')),
+    (v_program_id,  6,  3, 1, 'Heavy - swing/snatch',  pg_temp.snatch_build_options(35, 28, 'Snatch Test W3D1 - Heavy - 6 sets alternating one-arm swing/snatch, 20 reps/set (per hand), rest 35s.')),
+    (v_program_id,  7,  3, 2, 'Medium - swing/snatch', pg_temp.snatch_build_options(35, 24, 'Snatch Test W3D2 - Medium - 6 sets alternating one-arm swing/snatch, 20 reps/set (per hand), rest 35s.')),
+    (v_program_id,  8,  3, 3, 'Light - swing/snatch',  pg_temp.snatch_build_options(35, 20, 'Snatch Test W3D3 - Light - 6 sets alternating one-arm swing/snatch, 20 reps/set (per hand), rest 35s.')),
+    (v_program_id,  9,  4, 1, 'Heavy - swing/snatch',  pg_temp.snatch_build_options(30, 28, 'Snatch Test W4D1 - Heavy - 6 sets alternating one-arm swing/snatch, 20 reps/set (per hand), rest 30s.')),
+    (v_program_id, 10,  4, 2, 'Medium - swing/snatch', pg_temp.snatch_build_options(30, 24, 'Snatch Test W4D2 - Medium - 6 sets alternating one-arm swing/snatch, 20 reps/set (per hand), rest 30s.')),
+    (v_program_id, 11,  4, 3, 'Light - swing/snatch',  pg_temp.snatch_build_options(30, 20, 'Snatch Test W4D3 - Light - 6 sets alternating one-arm swing/snatch, 20 reps/set (per hand), rest 30s.')),
+    (v_program_id, 12,  5, 1, 'Heavy - swing/snatch',  pg_temp.snatch_build_options(25, 28, 'Snatch Test W5D1 - Heavy - 6 sets alternating one-arm swing/snatch, 20 reps/set (per hand), rest 25s.')),
+    (v_program_id, 13,  5, 2, 'Medium - swing/snatch', pg_temp.snatch_build_options(25, 24, 'Snatch Test W5D2 - Medium - 6 sets alternating one-arm swing/snatch, 20 reps/set (per hand), rest 25s.')),
+    (v_program_id, 14,  5, 3, 'Light - swing/snatch',  pg_temp.snatch_build_options(25, 20, 'Snatch Test W5D3 - Light - 6 sets alternating one-arm swing/snatch, 20 reps/set (per hand), rest 25s.')),
+    (v_program_id, 15,  6, 1, 'Heavy - swing/snatch',  pg_temp.snatch_build_options(20, 28, 'Snatch Test W6D1 - Heavy - 6 sets alternating one-arm swing/snatch, 20 reps/set (per hand), rest 20s.')),
+    (v_program_id, 16,  6, 2, 'Medium - swing/snatch', pg_temp.snatch_build_options(20, 24, 'Snatch Test W6D2 - Medium - 6 sets alternating one-arm swing/snatch, 20 reps/set (per hand), rest 20s.')),
+    (v_program_id, 17,  6, 3, 'Light - swing/snatch',  pg_temp.snatch_build_options(20, 20, 'Snatch Test W6D3 - Light - 6 sets alternating one-arm swing/snatch, 20 reps/set (per hand), rest 20s.')),
+    (v_program_id, 18,  7, 1, 'Heavy - swing/snatch',  pg_temp.snatch_build_options(15, 28, 'Snatch Test W7D1 - Heavy - 6 sets alternating one-arm swing/snatch, 20 reps/set (per hand), rest 15s.')),
+    (v_program_id, 19,  7, 2, 'Medium - swing/snatch', pg_temp.snatch_build_options(15, 24, 'Snatch Test W7D2 - Medium - 6 sets alternating one-arm swing/snatch, 20 reps/set (per hand), rest 15s.')),
+    (v_program_id, 20,  7, 3, 'Light - swing/snatch',  pg_temp.snatch_build_options(15, 20, 'Snatch Test W7D3 - Light - 6 sets alternating one-arm swing/snatch, 20 reps/set (per hand), rest 15s.')),
+    (v_program_id, 21,  8, 1, 'Test prep - 100 snatches', pg_temp.snatch_test_options(12, 28, 'Snatch Test W8D1 - Heavy - 100-snatch rehearsal: 5 sets of 20 (per hand), rest 12s. Load is a placeholder; the 24 kg (men) / 16 kg (women) test bell is the standard.')),
+    (v_program_id, 22,  8, 2, 'Test prep - 100 snatches', pg_temp.snatch_test_options(12, 24, 'Snatch Test W8D2 - Medium - 100-snatch rehearsal: 5 sets of 20 (per hand), rest 12s.')),
+    (v_program_id, 23,  8, 3, 'Test prep - 100 snatches', pg_temp.snatch_test_options(12, 20, 'Snatch Test W8D3 - Light - 100-snatch rehearsal: 5 sets of 20 (per hand), rest 12s.')),
+    (v_program_id, 24,  9, 1, 'Test prep - 100 snatches', pg_temp.snatch_test_options(10, 28, 'Snatch Test W9D1 - Heavy - 100-snatch rehearsal: 5 sets of 20 (per hand), rest 10s.')),
+    (v_program_id, 25,  9, 2, 'Test prep - 100 snatches', pg_temp.snatch_test_options(10, 24, 'Snatch Test W9D2 - Medium - 100-snatch rehearsal: 5 sets of 20 (per hand), rest 10s.')),
+    (v_program_id, 26,  9, 3, 'Test prep - 100 snatches', pg_temp.snatch_test_options(10, 20, 'Snatch Test W9D3 - Light - 100-snatch rehearsal: 5 sets of 20 (per hand), rest 10s.')),
+    (v_program_id, 27, 10, 1, 'Test week - 100 snatches', pg_temp.snatch_test_options(8, 24, 'Snatch Test W10D1 - Test week - 100 snatches with the test bell (24 kg men / 16 kg women). 5 sets of 20 (per hand), minimal rest 8s; on test day the standard is 100 reps in 5 minutes.')),
+    (v_program_id, 28, 10, 2, 'Test week - practice',     pg_temp.snatch_test_options(8, 20, 'Snatch Test W10D2 - Test week - light practice: 5 sets of 20 (per hand), rest 8s.')),
+    (v_program_id, 29, 10, 3, 'Test week - the test',     pg_temp.snatch_test_options(8, 24, 'Snatch Test W10D3 - THE TEST - 100 snatches, test bell, as few sets as possible in 5 minutes. Modeled as 5 sets of 20 (per hand); rest 8s is a placeholder for a continuous effort.'));
+END $$;


### PR DESCRIPTION
## What
Adds StrongFirst's free "Snatch Test Training Plan" (Dr. Michael Hartle) as a shared, system-owned program alongside DFW, behind the existing `programs` flag. Seed-data only.

## Why
PROD-228. None of DFW or the other new programs touch the snatch, arguably the signature kettlebell ballistic movement. This plan's defining feature — rest interval shrinking week over week — maps cleanly onto `restTimer` varying session-to-session, the same authoring pattern DFW already uses for varying weight/reps by session.

10 weeks × 3 days = 30 ordered sessions. `restTimer` is uniform within a week and strictly decreases across weeks: 45, 40, 35, 30, 25, 20, 15, 12, 10, 8 seconds. Three modeling decisions, documented in the migration header:
1. Weeks 1–7's "6 sets alternating swing/snatch, 20 reps" is modeled as two movements (One-Arm Swing + One-Arm Snatch, `complexSet: false`, alternating rung-by-rung like DFW's press/squat pairing), `repScheme [20]`, 3 rounds × 2 movements = 6 sets.
2. Weeks 8–10 (test prep + test week) is a single One-Arm Snatch movement, `repScheme [20]` × 5 rounds = 100 reps — the test's namesake number.
3. Heavy/medium/light bell rotation is encoded as `weightOneValue` varying by day (28/24/20kg) — placeholder loads the user overrides in the builder, same precedent as DFW's own loads.

Deliberately did not touch `ProgramsPage.tsx` — surfacing shared programs in the UI is the separate, centrally-coordinated PROD-231 change.

## How tested
- Extended `e2e/program-schema.spec.ts` with a describe block asserting presence/public/system-owned/10-week/3-day metadata, 30 contiguous ordered sessions, the monotonic `restTimer` decrease (the defining feature), and per-phase movement/rep/weight structure — all 3 tests pass against real Postgres via local Supabase.
- Applied the migration to real Postgres directly and confirmed via SQL: the program row (public/system-owned/10wk/3day), 30 contiguous sessions (seq 0–29), the weekly `restTimer` decrease (45→8s), and idempotency (re-applying skips with a NOTICE, no row duplication).
- `tsc` clean, lint clean, 394 unit tests green.
- One intermediate e2e run failed with an empty `programs` result because a parallel worktree reset the shared local Supabase mid-run — the known cross-crewmate `db reset` contention, not a defect. Re-seeding and re-running produced a clean 3/3 pass; CI's isolated instance is the authoritative check.

## Tradeoffs
Review caught a real encoding bug during this run: the one-arm Swing/Snatch movements were seeded with `weightTwoValue = NULL`, which the app reads as Two-Hand mode — the runtime's per-hand mirroring (`isOneHanded`, `ActiveWorkoutPage.tsx:142`) keys off `weightTwoValue === 0`, so NULL silently disabled mirroring and mislabeled a one-arm movement as two-handed, contradicting the migration's own header. Fixed to `weightTwoValue: 0` with `repScheme` halved so the mirrored per-hand total still matches the source's specified reps (e.g. the 100-rep test stays 100, not 200) — applied consistently across every session, not just the test week, so the whole seed is internally consistent.

<details>
<summary>Evidence: Seeded plan DB state</summary>

```text
# StrongFirst Snatch Test Training Plan — seeded state (real Postgres, local Supabase)

## restTimer strictly decreases week over week (the defining feature)
week_number | rest_seconds
1 | 45
2 | 40
3 | 35
4 | 30
5 | 25
6 | 20
7 | 15
8 | 12
9 | 10
10 | 8
```
</details>
<details>
<summary>Evidence: Playwright e2e run — 3/3 Snatch Test seed tests passing</summary>

```text
Running 3 tests using 1 worker

  ✓  1 [chromium] › e2e/program-schema.spec.ts:204:7 › program schema — StrongFirst Snatch Test seed › the shared Snatch Test plan is present, public, system-owned, with 30 ordered sessions (212ms)
  ✓  2 [chromium] › e2e/program-schema.spec.ts:233:7 › program schema — StrongFirst Snatch Test seed › restTimer strictly decreases week over week (126ms)
  ✓  3 [chromium] › e2e/program-schema.spec.ts:264:7 › program schema — StrongFirst Snatch Test seed › session shape matches the plan: build weeks alternate swing/snatch, test weeks are snatch-only 100 reps (176ms)

  3 passed (1.5s)
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ `supabase/migrations/20260713181831_seed_strongfirst_snatch_test_plan.sql:71` - One-Arm Kettlebell Swing/Snatch are seeded with weightTwoValue = NULL, which the app treats as Two-Hand ('2h') mode. Per-hand mirroring in the runtime keys off weightTwoValue === 0 (isOneHanded, ActiveWorkoutPage.tsx:142; shouldMirrorReps, :184), and the builder's Single tab writes 0 (StartWorkoutPage.tsx:381). With NULL, isOneHanded is false, so the runtime does NO per-hand mirroring and the builder shows a 'Two-Hand' tab for a one-arm movement — contradicting the migration header ('One-Arm movements are mirrored per-hand by the runtime') and the '20 reps/set (per hand)' workoutDetails. Correct encoding is weightTwoValue = 0. The e2e assertion at program-schema.spec.ts:284 (toBeNull) bakes in the wrong expectation and won't catch it.

🔧 Fix: fix one-arm snatch seed to Single mode (weightTwo 0, per-hand reps)
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- Applied migration to real Postgres: `docker exec -i supabase_db_kettlebells psql -U postgres -d postgres < supabase/migrations/20260713181831_seed_strongfirst_snatch_test_plan.sql`
- `npx playwright test program-schema.spec.ts -g "Snatch Test seed"` — 3/3 passed against local Supabase REST API
- Idempotency: re-applied the migration, confirmed skip NOTICE and no row duplication (1 program / 30 sessions)
- SQL queries verifying program row (public/system-owned/10wk/3day), 30 contiguous sessions (seq 0-29), restTimer monotonic weekly decrease, and per-phase movement/rep/weight/goal structure
- `npm ci` to install missing worktree dependencies (node_modules was empty)

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
