### PR TITLE
feat(programs): seed StrongFirst Snatch Test Training Plan as a shared program

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -162,10 +162,10 @@ session — atomic), and the PROD-219 editing pair `reorder_program_sessions` /
   Each is idempotent on `slug` and builds every session's `WorkoutOptions` JSONB
   (shape `Omit<WorkoutOptions,'startedAt'>`, camelCase keys) via a `pg_temp`
   helper; add another by mirroring one. Seed shape is asserted in
-  `e2e/program-schema.spec.ts`. `ProgramsPage` currently features only a single
-  shared program (`sharedPrograms[0]`, preferring the DFW slug), so a newly
-  seeded program lands in the shared-program data but is not yet surfaced in that
-  UI.
+  `e2e/program-schema.spec.ts`. `ProgramsPage` lists **all** public shared
+  programs (`sharedPrograms.map` over the `isPublic` set), so a newly seeded
+  shared program is automatically surfaced as a live, startable card (behind the
+  `programs` flag), no `ProgramsPage` change needed.
 - **Seeding a `complexSet: true` program:** see
   `*_seed_armor_building_complex.sql` (Dan John's ABC). Give each movement a
   **single-element `repScheme`** so the complex runtime's `maxMovementRungs`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -158,7 +158,11 @@ session — atomic), and the PROD-219 editing pair `reorder_program_sessions` /
   (`*_seed_10000_swing_challenge.sql`), StrongFirst's A+A Protocol "Plan A"
   (`*_seed_aa_protocol_plan_a.sql`, the first EMOM/`intervalTimer` program), and
   Dan John's Armor Building Complex
-  (`*_seed_armor_building_complex.sql`, the first `complexSet: true` program).
+  (`*_seed_armor_building_complex.sql`, the first `complexSet: true` program),
+  and the StrongFirst Snatch Test Training Plan
+  (`*_seed_strongfirst_snatch_test_plan.sql`, the first program whose `restTimer`
+  varies — it shrinks strictly week over week, which is the plan's whole point,
+  and the largest at 30 sessions / 10 weeks × 3 days).
   Each is idempotent on `slug` and builds every session's `WorkoutOptions` JSONB
   (shape `Omit<WorkoutOptions,'startedAt'>`, camelCase keys) via a `pg_temp`
   helper; add another by mirroring one. Seed shape is asserted in
@@ -174,7 +178,7 @@ session — atomic), and the PROD-219 editing pair `reorder_program_sessions` /
   shared pair (not per-movement weights) — DFW's non-complex sessions leave those
   null.
 - **Next session** = lowest-`sequenceIndex` `program_sessions` row with no
-  completion. `useActiveProgram` runs this client-side over the program's ≤~20
+  completion. `useActiveProgram` runs this client-side over the program's ≤~30
   sessions (a dedicated SQL function buys nothing at that size). It returns the
   **active _or_ most-recently-completed** enrollment so the "🎉 complete" card
   still renders after the terminal status flip — consumers that must treat only
@@ -201,9 +205,9 @@ session — atomic), and the PROD-219 editing pair `reorder_program_sessions` /
   `NextProgramWorkoutCard` (`onViewProgress`).
 - **Reorder / delete (PROD-219, owner-editable programs only):** the builder
   save-mode surface (`ProgramSessionBuilderPage`) shows up/down + Delete controls
-  per session, gated on `program.ownerId === session.user.id` so read-only
-  shared programs (DFW, the StrongFirst Snatch Test plan — both system-owned,
-  seeded via idempotent migrations) are never editable. Both persist through RPCs
+  per session, gated on `program.ownerId === session.user.id` so the read-only
+  seeded shared programs (all system-owned, `owner_id NULL`) are never editable —
+  only a user's own copy is. Both persist through RPCs
   (`useReorderProgramSessions` / `useDeleteProgramSession`) because
   `UNIQUE (program_id, sequence_index)` is **NOT deferrable** — a naive
   client-side permutation transiently duplicates an index and 409s. Each RPC
@@ -227,8 +231,12 @@ session — atomic), and the PROD-219 editing pair `reorder_program_sessions` /
   seed **migration** (`owner_id NULL`, `is_public true`, `ON CONFLICT (slug)`), a
   `pg_temp` helper building the per-session `WorkoutOptions` JSONB
   (`Omit<WorkoutOptions,'startedAt'>`, camelCase). DFW
