### PR TITLE
feat(programs): seed Dan John's Armor Building Complex

### DIFF
--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -44,7 +44,7 @@ jobs:
       - name: Set up Supabase CLI
         uses: supabase/setup-cli@v1
         with:
-          version: latest
+          version: 2.109.1
 
       - name: Start local Supabase
         run: supabase start

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -155,15 +155,24 @@ session — atomic), and the PROD-219 editing pair `reorder_program_sessions` /
   (`owner_id NULL`, `is_public`) ship as migrations (not `seed.sql`, so they
   also reach staging/prod) — Dry Fighting Weight
   (`*_seed_dry_fighting_weight.sql`), Dan John's 10,000 Swing Challenge
-  (`*_seed_10000_swing_challenge.sql`), and StrongFirst's A+A Protocol "Plan A"
-  (`*_seed_aa_protocol_plan_a.sql`, the first EMOM/`intervalTimer` program). Each
-  is idempotent on `slug` and builds
-  every session's `WorkoutOptions` JSONB (shape `Omit<WorkoutOptions,'startedAt'>`,
-  camelCase keys) via a `pg_temp` helper; add another by mirroring one. Seed
-  shape is asserted in `e2e/program-schema.spec.ts`. `ProgramsPage` currently
-  features only a single shared program (`sharedPrograms[0]`, preferring the DFW
-  slug), so a newly seeded program lands in the shared-program data but is not
-  yet surfaced in that UI.
+  (`*_seed_10000_swing_challenge.sql`), StrongFirst's A+A Protocol "Plan A"
+  (`*_seed_aa_protocol_plan_a.sql`, the first EMOM/`intervalTimer` program), and
+  Dan John's Armor Building Complex
+  (`*_seed_armor_building_complex.sql`, the first `complexSet: true` program).
+  Each is idempotent on `slug` and builds every session's `WorkoutOptions` JSONB
+  (shape `Omit<WorkoutOptions,'startedAt'>`, camelCase keys) via a `pg_temp`
+  helper; add another by mirroring one. Seed shape is asserted in
+  `e2e/program-schema.spec.ts`. `ProgramsPage` currently features only a single
+  shared program (`sharedPrograms[0]`, preferring the DFW slug), so a newly
+  seeded program lands in the shared-program data but is not yet surfaced in that
+  UI.
+- **Seeding a `complexSet: true` program:** see
+  `*_seed_armor_building_complex.sql` (Dan John's ABC). Give each movement a
+  **single-element `repScheme`** so the complex runtime's `maxMovementRungs`
+  (longest repScheme) is 1 and one "Complete Set" completes a whole round, and
+  **populate `sharedWeightOne/Two`** because `ComplexMovementDisplay` reads the
+  shared pair (not per-movement weights) — DFW's non-complex sessions leave those
+  null.
 - **Next session** = lowest-`sequenceIndex` `program_sessions` row with no
   completion. `useActiveProgram` runs this client-side over the program's ≤~15
   sessions (a dedicated SQL function buys nothing at that size). It returns the

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -174,7 +174,7 @@ session — atomic), and the PROD-219 editing pair `reorder_program_sessions` /
   shared pair (not per-movement weights) — DFW's non-complex sessions leave those
   null.
 - **Next session** = lowest-`sequenceIndex` `program_sessions` row with no
-  completion. `useActiveProgram` runs this client-side over the program's ≤~15
+  completion. `useActiveProgram` runs this client-side over the program's ≤~20
   sessions (a dedicated SQL function buys nothing at that size). It returns the
   **active _or_ most-recently-completed** enrollment so the "🎉 complete" card
   still renders after the terminal status flip — consumers that must treat only

