### PR TITLE
feat(programs): seed StrongFirst "A+A Protocol, Plan A" shared program

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -211,6 +211,19 @@ session — atomic), and the PROD-219 editing pair `reorder_program_sessions` /
   `onError`; a new program mutation reuses it by adding that `onError`. The
   behavior is scoped to programs structurally (it is wired only into program
   hooks), not via a runtime flag check.
+- **Shared program seeds:** each canonical public program is its own idempotent
+  seed **migration** (`owner_id NULL`, `is_public true`, `ON CONFLICT (slug)`), a
+  `pg_temp` helper building the per-session `WorkoutOptions` JSONB
+  (`Omit<WorkoutOptions,'startedAt'>`, camelCase). DFW
+  (`*_seed_dry_fighting_weight.sql`) is the template; add a focused
+  `e2e/program-<slug>.spec.ts` asserting the seeded shape.
+- **`intervalTimer` (EMOM programs):** DFW leaves it `0`; the A+A Protocol seed
+  (`*_seed_aa_protocol_plan_a.sql`) is the first/reference use. It is a
+  per-session seconds cadence — `ActiveWorkoutPage` auto-fires one "continue"
+  every `intervalTimer` seconds. On a **one-handed** movement (`weightTwoValue: 0`)
+  each auto-fire alternates sides, so `intervalTimer: 30` gives "left on the
+  minute, right 30s later." See the `AAProtocolPlanASession` story +
+  `ActiveWorkoutPage.test.jsx` EMOM-cadence test.
 
 ## Runtime Feature Flags (PROD-175)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -154,8 +154,10 @@ session — atomic), and the PROD-219 editing pair `reorder_program_sessions` /
 - **Shared programs (seeded, system-owned):** the public shared programs
   (`owner_id NULL`, `is_public`) ship as migrations (not `seed.sql`, so they
   also reach staging/prod) — Dry Fighting Weight
-  (`*_seed_dry_fighting_weight.sql`) and Dan John's 10,000 Swing Challenge
-  (`*_seed_10000_swing_challenge.sql`). Each is idempotent on `slug` and builds
+  (`*_seed_dry_fighting_weight.sql`), Dan John's 10,000 Swing Challenge
+  (`*_seed_10000_swing_challenge.sql`), and StrongFirst's A+A Protocol "Plan A"
+  (`*_seed_aa_protocol_plan_a.sql`, the first EMOM/`intervalTimer` program). Each
+  is idempotent on `slug` and builds
   every session's `WorkoutOptions` JSONB (shape `Omit<WorkoutOptions,'startedAt'>`,
   camelCase keys) via a `pg_temp` helper; add another by mirroring one. Seed
   shape is asserted in `e2e/program-schema.spec.ts`. `ProgramsPage` currently

