### PR TITLE
fix(activation): relink curated names to catalog

### DIFF
--- a/src/constants/curatedWorkouts.test.ts
+++ b/src/constants/curatedWorkouts.test.ts
@@ -1,6 +1,20 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
 import { getWeightTabValue } from '~/utils';
 
 import { CURATED_WORKOUTS, CURATED_WORKOUTS_VERSION } from './curatedWorkouts';
+
+// The movement catalog's source of truth (PROD-153). Reading it here — rather
+// than hardcoding the expected names — means a future catalog rename that
+// orphans a curated movement fails this test instead of drifting silently.
+const CATALOG_MOVEMENT_NAMES = new Set(
+  readFileSync(resolve(process.cwd(), 'scripts/data/movements.csv'), 'utf-8')
+    .split(/\r?\n/)
+    .slice(1) // drop the header row
+    .filter((line) => line.trim().length > 0)
+    .map((line) => line.slice(0, line.indexOf(',')).trim()),
+);
 
 describe('CURATED_WORKOUTS', () => {
   test('exports a numeric version', () => {
@@ -45,16 +59,12 @@ describe('CURATED_WORKOUTS', () => {
     },
   );
 
-  test('uses catalog movement names', () => {
-    const byId = Object.fromEntries(CURATED_WORKOUTS.map((w) => [w.id, w]));
-    const nameOf = (id: string) =>
-      byId[id].workoutOptions.movements[0].movementName;
-
-    expect(nameOf('beginner-two-hand-swing')).toBe('Kettlebell Swing');
-    expect(nameOf('beginner-overhead-press')).toBe(
-      'Single Arm Kettlebell Overhead Press',
-    );
-    expect(nameOf('beginner-goblet-squat')).toBe('Kettlebell Goblet Squat');
+  test('every movement name exists in the catalog', () => {
+    for (const workout of CURATED_WORKOUTS) {
+      for (const movement of workout.workoutOptions.movements) {
+        expect(CATALOG_MOVEMENT_NAMES).toContain(movement.movementName);
+      }
+    }
   });
 
   test('encodes weight modes the same way the builder would', () => {

--- a/src/constants/curatedWorkouts.ts
+++ b/src/constants/curatedWorkouts.ts
@@ -9,7 +9,7 @@ import { CuratedWorkout } from '~/types';
  * Bump CURATED_WORKOUTS_VERSION whenever the content changes so analytics can
  * attribute starts to a known revision.
  */
-export const CURATED_WORKOUTS_VERSION = 2;
+export const CURATED_WORKOUTS_VERSION = 3;
 
 export const CURATED_WORKOUTS: CuratedWorkout[] = [
   {
@@ -51,7 +51,7 @@ export const CURATED_WORKOUTS: CuratedWorkout[] = [
       restTimer: 60,
       movements: [
         {
-          movementName: 'Single Arm Kettlebell Overhead Press',
+          movementName: 'One-Arm Kettlebell Military Press',
           repScheme: [5],
           weightOneUnit: 'kilograms',
           weightOneValue: 12,
@@ -80,7 +80,7 @@ export const CURATED_WORKOUTS: CuratedWorkout[] = [
       restTimer: 60,
       movements: [
         {
-          movementName: 'Kettlebell Goblet Squat',
+          movementName: 'Goblet Squat',
           repScheme: [8],
           weightOneUnit: 'kilograms',
           weightOneValue: 16,


### PR DESCRIPTION
## What
Relink two curated first-workout movements to their current catalog names, bump `CURATED_WORKOUTS_VERSION`, and rewrite the guard test to assert catalog membership.

## Why
PROD-172's shipping half asks that the curated beginner first-workout content be gated behind the launchpad experiment flag (no unflagged path contaminating the control baseline) and be complete enough to fairly test as the activation intervention.

Gating is already fully handled by the merged PROD-171 `launchpad_shell` master flag (seeded OFF): curated content flows only through `StartWorkoutPage` and renders nothing when the flag is off, so no gating change was needed. The one real issue was content quality — the PROD-153 slim-catalog rename orphaned two of the three curated movement names: `Single Arm Kettlebell Overhead Press` and `Kettlebell Goblet Squat` now match zero catalog rows, so their autocomplete and movement-detail links no longer resolved. The `curatedWorkouts.test.ts` guard only compared literal strings, so the drift shipped silently.

Same PROD-153 catalog-rename fallout pattern as PROD-234 — correcting a broken internal reference, not changing the prescribed exercise or the experiment design.

Refs PROD-172 (https://linear.app/bellskill/issue/PROD-172).

## How tested
- `npx vitest run src/constants/curatedWorkouts.test.ts` — 8 pass, including the new catalog-membership assertion (fails on an orphaned name instead of drifting).
- `npx vitest run src/pages/StartWorkoutPage` — 63 pass.
- `npm run compile:ts`, `npm run lint`, `npx prettier --check` — all clean.
- no-mistakes pipeline (review, test, document, lint) — all green; review independently confirmed both relinked names exist in the catalog and their weight modes are preserved.

## Tradeoffs
The membership test parses the CSV with a naive split-on-first-comma rather than a full CSV parser. I verified no movement name contains a comma or quote, so the simple parse is correct for the current catalog and keeps the test dependency-free. A real CSV parser would be more robust to future quoting, but it adds a dependency for data that doesn't need it today.

The relinked names preserve each exercise and weight mode exactly — `One-Arm Kettlebell Military Press` is Single Arm (matches the `weightTwoValue: 0` 1H encoding) and `Goblet Squat` is Double Arm (matches the 2H encoding). A user still gets an overhead press and a goblet squat. The `launchpad_shell` flag stays OFF — this enables no experiment.
