### PR TITLE
feat(programs): seed Dan John's Easy Strength as a shared program

### DIFF
--- a/e2e/program-easy-strength.spec.ts
+++ b/e2e/program-easy-strength.spec.ts
@@ -1,0 +1,211 @@
+import { expect, test } from '@playwright/test';
+
+// Backend coverage for the seeded shared "Easy Strength" program (Dan John),
+// mirroring program-schema.spec.ts: hit the LOCAL Supabase REST API directly
+// rather than driving the browser, since this is pure seed-data verification.
+// Confirms the 10-workout / 2-week "Even Easier Strength" cycle carries the right
+// rep schemes per session, the correct 5 movement patterns + weight modes, and
+// that the approximated ascending-weight day flags itself in workoutDetails.
+
+const SUPABASE_URL = process.env.VITE_SUPABASE_URL!;
+const SUPABASE_ANON_KEY = process.env.VITE_SUPABASE_ANON_KEY!;
+const ES_SLUG = 'easy-strength';
+const ES_SESSION_COUNT = 10;
+
+interface AuthSession {
+  access_token: string;
+  user: { id: string; email: string; [key: string]: unknown };
+}
+
+interface TestUser {
+  token: string;
+  uid: string;
+  email: string;
+}
+
+async function signUpThrowawayUser(): Promise<TestUser> {
+  const email = `es-${Date.now()}-${Math.floor(Math.random() * 1e9)}@example.com`;
+  const password = 'testpassword123';
+
+  const res = await fetch(`${SUPABASE_URL}/auth/v1/signup`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', apikey: SUPABASE_ANON_KEY },
+    body: JSON.stringify({ email, password }),
+  });
+  if (!res.ok) {
+    throw new Error(`signup failed (${res.status}): ${await res.text()}`);
+  }
+
+  const body = (await res.json()) as Partial<AuthSession>;
+  if (body.access_token && body.user) {
+    return { token: body.access_token, uid: body.user.id, email };
+  }
+
+  const signInRes = await fetch(
+    `${SUPABASE_URL}/auth/v1/token?grant_type=password`,
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', apikey: SUPABASE_ANON_KEY },
+      body: JSON.stringify({ email, password }),
+    },
+  );
+  if (!signInRes.ok) {
+    throw new Error(`sign-in failed (${signInRes.status}): ${await signInRes.text()}`);
+  }
+  const session = (await signInRes.json()) as AuthSession;
+  return { token: session.access_token, uid: session.user.id, email };
+}
+
+async function restJson<T = unknown>(path: string, token: string): Promise<T> {
+  const res = await fetch(`${SUPABASE_URL}/rest/v1/${path}`, {
+    headers: { apikey: SUPABASE_ANON_KEY, Authorization: `Bearer ${token}` },
+  });
+  if (!res.ok) {
+    throw new Error(`GET ${path} failed (${res.status}): ${await res.text()}`);
+  }
+  return res.json() as Promise<T>;
+}
+
+// ── Types for the seeded WorkoutOptions blob ─────────────────────────────────
+
+interface MovementOpt {
+  movementName: string;
+  repScheme: number[];
+  weightOneValue: number | null;
+  weightTwoValue: number | null;
+}
+interface WorkoutOpts {
+  complexSet: boolean;
+  workoutGoal: number;
+  workoutGoalUnits: string;
+  workoutDetails: string;
+  movements: MovementOpt[];
+}
+interface SessionRow {
+  sequence_index: number;
+  week_number: number;
+  day_number: number;
+  workout_options: WorkoutOpts;
+}
+
+// The "Even Easier Strength" 10-workout / 2-week cycle: one shared rep scheme per
+// session applied across all five movement patterns.
+const EXPECTED_REP_SCHEMES: number[][] = [
+  [5, 5], // W1D1 2x5
+  [5, 5], // W1D2 2x5
+  [5, 3, 2], // W1D3 5-3-2
+  [5, 5], // W1D4 2x5
+  [5, 5], // W1D5 2x5
+  [5, 5], // W2D1 2x5
+  [1, 1, 1, 1, 1, 1], // W2D2 6x1 ascending (approximated)
+  [10], // W2D3 1x10
+  [5, 5], // W2D4 2x5
+  [5, 3, 1], // W2D5 5-3-1
+];
+
+const EXPECTED_MOVEMENTS = [
+  'Two-Arm Kettlebell Military Press',
+  'Pull-Up',
+  'Kettlebell Swing',
+  'Front Squat With Two Kettlebells',
+  "Kettlebell Farmer's Carry",
+];
+
+const ASCENDING_DAY_SEQ = 6;
+
+test.describe('program schema — Easy Strength seed', () => {
+  test('is present, public, system-owned, with the right metadata', async () => {
+    const user = await signUpThrowawayUser();
+
+    const programs = await restJson<
+      Array<{
+        is_public: boolean;
+        owner_id: string | null;
+        num_weeks: number;
+        days_per_week: number;
+        author_name: string;
+        title: string;
+      }>
+    >(`programs?slug=eq.${ES_SLUG}&select=*`, user.token);
+
+    expect(programs).toHaveLength(1);
+    const es = programs[0];
+    expect(es.is_public).toBe(true);
+    expect(es.owner_id).toBeNull();
+    expect(es.num_weeks).toBe(2);
+    expect(es.days_per_week).toBe(5);
+    expect(es.author_name).toBe('Dan John');
+    expect(es.title).toBe('Easy Strength');
+  });
+
+  test('has 10 ordered sessions whose rep schemes follow the Week A/B cycle', async () => {
+    const user = await signUpThrowawayUser();
+    const [es] = await restJson<Array<{ id: string }>>(
+      `programs?slug=eq.${ES_SLUG}&select=id`,
+      user.token,
+    );
+
+    const sessions = await restJson<SessionRow[]>(
+      `program_sessions?program_id=eq.${es.id}&select=sequence_index,week_number,day_number,workout_options&order=sequence_index.asc`,
+      user.token,
+    );
+
+    expect(sessions).toHaveLength(ES_SESSION_COUNT);
+    expect(sessions.map((s) => s.sequence_index)).toEqual(
+      Array.from({ length: ES_SESSION_COUNT }, (_, i) => i),
+    );
+
+    sessions.forEach((s, i) => {
+      const expectedReps = EXPECTED_REP_SCHEMES[i];
+
+      // The five movement patterns, in order, on every session.
+      expect(s.workout_options.movements.map((m) => m.movementName)).toEqual(
+        EXPECTED_MOVEMENTS,
+      );
+
+      // Each movement carries this session's rep scheme (alternating-rung, like DFW).
+      for (const m of s.workout_options.movements) {
+        expect(m.repScheme).toEqual(expectedReps);
+      }
+
+      // Goal is 'rounds' == number of rungs (one full cycle per rung).
+      expect(s.workout_options.complexSet).toBe(false);
+      expect(s.workout_options.workoutGoalUnits).toBe('rounds');
+      expect(s.workout_options.workoutGoal).toBe(expectedReps.length);
+
+      // Weight modes: press/squat/carry double, swing two-hand single, pull-up bodyweight.
+      const byName = Object.fromEntries(
+        s.workout_options.movements.map((m) => [m.movementName, m]),
+      );
+      expect(byName['Pull-Up'].weightOneValue).toBeNull();
+      expect(byName['Pull-Up'].weightTwoValue).toBeNull();
+      expect(byName['Kettlebell Swing'].weightOneValue).toBe(24);
+      expect(byName['Kettlebell Swing'].weightTwoValue).toBeNull();
+      expect(byName['Two-Arm Kettlebell Military Press'].weightTwoValue).toBe(24);
+      expect(byName['Front Squat With Two Kettlebells'].weightTwoValue).toBe(24);
+      expect(byName["Kettlebell Farmer's Carry"].weightTwoValue).toBe(24);
+    });
+  });
+
+  test('the ascending-weight day is 6 singles and flags its approximation in workoutDetails', async () => {
+    const user = await signUpThrowawayUser();
+    const [es] = await restJson<Array<{ id: string }>>(
+      `programs?slug=eq.${ES_SLUG}&select=id`,
+      user.token,
+    );
+
+    const [session] = await restJson<SessionRow[]>(
+      `program_sessions?program_id=eq.${es.id}&sequence_index=eq.${ASCENDING_DAY_SEQ}&select=sequence_index,workout_options`,
+      user.token,
+    );
+
+    expect(session.workout_options.movements[0].repScheme).toEqual([1, 1, 1, 1, 1, 1]);
+
+    // The seam that makes the schema-level approximation honest to the user: the
+    // details must tell them to add weight manually across the six singles.
+    const details = session.workout_options.workoutDetails.toLowerCase();
+    expect(details).toContain('add');
+    expect(details).toMatch(/weight|load/);
+    expect(details).toMatch(/single|placeholder|manual/);
+  });
+});

