### PR TITLE
feat(programs): derive enroll starting-weight default per program

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,7 +102,7 @@ pages/
 - Supabase client is the `supabase` named export from `~/supabaseClient`.
 - Query keys are defined in `src/constants/queries.enum.ts`.
 - `npm run gen:types` writes the **repo-root** `types/supabase.ts` — commit that file after any schema change (requires `supabase start` to be running). `src/types/supabase.ts` is just a 3-line alias (`export type Supabase = Database`) re-exporting the root file; it is not regenerated.
-- Schema changes that must reach **production** (e.g. seeded shared content) belong in a **migration**, not `supabase/seed.sql`. Production only ever applies migrations (forward-only `db push`); `seed.sql` never reaches it. Staging is rebuilt with `db reset --linked`, which replays migrations *and* runs `seed.sql`, so seed data reaches staging but stops there. See `.github/workflows/supabase-*.yaml`.
+- Schema changes that must reach **production** (e.g. seeded shared content) belong in a **migration**, not `supabase/seed.sql`. Production only ever applies migrations (forward-only `db push`); `seed.sql` never reaches it. Staging is rebuilt with `db reset --linked`, which replays migrations _and_ runs `seed.sql`, so seed data reaches staging but stops there. See `.github/workflows/supabase-*.yaml`.
 
 ## Movement Catalog (PROD-153)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -256,7 +256,14 @@ you`), reusing the live builder's shared-weight picker
   (`WeightModeTabs` + `ModifyCountButtons`/`WeightUnitTabs`, now in
   `~/components`) so the enrollee can pick two-hand/single/double loading,
   independent left/right (mixed) weights, and kg or lb. Your own programs are
-  already fully weight-configured in the builder.
+  already fully weight-configured in the builder. The prompt's **pre-fill** is
+  derived per-program (PROD-232) — `ProgramsPage` lazily fetches the pending
+  program's sessions (`useProgram`) and seeds the picker from
+  `deriveStartingWeight` (`ProgramsPage/utils`), the modal placeholder
+  weight/mode across the program's sessions (same `resolveSharedWeights`
+  priority + modal/tie-break as the RPC). So single-bell programs (Snatch Test)
+  pre-fill single, swing-only (10K Swing) two-hand, DFW/Armor/Easy double — not
+  a fixed 24kg.
 
 ## Runtime Feature Flags (PROD-175)
 

--- a/src/pages/ProgramsPage/ProgramsPage.test.tsx
+++ b/src/pages/ProgramsPage/ProgramsPage.test.tsx
@@ -214,6 +214,39 @@ describe('ProgramsPage', () => {
     );
   });
 