--- a/e2e/program-aa-protocol.spec.ts
+++ b/e2e/program-aa-protocol.spec.ts
@@ -1,0 +1,148 @@
+import { expect, test } from '@playwright/test';
+
+// Focused backend test for the seeded StrongFirst "A+A Protocol, Plan A" program
+// (PROD-229). This is the FIRST shipped program to use intervalTimer, so it
+// asserts every session carries the non-zero EMOM interval plus the single-KB
+// one-arm clean & jerk / minutes-goal shape the seed migration encodes. Like
+// e2e/program-schema.spec.ts it hits the LOCAL Supabase REST API directly rather
+// than driving the browser; programs REVOKE anon, so it authenticates as a
+// throwaway user (public rows are readable by any authenticated user).
+
+const SUPABASE_URL = process.env.VITE_SUPABASE_URL!;
+const SUPABASE_ANON_KEY = process.env.VITE_SUPABASE_ANON_KEY!;
+const AA_SLUG = 'aa-protocol-plan-a';
+const MOVEMENT = 'One-Arm Kettlebell Clean and Jerk';
+const EMOM_INTERVAL_SECONDS = 30;
+
+// Per-session expectations, in sequence order: 4 progression stages building to
+// 30 minutes, then the monthly deload (lighter + shorter).
+const EXPECTED_SESSIONS = [
+  { seq: 0, goal: 8, weight: 24 },
+  { seq: 1, goal: 15, weight: 24 },
+  { seq: 2, goal: 22, weight: 24 },
+  { seq: 3, goal: 30, weight: 24 },
+  { seq: 4, goal: 15, weight: 20 }, // deload
+];
+
+interface MovementOption {
+  movementName: string;
+  repScheme: number[];
+  weightOneValue: number;
+  weightTwoValue: number;
+}
+
+interface WorkoutOptions {
+  complexSet: boolean;
+  intervalTimer: number;
+  restTimer: number;
+  workoutGoal: number;
+  workoutGoalUnits: string;
+  movements: MovementOption[];
+}
+
+async function signUpThrowawayUser(): Promise<string> {
+  const email = `aa-${Date.now()}-${Math.floor(Math.random() * 1e9)}@example.com`;
+  const password = 'testpassword123';
+
+  const res = await fetch(`${SUPABASE_URL}/auth/v1/signup`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', apikey: SUPABASE_ANON_KEY },
+    body: JSON.stringify({ email, password }),
+  });
+  if (!res.ok) throw new Error(`signup failed (${res.status}): ${await res.text()}`);
+
+  const body = (await res.json()) as { access_token?: string };
+  if (body.access_token) return body.access_token;
+
+  const signInRes = await fetch(
+    `${SUPABASE_URL}/auth/v1/token?grant_type=password`,
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', apikey: SUPABASE_ANON_KEY },
+      body: JSON.stringify({ email, password }),
+    },
+  );
+  if (!signInRes.ok) {
+    throw new Error(`sign-in failed (${signInRes.status}): ${await signInRes.text()}`);
+  }
+  const session = (await signInRes.json()) as { access_token: string };
+  return session.access_token;
+}
+
+async function restJson<T = unknown>(path: string, token: string): Promise<T> {
+  const res = await fetch(`${SUPABASE_URL}/rest/v1/${path}`, {
+    headers: { apikey: SUPABASE_ANON_KEY, Authorization: `Bearer ${token}` },
+  });
+  if (!res.ok) throw new Error(`GET ${path} failed (${res.status}): ${await res.text()}`);
+  return res.json() as Promise<T>;
+}
+
+test.describe('program schema — A+A Protocol "Plan A" seed', () => {
+  test('is present, public, system-owned, with intervalTimer-paced sessions', async () => {
+    const token = await signUpThrowawayUser();
+
+    const programs = await restJson<
+      Array<{
+        id: string;
+        title: string;
+        author_name: string;
+        is_public: boolean;
+        owner_id: string | null;
+        num_weeks: number;
+        days_per_week: number;
+      }>
+    >(`programs?slug=eq.${AA_SLUG}&select=*`, token);
+
+    expect(programs).toHaveLength(1);
+    const aa = programs[0];
+    expect(aa.title).toBe('A+A Protocol "Plan A"');
+    expect(aa.author_name).toBe('Pavel Tsatsouline / StrongFirst');
+    expect(aa.is_public).toBe(true);
+    expect(aa.owner_id).toBeNull();
+    expect(aa.num_weeks).toBe(4);
+    expect(aa.days_per_week).toBe(3);
+
+    const sessions = await restJson<
+      Array<{ sequence_index: number; workout_options: WorkoutOptions }>
+    >(
+      `program_sessions?program_id=eq.${aa.id}&select=sequence_index,workout_options&order=sequence_index.asc`,
+      token,
+    );
+
+    expect(sessions).toHaveLength(EXPECTED_SESSIONS.length);
+    // Contiguous 0..N-1 order.
+    expect(sessions.map((s) => s.sequence_index)).toEqual(
+      EXPECTED_SESSIONS.map((e) => e.seq),
+    );
+
+    sessions.forEach((s, i) => {
+      const expected = EXPECTED_SESSIONS[i];
+      const wo = s.workout_options;
+
+      // The defining feature: every session is EMOM-paced by a non-zero interval,
+      // with no separate between-set rest.
+      expect(wo.intervalTimer).toBe(EMOM_INTERVAL_SECONDS);
+      expect(wo.intervalTimer).toBeGreaterThan(0);
+      expect(wo.restTimer).toBe(0);
+
+      // Single-movement, minutes-goal shape (not a complex).
+      expect(wo.complexSet).toBe(false);
+      expect(wo.workoutGoalUnits).toBe('minutes');
+      expect(wo.workoutGoal).toBe(expected.goal);
+      expect(wo.movements).toHaveLength(1);
+
+      const movement = wo.movements[0];
+      expect(movement.movementName).toBe(MOVEMENT);
+      expect(movement.repScheme).toEqual([1]);
+      // One-handed: primary weight set, secondary 0 -> drives left/right EMOM
+      // alternation at runtime.
+      expect(movement.weightOneValue).toBe(expected.weight);
+      expect(movement.weightTwoValue).toBe(0);
+    });
+
+    // Stages build monotonically to the 30-minute target, then the deload drops.
+    const goals = sessions.map((s) => s.workout_options.workoutGoal);
+    expect(goals.slice(0, 4)).toEqual([8, 15, 22, 30]);
+    expect(goals[4]).toBeLessThan(goals[3]);
+  });
+});

