### PR TITLE
feat(skill-tree): preserve swing-progression PoC as draft (do not merge)

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -26,6 +26,7 @@ export * from './useRecentRepeatableWorkouts';
 export * from './useRecommendSession';
 export * from './useSelectRPE';
 export * from './useSetSubscription';
+export * from './useSwingProgression';
 export * from './useUpdateWorkoutNotes';
 export * from './useInfiniteWorkoutLogs';
 export * from './useWorkoutLog';

--- a/src/api/useSwingProgression.test.ts
+++ b/src/api/useSwingProgression.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it } from 'vitest';
+
+import { ExampleMovementLog } from '~/examples';
+
+import { deriveProgressionData } from './useSwingProgression';
+
+const VARIATIONS = ['2h', '1h', 'dead-stop', 'double'] as const;
+
+const swingLog = (
+  movementName: string,
+  weightKg: number,
+  repScheme: number[],
+  workoutLogId: number,
+) =>
+  new ExampleMovementLog({
+    movement_name: movementName,
+    weight_one_value: weightKg,
+    weight_one_unit: 'kilograms',
+    rep_scheme: repScheme,
+    workout_log_id: workoutLogId,
+  });
+
+// Build enough logs to pass the done threshold for a given variation/weight.
+// 300 reps across 10 distinct workouts: 30 reps per workout.
+const doneLogsFor = (movementName: string, weightKg: number) =>
+  Array.from({ length: 10 }, (_, i) =>
+    swingLog(movementName, weightKg, Array(30).fill(1), i + 1),
+  );
+
+describe('deriveProgressionData', () => {
+  it('zero history — each variation: 16kg=current, 20kg=next, rest locked', () => {
+    const result = deriveProgressionData([]);
+
+    for (const variation of VARIATIONS) {
+      expect(result.find((n) => n.variation === variation && n.weightKg === 16)).toMatchObject({
+        state: 'current',
+        totalReps: 0,
+        totalWorkouts: 0,
+      });
+      expect(result.find((n) => n.variation === variation && n.weightKg === 20)).toMatchObject({
+        state: 'next',
+      });
+      for (const kg of [24, 28, 32]) {
+        expect(result.find((n) => n.variation === variation && n.weightKg === kg)).toMatchObject({
+          state: 'locked',
+        });
+      }
+    }
+  });
+
+  it('partial progress — 2h/16kg done, 2h/20kg in progress → 20kg=current, 24kg=next', () => {
+    const logs = [
+      ...doneLogsFor('Kettlebell Swing', 16),
+      // 2h/20kg: 150 reps, 5 workouts (below both thresholds)
+      ...Array.from({ length: 5 }, (_, i) =>
+        swingLog('Kettlebell Swing', 20, Array(30).fill(1), 100 + i),
+      ),
+    ];
+
+    const result = deriveProgressionData(logs);
+    const get2h = (kg: number) =>
+      result.find((n) => n.variation === '2h' && n.weightKg === kg)!;
+
+    expect(get2h(16).state).toBe('done');
+    expect(get2h(20).state).toBe('current');
+    expect(get2h(20).totalReps).toBe(150);
+    expect(get2h(20).totalWorkouts).toBe(5);
+    expect(get2h(24).state).toBe('next');
+    expect(get2h(28).state).toBe('locked');
+    expect(get2h(32).state).toBe('locked');
+  });
+
+  it('variation fully done — all 2h nodes = done', () => {
+    const logs = [
+      ...doneLogsFor('Kettlebell Swing', 16),
+      ...doneLogsFor('Kettlebell Swing', 20),
+      ...doneLogsFor('Kettlebell Swing', 24),
+      ...doneLogsFor('Kettlebell Swing', 28),
+      ...doneLogsFor('Kettlebell Swing', 32),
+    ];
+
+    const result = deriveProgressionData(logs);
+    const twoHand = result.filter((n) => n.variation === '2h');
+    expect(twoHand).toHaveLength(5);
+    for (const node of twoHand) {
+      expect(node.state).toBe('done');
+    }
+  });
+
+  it('threshold boundaries — 299 reps + 10 workouts is not done', () => {
+    // 299 reps across 10 workouts: workouts threshold met, reps not
+    const logs = [
+      ...Array.from({ length: 9 }, (_, i) =>
+        swingLog('Kettlebell Swing', 16, Array(33).fill(1), i + 1),
+      ),
+      swingLog('Kettlebell Swing', 16, Array(2).fill(1), 10),
+    ];
+
+    const result = deriveProgressionData(logs);
+    const node = result.find((n) => n.variation === '2h' && n.weightKg === 16)!;
+    expect(node.totalReps).toBe(299);
+    expect(node.totalWorkouts).toBe(10);
+    expect(node.state).toBe('current');
+  });
+
+  it('threshold boundaries — 300 reps + 9 workouts is not done', () => {
+    // Exactly 300 reps but only 9 distinct workouts
+    const logs = Array.from({ length: 9 }, (_, i) =>
+      swingLog(
+        'Kettlebell Swing',
+        16,
+        // distribute 300 reps across 9 logs: first 3 get 34 reps, rest get 33
+        i < 3 ? Array(34).fill(1) : Array(33).fill(1),
+        i + 1,
+      ),
+    );
+
+    const result = deriveProgressionData(logs);
+    const node = result.find((n) => n.variation === '2h' && n.weightKg === 16)!;
+    expect(node.totalReps).toBe(300);
+    expect(node.totalWorkouts).toBe(9);
+    expect(node.state).toBe('current');
+  });
+
+  it('reps from same workout are counted once toward workout total', () => {
+    // Two movement_logs from the same workout_log_id
+    const logs = [
+      swingLog('Kettlebell Swing', 16, [10, 10], 1),
+      swingLog('Kettlebell Swing', 16, [10, 10], 1),
+    ];
+
+    const result = deriveProgressionData(logs);
+    const node = result.find((n) => n.variation === '2h' && n.weightKg === 16)!;
+    expect(node.totalReps).toBe(40);
+    expect(node.totalWorkouts).toBe(1);
+  });
+
+  it('returns 20 nodes total — 4 variations × 5 weight tiers', () => {
+    const result = deriveProgressionData([]);
+    expect(result).toHaveLength(20);
+  });
+});

