### PR TITLE
fix(pwa): clear the Default story's timer on unmount

### DIFF
--- a/src/components/PWAInstallPrompt/PWAInstallPrompt.stories.tsx
+++ b/src/components/PWAInstallPrompt/PWAInstallPrompt.stories.tsx
@@ -86,10 +86,12 @@ export const Default: Story = {
   decorators: [
     (Story: any) => {
       useEffect(() => {
-        setTimeout(() => {
+        const timeoutId = setTimeout(() => {
           const event = mockBeforeInstallPrompt();
           window.dispatchEvent(event);
         }, 100);
+
+        return () => clearTimeout(timeoutId);
       }, []);
 
       return <Story />;

--- a/src/components/PWAInstallPrompt/PWAInstallPrompt.test.tsx
+++ b/src/components/PWAInstallPrompt/PWAInstallPrompt.test.tsx
@@ -217,6 +217,26 @@ describe('PWAInstallPrompt', () => {
     });
   });
 
+  describe('Story teardown', () => {
+    // The Default story dispatches beforeinstallprompt on a timer. A timer left
+    // pending outlives the jsdom window and throws "window is not defined" once
+    // Vitest tears the environment down, failing the whole run while every test
+    // still passes. Only the sync tests are fast enough to lose the race, so it
+    // surfaces as an intermittent CI failure that never reproduces locally.
+    it('leaves no pending timer after unmount', () => {
+      vi.useFakeTimers();
+
+      try {
+        const { unmount } = render(<Default />);
+        unmount();
+
+        expect(vi.getTimerCount()).toBe(0);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+  });
+
   describe('Component Structure', () => {
     it('should have the correct CSS classes for positioning', async () => {
       const { container } = render(<Default />);


### PR DESCRIPTION
## What

Returns a cleanup from the `Default` story decorator in `PWAInstallPrompt.stories.tsx` that clears its `setTimeout`, plus a deterministic guard asserting the story leaves no pending timer after unmount.

## Why

`build` has been failing on roughly **a quarter of runs across every branch** — most recently on #123, where it was unrelated noise on a CI-only diff.

It isn't a test failure. All tests pass; Vitest exits 1 on an unhandled error:

```
Test Files  59 passed (59)
     Tests  397 passed (397)
    Errors  2 errors

ReferenceError: window is not defined
 ❯ Timeout._onTimeout src/components/PWAInstallPrompt/PWAInstallPrompt.stories.tsx:91:11
```

The `Default` decorator schedules a 100ms timer that dispatches `beforeinstallprompt` and never clears it. `PWAInstallPrompt.test.tsx` pulls the story in via `composeStories`, so each of its 11 `render(<Default />)` calls schedules a timer that outlives RTL's auto-unmount. If Vitest tears the environment down before it fires, the callback lands on a window that no longer exists.

Only the **synchronous** tests are fast enough to lose the race — the ones awaiting `waitFor` run long enough that the timer fires harmlessly while still mounted. That timing dependence is why the error count varies (0 or 2), why it never reproduces on a dev machine, and why it only bites the slower CI runner.

## How tested

- **Reproduced the leak deterministically** with fake timers rather than relying on the race: without the fix `vi.getTimerCount()` is `1` after unmount (`expected 1 to be +0`); with it, `0`.
- Guard fails against the unfixed story (`1 failed | 11 passed`) and passes with it (`12 passed`) — so it genuinely catches the regression rather than trivially passing.
- Full suite: `59 files, 398 passed`, **0 errors**.
- `npm run compile:ts` and `npm run lint` clean; prettier clean.
- Note: I could *not* reproduce the original flake locally (full suite is 2/2 clean on this machine even unfixed) — hence the fake-timer proof instead of re-running and hoping.

## Tradeoffs

- **Kept a guard test rather than shipping the one-line fix alone.** The bug is invisible locally and only ever surfaces as an intermittent CI failure, which is exactly the kind of thing that gets reintroduced and misdiagnosed for hours. A 6ms deterministic assertion converts that into a hard failure. The cost is a slightly exotic test — it scopes `vi.useFakeTimers()` to one case inside an otherwise real-timer file, restored in a `finally`.
- Fixed the story rather than the test. The test is reasonable; the decorator's uncleaned timer is the actual defect, and it would leak in Storybook too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)