--- a/e2e/program-aa-protocol.spec.ts
+++ b/e2e/program-aa-protocol.spec.ts
@@ -49,7 +49,8 @@ async function signUpThrowawayUser(): Promise<string> {
     headers: { 'Content-Type': 'application/json', apikey: SUPABASE_ANON_KEY },
     body: JSON.stringify({ email, password }),
   });
-  if (!res.ok) throw new Error(`signup failed (${res.status}): ${await res.text()}`);
+  if (!res.ok)
+    throw new Error(`signup failed (${res.status}): ${await res.text()}`);
 
   const body = (await res.json()) as { access_token?: string };
   if (body.access_token) return body.access_token;
@@ -58,12 +59,17 @@ async function signUpThrowawayUser(): Promise<string> {
     `${SUPABASE_URL}/auth/v1/token?grant_type=password`,
     {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json', apikey: SUPABASE_ANON_KEY },
+      headers: {
+        'Content-Type': 'application/json',
+        apikey: SUPABASE_ANON_KEY,
+      },
       body: JSON.stringify({ email, password }),
     },
   );
   if (!signInRes.ok) {
-    throw new Error(`sign-in failed (${signInRes.status}): ${await signInRes.text()}`);
+    throw new Error(
+      `sign-in failed (${signInRes.status}): ${await signInRes.text()}`,
+    );
   }
   const session = (await signInRes.json()) as { access_token: string };
   return session.access_token;
@@ -73,7 +79,8 @@ async function restJson<T = unknown>(path: string, token: string): Promise<T> {
   const res = await fetch(`${SUPABASE_URL}/rest/v1/${path}`, {
     headers: { apikey: SUPABASE_ANON_KEY, Authorization: `Bearer ${token}` },
   });
-  if (!res.ok) throw new Error(`GET ${path} failed (${res.status}): ${await res.text()}`);
+  if (!res.ok)
+    throw new Error(`GET ${path} failed (${res.status}): ${await res.text()}`);
   return res.json() as Promise<T>;
 }
 

--- a/src/pages/ActiveWorkoutPage/ActiveWorkoutPage.stories.tsx
+++ b/src/pages/ActiveWorkoutPage/ActiveWorkoutPage.stories.tsx
@@ -243,6 +243,33 @@ export const IntervalTimer: Story = {
   },
 };
 