--- a/e2e/program-easy-strength.spec.ts
+++ b/e2e/program-easy-strength.spec.ts
@@ -168,10 +168,10 @@ test.describe('program schema — Easy Strength seed', () => {
         expect(m.repScheme).toEqual(expectedReps);
       }
 
-      // Goal is 'rounds' == number of rungs (one full cycle per rung).
+      // Goal is a fixed 1 round: one round == completing the whole ladder once.
       expect(s.workout_options.complexSet).toBe(false);
       expect(s.workout_options.workoutGoalUnits).toBe('rounds');
-      expect(s.workout_options.workoutGoal).toBe(expectedReps.length);
+      expect(s.workout_options.workoutGoal).toBe(1);
 
       // Weight modes: press/squat/carry double, swing two-hand single, pull-up bodyweight.
       const byName = Object.fromEntries(

--- a/e2e/program-easy-strength.spec.ts
+++ b/e2e/program-easy-strength.spec.ts
@@ -45,12 +45,17 @@ async function signUpThrowawayUser(): Promise<TestUser> {
     `${SUPABASE_URL}/auth/v1/token?grant_type=password`,
     {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json', apikey: SUPABASE_ANON_KEY },
+      headers: {
+        'Content-Type': 'application/json',
+        apikey: SUPABASE_ANON_KEY,
+      },
       body: JSON.stringify({ email, password }),
     },
   );
   if (!signInRes.ok) {
-    throw new Error(`sign-in failed (${signInRes.status}): ${await signInRes.text()}`);
+    throw new Error(
+      `sign-in failed (${signInRes.status}): ${await signInRes.text()}`,
+    );
   }
   const session = (await signInRes.json()) as AuthSession;
   return { token: session.access_token, uid: session.user.id, email };
@@ -181,8 +186,12 @@ test.describe('program schema — Easy Strength seed', () => {
       expect(byName['Pull-Up'].weightTwoValue).toBeNull();
       expect(byName['Kettlebell Swing'].weightOneValue).toBe(24);
       expect(byName['Kettlebell Swing'].weightTwoValue).toBeNull();
-      expect(byName['Two-Arm Kettlebell Military Press'].weightTwoValue).toBe(24);
-      expect(byName['Front Squat With Two Kettlebells'].weightTwoValue).toBe(24);
+      expect(byName['Two-Arm Kettlebell Military Press'].weightTwoValue).toBe(
+        24,
+      );
+      expect(byName['Front Squat With Two Kettlebells'].weightTwoValue).toBe(
+        24,
+      );
       expect(byName["Kettlebell Farmer's Carry"].weightTwoValue).toBe(24);
     });
   });
