### PR TITLE
feat(launchpad): gate start-screen shell behind master flag with population routing and exposure logging

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,7 +102,7 @@ pages/
 - Supabase client is the `supabase` named export from `~/supabaseClient`.
 - Query keys are defined in `src/constants/queries.enum.ts`.
 - `npm run gen:types` writes the **repo-root** `types/supabase.ts` — commit that file after any schema change (requires `supabase start` to be running). `src/types/supabase.ts` is just a 3-line alias (`export type Supabase = Database`) re-exporting the root file; it is not regenerated.
-- Schema changes that must reach **production** (e.g. seeded shared content) belong in a **migration**, not `supabase/seed.sql`. Production only ever applies migrations (forward-only `db push`); `seed.sql` never reaches it. Staging is rebuilt with `db reset --linked`, which replays migrations *and* runs `seed.sql`, so seed data reaches staging but stops there. See `.github/workflows/supabase-*.yaml`.
+- Schema changes that must reach **production** (e.g. seeded shared content) belong in a **migration**, not `supabase/seed.sql`. Production only ever applies migrations (forward-only `db push`); `seed.sql` never reaches it. Staging is rebuilt with `db reset --linked`, which replays migrations _and_ runs `seed.sql`, so seed data reaches staging but stops there. See `.github/workflows/supabase-*.yaml`.
 
 ## Movement Catalog (PROD-153)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -286,8 +286,8 @@ the release-toggle flags in `~/config/features`, which stay build-time).
   written, so re-enabling later re-buckets fresh.
 * `useFeatureFlags()` returns that record alongside an `isPending` gate. It maps
   DB variants to the app-facing `ExperimentFeatures` boolean record
-  (`curatedFirstWorkout`, `repeatPrevious`, `recommender` — the PROD-174
-  discovery flags plus the AI recommender), falling back to
+  (`launchpadShell` — the PROD-171 master gate — plus `curatedFirstWorkout`,
+  `repeatPrevious`, `recommender`), falling back to
   `SAFE_DEFAULT_FEATURES` (all off) on any query error, while loading, and when
   unauthenticated — the eval client never flips a user into treatment on
   failure. `staleTime: Infinity` since assignment is server-sticky. Owners