--- a/src/api/useSwingProgression.ts
+++ b/src/api/useSwingProgression.ts
@@ -1,0 +1,138 @@
+import { useQuery } from 'react-query';
+
+import { QUERIES } from '~/constants';
+import { useSession } from '~/contexts';
+import {
+  SwingNodeState,
+  SwingProgressionData,
+  SwingProgressionNode,
+  SwingVariation,
+} from '~/types';
+
+import { supabase } from '../supabaseClient';
+
+const SWING_WEIGHT_TIERS = [16, 20, 24, 28, 32] as const;
+
+const SWING_THRESHOLDS = { reps: 300, workouts: 10 };
+
+// Canonical names as stored in movement_logs.movement_name.
+// "Dead Stop Swing" and "Double Kettlebell Swing" should be verified against
+// the live movements catalog before first use.
+const SWING_VARIATION_NAMES: Record<SwingVariation, string> = {
+  '2h': 'Kettlebell Swing',
+  '1h': 'Single Arm Swing',
+  'dead-stop': 'Dead Stop Swing',
+  double: 'Double Kettlebell Swing',
+};
+
+export const useSwingProgression = () => {
+  const session = useSession();
+  const userId = session?.user?.id;
+
+  return useQuery(
+    [QUERIES.SWING_PROGRESSION, userId],
+    () => fetchSwingProgression(userId!),
+    { enabled: !!userId },
+  );
+};
+
+export const fetchSwingProgression = async (
+  userId: string,
+): Promise<SwingProgressionData> => {
+  const { data: rows, error } = await supabase
+    .from('movement_logs')
+    .select(
+      'movement_name, rep_scheme, weight_one_value, weight_one_unit, workout_log_id',
+    )
+    .eq('user_id', userId)
+    .in('movement_name', Object.values(SWING_VARIATION_NAMES));
+
+  if (error) {
+    console.error(error);
+    throw error;
+  }
+
+  return deriveProgressionData(rows ?? []);
+};
+
+type RawRow = {
+  movement_name: string;
+  rep_scheme: number[];
+  weight_one_value: number | null;
+  weight_one_unit: 'kilograms' | 'pounds' | null;
+  workout_log_id: number;
+};
+
+export const deriveProgressionData = (rows: RawRow[]): SwingProgressionData => {
+  const nameToVariation = Object.fromEntries(
+    (Object.entries(SWING_VARIATION_NAMES) as [SwingVariation, string][]).map(
+      ([variation, name]) => [name, variation],
+    ),
+  );
+
+  type Bucket = { reps: number; workoutIds: Set<number> };
+  const buckets = new Map<string, Bucket>();
+
+  for (const row of rows) {
+    const variation = nameToVariation[row.movement_name];
+    if (!variation) continue;
+
+    const weightKg = toKg(row.weight_one_value, row.weight_one_unit);
+    if (weightKg === null) continue;
+
+    const key = `${variation}-${weightKg}`;
+    let bucket = buckets.get(key);
+    if (!bucket) {
+      bucket = { reps: 0, workoutIds: new Set() };
+      buckets.set(key, bucket);
+    }
+
+    bucket.reps += row.rep_scheme.reduce((sum, r) => sum + r, 0);
+    bucket.workoutIds.add(row.workout_log_id);
+  }
+
+  const nodes: SwingProgressionNode[] = [];
+
+  for (const variation of Object.keys(SWING_VARIATION_NAMES) as SwingVariation[]) {
+    let currentWeightKg: number | null = null;
+
+    for (const weightKg of SWING_WEIGHT_TIERS) {
+      const bucket = buckets.get(`${variation}-${weightKg}`);
+      const totalReps = bucket?.reps ?? 0;
+      const totalWorkouts = bucket?.workoutIds.size ?? 0;
+
+      let state: SwingNodeState;
+      if (
+        totalReps >= SWING_THRESHOLDS.reps &&
+        totalWorkouts >= SWING_THRESHOLDS.workouts
+      ) {
+        state = 'done';
+      } else if (currentWeightKg === null) {
+        state = 'current';
+        currentWeightKg = weightKg;
+      } else if (weightKg === nextTier(currentWeightKg)) {
+        state = 'next';
+      } else {
+        state = 'locked';
+      }
+
+      nodes.push({ variation, weightKg, totalReps, totalWorkouts, state });
+    }
+  }
+
+  return nodes;
+};
+
+const toKg = (
+  value: number | null,
+  unit: 'kilograms' | 'pounds' | null,
+): number | null => {
+  if (value === null || unit === null) return null;
+  if (unit === 'kilograms') return value;
+  return Math.round(value * 0.453592);
+};
+
+const nextTier = (weightKg: number): number | undefined => {
+  const idx = SWING_WEIGHT_TIERS.indexOf(weightKg as (typeof SWING_WEIGHT_TIERS)[number]);
+  return idx !== -1 ? SWING_WEIGHT_TIERS[idx + 1] : undefined;
+};