@@ -199,7 +208,9 @@ test.describe('program schema — Easy Strength seed', () => {
       user.token,
     );
 
-    expect(session.workout_options.movements[0].repScheme).toEqual([1, 1, 1, 1, 1, 1]);
+    expect(session.workout_options.movements[0].repScheme).toEqual([
+      1, 1, 1, 1, 1, 1,
+    ]);
 
     // The seam that makes the schema-level approximation honest to the user: the
     // details must tell them to add weight manually across the six singles.

--- a/supabase/migrations/20260713181755_seed_easy_strength.sql
+++ b/supabase/migrations/20260713181755_seed_easy_strength.sql
@@ -17,9 +17,9 @@
 --   Week A: 2x5, 2x5, 5-3-2, 2x5, 2x5
 --   Week B: 2x5, 6x1 (ascending), 1x10, 2x5, 5-3-1
 --
--- workoutGoalUnits is 'rounds' with the goal = number of rungs (repScheme length),
--- so one full cycle through all five movements = one round (ladder-style, matching
--- how the runtime advances the shared rung index).
+-- workoutGoalUnits is 'rounds' with a fixed goal of 1: the runtime only counts a
+-- round after every rung of every movement is done, so one round = completing the
+-- whole prescribed ladder once (the repScheme already encodes all the sets/reps).
 --
 -- Movement -> catalog weight mode (see src/utils/movementWeightModeFilter.ts):
 --   * Press  Two-Arm Kettlebell Military Press  -> double bells (weightOne+weightTwo)
@@ -48,7 +48,7 @@ RETURNS JSONB LANGUAGE sql IMMUTABLE AS $$
     'complexSet', false,
     'intervalTimer', 0,
     'restTimer', 0,
-    'workoutGoal', array_length(p_reps, 1),
+    'workoutGoal', 1,
     'workoutGoalUnits', 'rounds',
     'workoutDetails', p_details,
     'sharedWeightOneUnit', NULL,

--- a/supabase/migrations/20260713181755_seed_easy_strength.sql
+++ b/supabase/migrations/20260713181755_seed_easy_strength.sql
@@ -1,0 +1,124 @@
+-- Seed the shared "Easy Strength" program (Dan John, concept co-credited to
+-- Pavel), modeled as the fixed 10-workout / 2-week "Even Easier Strength" cycle.
+-- Public + system-owned (owner_id NULL, is_public true) so every user sees it
+-- and can one-tap "Start Easy Strength"; enrolling clones it into an editable
+-- copy (enroll_in_program). Idempotent on slug: a re-run (or a fresh env) skips
+-- re-seeding sessions. Mirrors the DFW seed migration's conventions
+-- (20260706170001_seed_dry_fighting_weight.sql).
+--
+-- Runs as the migration role, which bypasses RLS, so the NULL-owner public row
+-- inserts cleanly. This is a MIGRATION (not seed.sql) so it also reaches
+-- staging/production, where seed.sql never runs.
+--
+-- 10 trackable sessions (seq 0-9), five each across two weeks. Every session runs
+-- the same 5 movement patterns (press / pull / hinge / squat / carry) alternated
+-- rung-by-rung (complexSet false, like DFW). Only the shared rep scheme and the
+-- session notes change day to day; the "Even Easier Strength" set/rep cycle is:
+--   Week A: 2x5, 2x5, 5-3-2, 2x5, 2x5
+--   Week B: 2x5, 6x1 (ascending), 1x10, 2x5, 5-3-1
+--
+-- workoutGoalUnits is 'rounds' with the goal = number of rungs (repScheme length),
+-- so one full cycle through all five movements = one round (ladder-style, matching
+-- how the runtime advances the shared rung index).
+--
+-- Movement -> catalog weight mode (see src/utils/movementWeightModeFilter.ts):
+--   * Press  Two-Arm Kettlebell Military Press  -> double bells (weightOne+weightTwo)
+--   * Pull   Pull-Up                            -> bodyweight (all weights NULL => 'none')
+--   * Hinge  Kettlebell Swing                   -> single bell, two-hand (weightTwo NULL => '2h')
+--   * Squat  Front Squat With Two Kettlebells   -> double bells
+--   * Carry  Kettlebell Farmer's Carry          -> double bells
+-- Load defaults are 24 kg placeholders so the program is runnable out of the box;
+-- the user adjusts load per session in the builder at start time.
+--
+-- KNOWN, DELIBERATE APPROXIMATION (Week B Day 2 / seq 6, "6x1 add weight each set"):
+-- the source ramps load up across the six singles, but WorkoutOptions holds one
+-- fixed weight per movement per session -- there is no in-session weight ramp. So
+-- this day is seeded with the flat 24 kg placeholder and workoutDetails that tell
+-- the user to add weight manually on each of the six singles. This is the same
+-- workaround DFW itself uses for autoregulated days; see PROD-230 / PROD-225 and
+-- data/research-kb-programs-r3/report.md -- it is resolved as the right call, not
+-- a gap to fix here.
+
+-- Session-local helper (pg_temp: auto-dropped at connection end, never persisted
+-- to the committed schema) that builds the WorkoutOptions JSONB for one session.
+-- Shape MUST match Omit<WorkoutOptions,'startedAt'> exactly (camelCase keys).
+CREATE OR REPLACE FUNCTION pg_temp.es_options(p_reps INT[], p_details TEXT)
+RETURNS JSONB LANGUAGE sql IMMUTABLE AS $$
+  SELECT jsonb_build_object(
+    'complexSet', false,
+    'intervalTimer', 0,
+    'restTimer', 0,
+    'workoutGoal', array_length(p_reps, 1),
+    'workoutGoalUnits', 'rounds',
+    'workoutDetails', p_details,
+    'sharedWeightOneUnit', NULL,
+    'sharedWeightOneValue', NULL,
+    'sharedWeightTwoUnit', NULL,
+    'sharedWeightTwoValue', NULL,
+    'movements', jsonb_build_array(
+      jsonb_build_object(
+        'movementName', 'Two-Arm Kettlebell Military Press',
+        'repScheme', to_jsonb(p_reps),
+        'weightOneUnit', 'kilograms', 'weightOneValue', 24,
+        'weightTwoUnit', 'kilograms', 'weightTwoValue', 24),
+      jsonb_build_object(
+        'movementName', 'Pull-Up',
+        'repScheme', to_jsonb(p_reps),
+        'weightOneUnit', NULL, 'weightOneValue', NULL,
+        'weightTwoUnit', NULL, 'weightTwoValue', NULL),
+      jsonb_build_object(
+        'movementName', 'Kettlebell Swing',
+        'repScheme', to_jsonb(p_reps),
+        'weightOneUnit', 'kilograms', 'weightOneValue', 24,
+        'weightTwoUnit', NULL, 'weightTwoValue', NULL),
+      jsonb_build_object(
+        'movementName', 'Front Squat With Two Kettlebells',
+        'repScheme', to_jsonb(p_reps),
+        'weightOneUnit', 'kilograms', 'weightOneValue', 24,
+        'weightTwoUnit', 'kilograms', 'weightTwoValue', 24),
+      jsonb_build_object(
+        'movementName', 'Kettlebell Farmer''s Carry',
+        'repScheme', to_jsonb(p_reps),
+        'weightOneUnit', 'kilograms', 'weightOneValue', 24,
+        'weightTwoUnit', 'kilograms', 'weightTwoValue', 24)
+    ));
+$$;
+
+DO $$
+DECLARE
+  v_program_id UUID;
+BEGIN
+  INSERT INTO programs (owner_id, slug, title, description, author_name, num_weeks, days_per_week, is_public)
+  VALUES (NULL, 'easy-strength',
+          'Easy Strength',
+          'Dan John''s basic full-body strength template: five movement patterns '
+          '(press, pull, hinge, squat, carry) trained daily on a fixed 10-workout, '
+          '2-week "Even Easier Strength" set/rep cycle. Grease the groove, never grind.',
+          'Dan John', 2, 5, true)
+  ON CONFLICT (slug) DO NOTHING
+  RETURNING id INTO v_program_id;
+
+  -- If the row already existed, skip re-seeding sessions.
+  IF v_program_id IS NULL THEN
+    RAISE NOTICE 'Easy Strength program already seeded; skipping sessions.';
+    RETURN;
+  END IF;
+
+  INSERT INTO program_sessions
+    (program_id, sequence_index, week_number, day_number, title, workout_options)
+  VALUES
+    (v_program_id, 0, 1, 1, '2x5',   pg_temp.es_options(ARRAY[5,5]::INT[],       'Easy Strength W1D1 - 2 sets of 5 per movement. Keep it easy; leave reps in the tank.')),
+    (v_program_id, 1, 1, 2, '2x5',   pg_temp.es_options(ARRAY[5,5]::INT[],       'Easy Strength W1D2 - 2 sets of 5 per movement.')),
+    (v_program_id, 2, 1, 3, '5-3-2', pg_temp.es_options(ARRAY[5,3,2]::INT[],     'Easy Strength W1D3 - 5, 3, then 2 reps per movement (drop reps, you may nudge load up).')),
+    (v_program_id, 3, 1, 4, '2x5',   pg_temp.es_options(ARRAY[5,5]::INT[],       'Easy Strength W1D4 - 2 sets of 5 per movement.')),
+    (v_program_id, 4, 1, 5, '2x5',   pg_temp.es_options(ARRAY[5,5]::INT[],       'Easy Strength W1D5 - 2 sets of 5 per movement.')),
+    (v_program_id, 5, 2, 1, '2x5',   pg_temp.es_options(ARRAY[5,5]::INT[],       'Easy Strength W2D1 - 2 sets of 5 per movement.')),
+    (v_program_id, 6, 2, 2, '6x1 (ascending load)',
+                                     pg_temp.es_options(ARRAY[1,1,1,1,1,1]::INT[],
+                                       'Easy Strength W2D2 - 6 heavy singles per movement, ADDING WEIGHT each single (never miss a rep). '
+                                       'The app holds one fixed weight per movement per session, so the seeded 24 kg is only a starting '
+                                       'placeholder - manually increase the load before each of the six singles.')),
+    (v_program_id, 7, 2, 3, '1x10',  pg_temp.es_options(ARRAY[10]::INT[],        'Easy Strength W2D3 - 1 set of 10 reps per movement (lighter, higher-rep day).')),
+    (v_program_id, 8, 2, 4, '2x5',   pg_temp.es_options(ARRAY[5,5]::INT[],       'Easy Strength W2D4 - 2 sets of 5 per movement.')),
+    (v_program_id, 9, 2, 5, '5-3-1', pg_temp.es_options(ARRAY[5,3,1]::INT[],     'Easy Strength W2D5 - 5, 3, then 1 rep per movement (work up to a heavy single).'));
+END $$;


### PR DESCRIPTION
## What
Adds Dan John's "Easy Strength" ("Even Easier Strength") as a shared kettlebell program — a fixed 10-workout / 2-week general-strength cycle.

## Why
PROD-230. This rounds out the 5-program batch with a basic full-body strength template — nothing else in the set covers this. Five movement patterns (press/pull/hinge/squat/carry) run every session, alternated rung-by-rung (`complexSet: false`, like DFW), with the shared rep scheme varying by day: Week A is 2×5, 2×5, 5-3-2, 2×5, 2×5; Week B is 2×5, 6×1 (ascending), 1×10, 2×5, 5-3-1.

Movements checked against `scripts/data/movements.csv`: Two-Arm Kettlebell Military Press (double), Pull-Up (bodyweight — all weight fields NULL), Kettlebell Swing (single bell, two-hand), Front Squat With Two Kettlebells (double), Kettlebell Farmer's Carry (double). Load defaults are 24kg placeholders, adjustable at start.

Known, deliberate approximation (flagged in a code comment and `workoutDetails`): Week B Day 2's "6×1, add weight each single" can't be modeled exactly since `WorkoutOptions` holds one fixed weight per movement per session. Seeded as a flat 24kg placeholder plus `workoutDetails` telling the user to ramp load manually — the same workaround DFW already uses for autoregulated days. This was resolved in PROD-230/PROD-225 as the right call, not a gap.

Deliberately out of scope: surfacing the program in `ProgramsPage` is the separate, centrally-coordinated PROD-231 change.

## How tested
- Applied the migration end-to-end against local Supabase and against real Postgres directly; persisted rows match the intent exactly — public/system-owned Easy Strength program, 10 sessions with the Week A/B rep-scheme cycle, the five movements with correct weight modes, `workoutGoal=1` per session (see Tradeoffs), and the ascending-load day's manual-ramp approximation flagged in `workoutDetails`.
- `e2e/program-easy-strength.spec.ts` — 3/3 passing: metadata, the Week A/B rep-scheme cycle + weight modes, and the ascending-day approximation flag.
- Idempotency verified (re-running the migration emits a skip notice, counts stay 1 program / 10 sessions).
- `tsc` clean, lint clean, 394 unit tests green, `movements:check` passes.
- One e2e run failed locally because a sibling worktree reset the shared local Supabase mid-run (program count dropped to 0) — reproduced and confirmed it's the known cross-crewmate `db reset` race, not a defect; re-seeding produced a clean 3/3 pass. No screenshot evidence applies — this is a backend seed migration with no rendered UI surface, so persisted DB state is the reviewer-visible evidence.

## Tradeoffs
Review caught a real bug: I'd set `workoutGoal = array_length(repScheme)` with `workoutGoalUnits='rounds'`, but the runtime (`ActiveWorkoutPage.tsx` `goToNextRung`/`goToNextMovement`) only increments `completedRounds` after the *last* rung of the *last* movement — one round is one full pass through the whole prescribed ladder, not one rung. That over-prescribed every multi-rung session by its rung count (`[5,5]` → goal 2 meant doing the 2×5 ladder twice; `[1,1,1,1,1,1]` → goal 6 meant 36 singles). Fixed to `workoutGoal=1` for every session, updated the code comment and the e2e assertion to match.

<details>
<summary>Evidence: Easy Strength persisted DB state (program row, 10 sessions, weight modes, ascending-day details)</summary>

```text
=== programs row (public, system-owned) ===
     slug      |     title     | author_name | num_weeks | days_per_week | is_public | owner_id 
---------------+---------------+-------------+-----------+---------------+-----------+----------
 easy-strength | Easy Strength | Dan John    |         2 |             5 | t         | 
(1 row)


=== 10 sessions: Week A/B rep-scheme cycle, rounds goal=1, complexSet=false ===
 seq | wk | day |        title         | goal_units | goal | complex |     rep_scheme     
-----+----+-----+----------------------+------------+------+---------+--------------------
   0 |  1 |   1 | 2x5                  | rounds     | 1    | false   | [5, 5]
   1 |  1 |   2 | 2x5                  | rounds     | 1    | false   | [5, 5]
   2 |  1 |   3 | 5-3-2                | rounds     | 1    | false   | [5, 3, 2]
   3 |  1 |   4 | 2x5                  | rounds     | 1    | false   | [5, 5]
   4 |  1 |   5 | 2x5                  | rounds     | 1    | false   | [5, 5]
   5 |  2 |   1 | 2x5                  | rounds     | 1    | false   | [5, 5]
   6 |  2 |   2 | 6x1 (ascending load) | rounds     | 1    | false   | [1, 1, 1, 1, 1, 1]
   7 |  2 |   3 | 1x10                 | rounds     | 1    | false   | [10]
   8 |  2 |   4 | 2x5                  | rounds     | 1    | false   | [5, 5]
   9 |  2 |   5 | 5-3-1                | rounds     | 1    | false   | [5, 3, 1]
(10 rows)


=== session 0 movements + weight modes (press/squat/carry double, swing 2h single, pull-up bodyweight) ===
             movement              | w1 | w2 
-----------------------------------+----+----
 Front Squat With Two Kettlebells  | 24 | 24
 Kettlebell Farmer's Carry         | 24 | 24
 Kettlebell Swing                  | 24 | 
 Pull-Up                           |    | 
 Two-Arm Kettlebell Military Press | 24 | 24
(5 rows)


=== ascending-load day (seq 6) workoutDetails: flags the manual-ramp approximation ===
                                                                                                                                 ?column?                                                                                                                                  
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Easy Strength W2D2 - 6 heavy singles per movement, ADDING WEIGHT each single (never miss a rep). The app holds one fixed weight per movement per session, so the seeded 24 kg is only a starting placeholder - manually increase the load before each of the six singles.
(1 row)
```
</details>
<details>
<summary>Evidence: e2e spec result</summary>

```text
npx playwright test e2e/program-easy-strength.spec.ts
✓ is present, public, system-owned, with the right metadata (110ms)
✓ has 10 ordered sessions whose rep schemes follow the Week A/B cycle (121ms)
✓ the ascending-weight day is 6 singles and flags its approximation in workoutDetails (85ms)
3 passed (1.3s)
```
</details>
<details>
<summary>Evidence: Idempotency re-run (skips re-seed, counts stay 1 program / 10 sessions)</summary>

```text
=== idempotency re-run ===
CREATE FUNCTION
NOTICE: Easy Strength program already seeded; skipping sessions.
DO
=== count after re-run ===
1 | 10
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ `supabase/migrations/20260713181755_seed_easy_strength.sql:51` - Rounds goal over-prescribes every multi-rung session. `es_options` sets `workoutGoal = array_length(p_reps, 1)` with `workoutGoalUnits='rounds'` (line 51), and the code comment (lines 20-22) asserts "one full cycle through all five movements = one round." But in the runtime (ActiveWorkoutPage.tsx `goToNextRung`/`goToNextMovement`) `completedRounds` increments only after the LAST rung of the LAST movement — i.e. one round = one complete pass through ALL rungs of all movements (verified by the `WorkoutGoalRounds` single-rung fixture where 1 continue = 1 round). So for `[5,5]` (a single "2x5") the goal should be 1 round, but the migration sets it to 2, so the workout only auto-finishes after the user does the full 2x5-per-movement ladder twice (4x5). `[5,3,2]`→goal 3 (3× the ladder), `[1,1,1,1,1,1]`→goal 6, `[5,3,1]`→goal 3. Only the single-rung `1x10` day (goal 1) is correct. The intended per-session prescription (one pass through the rep scheme) corresponds to goal=1 for every session regardless of rung count. The e2e spec (line 174, `workoutGoal === expectedReps.length`) enshrines the same wrong assumption, so tests won't catch it. The program is still runnable/manually-finishable, so this is not a hard break, but the auto-finish target and displayed round count misrepresent the program for 9 of 10 sessions.

🔧 Fix: fix(programs): set Easy Strength session round goal to 1
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- Applied the migration to local Supabase: `docker exec -i supabase_db_kettlebells psql ... < supabase/migrations/20260713181755_seed_easy_strength.sql` — completed with no errors
- Queried persisted DB state via psql: programs row (public/system-owned/Dan John/2wk/5day) and all 10 program_sessions with per-session repScheme, workoutGoalUnits='rounds', workoutGoal=1, complexSet=false
- Verified session-0 movements + weight modes (press/squat/carry 24/24 double, swing 24/NULL two-hand, pull-up NULL/NULL bodyweight) and the seq-6 ascending-load workoutDetails approximation flag
- Idempotency: re-ran the migration — raised NOTICE 'already seeded; skipping sessions', program/session counts stayed 1/10
- Confirmed all five seeded movement names resolve against the `movements` catalog
- `npx playwright test e2e/program-easy-strength.spec.ts` — 3 passed (metadata, Week A/B rep-scheme cycle + weight modes, ascending-day workoutDetails approximation) after re-seeding to win the shared-instance reset race

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