@@ -315,6 +315,29 @@ false` **or** an independent hard timeout (`FLAGS_TIMEOUT_MS`, ~1.75s),
   to the migration's seed `INSERT` (defaulted `enabled = false` to preserve
   current behavior), and swap the read site from `useFeatures()` to
   `useFeatureFlags()`.
+
+## Launchpad Shell (PROD-171)
+
+The launchpad "start screen" is gated behind **one master runtime flag**,
+`launchpad_shell` (seed migration `*_seed_launchpad_shell_flag.sql`), not a pile
+of per-content flags. It lives entirely in `StartWorkoutPage.tsx`:
+
+- **Master gate:** `experimentFeatures.launchpadShell` OFF → the pure custom
+  builder (the true control baseline); ON → the browse shell. An active program
+  still forces browse independently (separate `programs` release feature).
+- **Population routing** (derived from `useWorkoutLogs()` count, tri-state
+  `isFirstWorkout`): new user (0 logs) → curated first-workout content; returning
+  (≥1) → repeat-previous + build-custom, plus the Phase-2 `recommender` nested
+  flag. Content is routed by population, **not** by the old `curated_first_workout`
+  / `repeat_previous` flags — those are retained in the registry for optionality
+  but no longer gate the shell.
+- **Exposure logging:** the `launchpad_exposed` analytics event
+  (`AnalyticsEvent.LaunchpadExposed`, fired once per mount from a `useEffect`)
+  records `{ shell_variant, population, content }`, keyed by `user_id` so it joins
+  to the PROD-170 funnel events in `analytics_events`. The sticky assignment
+  itself is the server-side `feature_flag_assignments` row. Behavior is covered by
+  `StartWorkoutPage.launchpad.test.jsx` (gate + logging) and
+  `StartWorkoutPage.recommendations.test.jsx` (population content).
 
 ## Authentication
 

--- a/src/api/analytics.ts
+++ b/src/api/analytics.ts
@@ -12,6 +12,10 @@ export enum AnalyticsEvent {
   FirstSessionStarted = 'first_session_started',
   WorkoutStarted = 'workout_started',
   WorkoutCompleted = 'workout_completed',
+  // Launchpad shell exposure (PROD-171): records the sticky shell variant, the
+  // user's population (new/returning), and the content shown, so the launchpad
+  // A/B is joinable to the funnel events above by `user_id`.
+  LaunchpadExposed = 'launchpad_exposed',
   // AI Next Session Recommender (PROD-89).
   RecommendationRequested = 'recommendation_requested',
   RecommendationAccepted = 'recommendation_accepted',

--- a/src/api/useFeatureFlags.test.ts
+++ b/src/api/useFeatureFlags.test.ts
@@ -51,6 +51,7 @@ describe('fetchExperimentFeatures', () => {
     );
 
     await expect(fetchExperimentFeatures()).resolves.toEqual({
+      launchpadShell: false,
       curatedFirstWorkout: true,
       repeatPrevious: false,
       recommender: true,
@@ -73,6 +74,7 @@ describe('fetchExperimentFeatures', () => {
 
     expect(first).toEqual(second);
     expect(first).toEqual({
+      launchpadShell: false,
       curatedFirstWorkout: true,
       repeatPrevious: true,
       recommender: false,
@@ -110,6 +112,7 @@ describe('useFeatureFlags', () => {
     expect(result.current.isPending).toBe(true);
     await waitFor(() =>
       expect(result.current.features).toEqual({
+        launchpadShell: false,
         curatedFirstWorkout: true,
         repeatPrevious: false,
         recommender: false,

--- a/src/config/experiments.test.ts
+++ b/src/config/experiments.test.ts
@@ -30,6 +30,7 @@ describe('resolveExperimentFeatures', () => {
   test('every flag in treatment matches ALL_EXPERIMENT_FEATURES_ON', () => {
     expect(
       resolveExperimentFeatures({
+        launchpad_shell: 'treatment',
         curated_first_workout: 'treatment',
         repeat_previous: 'treatment',
         recommender: 'treatment',

--- a/src/config/experiments.ts
+++ b/src/config/experiments.ts
@@ -13,6 +13,15 @@
  */
 
 export const EXPERIMENT_FLAG_KEYS = [
+  // Master gate for the launchpad "start screen" shell (PROD-171). Treatment =
+  // land on the launchpad; control = drop straight into the pure custom builder
+  // (the true baseline). Repeat-previous and curated are *content* of the shell,
+  // not their own gates — this one flag decides shell vs. builder for both the
+  // new-user activation test (PROD-172) and the returning-user retention test.
+  'launchpad_shell',
+  // Retained for optionality (PROD-171 builds all the flags now), but no longer
+  // the gate: shell content is routed by population, not these. `recommender` is
+  // still read as the Phase-2 nested content flag inside the returning-user shell.
   'curated_first_workout',
   'repeat_previous',
   'recommender',
@@ -26,6 +35,7 @@ export const TREATMENT_VARIANT = 'treatment';
 
 /** App-facing boolean record for the migrated experiment flags. */
 export interface ExperimentFeatures {
+  launchpadShell: boolean;
   curatedFirstWorkout: boolean;
   repeatPrevious: boolean;
   recommender: boolean;
@@ -33,6 +43,7 @@ export interface ExperimentFeatures {
 
 /** DB flag key → app-facing boolean field. */
 const KEY_TO_FEATURE: Record<ExperimentFlagKey, keyof ExperimentFeatures> = {
+  launchpad_shell: 'launchpadShell',
   curated_first_workout: 'curatedFirstWorkout',
   repeat_previous: 'repeatPrevious',
   recommender: 'recommender',
@@ -46,6 +57,7 @@ const KEY_TO_FEATURE: Record<ExperimentFlagKey, keyof ExperimentFeatures> = {
  * error.
  */
 export const SAFE_DEFAULT_FEATURES: ExperimentFeatures = {
+  launchpadShell: false,
   curatedFirstWorkout: false,
   repeatPrevious: false,
   recommender: false,
@@ -53,6 +65,7 @@ export const SAFE_DEFAULT_FEATURES: ExperimentFeatures = {
 
 /** Every experiment feature ON — used only for the owner preview override. */
 export const ALL_EXPERIMENT_FEATURES_ON: ExperimentFeatures = {
+  launchpadShell: true,
   curatedFirstWorkout: true,
   repeatPrevious: true,
   recommender: true,

--- a/src/pages/StartWorkoutPage/StartWorkoutPage.launchpad.test.jsx
+++ b/src/pages/StartWorkoutPage/StartWorkoutPage.launchpad.test.jsx
@@ -1,0 +1,207 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { HttpResponse, http } from 'msw';
+import { QueryClient, QueryClientProvider } from 'react-query';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+
+import {
+  DEFAULT_WORKOUT_OPTIONS,
+  EntitlementContext,
+  SessionProvider,
+  WorkoutOptionsContext,
+} from '~/contexts';
+import { VITE_SUPABASE_URL } from '~/env';
+import { server } from '~/mocks/server';
+
+import { StartWorkoutPage } from './StartWorkoutPage';
+
+// The launchpad shell (PROD-171) is the master gate. These tests exercise the
+// gate itself and the exposure logging, so both the flag hook and trackEvent are
+// mocked: the flag hook is driven per-test, and trackEvent is a spy asserting the
+// launchpad_exposed event's variant / population / content payload.
+const { mockUseFeatureFlags, mockTrackEvent } = vi.hoisted(() => ({
+  mockUseFeatureFlags: vi.fn(),
+  mockTrackEvent: vi.fn(),
+}));
+
+vi.mock('~/api', async (importOriginal) => ({
+  ...(await importOriginal()),
+  useFeatureFlags: mockUseFeatureFlags,
+  trackEvent: mockTrackEvent,
+}));
+
+const ALL_OFF = {
+  launchpadShell: false,
+  curatedFirstWorkout: false,
+  repeatPrevious: false,
+  recommender: false,
+};
+
+const setFlags = (overrides = {}) =>
+  mockUseFeatureFlags.mockReturnValue({
+    features: { ...ALL_OFF, ...overrides },
+    isPending: false,
+  });
+
+const mockSession = {
+  user: {
+    id: 'user-123',
+    app_metadata: {},
+    user_metadata: {},
+    created_at: '',
+    aud: '',
+  },
+  access_token: '',
+  refresh_token: '',
+  expires_in: 10000,
+  token_type: '',
+};
+
+const freeEntitlement = {
+  isPremium: false,
+  isTrialing: false,
+  trialExpired: false,
+  trialDaysRemaining: null,
+  effectiveAccess: 'free',
+  isLoading: false,
+  refetch: () => {},
+};
+
+const makeQueryClient = () =>
+  new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+
+const renderPage = () =>
+  render(
+    <QueryClientProvider client={makeQueryClient()}>
+      <MemoryRouter initialEntries={['/']}>
+        <SessionProvider value={mockSession}>
+          <EntitlementContext.Provider value={freeEntitlement}>
+            <WorkoutOptionsContext.Provider
+              value={[DEFAULT_WORKOUT_OPTIONS, vi.fn()]}
+            >
+              <Routes>
+                <Route path="/" element={<StartWorkoutPage />} />
+                <Route
+                  path="/active"
+                  element={<div>active workout page</div>}
+                />
+              </Routes>
+            </WorkoutOptionsContext.Provider>
+          </EntitlementContext.Provider>
+        </SessionProvider>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+
+// Default MSW returns a user with history (returning); override for a new user.
+const returnZeroWorkoutLogs = () =>
+  server.use(
+    http.get(`${VITE_SUPABASE_URL}/rest/v1/workout_logs`, () =>
+      HttpResponse.json([]),
+    ),
+  );
+
+beforeEach(() => {
+  mockTrackEvent.mockClear();
+});
+
+describe('StartWorkoutPage — launchpad shell master gate', () => {
+  describe('shell OFF (control)', () => {
+    test('drops a returning user straight into the pure builder', async () => {
+      setFlags(); // all off — true control baseline
+      renderPage();
+
+      // Pure builder: the movement input is present with no browse surface and
+      // no escape-hatch button (that only exists inside the shell).
+      expect(
+        await screen.findByLabelText('Movement Input'),
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByRole('button', { name: /build custom workout/i }),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByText('Pick up where you left off'),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole('button', { name: 'Two-Hand Swing' }),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  describe('shell ON — content routed by the master flag alone', () => {
+    test('a new user sees curated first-workout content (no sub-flags needed)', async () => {
+      returnZeroWorkoutLogs();
+      setFlags({ launchpadShell: true });
+      renderPage();
+
+      expect(
+        await screen.findByRole('button', { name: 'Two-Hand Swing' }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole('heading', { name: 'Your recommended first workout' }),
+      ).toBeInTheDocument();
+      // New-user shell is curated, not repeat-previous.
+      expect(
+        screen.queryByText('Pick up where you left off'),
+      ).not.toBeInTheDocument();
+    });
+
+    test('a returning user sees repeat-previous content (no sub-flags needed)', async () => {
+      setFlags({ launchpadShell: true });
+      renderPage();
+
+      expect(
+        await screen.findByText('Pick up where you left off'),
+      ).toBeInTheDocument();
+      // Returning-user shell is repeat-previous, not curated.
+      expect(
+        screen.queryByRole('heading', { name: 'Recommended sessions' }),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  describe('exposure logging (joinable to the PROD-170 funnel by user_id)', () => {
+    test('logs the treatment exposure for a new user in the shell', async () => {
+      returnZeroWorkoutLogs();
+      setFlags({ launchpadShell: true });
+      renderPage();
+
+      await waitFor(() =>
+        expect(mockTrackEvent).toHaveBeenCalledWith(
+          expect.objectContaining({
+            event: 'launchpad_exposed',
+            userId: 'user-123',
+            properties: expect.objectContaining({
+              shell_variant: 'on',
+              population: 'new',
+              content: expect.arrayContaining([
+                'curated_first',
+                'build_custom',
+              ]),
+            }),
+          }),
+        ),
+      );
+    });
+
+    test('logs the control exposure (pure builder) for a returning user', async () => {
+      setFlags(); // all off
+      renderPage();
+
+      await waitFor(() =>
+        expect(mockTrackEvent).toHaveBeenCalledWith(
+          expect.objectContaining({
+            event: 'launchpad_exposed',
+            userId: 'user-123',
+            properties: expect.objectContaining({
+              shell_variant: 'off',
+              population: 'returning',
+              content: ['builder'],
+            }),
+          }),
+        ),
+      );
+    });
+  });
+});

--- a/src/pages/StartWorkoutPage/StartWorkoutPage.recommendations.test.jsx
+++ b/src/pages/StartWorkoutPage/StartWorkoutPage.recommendations.test.jsx
@@ -15,10 +15,10 @@ import { server } from '~/mocks/server';
 
 import { StartWorkoutPage } from './StartWorkoutPage';
 
-// These discovery surfaces (curated / repeat / recommender) migrated off the
-// build-time env flags onto the runtime feature-flag mechanism (PROD-175) —
-// force them on so this suite still exercises the browse-mode behavior it did
-// under the old always-on test-env flags.
+// The launchpad shell (PROD-171) is the master gate: with it on the page opens
+// in browse mode, and content is routed by population — curated for new users,
+// repeat-previous for returning. The content sub-flags are on too so the
+// recommender surface mounts for a returning user.
 const { mockUseFeatureFlags } = vi.hoisted(() => ({
   mockUseFeatureFlags: vi.fn(),
 }));
@@ -28,6 +28,7 @@ vi.mock('~/api', async (importOriginal) => ({
 }));
 mockUseFeatureFlags.mockReturnValue({
   features: {
+    launchpadShell: true,
     curatedFirstWorkout: true,
     repeatPrevious: true,
     recommender: true,
@@ -155,17 +156,22 @@ describe('StartWorkoutPage recommendations', () => {
   });
 
   describe('returning user (has history)', () => {
-    test('shows recent repeats alongside the curated workouts', async () => {
+    test('shows recent repeats and the build-custom entry, but not curated', async () => {
       renderPage();
 
       expect(
         await screen.findByText('Pick up where you left off'),
       ).toBeInTheDocument();
+      // Curated first-workout content is routed to new users only — a returning
+      // user's shell is repeat-previous + build custom (PROD-171).
       expect(
-        screen.getByRole('heading', { name: 'Recommended sessions' }),
-      ).toBeInTheDocument();
+        screen.queryByRole('heading', { name: 'Recommended sessions' }),
+      ).not.toBeInTheDocument();
       expect(
-        screen.getByRole('button', { name: 'Two-Hand Swing' }),
+        screen.queryByRole('button', { name: 'Two-Hand Swing' }),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.getByRole('button', { name: /build custom workout/i }),
       ).toBeInTheDocument();
     });
 

--- a/src/pages/StartWorkoutPage/StartWorkoutPage.test.jsx
+++ b/src/pages/StartWorkoutPage/StartWorkoutPage.test.jsx
@@ -14,10 +14,10 @@ import {
 import { StartWorkoutPage } from './StartWorkoutPage';
 import * as stories from './StartWorkoutPage.stories';
 
-// These discovery surfaces (curated / repeat / recommender) migrated off the
-// build-time env flags onto the runtime feature-flag mechanism (PROD-175) —
-// force them on so this suite still opens in browse mode (enterBuildMode()
-// below) the way it did under the old always-on test-env flags.
+// The launchpad shell is the master gate (PROD-171): with it on, the page opens
+// in browse mode and this suite reaches the builder via enterBuildMode() below.
+// The content sub-flags are forced on too so the recommender surface still
+// mounts under EntitlementContext for a returning user.
 const { mockUseFeatureFlags } = vi.hoisted(() => ({
   mockUseFeatureFlags: vi.fn(),
 }));
@@ -27,6 +27,7 @@ vi.mock('~/api', async (importOriginal) => ({
 }));
 mockUseFeatureFlags.mockReturnValue({
   features: {
+    launchpadShell: true,
     curatedFirstWorkout: true,
     repeatPrevious: true,
     recommender: true,

--- a/src/pages/StartWorkoutPage/StartWorkoutPage.tsx
+++ b/src/pages/StartWorkoutPage/StartWorkoutPage.tsx
@@ -121,18 +121,36 @@ export const StartWorkoutPage = ({
     !activeProgramQuery.isError;
   const completeProgramSession = useCompleteProgramSession();
 
-  // Discovery surfaces are individually flag-gated (PROD-174); with all of
-  // them off the page is the pure custom builder. Save-session mode never
-  // browses; an active program forces browse so its card is seen first.
-  const showCurated = experimentFeatures.curatedFirstWorkout;
-  const showRepeat = experimentFeatures.repeatPrevious;
+  // Population signal for the launchpad (PROD-171): a user with zero workout
+  // logs is "new". `isFirstWorkout` is tri-state — null while the logs query
+  // loads, so we never treat a genuine first-timer as returning before it
+  // resolves. The funnel effect below reuses these, so they're derived once.
+  const session = useSession();
+  const userId = session?.user?.id;
+  const { data: workoutLogs } = useWorkoutLogs();
+  const isFirstWorkout =
+    workoutLogs === undefined ? null : workoutLogs.length === 0;
+  const population: 'new' | 'returning' | null =
+    isFirstWorkout === null ? null : isFirstWorkout ? 'new' : 'returning';
+
+  // Master gate (PROD-171): the launchpad shell replaces the pure custom builder
+  // when its flag resolves to treatment; control drops straight into the builder
+  // (the true baseline). Content inside the shell is routed by population, not by
+  // standalone content flags. An active program still forces the shell — it's a
+  // separate release feature, orthogonal to the experiment. Save-session mode
+  // never browses.
+  const shellOn = experimentFeatures.launchpadShell;
   const showBrowse =
-    !programSaveMode &&
-    (hasActiveProgram ||
-      programGatePending ||
-      showCurated ||
-      showRepeat ||
-      experimentFeatures.recommender);
+    !programSaveMode && (shellOn || hasActiveProgram || programGatePending);
+
+  // Population-routed shell content: curated first workout for new users,
+  // repeat-previous for returning. The AI next-session recommender is Phase-2
+  // nested content within the shell for returning users (its own flag), not a
+  // standalone browse trigger.
+  const showCurated = shellOn && population === 'new';
+  const showRepeat = shellOn && population === 'returning';
+  const showRecommender =
+    shellOn && population === 'returning' && experimentFeatures.recommender;
 
   // Browse mode shows recommendations plus a Build-custom button; the builder
   // opens directly when there's nothing to browse or when history's "Repeat"
@@ -165,15 +183,6 @@ export const StartWorkoutPage = ({
   // Save-session mode only: the title for the program session being authored.
   const [sessionTitle, setSessionTitle] = useState<string>('');
 
-  // Activation funnel (PROD-157): a user with zero workout logs is "new".
-  // While the logs query is still loading (workoutLogs === undefined) we don't
-  // yet know, so emit null rather than a misleading `false` for a genuine
-  // first-timer who taps Start before the query resolves.
-  const session = useSession();
-  const userId = session?.user?.id;
-  const { data: workoutLogs } = useWorkoutLogs();
-  const isFirstWorkout =
-    workoutLogs === undefined ? null : workoutLogs.length === 0;
   const firstSessionTracked = useRef(false);
 
   useEffect(
@@ -191,6 +200,56 @@ export const StartWorkoutPage = ({
     // Depend on the stable user id, not the session object (which is replaced on
     // every token refresh), so this effect doesn't needlessly re-run.
     [userId, workoutLogs],
+  );
+
+  // Launchpad exposure (PROD-171): once the shell decision is settled, log which
+  // variant / population / content the user landed on, keyed by user_id so it
+  // joins to the PROD-170 funnel events. Fires once per mount; the sticky
+  // assignment itself lives server-side in feature_flag_assignments.
+  const launchpadExposureTracked = useRef(false);
+
+  useEffect(
+    function trackLaunchpadExposure() {
+      if (launchpadExposureTracked.current) return;
+      if (programSaveMode || editWorkout) return;
+      if (!userId || population === null || programGatePending) return;
+
+      launchpadExposureTracked.current = true;
+
+      const content: string[] = [];
+      if (showBrowse) {
+        if (hasActiveProgram) content.push('program');
+        if (showCurated) content.push('curated_first');
+        if (showRepeat) content.push('repeat_previous');
+        if (showRecommender) content.push('recommender');
+        content.push('build_custom');
+      } else {
+        content.push('builder');
+      }
+
+      void trackEvent({
+        event: AnalyticsEvent.LaunchpadExposed,
+        userId,
+        properties: {
+          shell_variant: shellOn ? 'on' : 'off',
+          population,
+          content,
+        },
+      });
+    },
+    [
+      userId,
+      population,
+      programGatePending,
+      programSaveMode,
+      editWorkout,
+      showBrowse,
+      hasActiveProgram,
+      showCurated,
+      showRepeat,
+      showRecommender,
+      shellOn,
+    ],
   );
 
   const [workoutGoal, setWorkoutGoal] = useState<number>(
@@ -668,7 +727,7 @@ export const StartWorkoutPage = ({
             onSelectRepeat={handleSelectRepeat}
           />
 
-          {experimentFeatures.recommender && (
+          {showRecommender && (
             <RecommendSessionSection
               userId={userId}
               onAccept={handleAcceptRecommendation}

--- a/supabase/migrations/20260716080720_seed_launchpad_shell_flag.sql
+++ b/supabase/migrations/20260716080720_seed_launchpad_shell_flag.sql
@@ -1,0 +1,16 @@
+-- Launchpad shell master flag (PROD-171).
+--
+-- The launchpad "start screen" shell is gated behind ONE master runtime flag on
+-- the PROD-175 mechanism, rather than a pile of per-content flags. Treatment =
+-- the user lands on the launchpad first; control = they drop straight into the
+-- pure custom builder, restoring a true pure-builder baseline. Repeat-previous
+-- and curated workouts are content of the shell (routed by population), not
+-- their own gates.
+--
+-- Seeded with the shared defaults (enabled=false, rollout_percentage=0,
+-- default_variant='control'), so every user resolves to control (pure builder)
+-- until the flag is deliberately toggled via Studio/SQL — production behavior is
+-- unchanged. Idempotent on the primary key so a reset/replay is safe.
+INSERT INTO public.feature_flags (key, description) VALUES
+  ('launchpad_shell', 'Master launchpad start-screen shell (PROD-171).')
+ON CONFLICT (key) DO NOTHING;


### PR DESCRIPTION
## What
Gate the launchpad "start screen" shell behind one master flag, route its content by population (new vs. returning user), and log per-user exposure joinable to the activation funnel. This is shared infrastructure — the activation experiment (PROD-172) and a queued retention experiment sit on top of it.

## Why
Repeat-previous is currently live and unflagged, so it's already baked into returning-user behavior — there's no clean "pure builder" baseline to measure against. Gating the shell itself (not a standalone repeat-previous flag) restores that control and unlocks a "drop into builder vs. land on a start screen" comparison for both populations, per PROD-171.

Three decisions a reviewer won't get from the diff alone:
1. **One master flag, not per-content flags.** `launchpad_shell` OFF drops straight into the pure custom builder (the true control); ON routes by population — new users (0 logs) see curated first-workout content, returning users (≥1 log) see repeat-previous + a build-custom escape hatch. The existing `curated_first_workout`/`repeat_previous` flags stay in the registry for optionality (per the ticket's "build all the flags now") but deliberately no longer gate shell content — they're defined-but-unused as gates on purpose, not dead code.
2. **Sticky assignment is server-side, the event is the join bridge.** Per-user stickiness already comes from the PROD-175 `feature_flag_assignments` row; the new `launchpad_exposed` event fires once per mount (after population resolves) recording `{ shell_variant, population, content }` keyed by `user_id`, so it's what actually joins to the PROD-170 funnel. Both arms log exposure so the A/B is analyzable from either side.
3. **Seeded disabled.** The flag migration seeds `launchpad_shell` with `enabled = false`, so production behavior is unchanged until someone deliberately toggles it — verified it resolves to "control" against local Supabase.

An active program still forces the browse view independently of this flag — that's a separate, orthogonal feature (unflagged program-in-progress routing), and I preserved it rather than regressing it. Curated content is the existing `CURATED_WORKOUTS` catalog serving as a placeholder; actual curated-workout selection and the activation-lift measurement are PROD-172's job, not this one's.

## How tested
60 unit tests across the launchpad, recommendations, baseline, and flag-config/eval suites, asserting the exact user-visible routing and the `launchpad_exposed` event payload. For reviewer-visible evidence on this UI-facing routing change, drove the real `StartWorkoutPage` component through Storybook (real Tailwind + MSW-mocked data) and screenshotted all three states: flag OFF (pure builder), flag ON + returning user (repeat-previous shell), flag ON + new user (curated first-workout shell). The exposure event itself isn't visually observable but is precisely asserted by the unit tests. Evidence below; the temporary Storybook story used to produce it was removed, working tree clean.

## Tradeoffs
Considered adding a full-page loading gate while the population (workout-log) query resolves, but that means a spinner on every home visit for a query that's usually fast — instead the shell renders progressively as logs settle, and the exposure event itself waits for population to resolve before firing, so the logged population stays accurate even though the visible page isn't gated on it.

- Evidence: Control (flag OFF) — pure custom builder baseline (local file: <code>/var/folders/2p/zdp7pmgx05z1k3dd8xyttrv80000gn/T/no-mistakes-evidence/01KXNHCX9BEF63C2NQVYNYGZWX/01-control-pure-builder.png</code>)
- Evidence: Treatment + returning user — repeat-previous shell (local file: <code>/var/folders/2p/zdp7pmgx05z1k3dd8xyttrv80000gn/T/no-mistakes-evidence/01KXNHCX9BEF63C2NQVYNYGZWX/02-treatment-returning.png</code>)
- Evidence: Treatment + new user (0 logs) — curated first-workout shell (local file: <code>/var/folders/2p/zdp7pmgx05z1k3dd8xyttrv80000gn/T/no-mistakes-evidence/01KXNHCX9BEF63C2NQVYNYGZWX/03-treatment-new.png</code>)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`vitest run src/pages/StartWorkoutPage/StartWorkoutPage.launchpad.test.jsx` (gate + exposure-event payload assertions)</code>
- <code>`vitest run src/pages/StartWorkoutPage/StartWorkoutPage.recommendations.test.jsx` (population-routed content)</code>
- <code>`vitest run src/pages/StartWorkoutPage/StartWorkoutPage.test.jsx` (page baseline)</code>
- <code>`vitest run src/config/experiments.test.ts src/api/useFeatureFlags.test.ts` (flag key/mapping + eval fallback)</code>
- `Rendered StartWorkoutPage in Storybook across three flag/population states and screenshotted each real surface (control builder, treatment returning, treatment new)`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>