+// Mirrors the seeded A+A Protocol "Plan A" session (Stage 4): single-KB one-arm
+// clean & jerk, EMOM-paced at a 30s interval so consecutive auto-fires alternate
+// hands (left on the minute, right 30s later). First shipped program to use
+// intervalTimer.
+export const AAProtocolPlanASession: Story = {
+  parameters: {
+    workoutOptions: {
+      intervalTimer: 30,
+      restTimer: 0,
+      complexSet: false,
+      workoutGoal: 30,
+      workoutGoalUnits: 'minutes',
+      movements: [
+        {
+          ...DEFAULT_MOVEMENT_OPTIONS,
+          movementName: 'One-Arm Kettlebell Clean and Jerk',
+          repScheme: [1],
+          weightOneValue: 24,
+          weightOneUnit: 'kilograms',
+          weightTwoValue: 0,
+          weightTwoUnit: 'kilograms',
+        },
+      ] satisfies MovementOptions[],
+    },
+  },
+};
+
 export const RestTimer: Story = {
   parameters: {
     workoutOptions: {

--- a/src/pages/ActiveWorkoutPage/ActiveWorkoutPage.test.jsx
+++ b/src/pages/ActiveWorkoutPage/ActiveWorkoutPage.test.jsx
@@ -1,5 +1,5 @@
 import { composeStories } from '@storybook/react';
-import { render, screen } from '@testing-library/react';
+import { act, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { vi } from 'vitest';
 
@@ -17,6 +17,7 @@ const {
   MultipleMovements,
   MultipleMovementsAndMixedWeights,
   OneHanded,
+  AAProtocolPlanASession,
   RepLadders,
   TwoHanded,
   WorkoutGoalRounds,
@@ -1272,6 +1273,56 @@ describe('active workout page (complex mode, different rep schemes)', () => {
     expect(screen.getByTestId('complex-movement-reps-1')).toHaveTextContent(
       '3',
     ); // Clean resets
+  });
+});
+
+// First shipped program to use intervalTimer (A+A Protocol "Plan A"). This
+// proves the runtime EMOM behavior the seed relies on: the interval timer
+// auto-fires a "continue" every 30s with NO button press, and because the
+// one-arm clean & jerk is one-handed each auto-fire alternates hands — left on
+// the minute, right 30s later.
+describe('active workout page (A+A Protocol interval EMOM cadence)', () => {
+  vi.mock('~/api', () => ({
+    useLogWorkout: vi.fn(),
+  }));
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    useLogWorkout.mockReturnValue({
+      mutate: vi.fn(),
+      data: null,
+      isLoading: false,
+    });
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    vi.useRealTimers();
+  });
+
+  test('auto-advances one side every 30s, alternating hands and completing a round each L+R cycle', () => {
+    render(<AAProtocolPlanASession />);
+
+    const leftWeight = screen.getByTestId('left-weight');
+    const rightWeight = screen.getByTestId('right-weight');
+    const round = screen.getByTestId('current-round');
+
+    // Left hand active "on the minute", before any interval has elapsed.
+    expect(leftWeight).toHaveAttribute('data-active', 'true');
+    expect(rightWeight).toHaveAttribute('data-active', 'false');
+    expect(round).toHaveTextContent('1');
+
+    // 30s later the interval timer fires a continue on its own -> right hand.
+    act(() => vi.advanceTimersByTime(30_000));
+    expect(leftWeight).toHaveAttribute('data-active', 'false');
+    expect(rightWeight).toHaveAttribute('data-active', 'true');
+    expect(round).toHaveTextContent('1');
+
+    // Another 30s completes the left+right cycle -> back to left, round 2.
+    act(() => vi.advanceTimersByTime(30_000));
+    expect(leftWeight).toHaveAttribute('data-active', 'true');
+    expect(rightWeight).toHaveAttribute('data-active', 'false');
+    expect(round).toHaveTextContent('2');
   });
 });
 

--- a/supabase/migrations/20260713181819_seed_aa_protocol_plan_a.sql
+++ b/supabase/migrations/20260713181819_seed_aa_protocol_plan_a.sql
@@ -1,0 +1,96 @@
+-- Seed the shared StrongFirst "A+A Protocol, Plan A" program (PROD-153/PROD-229).
+-- Public + system-owned (owner_id NULL, is_public true) so every user sees it and
+-- can one-tap start it; enrolling clones it into an editable copy (enroll_in_program).
+-- Idempotent on slug: a re-run (or a fresh env) skips re-seeding sessions.
+--
+-- This is a MIGRATION (not seed.sql) so it also reaches staging/production, where
+-- seed.sql never runs. Runs as the migration role, which bypasses RLS, so the
+-- NULL-owner public row inserts cleanly. Mirrors the DFW seed migration's
+-- conventions (pg_temp helper -> WorkoutOptions JSONB matching
+-- Omit<WorkoutOptions,'startedAt'> exactly, camelCase keys).
+--
+-- Source: StrongFirst's free "The Best All-Around Training Method Ever" A+A article
+-- (the fully-disclosed free sibling to the paid Iron Cardio). Single-KB one-arm
+-- clean & jerk, EMOM-style: left arm on the minute, right arm 30s later, over a
+-- fixed duration that grows across a 4-stage progression, 2-3x/wk with a monthly
+-- deload.
+--
+-- ── First real use of intervalTimer ─────────────────────────────────────────
+-- DFW leaves intervalTimer at 0 in every session; this program is defined by it.
+-- In ActiveWorkoutPage.tsx the interval countdown auto-fires "continue" (with a
+-- ding) every `intervalTimer` seconds (finishInterval, lines ~315/407-413), and
+-- each continue completes exactly one SIDE of work. Because the one-arm clean &
+-- jerk is modeled one-handed (weightOne set, weightTwo = 0 -> isOneHanded ->
+-- shouldMirrorReps), consecutive fires alternate left/right. So intervalTimer = 30
+-- reproduces the source cadence precisely: left arm at 0:00, right arm at 0:30,
+-- left at 1:00, ... a full left+right cycle every 60s. restTimer stays 0 (the
+-- EMOM interval IS the pacing; there is no separate between-set rest here).
+--
+-- ── 4-stage progression (workout_details spell out the numbers) ─────────────
+-- Modeled as workoutGoalUnits='minutes' with the goal growing ~quarterly toward
+-- 30 min: Stage 1 = 8, Stage 2 = 15, Stage 3 = 22, Stage 4 = 30. Load is a single
+-- 24 kg placeholder (men's standard; user overrides at start). repScheme=[1] = one
+-- clean & jerk per arm per 30s slot. A monthly deload session (seq 4) drops both
+-- load (20 kg) and duration (15 min).
+
+-- Session-local helper (pg_temp: auto-dropped at connection end, never persisted
+-- to the committed schema) that builds the WorkoutOptions JSONB for each session.
+CREATE OR REPLACE FUNCTION pg_temp.aa_options(
+  p_minutes INT, p_weight INT, p_details TEXT
+)
+RETURNS JSONB LANGUAGE sql IMMUTABLE AS $$
+  SELECT jsonb_build_object(
+    'complexSet', false,
+    'intervalTimer', 30,
+    'restTimer', 0,
+    'workoutGoal', p_minutes,
+    'workoutGoalUnits', 'minutes',
+    'workoutDetails', p_details,
+    'sharedWeightOneUnit', NULL,
+    'sharedWeightOneValue', NULL,
+    'sharedWeightTwoUnit', NULL,
+    'sharedWeightTwoValue', NULL,
+    'movements', jsonb_build_array(
+      jsonb_build_object(
+        'movementName', 'One-Arm Kettlebell Clean and Jerk',
+        'repScheme', to_jsonb(ARRAY[1]::INT[]),
+        'weightOneUnit', 'kilograms', 'weightOneValue', p_weight,
+        'weightTwoUnit', 'kilograms', 'weightTwoValue', 0)
+    ));
+$$;
+
+DO $$
+DECLARE
+  v_program_id UUID;
+BEGIN
+  INSERT INTO programs (owner_id, slug, title, description, author_name, num_weeks, days_per_week, is_public)
+  VALUES (NULL, 'aa-protocol-plan-a',
+          'A+A Protocol "Plan A"',
+          'A single-kettlebell alactic+aerobic conditioning protocol built on the '
+          'one-arm clean & jerk, paced EMOM-style (left arm on the minute, right arm '
+          '30 seconds later) over a duration that grows across four stages toward '
+          '30 minutes, trained 2-3x per week with a monthly deload.',
+          'Pavel Tsatsouline / StrongFirst', 4, 3, true)
+  ON CONFLICT (slug) DO NOTHING
+  RETURNING id INTO v_program_id;
+
+  -- If the row already existed, skip re-seeding sessions.
+  IF v_program_id IS NULL THEN
+    RAISE NOTICE 'A+A Protocol program already seeded; skipping sessions.';
+    RETURN;
+  END IF;
+
+  INSERT INTO program_sessions
+    (program_id, sequence_index, week_number, day_number, title, workout_options)
+  VALUES
+    (v_program_id, 0, 1, 1, 'Stage 1 - 8 min',
+       pg_temp.aa_options(8,  24, 'A+A Plan A Stage 1 - 8 min of one-arm clean & jerk, 24 kg. Left arm on the minute, right arm 30s later (30s cadence).')),
+    (v_program_id, 1, 2, 1, 'Stage 2 - 15 min',
+       pg_temp.aa_options(15, 24, 'A+A Plan A Stage 2 - 15 min of one-arm clean & jerk, 24 kg. Same 30s left/right cadence; hold power output as the clock grows.')),
+    (v_program_id, 2, 3, 1, 'Stage 3 - 22 min',
+       pg_temp.aa_options(22, 24, 'A+A Plan A Stage 3 - 22 min of one-arm clean & jerk, 24 kg. Same 30s left/right cadence; stay crisp and unhurried.')),
+    (v_program_id, 3, 4, 1, 'Stage 4 - 30 min',
+       pg_temp.aa_options(30, 24, 'A+A Plan A Stage 4 - the full 30 min of one-arm clean & jerk, 24 kg. Same 30s left/right cadence; this is the target session.')),
+    (v_program_id, 4, 4, 2, 'Monthly deload',
+       pg_temp.aa_options(15, 20, 'A+A Plan A monthly deload - lighter and shorter: 15 min at 20 kg. Same 30s left/right cadence; keep it easy and restorative.'));
+END $$;


### PR DESCRIPTION
## What
Adds StrongFirst's "A+A Protocol, Plan A" as a shared, public program alongside DFW — the first shipped program to exercise `intervalTimer` (EMOM pacing).

## Why
PROD-229. A+A Protocol is the legitimate free sibling to the paid Iron Cardio, and it's the only strong candidate that showcases `intervalTimer` — DFW leaves this field at 0 in every session.

The one-arm clean & jerk is modeled one-handed (`weightOneValue` 24/20kg, `weightTwoValue: 0`, `repScheme [1]`) so `ActiveWorkoutPage` alternates sides on each interval fire; `intervalTimer: 30` reproduces the source's cadence exactly — left arm on the minute, right arm 30s later, a full left+right cycle every 60s. `restTimer: 0` since the EMOM interval *is* the pacing; there's no separate between-set rest concept here. Four minutes-goal stages build to 30 minutes (8/15/22/30), plus a lighter, shorter monthly deload session (15 min at 20kg).

Deliberately did not touch `ProgramsPage.tsx` — surfacing shared programs in the UI is the separate, centrally-coordinated PROD-231 change. Migration timestamp (`20260713181819`) is later than the already-landed sibling 10,000 Swing Challenge seed (`20260713181620`), so ordering is clean.

## How tested
- Reset the local Supabase DB to apply the new migration, then verified the persisted rows match the intended shape exactly (see evidence below).
- Because this is the first program to actually exercise `intervalTimer`, I didn't stop at DB/unit evidence: added a deterministic fake-timers test in `ActiveWorkoutPage.test.jsx` plus an `AAProtocolPlanASession` Storybook story, and screenshotted the real runtime firing the interval with no button press — the display auto-alternates from left hand to right hand and logs a rep, proving the EMOM cadence actually works, not just that the JSONB looks right. Screenshots below.
- New `e2e/program-aa-protocol.spec.ts` asserting the seeded program/session/movement/goal/weight shape against local Supabase — passes.
- Full `ActiveWorkoutPage` suite (54 tests) green, including the new interval cadence test.

## Tradeoffs
None of real weight — this mirrors the DFW seed conventions directly; the one-handed encoding was the only real modeling decision, and it's dictated by how the runtime's interval-alternation logic actually works, not a stylistic choice.

- Evidence: ActiveWorkoutPage rendering the seeded A+A session (left hand active, 30s interval countdown)
- Evidence: After 30s interval auto-fires with no click — display alternates to Right hand, Reps 1 logged (proves EMOM left/right cadence)

<details>
<summary>Evidence: Persisted seeded DB state (all 5 sessions, intervalTimer=30, one-handed clean & jerk)</summary>

```text
seq | wk | day | title | interval | rest | complex | goal | units | movement | reps | w1 | w2
0 | 1 | 1 | Stage 1 - 8 min | 30 | 0 | false | 8 | minutes | One-Arm Kettlebell Clean and Jerk | [1] | 24 | 0
1 | 2 | 1 | Stage 2 - 15 min | 30 | 0 | false | 15 | minutes | One-Arm Kettlebell Clean and Jerk | [1] | 24 | 0
2 | 3 | 1 | Stage 3 - 22 min | 30 | 0 | false | 22 | minutes | One-Arm Kettlebell Clean and Jerk | [1] | 24 | 0
3 | 4 | 1 | Stage 4 - 30 min | 30 | 0 | false | 30 | minutes | One-Arm Kettlebell Clean and Jerk | [1] | 24 | 0
4 | 4 | 2 | Monthly deload | 30 | 0 | false | 15 | minutes | One-Arm Kettlebell Clean and Jerk | [1] | 20 | 0
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `supabase db reset` — applied `20260713181819_seed_aa_protocol_plan_a.sql` cleanly
- psql query of `programs`/`program_sessions` confirming owner_id NULL, is_public true, num_weeks 4, days_per_week 3, and all 5 sessions with intervalTimer=30, restTimer=0, complexSet false, one-arm clean & jerk (weightOneValue 24/20, weightTwoValue 0, repScheme [1]), goals 8/15/22/30 + deload 15
- `npx playwright test e2e/program-aa-protocol.spec.ts` — passed against local seeded Supabase
- `npx vitest run src/pages/ActiveWorkoutPage/ActiveWorkoutPage.test.jsx` — all 54 tests pass, incl. the new A+A interval EMOM cadence test
- Storybook screenshot of the `AAProtocolPlanASession` story showing left-hand-active 24kg with a 30s INTERVAL countdown
- Storybook screenshot after the 30s interval auto-fired with no click — display alternated to Right hand · side 2 of 2 (Reps 1 logged, interval reset)

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