--- a/e2e/program-armor-building-complex.spec.ts
+++ b/e2e/program-armor-building-complex.spec.ts
@@ -1,0 +1,225 @@
+import { expect, test } from '@playwright/test';
+
+// Backend tests for the seeded Armor Building Complex (Dan John) program — the
+// FIRST shipped program to use complexSet=true. These assert the migration's
+// data shape against the LOCAL Supabase REST API (not the browser): every
+// session is a flowing double-KB complex (clean → press → squat, bells never
+// set down), encoded so the ActiveWorkoutPage complex runtime treats one
+// "continue" as one full round. Auth mirrors e2e/program-schema.spec.ts.
+
+// ── Constants ────────────────────────────────────────────────────────────────
+
+const SUPABASE_URL = process.env.VITE_SUPABASE_URL!;
+const SUPABASE_ANON_KEY = process.env.VITE_SUPABASE_ANON_KEY!;
+const ABC_SLUG = 'armor-building-complex';
+const ABC_SESSION_COUNT = 20;
+
+// One round of the ABC: 2 cleans, 1 press, 3 squats. Each movement carries a
+// SINGLE-element repScheme, so maxMovementRungs = 1 and a single "continue"
+// press in the complex runtime completes a whole round.
+const EXPECTED_MOVEMENTS = [
+  { movementName: 'Two-Arm Kettlebell Clean', repScheme: [2] },
+  { movementName: 'Two-Arm Kettlebell Military Press', repScheme: [1] },
+  { movementName: 'Front Squat With Two Kettlebells', repScheme: [3] },
+];
+
+// Round-progression ramp (progression = add rounds, not weight), by sequence.
+const EXPECTED_GOAL_RAMP = [
+  5, 5, 6, 6, 6, 7, 7, 7, 8, 8, 8, 8, 9, 9, 9, 9, 10, 10, 10, 10,
+];
+
+// ── Types ────────────────────────────────────────────────────────────────────
+
+interface AuthSession {
+  access_token: string;
+  user: { id: string; email: string; [key: string]: unknown };
+}
+
+interface TestUser {
+  token: string;
+  uid: string;
+  email: string;
+}
+
+interface Movement {
+  movementName: string;
+  repScheme: number[];
+  weightOneUnit: string | null;
+  weightOneValue: number | null;
+  weightTwoUnit: string | null;
+  weightTwoValue: number | null;
+}
+
+interface WorkoutOptions {
+  complexSet: boolean;
+  intervalTimer: number;
+  restTimer: number;
+  workoutGoal: number;
+  workoutGoalUnits: string;
+  movements: Movement[];
+  sharedWeightOneUnit: string | null;
+  sharedWeightOneValue: number | null;
+  sharedWeightTwoUnit: string | null;
+  sharedWeightTwoValue: number | null;
+}
+
+// ── Auth helper ──────────────────────────────────────────────────────────────
+
+async function signUpThrowawayUser(): Promise<TestUser> {
+  const email = `abc-${Date.now()}-${Math.floor(Math.random() * 1e9)}@example.com`;
+  const password = 'testpassword123';
+
+  const res = await fetch(`${SUPABASE_URL}/auth/v1/signup`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', apikey: SUPABASE_ANON_KEY },
+    body: JSON.stringify({ email, password }),
+  });
+  if (!res.ok) throw new Error(`signup failed (${res.status}): ${await res.text()}`);
+
+  const body = (await res.json()) as Partial<AuthSession>;
+  if (body.access_token && body.user) {
+    return { token: body.access_token, uid: body.user.id, email };
+  }
+
+  const signInRes = await fetch(
+    `${SUPABASE_URL}/auth/v1/token?grant_type=password`,
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', apikey: SUPABASE_ANON_KEY },
+      body: JSON.stringify({ email, password }),
+    },
+  );
+  if (!signInRes.ok) {
+    throw new Error(`sign-in failed (${signInRes.status}): ${await signInRes.text()}`);
+  }
+  const session = (await signInRes.json()) as AuthSession;
+  return { token: session.access_token, uid: session.user.id, email };
+}
+
+// ── REST helper ──────────────────────────────────────────────────────────────
+
+async function restJson<T = unknown>(path: string, token: string): Promise<T> {
+  const res = await fetch(`${SUPABASE_URL}/rest/v1/${path}`, {
+    headers: { apikey: SUPABASE_ANON_KEY, Authorization: `Bearer ${token}` },
+  });
+  if (!res.ok) throw new Error(`GET ${path} failed (${res.status}): ${await res.text()}`);
+  return res.json() as Promise<T>;
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+test.describe('program schema — Armor Building Complex seed', () => {
+  test('is present, public, system-owned, with 20 ordered complex-set sessions', async () => {
+    const user = await signUpThrowawayUser();
+
+    const programs = await restJson<
+      Array<{
+        id: string;
+        is_public: boolean;
+        owner_id: string | null;
+        author_name: string;
+        num_weeks: number;
+        days_per_week: number;
+      }>
+    >(`programs?slug=eq.${ABC_SLUG}&select=*`, user.token);
+
+    expect(programs).toHaveLength(1);
+    const abc = programs[0];
+    expect(abc.is_public).toBe(true);
+    expect(abc.owner_id).toBeNull();
+    expect(abc.author_name).toBe('Dan John');
+    expect(abc.num_weeks).toBe(5);
+    expect(abc.days_per_week).toBe(4);
+
+    const sessions = await restJson<
+      Array<{ sequence_index: number; workout_options: WorkoutOptions }>
+    >(
+      `program_sessions?program_id=eq.${abc.id}&select=sequence_index,workout_options&order=sequence_index.asc`,
+      user.token,
+    );
+
+    expect(sessions).toHaveLength(ABC_SESSION_COUNT);
+    // Contiguous 0..19 order.
+    expect(sessions.map((s) => s.sequence_index)).toEqual(
+      Array.from({ length: ABC_SESSION_COUNT }, (_, i) => i),
+    );
+
+    for (const [i, s] of sessions.entries()) {
+      const wo = s.workout_options;
+
+      // Every session is a flowing complex for rounds.
+      expect(wo.complexSet).toBe(true);
+      expect(wo.workoutGoalUnits).toBe('rounds');
+      expect(wo.intervalTimer).toBe(0);
+      expect(wo.restTimer).toBeGreaterThan(0); // rest is BETWEEN rounds
+
+      // Rounds ramp upward toward the 10-round benchmark.
+      expect(wo.workoutGoal).toBe(EXPECTED_GOAL_RAMP[i]);
+
+      // The complex display reads the SHARED weight pair (double bells), so both
+      // must be populated — DFW leaves these null; ABC must not.
+      expect(wo.sharedWeightOneValue).toBeGreaterThan(0);
+      expect(wo.sharedWeightTwoValue).toBeGreaterThan(0);
+      expect(wo.sharedWeightOneUnit).toBe('kilograms');
+      expect(wo.sharedWeightTwoUnit).toBe('kilograms');
+
+      // Three movements as one chain, exact names + single-element repSchemes.
+      expect(wo.movements).toHaveLength(3);
+      wo.movements.forEach((m, mi) => {
+        expect(m.movementName).toBe(EXPECTED_MOVEMENTS[mi].movementName);
+        expect(m.repScheme).toEqual(EXPECTED_MOVEMENTS[mi].repScheme);
+        // Double kettlebell: both bells loaded.
+        expect(m.weightOneValue).toBeGreaterThan(0);
+        expect(m.weightTwoValue).toBeGreaterThan(0);
+      });
+
+      // maxMovementRungs (longest repScheme) === 1, so one "continue" per round.
+      const maxRungs = Math.max(...wo.movements.map((m) => m.repScheme.length));
+      expect(maxRungs).toBe(1);
+    }
+
+    // The final session is the classic 10-round ABC benchmark.
+    expect(sessions[ABC_SESSION_COUNT - 1].workout_options.workoutGoal).toBe(10);
+  });
+
+  test('enrolling clones the ABC into an isolated user-owned copy', async () => {
+    const user = await signUpThrowawayUser();
+
+    const [abc] = await restJson<Array<{ id: string }>>(
+      `programs?slug=eq.${ABC_SLUG}&select=id`,
+      user.token,
+    );
+
+    const res = await fetch(`${SUPABASE_URL}/rest/v1/rpc/enroll_in_program`, {
+      method: 'POST',
+      headers: {
+        apikey: SUPABASE_ANON_KEY,
+        Authorization: `Bearer ${user.token}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ p_program_id: abc.id }),
+    });
+    expect(res.ok).toBe(true);
+    const userProgramId = (await res.json()) as string;
+    expect(typeof userProgramId).toBe('string');
+
+    // A user-owned, private clone with all 20 complex-set sessions preserved.
+    const clones = await restJson<
+      Array<{ id: string; owner_id: string; is_public: boolean }>
+    >(
+      `programs?source_program_id=eq.${abc.id}&owner_id=eq.${user.uid}&select=id,owner_id,is_public`,
+      user.token,
+    );
+    expect(clones).toHaveLength(1);
+    expect(clones[0].is_public).toBe(false);
+
+    const cloneSessions = await restJson<
+      Array<{ workout_options: WorkoutOptions }>
+    >(
+      `program_sessions?program_id=eq.${clones[0].id}&select=workout_options&order=sequence_index.asc`,
+      user.token,
+    );
+    expect(cloneSessions).toHaveLength(ABC_SESSION_COUNT);
+    expect(cloneSessions.every((s) => s.workout_options.complexSet)).toBe(true);
+  });
+});

--- a/e2e/program-armor-building-complex.spec.ts
+++ b/e2e/program-armor-building-complex.spec.ts
@@ -74,7 +74,8 @@ async function signUpThrowawayUser(): Promise<TestUser> {
     headers: { 'Content-Type': 'application/json', apikey: SUPABASE_ANON_KEY },
     body: JSON.stringify({ email, password }),
   });
-  if (!res.ok) throw new Error(`signup failed (${res.status}): ${await res.text()}`);
+  if (!res.ok)
+    throw new Error(`signup failed (${res.status}): ${await res.text()}`);
 
   const body = (await res.json()) as Partial<AuthSession>;
   if (body.access_token && body.user) {
@@ -85,12 +86,17 @@ async function signUpThrowawayUser(): Promise<TestUser> {
     `${SUPABASE_URL}/auth/v1/token?grant_type=password`,
     {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json', apikey: SUPABASE_ANON_KEY },
+      headers: {
+        'Content-Type': 'application/json',
+        apikey: SUPABASE_ANON_KEY,
+      },
       body: JSON.stringify({ email, password }),
     },
   );
   if (!signInRes.ok) {
-    throw new Error(`sign-in failed (${signInRes.status}): ${await signInRes.text()}`);
+    throw new Error(
+      `sign-in failed (${signInRes.status}): ${await signInRes.text()}`,
+    );
   }
   const session = (await signInRes.json()) as AuthSession;
   return { token: session.access_token, uid: session.user.id, email };
@@ -102,7 +108,8 @@ async function restJson<T = unknown>(path: string, token: string): Promise<T> {
   const res = await fetch(`${SUPABASE_URL}/rest/v1/${path}`, {
     headers: { apikey: SUPABASE_ANON_KEY, Authorization: `Bearer ${token}` },
   });
-  if (!res.ok) throw new Error(`GET ${path} failed (${res.status}): ${await res.text()}`);
+  if (!res.ok)
+    throw new Error(`GET ${path} failed (${res.status}): ${await res.text()}`);
   return res.json() as Promise<T>;
 }
 
@@ -179,7 +186,9 @@ test.describe('program schema — Armor Building Complex seed', () => {
     }
 
     // The final session is the classic 10-round ABC benchmark.
-    expect(sessions[ABC_SESSION_COUNT - 1].workout_options.workoutGoal).toBe(10);
+    expect(sessions[ABC_SESSION_COUNT - 1].workout_options.workoutGoal).toBe(
+      10,
+    );
   });
 
   test('enrolling clones the ABC into an isolated user-owned copy', async () => {

--- a/src/pages/ActiveWorkoutPage/ActiveWorkoutPage.stories.tsx
+++ b/src/pages/ActiveWorkoutPage/ActiveWorkoutPage.stories.tsx
@@ -725,3 +725,73 @@ export const ComplexModeDifferentRepSchemes: Story = {
     },
   },
 };
+
+// Mirrors a seeded Armor Building Complex session (Dan John) exactly — the first
+// shipped program to use complexSet=true. One round = 2 cleans, 1 press, 3
+// squats flowed together with double bells never set down; each movement's
+// single-element repScheme means the longest is exhausted in ONE "Complete Set",
+// so one press completes a whole round. restTimer models the ~30s rest BETWEEN
+// rounds. Goal is 5 rounds (the W1D1 session).
+const ARMOR_BUILDING_COMPLEX_MOVEMENTS = [
+  {
+    ...DEFAULT_MOVEMENT_OPTIONS,
+    movementName: 'Two-Arm Kettlebell Clean',
+    repScheme: [2],
+    weightOneValue: 24,
+    weightOneUnit: 'kilograms',
+    weightTwoValue: 24,
+    weightTwoUnit: 'kilograms',
+  },
+  {
+    ...DEFAULT_MOVEMENT_OPTIONS,
+    movementName: 'Two-Arm Kettlebell Military Press',
+    repScheme: [1],
+    weightOneValue: 24,
+    weightOneUnit: 'kilograms',
+    weightTwoValue: 24,
+    weightTwoUnit: 'kilograms',
+  },
+  {
+    ...DEFAULT_MOVEMENT_OPTIONS,
+    movementName: 'Front Squat With Two Kettlebells',
+    repScheme: [3],
+    weightOneValue: 24,
+    weightOneUnit: 'kilograms',
+    weightTwoValue: 24,
+    weightTwoUnit: 'kilograms',
+  },
+] satisfies MovementOptions[];
+
+export const ArmorBuildingComplex: Story = {
+  parameters: {
+    workoutOptions: {
+      complexSet: true,
+      restTimer: 30,
+      workoutGoal: 5,
+      workoutGoalUnits: 'rounds',
+      sharedWeightOneValue: 24,
+      sharedWeightOneUnit: 'kilograms',
+      sharedWeightTwoValue: 24,
+      sharedWeightTwoUnit: 'kilograms',
+      movements: ARMOR_BUILDING_COMPLEX_MOVEMENTS,
+    },
+  },
+};
+
+// Same session with rest between rounds removed (a user-editable option), so a
+// full 5-round session can be run to its rounds goal in one continuous flow.
+export const ArmorBuildingComplexContinuous: Story = {
+  parameters: {
+    workoutOptions: {
+      complexSet: true,
+      restTimer: 0,
+      workoutGoal: 5,
+      workoutGoalUnits: 'rounds',
+      sharedWeightOneValue: 24,
+      sharedWeightOneUnit: 'kilograms',
+      sharedWeightTwoValue: 24,
+      sharedWeightTwoUnit: 'kilograms',
+      movements: ARMOR_BUILDING_COMPLEX_MOVEMENTS,
+    },
+  },
+};

--- a/src/pages/ActiveWorkoutPage/ActiveWorkoutPage.test.jsx
+++ b/src/pages/ActiveWorkoutPage/ActiveWorkoutPage.test.jsx
@@ -12,6 +12,8 @@ const {
   ComplexMode,
   ComplexModeDoubleBells,
   ComplexModeDifferentRepSchemes,
+  ArmorBuildingComplex,
+  ArmorBuildingComplexContinuous,
   DoubleWeights,
   MixedWeights,
   MultipleMovements,
@@ -1094,6 +1096,30 @@ describe('volume calculation for complex mode', () => {
     });
   });
 
+  test('runs a full Armor Building Complex session to its rounds goal (single-element repSchemes → one press per round)', async () => {
+    render(<ArmorBuildingComplexContinuous />);
+
+    // Each movement has a single-element repScheme ([2]/[1]/[3]), so
+    // maxMovementRungs = 1 and ONE "Complete Set" completes a whole round.
+    // Five presses reaches the 5-round goal, which auto-finishes the workout.
+    await clickCompleteSet(); // round 1
+    await clickCompleteSet(); // round 2
+    await clickCompleteSet(); // round 3
+    await clickCompleteSet(); // round 4
+    await clickCompleteSet(); // round 5 → rounds goal reached, auto-finish
+
+    // No manual "finish workout" click needed — the rounds goal ends it.
+    // Per round: (2+1+3) reps = 6; double 24kg bells = 48kg/movement.
+    // Volume/round = 48×(2+1+3) = 288kg; ×5 rounds = 1440kg.
+    expect(logWorkout).toHaveBeenCalledWith({
+      completedReps: 30, // 6 reps × 5 rounds
+      completedRounds: 5,
+      completedRungs: 5, // 1 rung per round × 5
+      completedSides: expect.any(Number),
+      completedVolume: 1440,
+    });
+  });
+
   test('calculates volume correctly for double bells in complex mode (20kg + 16kg × 5 reps, 2 movements = 360kg)', async () => {
     render(<ComplexModeDoubleBells />);
 
@@ -1323,6 +1349,63 @@ describe('active workout page (A+A Protocol interval EMOM cadence)', () => {
     expect(leftWeight).toHaveAttribute('data-active', 'true');
     expect(rightWeight).toHaveAttribute('data-active', 'false');
     expect(round).toHaveTextContent('2');
+  });
+});
+
+describe('active workout page (Armor Building Complex seed session)', () => {
+  const { workoutOptions } = ArmorBuildingComplex.parameters;
+
+  beforeEach(() => {
+    render(<ArmorBuildingComplex />);
+  });
+
+  test('flows all three movements as one chain with reps 2, 1, 3', () => {
+    // clean → press → squat shown together, each at its single rung.
+    expect(workoutOptions.movements.map((m) => m.movementName)).toEqual([
+      'Two-Arm Kettlebell Clean',
+      'Two-Arm Kettlebell Military Press',
+      'Front Squat With Two Kettlebells',
+    ]);
+    workoutOptions.movements.forEach((movement, index) => {
+      expect(screen.getByTestId(`complex-movement-name-${index}`)).toHaveTextContent(
+        movement.movementName,
+      );
+      expect(screen.getByTestId(`complex-movement-reps-${index}`)).toHaveTextContent(
+        String(movement.repScheme[0]),
+      );
+    });
+    expect(screen.getByTestId('complex-movement-reps-0')).toHaveTextContent('2');
+    expect(screen.getByTestId('complex-movement-reps-1')).toHaveTextContent('1');
+    expect(screen.getByTestId('complex-movement-reps-2')).toHaveTextContent('3');
+  });
+
+  test('shows the double-bell shared weight (24kg + 24kg)', () => {
+    expect(screen.getByTestId('complex-shared-weight')).toHaveTextContent('24');
+    expect(screen.getByTestId('complex-shared-weight-two')).toHaveTextContent('24');
+  });
+
+  test('uses the complex "Complete Set" control (not DFW\'s "Continue")', () => {
+    screen.getByRole('button', { name: 'Complete Set' });
+    expect(screen.queryByRole('button', { name: 'Continue' })).toBeNull();
+  });
+
+  test('one "Complete Set" completes a whole round (longest repScheme is length 1)', async () => {
+    // currentRound = completedRounds + 1, so the header reads "1" before any round.
+    expect(screen.getByTestId('current-round')).toHaveTextContent('1');
+
+    await clickCompleteSet();
+
+    // A single press exhausts the longest (length-1) repScheme, so the round
+    // advances immediately — unlike a multi-rung complex or DFW's alternation.
+    expect(screen.getByTestId('current-round')).toHaveTextContent('2');
+  });
+
+  test('rests between rounds (restTimer > 0 replaces the button with a rest bar)', async () => {
+    await clickCompleteSet();
+
+    // The between-rounds rest is active, so the set control is gone.
+    expect(screen.getByText('rest')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Complete Set' })).toBeNull();
   });
 });
 

--- a/src/pages/ActiveWorkoutPage/ActiveWorkoutPage.test.jsx
+++ b/src/pages/ActiveWorkoutPage/ActiveWorkoutPage.test.jsx
@@ -1367,21 +1367,29 @@ describe('active workout page (Armor Building Complex seed session)', () => {
       'Front Squat With Two Kettlebells',
     ]);
     workoutOptions.movements.forEach((movement, index) => {
-      expect(screen.getByTestId(`complex-movement-name-${index}`)).toHaveTextContent(
-        movement.movementName,
-      );
-      expect(screen.getByTestId(`complex-movement-reps-${index}`)).toHaveTextContent(
-        String(movement.repScheme[0]),
-      );
+      expect(
+        screen.getByTestId(`complex-movement-name-${index}`),
+      ).toHaveTextContent(movement.movementName);
+      expect(
+        screen.getByTestId(`complex-movement-reps-${index}`),
+      ).toHaveTextContent(String(movement.repScheme[0]));
     });
-    expect(screen.getByTestId('complex-movement-reps-0')).toHaveTextContent('2');
-    expect(screen.getByTestId('complex-movement-reps-1')).toHaveTextContent('1');
-    expect(screen.getByTestId('complex-movement-reps-2')).toHaveTextContent('3');
+    expect(screen.getByTestId('complex-movement-reps-0')).toHaveTextContent(
+      '2',
+    );
+    expect(screen.getByTestId('complex-movement-reps-1')).toHaveTextContent(
+      '1',
+    );
+    expect(screen.getByTestId('complex-movement-reps-2')).toHaveTextContent(
+      '3',
+    );
   });
 
   test('shows the double-bell shared weight (24kg + 24kg)', () => {
     expect(screen.getByTestId('complex-shared-weight')).toHaveTextContent('24');
-    expect(screen.getByTestId('complex-shared-weight-two')).toHaveTextContent('24');
+    expect(screen.getByTestId('complex-shared-weight-two')).toHaveTextContent(
+      '24',
+    );
   });
 
   test('uses the complex "Complete Set" control (not DFW\'s "Continue")', () => {

--- a/supabase/migrations/20260713181835_seed_armor_building_complex.sql
+++ b/supabase/migrations/20260713181835_seed_armor_building_complex.sql
@@ -1,0 +1,111 @@
+-- Seed the canonical shared Armor Building Complex (Dan John) program.
+-- Public + system-owned (owner_id NULL, is_public true) so every user sees it
+-- and can one-tap "Start Armor Building Complex"; enrolling clones it into an
+-- editable copy (enroll_in_program). Idempotent on slug: a re-run (or a fresh
+-- env) skips re-seeding sessions.
+--
+-- Runs as the migration role, which bypasses RLS, so the NULL-owner public row
+-- inserts cleanly. This is a MIGRATION (not seed.sql) so it also reaches
+-- staging/production, where seed.sql never runs.
+--
+-- FIRST shipped program to use complexSet=true. Unlike DFW (complexSet=false,
+-- movements alternate rung-by-rung), the ABC is one flowing double-KB chain per
+-- round -- clean -> press -> squat, bells never set down. In the runtime
+-- (ActiveWorkoutPage.tsx:204-207 / ComplexMovementDisplay.tsx) each movement
+-- carries a SINGLE-element repScheme, so maxMovementRungs = 1 and ONE "continue"
+-- press completes a whole round (2 cleans, 1 press, 3 squats shown together).
+-- The complex display renders the SHARED weight pair (sharedWeightOne/Two), so
+-- those are populated here -- DFW leaves them NULL because its per-movement
+-- display path reads the per-movement weights instead. Per-movement weights are
+-- also set (double 24 kg) so completed-volume tracking stays correct.
+--
+-- Round-progression ramp (progression = add ROUNDS, not weight -- ABC has no
+-- canonical numeric table in the source; report.md confirms this). Sensible
+-- linear default: start at 5 rounds, add ~1 round/week, reaching the classic
+-- "10 rounds" ABC benchmark by week 5, then holding it. num_weeks=5 /
+-- days_per_week=4 describe the ~30-day, 3-5x/wk arc (labels only); the 20 seeded
+-- session rows carry the actual programming. Each ramp step is documented in the
+-- session's workoutDetails and is content-editable later.
+--   W1: 5, 5, 6, 6   W2: 6, 7, 7, 7   W3: 8, 8, 8, 8   W4: 9, 9, 9, 9   W5: 10 x4
+-- restTimer is 30 s BETWEEN rounds (within a round the bells never leave the
+-- rack); it is a runnable default and editable at start. intervalTimer=0 (unused).
+
+-- Session-local helper (pg_temp: auto-dropped at connection end, never persisted
+-- to the committed schema) that builds the WorkoutOptions JSONB for one ABC
+-- session. Shape MUST match Omit<WorkoutOptions,'startedAt'> exactly (camelCase).
+CREATE OR REPLACE FUNCTION pg_temp.abc_options(p_rounds INT, p_details TEXT)
+RETURNS JSONB LANGUAGE sql IMMUTABLE AS $$
+  SELECT jsonb_build_object(
+    'complexSet', true,
+    'intervalTimer', 0,
+    'restTimer', 30,
+    'workoutGoal', p_rounds,
+    'workoutGoalUnits', 'rounds',
+    'workoutDetails', p_details,
+    'sharedWeightOneUnit', 'kilograms',
+    'sharedWeightOneValue', 24,
+    'sharedWeightTwoUnit', 'kilograms',
+    'sharedWeightTwoValue', 24,
+    'movements', jsonb_build_array(
+      jsonb_build_object(
+        'movementName', 'Two-Arm Kettlebell Clean',
+        'repScheme', to_jsonb(ARRAY[2]::INT[]),
+        'weightOneUnit', 'kilograms', 'weightOneValue', 24,
+        'weightTwoUnit', 'kilograms', 'weightTwoValue', 24),
+      jsonb_build_object(
+        'movementName', 'Two-Arm Kettlebell Military Press',
+        'repScheme', to_jsonb(ARRAY[1]::INT[]),
+        'weightOneUnit', 'kilograms', 'weightOneValue', 24,
+        'weightTwoUnit', 'kilograms', 'weightTwoValue', 24),
+      jsonb_build_object(
+        'movementName', 'Front Squat With Two Kettlebells',
+        'repScheme', to_jsonb(ARRAY[3]::INT[]),
+        'weightOneUnit', 'kilograms', 'weightOneValue', 24,
+        'weightTwoUnit', 'kilograms', 'weightTwoValue', 24)
+    ));
+$$;
+
+DO $$
+DECLARE
+  v_program_id UUID;
+BEGIN
+  INSERT INTO programs (owner_id, slug, title, description, author_name, num_weeks, days_per_week, is_public)
+  VALUES (NULL, 'armor-building-complex',
+          'Armor Building Complex',
+          'A double-kettlebell complex done without setting the bells down: '
+          'clean, press, squat back-to-back = one round. Build from 5 to 10 '
+          'rounds over ~5 weeks, 3-5x/week. Progression is adding rounds, not weight.',
+          'Dan John', 5, 4, true)
+  ON CONFLICT (slug) DO NOTHING
+  RETURNING id INTO v_program_id;
+
+  -- If the row already existed, skip re-seeding sessions.
+  IF v_program_id IS NULL THEN
+    RAISE NOTICE 'Armor Building Complex program already seeded; skipping sessions.';
+    RETURN;
+  END IF;
+
+  INSERT INTO program_sessions
+    (program_id, sequence_index, week_number, day_number, title, workout_options)
+  VALUES
+    (v_program_id,  0, 1, 1, '5 rounds',  pg_temp.abc_options(5,  'ABC W1D1 - 5 rounds. One round = 2 cleans, 1 press, 3 squats (double bells, never set down). ~30s rest between rounds (editable).')),
+    (v_program_id,  1, 1, 2, '5 rounds',  pg_temp.abc_options(5,  'ABC W1D2 - 5 rounds. Ease in; keep every round crisp.')),
+    (v_program_id,  2, 1, 3, '6 rounds',  pg_temp.abc_options(6,  'ABC W1D3 - 6 rounds.')),
+    (v_program_id,  3, 1, 4, '6 rounds',  pg_temp.abc_options(6,  'ABC W1D4 - 6 rounds.')),
+    (v_program_id,  4, 2, 1, '6 rounds',  pg_temp.abc_options(6,  'ABC W2D1 - 6 rounds.')),
+    (v_program_id,  5, 2, 2, '7 rounds',  pg_temp.abc_options(7,  'ABC W2D2 - 7 rounds.')),
+    (v_program_id,  6, 2, 3, '7 rounds',  pg_temp.abc_options(7,  'ABC W2D3 - 7 rounds.')),
+    (v_program_id,  7, 2, 4, '7 rounds',  pg_temp.abc_options(7,  'ABC W2D4 - 7 rounds.')),
+    (v_program_id,  8, 3, 1, '8 rounds',  pg_temp.abc_options(8,  'ABC W3D1 - 8 rounds.')),
+    (v_program_id,  9, 3, 2, '8 rounds',  pg_temp.abc_options(8,  'ABC W3D2 - 8 rounds.')),
+    (v_program_id, 10, 3, 3, '8 rounds',  pg_temp.abc_options(8,  'ABC W3D3 - 8 rounds.')),
+    (v_program_id, 11, 3, 4, '8 rounds',  pg_temp.abc_options(8,  'ABC W3D4 - 8 rounds.')),
+    (v_program_id, 12, 4, 1, '9 rounds',  pg_temp.abc_options(9,  'ABC W4D1 - 9 rounds.')),
+    (v_program_id, 13, 4, 2, '9 rounds',  pg_temp.abc_options(9,  'ABC W4D2 - 9 rounds.')),
+    (v_program_id, 14, 4, 3, '9 rounds',  pg_temp.abc_options(9,  'ABC W4D3 - 9 rounds.')),
+    (v_program_id, 15, 4, 4, '9 rounds',  pg_temp.abc_options(9,  'ABC W4D4 - 9 rounds.')),
+    (v_program_id, 16, 5, 1, '10 rounds', pg_temp.abc_options(10, 'ABC W5D1 - 10 rounds. The classic ABC benchmark.')),
+    (v_program_id, 17, 5, 2, '10 rounds', pg_temp.abc_options(10, 'ABC W5D2 - 10 rounds.')),
+    (v_program_id, 18, 5, 3, '10 rounds', pg_temp.abc_options(10, 'ABC W5D3 - 10 rounds.')),
+    (v_program_id, 19, 5, 4, '10 rounds', pg_temp.abc_options(10, 'ABC W5D4 - 10 rounds. Own the full 10.'));
+END $$;


### PR DESCRIPTION
## What
Adds Dan John's "Armor Building Complex" (ABC) as a shared, public program alongside DFW — the first shipped program to use `complexSet: true`.

## Why
PROD-227. ABC is a double-kettlebell complex done without setting the bells down (clean → press → squat = one round, building 5→10 rounds over 5 weeks), and it's the strongest free candidate that exercises `complexSet: true` — a runtime mode the schema already fully supports but that zero shipped programs use.

Encoding decision, verified against the actual runtime: in `complexSet: true` mode (`ActiveWorkoutPage.tsx:204-207`), each movement carries a single-element `repScheme` (clean `[2]`, press `[1]`, squat `[3]`) so `maxMovementRungs` is 1 and one "Complete Set" completes a whole round. Movement names confirmed against `scripts/data/movements.csv`: Two-Arm Kettlebell Clean, Two-Arm Kettlebell Military Press, Front Squat With Two Kettlebells. Both `sharedWeightOne/Two` and per-movement weights are populated at double 24kg — the complex display reads the shared pair, per-movement weights keep volume tracking correct. Rounds ramp 5→10 across 5 weeks, a deliberate linear default since the source has no canonical numeric table (documented in the migration header and each session's `workoutDetails`).

Deliberately did not touch `ProgramsPage.tsx` — surfacing new shared programs in the UI is the separate, centrally-coordinated PROD-231 change.

## How tested
- `npx supabase db reset` applies the new migration cleanly.
- New e2e spec (`e2e/program-armor-building-complex.spec.ts`) confirms the seeded program/sessions and enroll-clone against real local Postgres.
- 6 unit tests drive the real `ActiveWorkoutPage` complex runtime: the three-movement chain (2/1/3), shared double-bell weight, the "Complete Set" control (not DFW's "Continue"), one Complete Set completing a whole round, between-rounds rest, and a full 5-round run auto-finishing at rounds 5 / reps 30 / volume 1440kg.
- Because this is a first-of-its-kind runtime path, I didn't stop at DB/unit evidence: rendered the seeded session through the real `ActiveWorkoutPage` in Storybook and screenshotted the flow live — the initial round, the round advancing with between-rounds rest, and the auto-finished summary. Screenshots below confirm the complex behaves as documented and is visibly distinct from DFW's alternating `complexSet: false` style.
- `tsc`, lint, and all 400 unit tests green.

## Tradeoffs
None of real weight — this mirrors the DFW/swing-challenge seed conventions directly rather than introducing anything new.

- Evidence: ABC complex runtime — initial round (5 rounds remaining, Clean 2 / Press 1 / Squat 3, 24+24kg, 'Complete Set')
- Evidence: After one 'Complete Set' — round advances to 2 with between-rounds rest active
- Evidence: Continuous variant at round 5 of 5
- Evidence: Auto-finished summary — 0 rounds remaining, Rounds 5 / Reps 30 / Volume 1440 kg

<details>
<summary>Evidence: Persisted ABC program row (public, system-owned, Dan John, 5 weeks / 4 days)</summary>

```text
{
  "slug": "armor-building-complex",
  "title": "Armor Building Complex",
  "author_name": "Dan John",
  "is_public": true,
  "owner_id": null,
  "num_weeks": 5,
  "days_per_week": 4,
  "description": "A double-kettlebell complex done without setting the bells down: clean, press, squat back-to-back = one round. Build from 5 to 10 rounds over ~5 weeks, 3-5x/week. Progression is adding rounds, not weight."
}
```
</details>
<details>
<summary>Evidence: Persisted W1D1 session workout_options JSONB (complexSet, rounds goal, shared 24kg bells, 3 single-rung movements)</summary>

```text
{
  "week_number": 1,
  "day_number": 1,
  "title": "5 rounds",
  "workout_options": {
    "movements": [
      {
        "repScheme": [
          2
        ],
        "movementName": "Two-Arm Kettlebell Clean",
        "weightOneUnit": "kilograms",
        "weightTwoUnit": "kilograms",
        "weightOneValue": 24,
        "weightTwoValue": 24
      },
      {
        "repScheme": [
          1
        ],
        "movementName": "Two-Arm Kettlebell Military Press",
        "weightOneUnit": "kilograms",
        "weightTwoUnit": "kilograms",
        "weightOneValue": 24,
        "weightTwoValue": 24
      },
      {
        "repScheme": [
          3
        ],
        "movementName": "Front Squat With Two Kettlebells",
        "weightOneUnit": "kilograms",
        "weightTwoUnit": "kilograms",
        "weightOneValue": 24,
        "weightTwoValue": 24
      }
    ],
    "restTimer": 30,
    "complexSet": true,
    "workoutGoal": 5,
    "intervalTimer": 0,
    "workoutDetails": "ABC W1D1 - 5 rounds. One round = 2 cleans, 1 press, 3 squats (double bells, never set down). ~30s rest between rounds (editable).",
    "workoutGoalUnits": "rounds",
    "sharedWeightOneUnit": "kilograms",
    "sharedWeightTwoUnit": "kilograms",
    "sharedWeightOneValue": 24,
    "sharedWeightTwoValue": 24
  }
}
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Rebase** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ `AGENTS.md` - merge conflict rebasing onto origin/main

🔧 Fix applied.
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `npx supabase db reset --local` — applied migration 20260713181835_seed_armor_building_complex.sql cleanly (all migrations up to it, no errors)
- `npm run test:e2e -- e2e/program-armor-building-complex.spec.ts` — 2 backend tests green against local Postgres: ABC is present/public/system-owned with 20 ordered complex-set sessions (rounds ramp 5→10, single-element repSchemes, shared 24+24kg bells), and enrolling clones it into an isolated user-owned private copy
- `npx vitest run src/pages/ActiveWorkoutPage/ActiveWorkoutPage.test.jsx -t 'Armor Building Complex'` — 6 tests green on the real ActiveWorkoutPage: three-movement chain (2/1/3), shared double-bell weight, 'Complete Set' control (not DFW's 'Continue'), one Complete Set completes a whole round, between-rounds rest, and a full 5-round run auto-finishing at completedRounds 5 / completedReps 30 / completedVolume 1440
- Captured persisted DB state via authenticated Supabase REST (program row + W1D1 session workout_options JSONB)
- Drove the seeded session through the real ActiveWorkoutPage in Storybook (Playwright) and screenshotted the initial round, the round-advance + between-rounds rest, and the auto-finished summary (Rounds 5, Reps 30, Volume 1440 kg)

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