--- a/src/constants/queries.enum.ts
+++ b/src/constants/queries.enum.ts
@@ -8,6 +8,7 @@ export enum QUERIES {
   PROGRAM = 'program',
   PROGRAM_PROGRESS = 'programProgress',
   PROGRAMS = 'programs',
+  SWING_PROGRESSION = 'swingProgression',
   USER_MOVEMENTS = 'userMovements',
   WORKOUT_LOG = 'workoutLog',
   WORKOUT_LOGS = 'workoutLogs',

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -11,6 +11,7 @@ export * from './program-session-completion.interface';
 export * from './user-program.interface';
 export * from './recommendation.interface';
 export * from './rpe-options.type';
+export * from './swing-progression';
 export * from './weight-tab.type';
 export * from './weight-unit.type';
 export * from './workout-goal-units.type';

--- a/src/types/swing-progression.ts
+++ b/src/types/swing-progression.ts
@@ -1,0 +1,12 @@
+export type SwingVariation = '2h' | '1h' | 'dead-stop' | 'double';
+export type SwingNodeState = 'done' | 'current' | 'next' | 'locked';
+
+export interface SwingProgressionNode {
+  variation: SwingVariation;
+  weightKg: number;
+  totalReps: number;
+  totalWorkouts: number;
+  state: SwingNodeState;
+}
+
+export type SwingProgressionData = SwingProgressionNode[];


### PR DESCRIPTION
> **Draft — not a merge candidate.** This is preserved thinking, not shippable work. The design of the skill tree is still open, and this PR deliberately does not close it.

## What

An early proof-of-concept for the **skill tree** feature — swing progression — rescued from an uncommitted worktree and ported onto current `main`.

It models swings as a grid of nodes: 4 variations (`2h`, `1h`, `dead-stop`, `double`) × 5 weight tiers (16/20/24/28/32kg), each node in one of `done | current | next | locked`. A node is `done` at 300 reps **and** 10 distinct workouts, derived from `movement_logs`.

- `src/types/swing-progression.ts` — the node/state types
- `src/api/useSwingProgression.ts` — the query hook + `deriveProgressionData`, the pure reducer that does the real thinking
- `src/api/useSwingProgression.test.ts` — 7 tests over the reducer
- three one-line barrel exports

There is no UI. This is the data layer only.

## Why

The work existed **only** as uncommitted changes in an abandoned worktree (`vigorous-cartwright-b2e7ea`) and was one cleanup away from being gone for good. Skill tree is a north-star building block for the product, so the early thinking has value even if this code doesn't survive contact with the final design. Committing it makes it survive and makes it visible.

It was authored against a base **107 commits behind current `main`**.

## How tested

Ported onto `main` at 7f8f04b, then run for real:

| Check | Result |
| --- | --- |
| `npm run compile:ts` | ✅ pass (exit 0) |
| `npm test` | ✅ pass — 60 files, 419 tests |
| `npm run lint` | ✅ pass (exit 0) |
| `npx vitest run src/api/useSwingProgression.test.ts` | ✅ pass — 7/7 |

Better than expected for a 107-commit gap, and worth being precise about *why* it's green rather than reading it as a green light:

- The PoC's dependencies happen not to have drifted. `react-query` v3, `~/contexts` `useSession`, `~/supabaseClient`, and `~/examples` `ExampleMovementLog` all still exist with compatible shapes, and every `movement_logs` column it queries (`movement_name`, `rep_scheme`, `weight_one_value`, `weight_one_unit`, `workout_log_id`) is unchanged.
- **Zero code changes were needed.** The three new files are committed byte-identical to the originals (`diff -q` clean).
- The tests are green because `deriveProgressionData` is a pure function tested with the PoC's own name literals as fixtures — they never touch the live movements catalog. **Green tests here do not mean this works against real data.** See below.

## Tradeoffs

**Preserved as-authored, not finished.** The brief was to rescue, not to build, so I made no design or structural changes.

**The one adjustment made:** the three barrel-export lines were re-added in the slots matching each file's convention *on current main*, rather than copying the old versions of those files over (which would have clobbered 107 commits of work). No other change — no renamed imports, no moved paths, nothing.

**Prettier:** `useSwingProgression.ts` and `.test.ts` are flagged by `npx prettier --check`. Left unformatted deliberately to keep the files byte-identical to the author's originals. `npm run lint` is scoped to `--ext js,jsx` and doesn't cover `.ts`, so this is not a CI gate — trivial to fix with `npm run prettier` whenever this work is picked up.

### The design question I hit and deliberately did NOT answer

The PoC maps variations to canonical `movement_logs.movement_name` strings, with the author's own comment flagging it:

> `// "Dead Stop Swing" and "Double Kettlebell Swing" should be verified against the live movements catalog before first use.`

I verified. Against today's catalog (`scripts/data/movements.csv`), **2 of the 4 names don't exist**:

| PoC name | Today's catalog |
| --- | --- |
| `2h` → `Kettlebell Swing` | ✅ exact match |
| `double` → `Double Kettlebell Swing` | ✅ exact match |
| `1h` → `Single Arm Swing` | ❌ **not found** — nearest is `One-Arm Kettlebell Swing` |
| `dead-stop` → `Dead Stop Swing` | ❌ **not found** — no equivalent at all |

The catalog also contains `Alternating Kettlebell Swing`, which the PoC doesn't model.

This is fallout from **PROD-153**, which replaced the whole movements catalog after this PoC was written. As it stands, the `1h` and `dead-stop` rows would silently derive as all-zero against live data.

I did not "fix" this, because it isn't mechanical — **which movements the swing tree contains is the feature's design**, and that's the open work:

- Is `Single Arm Swing` → `One-Arm Kettlebell Swing` the same concept, or a different movement?
- `dead-stop` has no catalog equivalent. Drop the variation, add the movement, or map it elsewhere?
- Is `Alternating Kettlebell Swing` a node in this tree?

Also left open, and load-bearing if this is ever revived: matching on `movement_name` **string literals** is fragile against exactly this kind of catalog churn (`user_movement_id` exists), and the 300-reps/10-workouts thresholds and the 16–32kg tiers are unsourced round numbers that apply identically to every variation — a 32kg one-arm swing is not the same ask as a 32kg two-hand swing.

These are the captain's calls, not mine.