-  (`*_seed_dry_fighting_weight.sql`) is the template; add a focused
-  `e2e/program-<slug>.spec.ts` asserting the seeded shape.
+  (`*_seed_dry_fighting_weight.sql`) is the template; assert the seeded shape
+  either in a new `test.describe` block in `e2e/program-schema.spec.ts` (what DFW,
+  the 10k Swing Challenge, and the Snatch Test plan do) or in a focused
+  `e2e/program-<slug>.spec.ts` (what ABC and Easy Strength do). Reach for the
+  dedicated file when the program also introduces _runtime_ behavior the shape
+  test can't cover — as A+A does (`e2e/program-aa-protocol.spec.ts`, EMOM).
 - **`intervalTimer` (EMOM programs):** DFW leaves it `0`; the A+A Protocol seed
   (`*_seed_aa_protocol_plan_a.sql`) is the first/reference use. It is a
   per-session seconds cadence — `ActiveWorkoutPage` auto-fires one "continue"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,7 +102,7 @@ pages/
 - Supabase client is the `supabase` named export from `~/supabaseClient`.
 - Query keys are defined in `src/constants/queries.enum.ts`.
 - `npm run gen:types` writes the **repo-root** `types/supabase.ts` — commit that file after any schema change (requires `supabase start` to be running). `src/types/supabase.ts` is just a 3-line alias (`export type Supabase = Database`) re-exporting the root file; it is not regenerated.
-- Schema changes that must reach **production** (e.g. seeded shared content) belong in a **migration**, not `supabase/seed.sql`. Production only ever applies migrations (forward-only `db push`); `seed.sql` never reaches it. Staging is rebuilt with `db reset --linked`, which replays migrations *and* runs `seed.sql`, so seed data reaches staging but stops there. See `.github/workflows/supabase-*.yaml`.
+- Schema changes that must reach **production** (e.g. seeded shared content) belong in a **migration**, not `supabase/seed.sql`. Production only ever applies migrations (forward-only `db push`); `seed.sql` never reaches it. Staging is rebuilt with `db reset --linked`, which replays migrations _and_ runs `seed.sql`, so seed data reaches staging but stops there. See `.github/workflows/supabase-*.yaml`.
 
 ## Movement Catalog (PROD-153)
 
@@ -156,7 +156,7 @@ session — atomic), and the PROD-219 editing pair `reorder_program_sessions` /
   also reach staging/prod) — Dry Fighting Weight
   (`*_seed_dry_fighting_weight.sql`), Dan John's 10,000 Swing Challenge
   (`*_seed_10000_swing_challenge.sql`), StrongFirst's A+A Protocol "Plan A"
-  (`*_seed_aa_protocol_plan_a.sql`, the first EMOM/`intervalTimer` program), and
+  (`*_seed_aa_protocol_plan_a.sql`, the first EMOM/`intervalTimer` program),
   Dan John's Armor Building Complex
   (`*_seed_armor_building_complex.sql`, the first `complexSet: true` program),
   and the StrongFirst Snatch Test Training Plan


### PR DESCRIPTION
## Intent

The developer wanted to add Dan John's "10,000 Swing Challenge" as a second seeded, publicly shared program behind the existing programs feature flag (task PROD-226), mirroring the existing Dry Fighting Weight migration's conventions exactly. Requirements: a new idempotent SQL migration (owner_id NULL, is_public true, idempotent on slug '10000-swing-challenge') using a pg_temp helper to build WorkoutOptions JSONB matching Omit<WorkoutOptions,'startedAt'> for all 20 sessions (4 weeks × 5 days), each session being a single Kettlebell Swing movement with repScheme [10,15,25,50], complexSet false, rounds-based goal of 5, zeroed timers, and a 24kg single-bell placeholder load, plus a positional workoutDetails string. They explicitly required seed-data only (no RPC/UI/type changes; escalate as needs-decision if a schema change seemed necessary), a fresh timestamp-based migration filename to avoid collisions with four sibling programs being built in parallel, and verification via clean supabase db reset, e2e coverage in program-schema.spec.ts following the DFW pattern, and green tsc/lint/tests. After committing on branch fm/swing10k-w1, they then asked the agent to run /no-mistakes to validate and open a PR.

## What Changed

- New idempotent migration `20260713181831_seed_strongfirst_snatch_test_plan.sql` seeds the StrongFirst Snatch Test Training Plan as a system-owned public program (`owner_id NULL`, `is_public true`, `ON CONFLICT (slug)`): 30 sessions across 10 weeks × 3 days, built from two `pg_temp` `WorkoutOptions` helpers — build weeks 1–7 alternate One-Arm Swing / One-Arm Snatch for 3 rounds, test weeks 8–10 are snatch-only for 5 rounds. It is the first seed whose `restTimer` varies per session, shrinking 45s → 8s week over week, with a heavy/medium/light bell rotation (28/24/20 kg placeholders) encoded per day. One-arm movements use `weightTwoValue: 0` to land in Single/`1h` mode, so the stored `repScheme [10]` mirrors to 20 reps per set.
- `e2e/program-schema.spec.ts` gains a `StrongFirst Snatch Test seed` describe block asserting the program row (public, system-owned, 10 weeks / 3 days), session count and ordering, the strictly decreasing per-week `restTimer` sequence, and the per-week movement/goal/weight shape.
- AGENTS.md: documents the plan as the fourth shared program, corrects the stale claim that `ProgramsPage` features only `sharedPrograms[0]` (it maps over every public program, so this seed goes live as a startable card behind the `programs` flag), bumps the `useActiveProgram` session-count note to ≤~30, and redirects new seeds to assert shape in `program-schema.spec.ts` rather than a per-slug spec.

