### PR TITLE
feat(programs): seed Dan John's Armor Building Complex (first complexSet program)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -172,7 +172,8 @@ session — atomic), and the PROD-219 editing pair `reorder_program_sessions` /
   (longest repScheme) is 1 and one "Complete Set" completes a whole round, and
   **populate `sharedWeightOne/Two`** because `ComplexMovementDisplay` reads the
   shared pair (not per-movement weights) — DFW's non-complex sessions leave those
-  null.
+  null. See the `ArmorBuildingComplex` story + `ActiveWorkoutPage.test.jsx`
+  complex-round-completion test.
 - **Next session** = lowest-`sequenceIndex` `program_sessions` row with no
   completion. `useActiveProgram` runs this client-side over the program's ≤~20
   sessions (a dedicated SQL function buys nothing at that size). It returns the

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,7 +102,7 @@ pages/
 - Supabase client is the `supabase` named export from `~/supabaseClient`.
 - Query keys are defined in `src/constants/queries.enum.ts`.
 - `npm run gen:types` writes the **repo-root** `types/supabase.ts` — commit that file after any schema change (requires `supabase start` to be running). `src/types/supabase.ts` is just a 3-line alias (`export type Supabase = Database`) re-exporting the root file; it is not regenerated.
-- Schema changes that must reach **production** (e.g. seeded shared content) belong in a **migration**, not `supabase/seed.sql`. Production only ever applies migrations (forward-only `db push`); `seed.sql` never reaches it. Staging is rebuilt with `db reset --linked`, which replays migrations *and* runs `seed.sql`, so seed data reaches staging but stops there. See `.github/workflows/supabase-*.yaml`.
+- Schema changes that must reach **production** (e.g. seeded shared content) belong in a **migration**, not `supabase/seed.sql`. Production only ever applies migrations (forward-only `db push`); `seed.sql` never reaches it. Staging is rebuilt with `db reset --linked`, which replays migrations _and_ runs `seed.sql`, so seed data reaches staging but stops there. See `.github/workflows/supabase-*.yaml`.
 
 ## Movement Catalog (PROD-153)
 


### PR DESCRIPTION
## Intent

The developer's goal (PROD-227) was to add Dan John's "Armor Building Complex" as a seeded, publicly shared program (slug armor-building-complex, owner_id NULL, is_public, behind the existing programs flag) — the first shipped program to use complexSet: true. They required it be implemented as a new idempotent Supabase migration mirroring the existing Dry Fighting Weight seed (pg_temp helper building per-session WorkoutOptions JSONB), with each session running three double-kettlebell movements as one chain (clean/press/squat, repScheme [2,1,3]), workoutGoalUnits 'rounds', a sensible round ramp toward 10 over ~30 days, and 24kg placeholder weights. They stressed extra scrutiny because this was the first live use of the complexSet runtime path: verify db reset applies cleanly, manually run a full session in the app to confirm complex round-completion behavior, add e2e coverage of the seeded shape, and keep tsc/lint/tests green. The work was to be committed on a dedicated branch and validated/shipped via the /no-mistakes pipeline, escalating product decisions rather than guessing. In the final turns, after the captain fixed a DB issue and merged sibling PRs (#118, #122) that moved main ahead, the developer asked to rebase and re-validate the branch to confirm everything stayed green against current main via a fresh no-mistakes rerun.

## What Changed

- Add an idempotent migration (`20260713181835_seed_armor_building_complex.sql`) seeding Dan John's Armor Building Complex as a system-owned public program (`owner_id NULL`, `is_public`, `slug` armor-building-complex) — the first shipped program to use `complexSet: true`. A `pg_temp` helper builds each session's `WorkoutOptions` JSONB, chaining three double-kettlebell movements (clean/press/squat, `repScheme` `[2,1,3]`) with `workoutGoalUnits: 'rounds'` across 20 sessions ramping toward 10 rounds and 24kg shared weights, mirroring the Dry Fighting Weight seed.
- Add e2e coverage (`e2e/program-armor-building-complex.spec.ts`) asserting the seeded shape and that enrollment clones to a user-owned copy, plus an `ArmorBuildingComplex` Storybook story and complex-round-completion tests in `ActiveWorkoutPage`.
- Sync the program docs in `AGENTS.md` for the new complexSet seed and apply lint/CI formatting fixes; all pipeline stages (intent, review, test, document, lint) passed green against current main.

## Risk Assessment

✅ Low: The change is an additive, idempotent seed migration that faithfully mirrors the established shared-program seed template, with matching types, verified movement-catalog names, consistent ramp data across migration/tests/comments, and thorough e2e + unit coverage.

## Testing

Ran the full ABC seed validation: `supabase db reset` applied the new migration with no errors, direct DB queries confirmed the exact seeded shape (20 public system-owned sessions, 5→10 round ramp, double-24kg Clean/Press/Squat complex with single-element repSchemes), the Playwright backend spec (2 tests) and ActiveWorkoutPage complex unit tests (21 tests) both passed, and Storybook screenshots of the seeded session demonstrate the complex round-completion behavior as a user experiences it — one "Complete Set" advances a whole round and triggers the between-rounds rest. All green; no product or setup issues.

- Evidence: ABC complex session — round 1 (as end user sees it) (local file: <code>/var/folders/2p/zdp7pmgx05z1k3dd8xyttrv80000gn/T/no-mistakes-evidence/01KXGV8Y6SGRNX7GM5J0372NGV/abc-round1.png</code>)
- Evidence: After one &#39;Complete Set&#39; — round advanced 1→2, Reps 6 / Volume 288kg, 30s rest engaged (local file: <code>/var/folders/2p/zdp7pmgx05z1k3dd8xyttrv80000gn/T/no-mistakes-evidence/01KXGV8Y6SGRNX7GM5J0372NGV/abc-after-complete-set.png</code>)
<details>
<summary>Evidence: Seeded ABC row + goal ramp verified in local Supabase</summary>

```text
armor-building-complex,,t,Dan John,20
--- goals ramp ---
5 5 6 6 6 7 7 7 8 8 8 8 9 9 9 9 10 10 10 10
```
</details>
<details>
<summary>Evidence: e2e spec result</summary>

```text
✓ program schema — Armor Building Complex seed › is present, public, system-owned, with 20 ordered complex-set sessions (246ms)
✓ program schema — Armor Building Complex seed › enrolling clones the ABC into an isolated user-owned copy (105ms)
2 passed (1.5s)
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`npx supabase db reset --local` — migration `20260713181835_seed_armor_building_complex.sql` applied cleanly</code>
- <code>`psql` query against local DB: verified 20 sessions, owner_id NULL, is_public, author &#39;Dan John&#39;, goal ramp 5,5,6,6,6,7,7,7,8,8,8,8,9,9,9,9,10,10,10,10, and session-0 JSONB shape (complexSet true, shared 24/24kg, movements Clean[2]/Press[1]/Squat[3])</code>
- <code>`npx playwright test e2e/program-armor-building-complex.spec.ts` — 2 passed (seeded shape + enroll clones to user-owned copy)</code>
- <code>`npx vitest run src/pages/ActiveWorkoutPage/ActiveWorkoutPage.test.jsx -t &#39;Armor Building Complex|complex&#39;` — 21 passed (incl. full-session-to-rounds-goal and round-per-Complete-Set)</code>
- <code>Storybook `pages-activeworkoutpage--armor-building-complex` story driven via Playwright: captured initial round and post-Complete-Set states, confirming Round 1→2, Reps 6, Volume 288kg, and 30s rest bar</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