+  it('degrades to the editable double-24kg default when the program fetch errors', () => {
+    mockUseProgram.mockReturnValue({ data: undefined, isError: true });
+
+    renderPage();
+
+    fireEvent.click(screen.getByText('Start Dry Fighting Weight'));
+
+    // A failed sessions fetch must not brick enrollment: the picker still opens
+    // editable on the generic double-24kg fallback rather than sticking on
+    // "Loading…" with a disabled button.
+    expect(screen.queryByText('Loading…')).not.toBeInTheDocument();
+    const inputs = screen.getAllByRole('spinbutton');
+    expect(inputs).toHaveLength(2);
+    expect(inputs[0]).toHaveValue(24);
+    expect(inputs[1]).toHaveValue(24);
+
+    const startButton = screen.getByRole('button', { name: 'Start program' });
+    expect(startButton).not.toBeDisabled();
+
+    fireEvent.click(startButton);
+
+    expect(enrollMutate).toHaveBeenCalledWith(
+      {
+        programId: 'dfw-1',
+        sharedWeightOneValue: 24,
+        sharedWeightOneUnit: 'kilograms',
+        sharedWeightTwoValue: 24,
+        sharedWeightTwoUnit: 'kilograms',
+      },
+      expect.anything(),
+    );
+  });
+
   it('pre-fills single loading at the modal weight for a single-bell program', () => {
     mockUsePrograms.mockReturnValue({
       data: [snatchTest, myProgram],

--- a/src/pages/ProgramsPage/ProgramsPage.test.tsx
+++ b/src/pages/ProgramsPage/ProgramsPage.test.tsx
@@ -10,6 +10,7 @@ const {
   mockUseActiveProgram,
   mockUseCreateProgram,
   mockUseEnrollProgram,
+  mockUseProgram,
   enrollMutate,
   createMutate,
 } = vi.hoisted(() => ({
@@ -17,6 +18,7 @@ const {
   mockUseActiveProgram: vi.fn(),
   mockUseCreateProgram: vi.fn(),
   mockUseEnrollProgram: vi.fn(),
+  mockUseProgram: vi.fn(),
   enrollMutate: vi.fn(),
   createMutate: vi.fn(),
 }));
@@ -26,6 +28,7 @@ vi.mock('~/api', () => ({
   useActiveProgram: mockUseActiveProgram,
   useCreateProgram: mockUseCreateProgram,
   useEnrollProgram: mockUseEnrollProgram,
+  useProgram: mockUseProgram,
 }));
 
 vi.mock('~/contexts', async () => {
@@ -79,6 +82,72 @@ const myProgram = {
   createdAt: '',
 };
 
+const snatchTest = {
+  id: 'snatch-1',
+  ownerId: null,
+  sourceProgramId: null,
+  slug: 'strongfirst-snatch-test-plan',
+  title: 'Snatch Test Plan',
+  description: null,
+  authorName: 'StrongFirst',
+  numWeeks: 10,
+  daysPerWeek: 3,
+  isPublic: true,
+  createdAt: '',
+};
+
+// Minimal session whose first movement carries the given loading. `weightTwo`
+// null → two-hand, 0 → single, >0 → double.
+const sessionWith = (
+  weightOne: number,
+  weightTwo: number | null,
+  shared = false,
+) => ({
+  id: 's',
+  programId: 'p',
+  sequenceIndex: 0,
+  weekNumber: 1,
+  dayNumber: 1,
+  title: 't',
+  notes: null,
+  workoutOptions: {
+    complexSet: shared,
+    intervalTimer: 0,
+    restTimer: 0,
+    workoutDetails: null,
+    workoutGoal: 0,
+    workoutGoalUnits: 'minutes',
+    sharedWeightOneValue: shared ? weightOne : null,
+    sharedWeightOneUnit: shared ? 'kilograms' : null,
+    sharedWeightTwoValue: shared ? weightTwo : null,
+    sharedWeightTwoUnit: shared && weightTwo ? 'kilograms' : null,
+    movements: [
+      {
+        movementName: 'M',
+        repScheme: [1],
+        weightOneValue: weightOne,
+        weightOneUnit: 'kilograms',
+        weightTwoValue: weightTwo,
+        weightTwoUnit: weightTwo ? 'kilograms' : null,
+      },
+    ],
+  },
+});
+
+// Sessions for each seeded shared program, keyed by id, so the starting-weight
+// prompt derives its pre-fill from real per-program loading profiles.
+const SESSIONS_BY_ID: Record<string, ReturnType<typeof sessionWith>[]> = {
+  'dfw-1': Array.from({ length: 13 }, () => sessionWith(24, 24)).concat(
+    sessionWith(28, 28),
+  ),
+  'armor-1': Array.from({ length: 20 }, () => sessionWith(24, 24, true)),
+  'snatch-1': [
+    ...Array.from({ length: 9 }, () => sessionWith(28, 0)),
+    ...Array.from({ length: 11 }, () => sessionWith(24, 0)),
+    ...Array.from({ length: 10 }, () => sessionWith(20, 0)),
+  ],
+};
+
 const renderPage = () =>
   render(
     <MemoryRouter initialEntries={['/programs']}>
@@ -110,6 +179,11 @@ describe('ProgramsPage', () => {
       mutate: enrollMutate,
       isLoading: false,
     });
+    mockUseProgram.mockImplementation((id?: string) => ({
+      data: id
+        ? { program: {}, sessions: SESSIONS_BY_ID[id] ?? [] }
+        : undefined,
+    }));
   });
 
   it('prompts for a starting weight before enrolling in a shared program, defaulted to double 24kg', () => {
@@ -135,6 +209,36 @@ describe('ProgramsPage', () => {
         sharedWeightOneUnit: 'kilograms',
         sharedWeightTwoValue: 24,
         sharedWeightTwoUnit: 'kilograms',
+      },
+      expect.anything(),
+    );
+  });
+
+  it('pre-fills single loading at the modal weight for a single-bell program', () => {
+    mockUsePrograms.mockReturnValue({
+      data: [snatchTest, myProgram],
+      isLoading: false,
+    });
+
+    renderPage();
+
+    fireEvent.click(screen.getByText('Start Snatch Test Plan'));
+
+    // A single-bell program (Snatch Test) collapses to one weight input at the
+    // modal 24kg — not the double-24 the fixed default used to force.
+    const inputs = screen.getAllByRole('spinbutton');
+    expect(inputs).toHaveLength(1);
+    expect(inputs[0]).toHaveValue(24);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Start program' }));
+
+    expect(enrollMutate).toHaveBeenCalledWith(
+      {
+        programId: 'snatch-1',
+        sharedWeightOneValue: 24,
+        sharedWeightOneUnit: 'kilograms',
+        sharedWeightTwoValue: 0,
+        sharedWeightTwoUnit: null,
       },
       expect.anything(),
     );

--- a/src/pages/ProgramsPage/ProgramsPage.tsx
+++ b/src/pages/ProgramsPage/ProgramsPage.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 
 import {
@@ -6,6 +6,7 @@ import {
   useActiveProgram,
   useCreateProgram,
   useEnrollProgram,
+  useProgram,
   usePrograms,
 } from '~/api';
 import { ModifyCountButtons, Page, WeightUnitTabs } from '~/components';
@@ -26,14 +27,13 @@ import { useSession } from '~/contexts';
 import { Program, WeightUnit } from '~/types';
 import { getWeightTabValue, getWeightUnitLabel } from '~/utils';
 
+import { deriveStartingWeight } from './utils/deriveStartingWeight';
+
 const DEFAULT_WEEKS = 5;
 const DEFAULT_DAYS_PER_WEEK = 3;
-// Pre-fill for the starting-weight prompt: double loading at 24kg, which is
-// DFW's placeholder and a reasonable generic starting point the user can edit.
-// TODO(PROD-TBD): derive the pre-fill from the enrolled program's own
-// placeholder weight/mode once the other shared programs (Snatch Test / Armor
-// Building Complex / Easy Strength) land — the prompt fires for any non-owned
-// public program, so a fixed 24kg won't match every one.
+// Fallback weight/unit for the mode-switch handlers (when the user adds a
+// previously-null slot). The prompt's initial pre-fill is derived per-program
+// from the enrolled program's own sessions — see deriveStartingWeight.
 const DEFAULT_STARTING_WEIGHT_VALUE = 24;
 const DEFAULT_WEIGHT_UNIT: WeightUnit = 'kilograms';
 
@@ -56,9 +56,12 @@ export const ProgramsPage = () => {
   const [pendingWeightProgramId, setPendingWeightProgramId] = useState<
     string | null
   >(null);
+  // The program the picker has been pre-filled for; the prompt waits on this so
+  // it never briefly shows a stale default before its derived pre-fill lands.
+  const [seededProgramId, setSeededProgramId] = useState<string | null>(null);
   // Starting shared weight for the prompt, mirroring the live builder's shared
-  // weight picker (mode + independent left/right value + unit). Default: double
-  // loading at the 24kg placeholder.
+  // weight picker (mode + independent left/right value + unit). Seeded per
+  // program from its own sessions once the prompt opens (see the effect below).
   const [sharedWeightOneValue, setSharedWeightOneValue] = useState<
     number | null
   >(DEFAULT_STARTING_WEIGHT_VALUE);
@@ -72,6 +75,26 @@ export const ProgramsPage = () => {
 
   const sharedPrograms = programs.filter((p) => p.isPublic);
   const myPrograms = programs.filter((p) => !p.isPublic);
+
+  // Load the pending program's sessions so the prompt can pre-fill from its own
+  // modal placeholder weight/mode rather than a fixed default.
+  const { data: pendingProgram } = useProgram(
+    pendingWeightProgramId ?? undefined,
+  );
+  const startingWeightReady = seededProgramId === pendingWeightProgramId;
+
+  useEffect(() => {
+    if (!pendingWeightProgramId || !pendingProgram) return;
+    // Seed once per open (proceedToEnroll resets seededProgramId): re-running
+    // would clobber the user's own picker edits.
+    if (seededProgramId === pendingWeightProgramId) return;
+    const derived = deriveStartingWeight(pendingProgram.sessions);
+    setSharedWeightOneValue(derived.sharedWeightOneValue);
+    setSharedWeightOneUnit(derived.sharedWeightOneUnit);
+    setSharedWeightTwoValue(derived.sharedWeightTwoValue);
+    setSharedWeightTwoUnit(derived.sharedWeightTwoUnit);
+    setSeededProgramId(pendingWeightProgramId);
+  }, [pendingWeightProgramId, pendingProgram, seededProgramId]);
 
   const enrollIn = (
     programId: string,
@@ -120,13 +143,6 @@ export const ProgramsPage = () => {
   const handleChangeSharedWeightTwoValue = (value: number) =>
     setSharedWeightTwoValue(Math.max(1, value));
 
-  const resetStartingWeight = () => {
-    setSharedWeightOneValue(DEFAULT_STARTING_WEIGHT_VALUE);
-    setSharedWeightOneUnit(DEFAULT_WEIGHT_UNIT);
-    setSharedWeightTwoValue(DEFAULT_STARTING_WEIGHT_VALUE);
-    setSharedWeightTwoUnit(DEFAULT_WEIGHT_UNIT);
-  };
-
   // Only an *active* enrollment blocks a fresh enroll — a completed program may
   // still be returned by useActiveProgram (to drive the home "complete" card),
   // but starting a new program then needs no "switch?" confirmation.
@@ -142,7 +158,7 @@ export const ProgramsPage = () => {
   const proceedToEnroll = (programId: string) => {
     const program = programs.find((p) => p.id === programId);
     if (program && isSharedNotOwned(program)) {
-      resetStartingWeight();
+      setSeededProgramId(null);
       setPendingWeightProgramId(programId);
     } else {
       enrollIn(programId);
@@ -377,12 +393,17 @@ export const ProgramsPage = () => {
             </DialogDescription>
           </DialogHeader>
           <div className="flex flex-col gap-1">
-            <WeightModeTabs
-              value={sharedWeightTabValue}
-              onValueChange={handleChangeSharedWeightTab}
-              hideNone
-            />
-            {sharedWeightOneValue !== null && (
+            {!startingWeightReady && (
+              <p className="text-sm text-muted-foreground">Loading…</p>
+            )}
+            {startingWeightReady && (
+              <WeightModeTabs
+                value={sharedWeightTabValue}
+                onValueChange={handleChangeSharedWeightTab}
+                hideNone
+              />
+            )}
+            {startingWeightReady && sharedWeightOneValue !== null && (
               <ModifyCountButtons
                 onClickMinus={() =>
                   handleChangeSharedWeightOneValue(sharedWeightOneValue - 1)
@@ -401,25 +422,27 @@ export const ProgramsPage = () => {
                 onChange={handleChangeSharedWeightOneValue}
               />
             )}
-            {sharedWeightTwoValue !== null && sharedWeightTwoValue > 0 && (
-              <ModifyCountButtons
-                onClickMinus={() =>
-                  handleChangeSharedWeightTwoValue(sharedWeightTwoValue - 1)
-                }
-                onClickPlus={() =>
-                  handleChangeSharedWeightTwoValue(sharedWeightTwoValue + 1)
-                }
-                unit={getWeightUnitLabel(sharedWeightTwoUnit)}
-                unitTabs={
-                  <WeightUnitTabs
-                    value={sharedWeightTwoUnit}
-                    onChange={setSharedWeightTwoUnit}
-                  />
-                }
-                value={sharedWeightTwoValue}
-                onChange={handleChangeSharedWeightTwoValue}
-              />
-            )}
+            {startingWeightReady &&
+              sharedWeightTwoValue !== null &&
+              sharedWeightTwoValue > 0 && (
+                <ModifyCountButtons
+                  onClickMinus={() =>
+                    handleChangeSharedWeightTwoValue(sharedWeightTwoValue - 1)
+                  }
+                  onClickPlus={() =>
+                    handleChangeSharedWeightTwoValue(sharedWeightTwoValue + 1)
+                  }
+                  unit={getWeightUnitLabel(sharedWeightTwoUnit)}
+                  unitTabs={
+                    <WeightUnitTabs
+                      value={sharedWeightTwoUnit}
+                      onChange={setSharedWeightTwoUnit}
+                    />
+                  }
+                  value={sharedWeightTwoValue}
+                  onChange={handleChangeSharedWeightTwoValue}
+                />
+              )}
           </div>
           <DialogFooter>
             <Button
@@ -428,7 +451,10 @@ export const ProgramsPage = () => {
             >
               Cancel
             </Button>
-            <Button onClick={confirmStartingWeight} disabled={enroll.isLoading}>
+            <Button
+              onClick={confirmStartingWeight}
+              disabled={enroll.isLoading || !startingWeightReady}
+            >
               Start program
             </Button>
           </DialogFooter>

--- a/src/pages/ProgramsPage/ProgramsPage.tsx
+++ b/src/pages/ProgramsPage/ProgramsPage.tsx
@@ -78,23 +78,31 @@ export const ProgramsPage = () => {
 
   // Load the pending program's sessions so the prompt can pre-fill from its own
   // modal placeholder weight/mode rather than a fixed default.
-  const { data: pendingProgram } = useProgram(
+  const { data: pendingProgram, isError: pendingProgramError } = useProgram(
     pendingWeightProgramId ?? undefined,
   );
   const startingWeightReady = seededProgramId === pendingWeightProgramId;
 
   useEffect(() => {
-    if (!pendingWeightProgramId || !pendingProgram) return;
+    if (!pendingWeightProgramId) return;
     // Seed once per open (proceedToEnroll resets seededProgramId): re-running
     // would clobber the user's own picker edits.
     if (seededProgramId === pendingWeightProgramId) return;
-    const derived = deriveStartingWeight(pendingProgram.sessions);
+    // On a fetch error, fall back to deriveStartingWeight's generic default so
+    // the picker still opens editable rather than sticking on "Loading…".
+    if (!pendingProgram && !pendingProgramError) return;
+    const derived = deriveStartingWeight(pendingProgram?.sessions ?? []);
     setSharedWeightOneValue(derived.sharedWeightOneValue);
     setSharedWeightOneUnit(derived.sharedWeightOneUnit);
     setSharedWeightTwoValue(derived.sharedWeightTwoValue);
     setSharedWeightTwoUnit(derived.sharedWeightTwoUnit);
     setSeededProgramId(pendingWeightProgramId);
-  }, [pendingWeightProgramId, pendingProgram, seededProgramId]);
+  }, [
+    pendingWeightProgramId,
+    pendingProgram,
+    pendingProgramError,
+    seededProgramId,
+  ]);
 
   const enrollIn = (
     programId: string,

--- a/src/pages/ProgramsPage/utils/deriveStartingWeight.test.ts
+++ b/src/pages/ProgramsPage/utils/deriveStartingWeight.test.ts
@@ -1,0 +1,188 @@
+import { ProgramSession, WeightUnit, WorkoutOptions } from '~/types';
+
+import { deriveStartingWeight } from './deriveStartingWeight';
+
+type MovementWeights = Pick<
+  WorkoutOptions['movements'][number],
+  'weightOneValue' | 'weightOneUnit' | 'weightTwoValue' | 'weightTwoUnit'
+>;
+
+type SharedWeights = Pick<
+  WorkoutOptions,
+  | 'sharedWeightOneValue'
+  | 'sharedWeightOneUnit'
+  | 'sharedWeightTwoValue'
+  | 'sharedWeightTwoUnit'
+>;
+
+const NO_SHARED: SharedWeights = {
+  sharedWeightOneValue: null,
+  sharedWeightOneUnit: null,
+  sharedWeightTwoValue: null,
+  sharedWeightTwoUnit: null,
+};
+
+const kg = (value: number | null): WeightUnit | null =>
+  value == null ? null : 'kilograms';
+
+const firstMovementSession = (
+  firstMovement: MovementWeights,
+  shared: SharedWeights = NO_SHARED,
+): ProgramSession => ({
+  id: 'x',
+  programId: 'p',
+  sequenceIndex: 0,
+  weekNumber: 1,
+  dayNumber: 1,
+  title: 't',
+  notes: null,
+  workoutOptions: {
+    complexSet: false,
+    intervalTimer: 0,
+    restTimer: 0,
+    workoutDetails: null,
+    workoutGoal: 0,
+    workoutGoalUnits: 'minutes',
+    ...shared,
+    movements: [{ movementName: 'M', repScheme: [1], ...firstMovement }],
+  },
+});
+
+// value + loading mode from a two-hand (weight two null) first movement.
+const twoHand = (value: number): ProgramSession =>
+  firstMovementSession({
+    weightOneValue: value,
+    weightOneUnit: kg(value),
+    weightTwoValue: null,
+    weightTwoUnit: null,
+  });
+
+// single/offset loading (weight two === 0).
+const single = (value: number): ProgramSession =>
+  firstMovementSession({
+    weightOneValue: value,
+    weightOneUnit: kg(value),
+    weightTwoValue: 0,
+    weightTwoUnit: null,
+  });
+
+// double loading via the session's own first movement.
+const double = (value: number): ProgramSession =>
+  firstMovementSession({
+    weightOneValue: value,
+    weightOneUnit: kg(value),
+    weightTwoValue: value,
+    weightTwoUnit: kg(value),
+  });
+
+// double loading carried on the session's *shared* weight (complex programs).
+const sharedDouble = (value: number): ProgramSession =>
+  firstMovementSession(
+    {
+      weightOneValue: value,
+      weightOneUnit: kg(value),
+      weightTwoValue: value,
+      weightTwoUnit: kg(value),
+    },
+    {
+      sharedWeightOneValue: value,
+      sharedWeightOneUnit: 'kilograms',
+      sharedWeightTwoValue: value,
+      sharedWeightTwoUnit: 'kilograms',
+    },
+  );
+
+describe('deriveStartingWeight', () => {
+  it('derives two-hand loading for an all-two-hand program (10,000 Swing)', () => {
+    expect(
+      deriveStartingWeight(Array.from({ length: 20 }, () => twoHand(24))),
+    ).toEqual({
+      sharedWeightOneValue: 24,
+      sharedWeightOneUnit: 'kilograms',
+      sharedWeightTwoValue: null,
+      sharedWeightTwoUnit: null,
+    });
+  });
+
+  it('derives single loading and the modal weight (A+A Protocol)', () => {
+    // Four sessions at 24kg, one at 20kg — 24 is modal.
+    const sessions = [
+      single(24),
+      single(24),
+      single(24),
+      single(24),
+      single(20),
+    ];
+    expect(deriveStartingWeight(sessions)).toEqual({
+      sharedWeightOneValue: 24,
+      sharedWeightOneUnit: 'kilograms',
+      sharedWeightTwoValue: 0,
+      sharedWeightTwoUnit: null,
+    });
+  });
+
+  it('derives single loading with the modal weight across a rotating ladder (Snatch Test)', () => {
+    // 28×9, 24×11, 20×10 — 24 is modal despite 28 leading the sequence.
+    const counts: Array<[number, number]> = [
+      [28, 9],
+      [24, 11],
+      [20, 10],
+    ];
+    const sessions = counts.flatMap(([value, n]) =>
+      Array.from({ length: n }, () => single(value)),
+    );
+    expect(deriveStartingWeight(sessions)).toEqual({
+      sharedWeightOneValue: 24,
+      sharedWeightOneUnit: 'kilograms',
+      sharedWeightTwoValue: 0,
+      sharedWeightTwoUnit: null,
+    });
+  });
+
+  it('derives double loading from first-movement weights (Dry Fighting Weight)', () => {
+    // 13 sessions at double-24, one deliberately heavier test day at double-28.
+    const sessions = [
+      ...Array.from({ length: 13 }, () => double(24)),
+      double(28),
+    ];
+    expect(deriveStartingWeight(sessions)).toEqual({
+      sharedWeightOneValue: 24,
+      sharedWeightOneUnit: 'kilograms',
+      sharedWeightTwoValue: 24,
+      sharedWeightTwoUnit: 'kilograms',
+    });
+  });
+
+  it('derives double loading from the shared weight on a complex program (Armor Building)', () => {
+    expect(
+      deriveStartingWeight(Array.from({ length: 20 }, () => sharedDouble(24))),
+    ).toEqual({
+      sharedWeightOneValue: 24,
+      sharedWeightOneUnit: 'kilograms',
+      sharedWeightTwoValue: 24,
+      sharedWeightTwoUnit: 'kilograms',
+    });
+  });
+
+  it('breaks a weight tie toward the lighter first weight', () => {
+    const sessions = [single(24), single(20)];
+    expect(deriveStartingWeight(sessions).sharedWeightOneValue).toBe(20);
+  });
+
+  it('falls back to double-24kg for an empty or all-bodyweight program', () => {
+    expect(deriveStartingWeight([])).toEqual({
+      sharedWeightOneValue: 24,
+      sharedWeightOneUnit: 'kilograms',
+      sharedWeightTwoValue: 24,
+      sharedWeightTwoUnit: 'kilograms',
+    });
+
+    const bodyweight = firstMovementSession({
+      weightOneValue: null,
+      weightOneUnit: null,
+      weightTwoValue: null,
+      weightTwoUnit: null,
+    });
+    expect(deriveStartingWeight([bodyweight]).sharedWeightOneValue).toBe(24);
+  });
+});

--- a/src/pages/ProgramsPage/utils/deriveStartingWeight.ts
+++ b/src/pages/ProgramsPage/utils/deriveStartingWeight.ts
@@ -1,0 +1,95 @@
+import { ProgramSession, WeightUnit } from '~/types';
+
+export interface StartingWeight {
+  sharedWeightOneValue: number | null;
+  sharedWeightOneUnit: WeightUnit | null;
+  sharedWeightTwoValue: number | null;
+  sharedWeightTwoUnit: WeightUnit | null;
+}
+
+// Fallback for the degenerate case (no sessions, or a program with no loaded
+// bell weight at all): double loading at 24kg, the app's generic starting
+// point. No seeded shared program hits this today.
+const DEFAULT_STARTING_WEIGHT: StartingWeight = {
+  sharedWeightOneValue: 24,
+  sharedWeightOneUnit: 'kilograms',
+  sharedWeightTwoValue: 24,
+  sharedWeightTwoUnit: 'kilograms',
+};
+
+/**
+ * The weight a session's working sets actually start with, mirroring
+ * resolveSharedWeights' priority: the session's own shared weight if set,
+ * otherwise its first movement's weight (the placeholder load).
+ */
+const resolveSessionPlaceholder = (session: ProgramSession): StartingWeight => {
+  const options = session.workoutOptions;
+  const hasSharedWeight =
+    options.sharedWeightOneValue != null || options.sharedWeightOneUnit != null;
+
+  if (hasSharedWeight) {
+    return {
+      sharedWeightOneValue: options.sharedWeightOneValue,
+      sharedWeightOneUnit: options.sharedWeightOneUnit,
+      sharedWeightTwoValue: options.sharedWeightTwoValue,
+      sharedWeightTwoUnit: options.sharedWeightTwoUnit,
+    };
+  }
+
+  const first = options.movements[0];
+  return {
+    sharedWeightOneValue: first?.weightOneValue ?? null,
+    sharedWeightOneUnit: first?.weightOneUnit ?? null,
+    sharedWeightTwoValue: first?.weightTwoValue ?? null,
+    sharedWeightTwoUnit: first?.weightTwoUnit ?? null,
+  };
+};
+
+const weightKey = (weight: StartingWeight): string =>
+  [
+    weight.sharedWeightOneValue,
+    weight.sharedWeightOneUnit,
+    weight.sharedWeightTwoValue,
+    weight.sharedWeightTwoUnit,
+  ].join('|');
+
+/**
+ * Derives the starting-weight prompt's pre-fill from a shared program's own
+ * seeded sessions: the modal (most common) placeholder weight + loading mode
+ * across its sessions. This lets the prompt match each program's equipment
+ * profile — e.g. two-hand for the 10,000 Swing Challenge, single for the
+ * Snatch Test plan, double for Dry Fighting Weight — rather than assuming one
+ * fixed load. Ties break toward the lighter first weight, mirroring the
+ * enroll_in_program RPC's `ORDER BY cnt DESC, weight_val`.
+ *
+ * Sessions with no loaded bell weight (bodyweight placeholders) don't count
+ * toward the mode; a program that is entirely bodyweight falls back to the
+ * generic double-24kg default.
+ */
+export const deriveStartingWeight = (
+  sessions: ProgramSession[],
+): StartingWeight => {
+  const placeholders = sessions
+    .map(resolveSessionPlaceholder)
+    .filter((weight) => weight.sharedWeightOneValue != null);
+
+  if (placeholders.length === 0) return DEFAULT_STARTING_WEIGHT;
+
+  const counts = new Map<string, { weight: StartingWeight; count: number }>();
+  for (const weight of placeholders) {
+    const key = weightKey(weight);
+    const existing = counts.get(key);
+    if (existing) existing.count += 1;
+    else counts.set(key, { weight, count: 1 });
+  }
+
+  const modal = [...counts.values()].sort((a, b) => {
+    if (b.count !== a.count) return b.count - a.count;
+    return (
+      (a.weight.sharedWeightOneValue ?? 0) -
+      (b.weight.sharedWeightOneValue ?? 0)
+    );
+  })[0];
+
+  return modal.weight;
+};


### PR DESCRIPTION
## What
Derive the enroll starting-weight dialog's pre-filled mode (2h/1h/double) and weight from the program being enrolled in, instead of a hardcoded double-24kg default.

## Why
PROD-232: the dialog's double-24kg pre-fill was only ever accurate for Dry Fighting Weight. It now fires for any non-owned public program, and the 5 new programs (Easy Strength, Snatch Test, Armor Building Complex, 10K Swing, A+A Protocol) have different equipment profiles — Snatch Test is single-bell, 10K Swing is two-hand-only. Accepting the pre-fill on any of those gave a misleading starting config. The picker was always fully editable, so this was a convenience/accuracy issue, not data loss — but worth fixing before the new programs make it visible.

A new `deriveStartingWeight` util computes the modal placeholder weight/mode across a program's own seeded sessions, mirroring the same priority (`resolveSharedWeights`) and modal tie-break (highest count, then lightest weight) that `enroll_in_program` already uses server-side, so the dialog's default now agrees with what the RPC would pick. `ProgramsPage` lazily loads the pending program's sessions via `useProgram` and seeds the picker once, guarded so it never flashes a stale default or clobbers a user's edits. DFW is unchanged — double-24kg is genuinely its modal. The `enroll_in_program` override mechanism itself is untouched; this only changes the dialog's default.

## How tested
Verified the derivation against all 6 live seeded programs' actual session data — the shipped `deriveStartingWeight`, run against real local-Supabase seeded sessions, yields two-hand for 10K Swing, single for Snatch Test / A+A, and double 24+24 for DFW / Armor / Easy Strength, matching intent. 20 shipped unit + component tests pass (including the fetch-error fallback and single-bell cases). Rendered the actual `ProgramsPage` enroll dialog DOM from live seeded sessions and screenshotted it — DFW shows two weight inputs, the single-bell/two-hand programs show one. Full evidence below.

## Tradeoffs
Considered keeping the hardcoded default and just widening it per-program via a lookup table, but that reintroduces the exact problem (a static value drifting from what a program's sessions actually specify) every time a new program lands — the derivation approach stays correct automatically as programs are added. Cost: an extra `useProgram` fetch and a brief loading state before the dialog is fully interactive, which the review gate flagged as a real risk (dialog could get stuck loading forever, blocking enrollment, if that fetch errored) — fixed on this branch with a `DEFAULT_STARTING_WEIGHT` fallback on fetch error so enrollment is never blocked.

- Evidence: Enroll dialog rendered per program (real ProgramsPage DOM from live seeded sessions): DFW→2 inputs (double 24+24), Snatch→1 input (single 24), 10K Swing→1 input (two-hand 24) (local file: <code>/var/folders/2p/zdp7pmgx05z1k3dd8xyttrv80000gn/T/no-mistakes-evidence/01KXNGXRTNXSR16ET84RR7QS9W/enroll-dialogs.png</code>)
<details>
<summary>Evidence: deriveStartingWeight() over LIVE seeded programs — derived enroll pre-fill per program</summary>

<code>PROGRAM SESS DERIVED ENROLL PRE-FILL&#10;------------------------------------------------------------------------------&#10;10,000 Swing Challenge 20 2H (two-hand) w1=24kg&#10;A+A Protocol &#34;Plan A&#34; 5 1H (single) w1=24kg&#10;Armor Building Complex 20 Double w1=24kg w2=24kg&#10;Dry Fighting Weight 14 Double w1=24kg w2=24kg&#10;Easy Strength 10 Double w1=24kg w2=24kg&#10;StrongFirst Snatch Test Training Plan 30 1H (single) w1=24kg</code>

```text
deriveStartingWeight() run against LIVE local-Supabase seeded programs
(what the enroll starting-weight dialog will pre-fill per program)

PROGRAM                                   SESS  DERIVED ENROLL PRE-FILL
------------------------------------------------------------------------------
10,000 Swing Challenge                      20   2H (two-hand)  w1=24kg
A+A Protocol "Plan A"                        5   1H (single)  w1=24kg
Armor Building Complex                      20   Double  w1=24kg  w2=24kg
Dry Fighting Weight                         14   Double  w1=24kg  w2=24kg
Easy Strength                               10   Double  w1=24kg  w2=24kg
StrongFirst Snatch Test Training Plan       30   1H (single)  w1=24kg
```
</details>
<details>
<summary>Evidence: Rendered dialog HTML (source for the screenshot)</summary>

```text
<!doctype html><html><head><meta charset="utf-8">
<script src="https://cdn.tailwindcss.com"></script>
<style>
  body{background:#0b0f19;color:#e5e7eb;font-family:system-ui,sans-serif;padding:24px;margin:0}
  h1{font-size:18px;margin:0 0 4px} .sub{color:#94a3b8;font-size:13px;margin-bottom:20px}
  .grid{display:flex;gap:20px;flex-wrap:wrap}
  .card{margin:0;background:#111827;border:1px solid #1f2937;border-radius:12px;padding:16px;width:340px}
  figcaption{font-size:13px;font-weight:600;color:#a5b4fc;margin-bottom:12px}
  .frame [role=dialog]{position:static !important;transform:none !important;inset:auto !important;
    background:#020617;border:1px solid #334155;border-radius:10px;padding:16px;max-width:none;width:100%;color:#e5e7eb}
  .frame [role=dialog] button:last-of-type{background:#4f46e5;color:#fff}
  .frame input{background:#0f172a;color:#fff;border:1px solid #334155;border-radius:6px;padding:4px 8px}
  .frame [role=tablist]{display:inline-flex;gap:4px;background:#0f172a;border-radius:8px;padding:3px;margin-bottom:8px}
  .frame [role=tab]{padding:4px 10px;border-radius:6px;font-size:13px}
  .frame [role=tab][data-state=active],.frame [role=tab][aria-selected=true]{background:#4f46e5;color:#fff}
  .frame [role=dialog] button{border:1px solid #334155;border-radius:6px;padding:5px 10px;margin:2px;font-size:13px}
  .frame p{font-size:13px} .frame h2{font-size:15px;font-weight:600;margin:0 0 6px}
</style></head><body>
<h1>Enroll starting-weight dialog — pre-fill derived per program (PROD-232)</h1>
<div class="sub">Actual ProgramsPage dialog DOM, rendered from LIVE local-Supabase seeded sessions. Note the input count &amp; selected mode differ per program.</div>
<div class="grid"><figure class="card"><figcaption>Snatch Test → single-bell (1H), modal 24kg</figcaption><div class="frame"><div role="dialog" id="radix-:r3:" aria-describedby="radix-:r5:" aria-labelledby="radix-:r4:" data-state="open" class="fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-2 border bg-background p-3 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%]" tabindex="-1" style="pointer-events: auto;"><div class="flex flex-col space-y-1.5 text-center sm:text-left"><h2 id="radix-:r4:" class="text-lg font-semibold leading-none tracking-tight">Starting weight</h2><p id="radix-:r5:" class="text-sm text-muted-foreground">Set the weight your working sessions in this program start with. You can still adjust it session by session once you're in the program.</p></div><div class="flex flex-col gap-1"><div dir="ltr" data-orientation="horizontal" class="w-full"><div role="tablist" aria-orientation="horizontal" class="items-center justify-center rounded-md bg-muted p-0.5 text-muted-foreground flex w-full" tabindex="0" data-orientation="horizontal" style="outline: none;"><button type="button" role="tab" aria-selected="false" aria-controls="radix-:r6:-content-2h" data-state="inactive" id="radix-:r6:-trigger-2h" class="py-0.5 text-xs inline-flex items-center justify-center whitespace-nowrap rounded-md font-medium transition-all ring-offset-background focus-visible:ring-ring data-[state=active]:bg-background data-[state=active]:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:shadow min-w-0 flex-1 px-0.5" tabindex="-1" data-orientation="horizontal" data-radix-collection-item="">Two-Hand</button><button type="button" role="tab" aria-selected="true" aria-controls="radix-:r6:-content-1h" data-state="active" id="radix-:r6:-trigger-1h" class="py-0.5 text-xs inline-flex items-center justify-center whitespace-nowrap rounded-md font-medium transition-all ring-offset-background focus-visible:ring-ring data-[state=active]:bg-background data-[state=active]:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:shadow min-w-0 flex-1 px-0.5" tabindex="-1" data-orientation="horizontal" data-radix-collection-item="">Single</button><button type="button" role="tab" aria-selected="false" aria-controls="radix-:r6:-content-double" data-state="inactive" id="radix-:r6:-trigger-double" class="py-0.5 text-xs inline-flex items-center justify-center whitespace-nowrap rounded-md font-medium transition-all ring-offset-background focus-visible:ring-ring data-[state=active]:bg-background data-[state=active]:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:shadow min-w-0 flex-1 px-0.5" tabindex="-1" data-orientation="horizontal" data-radix-collection-item="">Double</button></div></div><div class="grid grid-cols-3 gap-5"><div class="flex items-center justify-end"><button class="inline-flex items-center rounded-md justify-center whitespace-nowrap text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 bg-primary text-primary-foreground shadow hover:bg-primary/90 h-4 w-4" aria-label="- kg"><svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true" data-slot="icon" class="h-2.5 w-2.5"><path stroke-linecap="round" stroke-linejoin="round" d="M5 12h14"></path></svg></button></div><div class="flex flex-col items-center justify-center gap-1"><input type="number" class="flex h-4 w-full rounded-md border border-input bg-transparent px-1 py-0.5 text-base shadow-sm transition-colors disabled:cursor-not-allowed disabled:opacity-50 file:border-0 file:bg-transparent file:text-sm file:font-medium focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring placeholder:text-muted-foreground text-center [&amp;::-webkit-inner-spin-button]:appearance-none [&amp;::-webkit-outer-spin-button]:appearance-none" value="24"><div dir="ltr" data-orientation="horizontal"><div role="tablist" aria-orientation="horizontal" class="inline-flex items-center justify-center rounded-md bg-muted p-0.5 text-muted-foreground" tabindex="0" data-orientation="horizontal" style="outline: none;"><button type="button" role="tab" aria-selected="true" aria-controls="radix-:ra:-content-kilograms" data-state="active" id="radix-:ra:-trigger-kilograms" class="px-1 py-0.5 text-xs inline-flex items-center justify-center whitespace-nowrap rounded-md font-medium transition-all ring-offset-background focus-visible:ring-ring data-[state=active]:bg-background data-[state=active]:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:shadow" tabindex="-1" data-orientation="horizontal" data-radix-collection-item="">kg</button><button type="button" role="tab" aria-selected="false" aria-controls="radix-:ra:-content-pounds" data-state="inactive" id="radix-:ra:-trigger-pounds" class="px-1 py-0.5 text-xs inline-flex items-center justify-center whitespace-nowrap rounded-md font-medium transition-all ring-offset-background focus-visible:ring-ring data-[state=active]:bg-background data-[state=active]:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:shadow" tabindex="-1" data-orientation="horizontal" data-radix-collection-item="">lb</button></div></div></div><div class="flex items-center justify-start"><button class="inline-flex items-center rounded-md justify-center whitespace-nowrap text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 bg-primary text-primary-foreground shadow hover:bg-primary

... [14645 bytes truncated] ...

1.5" stroke="currentColor" aria-hidden="true" data-slot="icon" class="h-2.5 w-2.5"><path stroke-linecap="round" stroke-linejoin="round" d="M5 12h14"></path></svg></button></div><div class="flex flex-col items-center justify-center gap-1"><input type="number" class="flex h-4 w-full rounded-md border border-input bg-transparent px-1 py-0.5 text-base shadow-sm transition-colors disabled:cursor-not-allowed disabled:opacity-50 file:border-0 file:bg-transparent file:text-sm file:font-medium focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring placeholder:text-muted-foreground text-center [&amp;::-webkit-inner-spin-button]:appearance-none [&amp;::-webkit-outer-spin-button]:appearance-none" value="24"><div dir="ltr" data-orientation="horizontal"><div role="tablist" aria-orientation="horizontal" class="inline-flex items-center justify-center rounded-md bg-muted p-0.5 text-muted-foreground" tabindex="0" data-orientation="horizontal" style="outline: none;"><button type="button" role="tab" aria-selected="true" aria-controls="radix-:r14:-content-kilograms" data-state="active" id="radix-:r14:-trigger-kilograms" class="px-1 py-0.5 text-xs inline-flex items-center justify-center whitespace-nowrap rounded-md font-medium transition-all ring-offset-background focus-visible:ring-ring data-[state=active]:bg-background data-[state=active]:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:shadow" tabindex="-1" data-orientation="horizontal" data-radix-collection-item="">kg</button><button type="button" role="tab" aria-selected="false" aria-controls="radix-:r14:-content-pounds" data-state="inactive" id="radix-:r14:-trigger-pounds" class="px-1 py-0.5 text-xs inline-flex items-center justify-center whitespace-nowrap rounded-md font-medium transition-all ring-offset-background focus-visible:ring-ring data-[state=active]:bg-background data-[state=active]:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:shadow" tabindex="-1" data-orientation="horizontal" data-radix-collection-item="">lb</button></div></div></div><div class="flex items-center justify-start"><button class="inline-flex items-center rounded-md justify-center whitespace-nowrap text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 bg-primary text-primary-foreground shadow hover:bg-primary/90 h-4 w-4" aria-label="+ kg"><svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true" data-slot="icon" class="h-2.5 w-2.5"><path stroke-linecap="round" stroke-linejoin="round" d="M12 4.5v15m7.5-7.5h-15"></path></svg></button></div></div><div class="grid grid-cols-3 gap-5"><div class="flex items-center justify-end"><button class="inline-flex items-center rounded-md justify-center whitespace-nowrap text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 bg-primary text-primary-foreground shadow hover:bg-primary/90 h-4 w-4" aria-label="- kg"><svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true" data-slot="icon" class="h-2.5 w-2.5"><path stroke-linecap="round" stroke-linejoin="round" d="M5 12h14"></path></svg></button></div><div class="flex flex-col items-center justify-center gap-1"><input type="number" class="flex h-4 w-full rounded-md border border-input bg-transparent px-1 py-0.5 text-base shadow-sm transition-colors disabled:cursor-not-allowed disabled:opacity-50 file:border-0 file:bg-transparent file:text-sm file:font-medium focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring placeholder:text-muted-foreground text-center [&amp;::-webkit-inner-spin-button]:appearance-none [&amp;::-webkit-outer-spin-button]:appearance-none" value="24"><div dir="ltr" data-orientation="horizontal"><div role="tablist" aria-orientation="horizontal" class="inline-flex items-center justify-center rounded-md bg-muted p-0.5 text-muted-foreground" tabindex="0" data-orientation="horizontal" style="outline: none;"><button type="button" role="tab" aria-selected="true" aria-controls="radix-:r17:-content-kilograms" data-state="active" id="radix-:r17:-trigger-kilograms" class="px-1 py-0.5 text-xs inline-flex items-center justify-center whitespace-nowrap rounded-md font-medium transition-all ring-offset-background focus-visible:ring-ring data-[state=active]:bg-background data-[state=active]:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:shadow" tabindex="-1" data-orientation="horizontal" data-radix-collection-item="">kg</button><button type="button" role="tab" aria-selected="false" aria-controls="radix-:r17:-content-pounds" data-state="inactive" id="radix-:r17:-trigger-pounds" class="px-1 py-0.5 text-xs inline-flex items-center justify-center whitespace-nowrap rounded-md font-medium transition-all ring-offset-background focus-visible:ring-ring data-[state=active]:bg-background data-[state=active]:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:shadow" tabindex="-1" data-orientation="horizontal" data-radix-collection-item="">lb</button></div></div></div><div class="flex items-center justify-start"><button class="inline-flex items-center rounded-md justify-center whitespace-nowrap text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 bg-primary text-primary-foreground shadow hover:bg-primary/90 h-4 w-4" aria-label="+ kg"><svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true" data-slot="icon" class="h-2.5 w-2.5"><path stroke-linecap="round" stroke-linejoin="round" d="M12 4.5v15m7.5-7.5h-15"></path></svg></button></div></div></div><div class="flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2"><button class="inline-flex items-center rounded-md justify-center whitespace-nowrap font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 bg-secondary text-secondary-foreground shadow-sm hover:bg-secondary/80 h-4 px-2 text-sm">Cancel</button><button class="inline-flex items-center rounded-md justify-center whitespace-nowrap font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 bg-primary text-primary-foreground shadow hover:bg-primary/90 h-4 px-2 text-sm">Start program</button></div><button type="button" class="absolute right-2 top-2 opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground"><svg width="15" height="15" viewBox="0 0 15 15" fill="none" xmlns="http://www.w3.org/2000/svg" class="h-2.5 w-2.5"><path d="M11.7816 4.03157C12.0062 3.80702 12.0062 3.44295 11.7816 3.2184C11.5571 2.99385 11.193 2.99385 10.9685 3.2184L7.50005 6.68682L4.03164 3.2184C3.80708 2.99385 3.44301 2.99385 3.21846 3.2184C2.99391 3.44295 2.99391 3.80702 3.21846 4.03157L6.68688 7.49999L3.21846 10.9684C2.99391 11.193 2.99391 11.557 3.21846 11.7816C3.44301 12.0061 3.80708 12.0061 4.03164 11.7816L7.50005 8.31316L10.9685 11.7816C11.193 12.0061 11.5571 12.0061 11.7816 11.7816C12.0062 11.557 12.0062 11.193 11.7816 10.9684L8.31322 7.49999L11.7816 4.03157Z" fill="currentColor" fill-rule="evenodd" clip-rule="evenodd"></path></svg><span class="sr-only">Close</span></button></div></div></figure></div>
</body></html>
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ `src/pages/ProgramsPage/ProgramsPage.tsx:84` - The enroll starting-weight dialog gates on `startingWeightReady`, which only flips true when the seeding effect runs — and that effect requires `pendingProgram` (from `useProgram`) to be truthy. If the program-sessions fetch fails, `pendingProgram` stays undefined forever, so the dialog is stuck showing &#34;Loading…&#34; with the &#34;Start program&#34; button permanently disabled (line 460: `disabled={... || !startingWeightReady}`). The user&#39;s only recourse is Cancel — they cannot enroll. This is a regression from the prior behavior, where a fixed double-24kg default always let enrollment proceed. Consider seeding the `DEFAULT_STARTING_WEIGHT` and marking ready on `useProgram` error (destructure `isError`/`error`) so the dialog degrades gracefully instead of bricking a core action.

🔧 Fix: fix(programs): unblock enroll weight dialog on program fetch error
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`npx vitest run src/pages/ProgramsPage/utils/deriveStartingWeight.test.ts src/pages/ProgramsPage/ProgramsPage.test.tsx` — 20 shipped unit + component tests pass (includes single-bell pre-fill and fetch-error editable-fallback cases)</code>
- <code>Ran the shipped `deriveStartingWeight` against LIVE local-Supabase seeded session data (all 6 public programs queried from `program_sessions`), asserting DFW→[24,24], Snatch→two null, 10K Swing→two null (two-hand) — output captured in `derive-live-seeded.txt`</code>
- <code>Rendered the actual ProgramsPage enroll dialog DOM for Snatch/10K Swing/DFW from live seeded sessions and screenshotted it (`enroll-dialogs.png`)</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>