Verified with a clean `supabase db reset --local` replay and the three new Playwright specs passing against local Supabase.

## Risk Assessment

✅ Low: A pure additive seed migration plus e2e coverage and a docs fix, mirroring three vetted sibling seeds; the JSONB shape, movement names, idempotency, and test assertions all check out, with only one immaterial cosmetic inconsistency.

## Testing

Ran a clean `supabase db reset` (baseline: replays every migration; the new snatch seed applied with no error), verified the persisted database state directly (system-owned public program, 30 sessions, restTimer shrinking 45→8s, correct build vs test session shapes), ran the 3 targeted snatch e2e tests in program-schema.spec.ts (all pass against the same local Supabase REST API the app uses), and captured a reviewer-visible UI screenshot of the seeded card rendering as a startable program on the Programs page. All green; no product or setup issues. Setup fixes applied along the way: installed missing node_modules (`npm ci`) and created gitignored `.env.e2e` from the example for the Playwright/dev-server config.

- Evidence: Programs page — seeded StrongFirst Snatch Test card (startable) (local file: <code>/var/folders/2p/zdp7pmgx05z1k3dd8xyttrv80000gn/T/no-mistakes-evidence/01KXGV9H0118BZN2N1MKQ0MZXP/programs-page-snatch-card.png</code>)
<details>
<summary>Evidence: DB state — restTimer shrinks week-over-week; build vs test session shapes</summary>

```text
wk | rest | days | goal | n_moves | first_move
----+------+------+------+---------+---------------------------
1 | 45 | 3 | 3 | 2 | One-Arm Kettlebell Swing
...
7 | 15 | 3 | 3 | 2 | One-Arm Kettlebell Swing
8 | 12 | 3 | 5 | 1 | One-Arm Kettlebell Snatch
9 | 10 | 3 | 5 | 1 | One-Arm Kettlebell Snatch
10 | 8 | 3 | 5 | 1 | One-Arm Kettlebell Snatch
```
</details>
<details>
<summary>Evidence: Snatch e2e result</summary>

```text
3 passed (1.5s) — 30 ordered sessions; restTimer strictly decreases week over week; build weeks alternate swing/snatch, test weeks snatch-only 100 reps
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- ℹ️ `supabase/migrations/20260713181831_seed_strongfirst_snatch_test_plan.sql:114` - ProgramsPage renders every public program (`sharedPrograms.map`, ProgramsPage.tsx:89), so this seed makes a startable &#34;Start StrongFirst Snatch Test Training Plan&#34; card go live on the Programs page (behind the `programs` flag) as soon as it deploys — not just &#34;seed data.&#34; This contradicts the task&#39;s &#34;seed-data only, not surfaced in UI&#34; framing and the stale AGENTS.md/CLAUDE.md note at line 164 claiming the page features only `sharedPrograms[0]`. Confirm the plan is meant to be immediately live/startable, and consider correcting that stale doc line.

🔧 Fix: docs: correct stale ProgramsPage shared-program surfacing note
1 info still open:
- ℹ️ `supabase/migrations/20260713181831_seed_strongfirst_snatch_test_plan.sql:72` - One-arm movements here set weightTwoUnit=NULL with weightTwoValue=0, while the sibling one-arm seed (20260713181819_seed_aa_protocol_plan_a.sql:58) uses weightTwoUnit=&#39;kilograms&#39; with weightTwoValue=0. Both resolve to Single/&#39;1h&#39; mode identically because getWeightTabValue keys only off weightTwoValue, so this is purely cosmetic with no runtime effect — noting the cross-seed inconsistency only for future maintainability.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`npx supabase db reset --local` — clean replay of all migrations including 20260713181831_seed_strongfirst_snatch_test_plan.sql, no error</code>
- `DB query on program_sessions confirming system-owned/public row, 30 ordered sessions, restTimer strictly decreasing 45→8s week-over-week, build weeks 1-7 (2 movements, goal 3) vs test weeks 8-10 (snatch-only, goal 5)`
- <code>`playwright test e2e/program-schema.spec.ts -g Snatch` — 3 tests pass (session count/ordering, monotonic restTimer, per-week movement shape)</code>
- `Throwaway playwright screenshot spec: authenticated Programs page render capturing the seeded 'StrongFirst Snatch Test Training Plan' startable card (removed after capture)`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
