### PR TITLE
feat(programs): compact list view for browsing programs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -180,10 +180,13 @@ session — atomic), and the PROD-219 editing pair `reorder_program_sessions` /
   Each is idempotent on `slug` and builds every session's `WorkoutOptions` JSONB
   (shape `Omit<WorkoutOptions,'startedAt'>`, camelCase keys) via a `pg_temp`
   helper; add another by mirroring one. Seed shape is asserted in
-  `e2e/program-schema.spec.ts`. `ProgramsPage` currently features only a single
-  shared program (`sharedPrograms[0]`, preferring the DFW slug), so a newly
-  seeded program lands in the shared-program data but is not yet surfaced in that
-  UI.
+  `e2e/program-schema.spec.ts`. `ProgramsPage` surfaces every public program
+  (`sharedPrograms = programs.filter(isPublic)`) in a compact "Browse programs"
+  list (PROD-237) — a single `divide-y` `Card` of rows, each with the title +
+  author/duration metadata and a `size="sm"` Start button (visible text
+  "Start", per-program accessible name via `aria-label={'Start ' + title}` so
+  `getByRole('button', { name: 'Start <title>' })` still resolves), so a newly
+  seeded program shows up automatically.
 - **Seeding a `complexSet: true` program:** see
   `*_seed_armor_building_complex.sql` (Dan John's ABC). Give each movement a
   **single-element `repScheme`** so the complex runtime's `maxMovementRungs`

--- a/src/pages/ProgramsPage/ProgramsPage.test.tsx
+++ b/src/pages/ProgramsPage/ProgramsPage.test.tsx
@@ -189,7 +189,7 @@ describe('ProgramsPage', () => {
   it('prompts for a starting weight before enrolling in a shared program, defaulted to double 24kg', () => {
     renderPage();
 
-    fireEvent.click(screen.getByText('Start Dry Fighting Weight'));
+    fireEvent.click(screen.getByRole('button', { name: 'Start Dry Fighting Weight' }));
 
     // The RPC is not called yet — the starting-weight prompt is shown first,
     // defaulting to double loading (two weight inputs) at 24kg each.
@@ -219,7 +219,7 @@ describe('ProgramsPage', () => {
 
     renderPage();
 
-    fireEvent.click(screen.getByText('Start Dry Fighting Weight'));
+    fireEvent.click(screen.getByRole('button', { name: 'Start Dry Fighting Weight' }));
 
     // A failed sessions fetch must not brick enrollment: the picker still opens
     // editable on the generic double-24kg fallback rather than sticking on
@@ -255,7 +255,7 @@ describe('ProgramsPage', () => {
 
     renderPage();
 
-    fireEvent.click(screen.getByText('Start Snatch Test Plan'));
+    fireEvent.click(screen.getByRole('button', { name: 'Start Snatch Test Plan' }));
 
     // A single-bell program (Snatch Test) collapses to one weight input at the
     // modal 24kg — not the double-24 the fixed default used to force.
@@ -280,7 +280,7 @@ describe('ProgramsPage', () => {
   it('omits the Bodyweight mode from the starting-weight prompt', () => {
     renderPage();
 
-    fireEvent.click(screen.getByText('Start Dry Fighting Weight'));
+    fireEvent.click(screen.getByRole('button', { name: 'Start Dry Fighting Weight' }));
 
     expect(
       screen.queryByRole('tab', { name: 'Bodyweight' }),
@@ -293,7 +293,7 @@ describe('ProgramsPage', () => {
   it('enrolls with mixed independent left/right weights', () => {
     renderPage();
 
-    fireEvent.click(screen.getByText('Start Dry Fighting Weight'));
+    fireEvent.click(screen.getByRole('button', { name: 'Start Dry Fighting Weight' }));
     // Left bell stays 24kg, right bell drops to 16kg (mixed pair).
     fireEvent.change(screen.getAllByRole('spinbutton')[1], {
       target: { value: '16' },
@@ -315,7 +315,7 @@ describe('ProgramsPage', () => {
   it('enrolls with a single two-hand weight when the Two-Hand mode is selected', async () => {
     renderPage();
 
-    fireEvent.click(screen.getByText('Start Dry Fighting Weight'));
+    fireEvent.click(screen.getByRole('button', { name: 'Start Dry Fighting Weight' }));
     await userEvent.click(screen.getByRole('tab', { name: 'Two-Hand' }));
 
     // Two-hand loading collapses to one weight input; weight two clears.
@@ -338,7 +338,7 @@ describe('ProgramsPage', () => {
   it('enrolls with a per-slot unit choice (kg or lb)', async () => {
     renderPage();
 
-    fireEvent.click(screen.getByText('Start Dry Fighting Weight'));
+    fireEvent.click(screen.getByRole('button', { name: 'Start Dry Fighting Weight' }));
     // Switch only the left bell to pounds; the right bell stays in kg.
     await userEvent.click(screen.getAllByRole('tab', { name: 'lb' })[0]);
     fireEvent.click(screen.getByRole('button', { name: 'Start program' }));
@@ -358,7 +358,7 @@ describe('ProgramsPage', () => {
   it('preserves the selected unit (lb) across a loading-mode switch', async () => {
     renderPage();
 
-    fireEvent.click(screen.getByText('Start Dry Fighting Weight'));
+    fireEvent.click(screen.getByRole('button', { name: 'Start Dry Fighting Weight' }));
     await userEvent.click(screen.getAllByRole('tab', { name: 'lb' })[0]);
     await userEvent.click(screen.getByRole('tab', { name: 'Two-Hand' }));
     fireEvent.click(screen.getByRole('button', { name: 'Start program' }));
@@ -397,7 +397,7 @@ describe('ProgramsPage', () => {
 
     renderPage();
 
-    fireEvent.click(screen.getByText('Start Dry Fighting Weight'));
+    fireEvent.click(screen.getByRole('button', { name: 'Start Dry Fighting Weight' }));
 
     // The RPC is not called yet — the switch prompt is shown first.
     expect(enrollMutate).not.toHaveBeenCalled();
@@ -423,7 +423,7 @@ describe('ProgramsPage', () => {
     );
   });
 
-  it('renders one card per shared program, each with its own enroll button', () => {
+  it('renders a compact row per shared program, each with its own enroll button', () => {
     mockUsePrograms.mockReturnValue({
       data: [dfw, armor, myProgram],
       isLoading: false,
@@ -456,7 +456,7 @@ describe('ProgramsPage', () => {
 
     renderPage();
 
-    fireEvent.click(screen.getByText('Start Armor Building Complex'));
+    fireEvent.click(screen.getByRole('button', { name: 'Start Armor Building Complex' }));
 
     // The switch prompt gates the RPC until confirmed.
     expect(enrollMutate).not.toHaveBeenCalled();

--- a/src/pages/ProgramsPage/ProgramsPage.test.tsx
+++ b/src/pages/ProgramsPage/ProgramsPage.test.tsx
@@ -189,7 +189,9 @@ describe('ProgramsPage', () => {
   it('prompts for a starting weight before enrolling in a shared program, defaulted to double 24kg', () => {
     renderPage();
 
-    fireEvent.click(screen.getByRole('button', { name: 'Start Dry Fighting Weight' }));
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Start Dry Fighting Weight' }),
+    );
 
     // The RPC is not called yet — the starting-weight prompt is shown first,
     // defaulting to double loading (two weight inputs) at 24kg each.
@@ -219,7 +221,9 @@ describe('ProgramsPage', () => {
 
     renderPage();
 
-    fireEvent.click(screen.getByRole('button', { name: 'Start Dry Fighting Weight' }));
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Start Dry Fighting Weight' }),
+    );
 
     // A failed sessions fetch must not brick enrollment: the picker still opens
     // editable on the generic double-24kg fallback rather than sticking on
@@ -255,7 +259,9 @@ describe('ProgramsPage', () => {
 
     renderPage();
 
-    fireEvent.click(screen.getByRole('button', { name: 'Start Snatch Test Plan' }));
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Start Snatch Test Plan' }),
+    );
 
     // A single-bell program (Snatch Test) collapses to one weight input at the
     // modal 24kg — not the double-24 the fixed default used to force.
@@ -280,7 +286,9 @@ describe('ProgramsPage', () => {
   it('omits the Bodyweight mode from the starting-weight prompt', () => {
     renderPage();
 
-    fireEvent.click(screen.getByRole('button', { name: 'Start Dry Fighting Weight' }));
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Start Dry Fighting Weight' }),
+    );
 
     expect(
       screen.queryByRole('tab', { name: 'Bodyweight' }),
@@ -293,7 +301,9 @@ describe('ProgramsPage', () => {
   it('enrolls with mixed independent left/right weights', () => {
     renderPage();
 
-    fireEvent.click(screen.getByRole('button', { name: 'Start Dry Fighting Weight' }));
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Start Dry Fighting Weight' }),
+    );
     // Left bell stays 24kg, right bell drops to 16kg (mixed pair).
     fireEvent.change(screen.getAllByRole('spinbutton')[1], {
       target: { value: '16' },
@@ -315,7 +325,9 @@ describe('ProgramsPage', () => {
   it('enrolls with a single two-hand weight when the Two-Hand mode is selected', async () => {
     renderPage();
 
-    fireEvent.click(screen.getByRole('button', { name: 'Start Dry Fighting Weight' }));
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Start Dry Fighting Weight' }),
+    );
     await userEvent.click(screen.getByRole('tab', { name: 'Two-Hand' }));
 
     // Two-hand loading collapses to one weight input; weight two clears.
@@ -338,7 +350,9 @@ describe('ProgramsPage', () => {
   it('enrolls with a per-slot unit choice (kg or lb)', async () => {
     renderPage();
 
-    fireEvent.click(screen.getByRole('button', { name: 'Start Dry Fighting Weight' }));
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Start Dry Fighting Weight' }),
+    );
     // Switch only the left bell to pounds; the right bell stays in kg.
     await userEvent.click(screen.getAllByRole('tab', { name: 'lb' })[0]);
     fireEvent.click(screen.getByRole('button', { name: 'Start program' }));
@@ -358,7 +372,9 @@ describe('ProgramsPage', () => {
   it('preserves the selected unit (lb) across a loading-mode switch', async () => {
     renderPage();
 
-    fireEvent.click(screen.getByRole('button', { name: 'Start Dry Fighting Weight' }));
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Start Dry Fighting Weight' }),
+    );
     await userEvent.click(screen.getAllByRole('tab', { name: 'lb' })[0]);
     await userEvent.click(screen.getByRole('tab', { name: 'Two-Hand' }));
     fireEvent.click(screen.getByRole('button', { name: 'Start program' }));
@@ -397,7 +413,9 @@ describe('ProgramsPage', () => {
 
     renderPage();
 
-    fireEvent.click(screen.getByRole('button', { name: 'Start Dry Fighting Weight' }));
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Start Dry Fighting Weight' }),
+    );
 
     // The RPC is not called yet — the switch prompt is shown first.
     expect(enrollMutate).not.toHaveBeenCalled();
@@ -456,7 +474,9 @@ describe('ProgramsPage', () => {
 
     renderPage();
 
-    fireEvent.click(screen.getByRole('button', { name: 'Start Armor Building Complex' }));
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Start Armor Building Complex' }),
+    );
 
     // The switch prompt gates the RPC until confirmed.
     expect(enrollMutate).not.toHaveBeenCalled();

--- a/src/pages/ProgramsPage/ProgramsPage.tsx
+++ b/src/pages/ProgramsPage/ProgramsPage.tsx
@@ -219,26 +219,37 @@ export const ProgramsPage = () => {
 
   return (
     <Page title="Programs">
-      {sharedPrograms.map((program) => (
-        <Card key={program.id}>
-          <CardHeader>
-            <CardTitle>{program.title}</CardTitle>
-            <p className="text-xs text-muted-foreground">
-              {program.authorName ? `${program.authorName} · ` : ''}
-              {program.numWeeks} weeks · {program.daysPerWeek}/week
-            </p>
-          </CardHeader>
-          <CardContent>
-            <Button
-              className="w-full"
-              onClick={() => handleEnroll(program.id)}
-              disabled={enroll.isLoading}
-            >
-              {`Start ${program.title}`}
-            </Button>
-          </CardContent>
-        </Card>
-      ))}
+      {sharedPrograms.length > 0 && (
+        <div className="flex flex-col gap-1">
+          <h2 className="text-sm font-semibold">Browse programs</h2>
+          <Card className="divide-y">
+            {sharedPrograms.map((program) => (
+              <div
+                key={program.id}
+                className="flex items-center justify-between gap-2 p-2"
+              >
+                <div className="min-w-0">
+                  <p className="truncate text-sm font-medium">
+                    {program.title}
+                  </p>
+                  <p className="truncate text-xs text-muted-foreground">
+                    {program.authorName ? `${program.authorName} · ` : ''}
+                    {program.numWeeks} weeks · {program.daysPerWeek}/week
+                  </p>
+                </div>
+                <Button
+                  size="sm"
+                  aria-label={`Start ${program.title}`}
+                  onClick={() => handleEnroll(program.id)}
+                  disabled={enroll.isLoading}
+                >
+                  Start
+                </Button>
+              </div>
+            ))}
+          </Card>
+        </div>
+      )}
 
       <div className="flex items-center justify-between">
         <h2 className="text-sm font-semibold">My programs</h2>


### PR DESCRIPTION
## What
Replace the shared/public programs browse list on `ProgramsPage` with a denser, compact list view — first of six PROD-237 polish slices.

## Why
The current full-`Card`-per-program layout wastes vertical space as the public catalog grows — six programs now (Dry Fighting Weight, Easy Strength, StrongFirst Snatch Test, Armor Building Complex, 10,000 Swing Challenge, A+A Protocol), each rendered as its own card. This is presentation-only for the browse/enroll list — chosen design is one `Card` holding a `divide-y` list of compact rows under a "Browse programs" heading (title + author/duration metadata on the left, both truncated; a small Start button on the right), following the app's existing divide-y list pattern rather than the heavier `MovementsPage` data-table.

Enroll behavior is deliberately unchanged: `handleEnroll`, the switch prompt, the starting-weight prompt (`pendingWeightProgramId`/`enrollIn`/shared-weight picker), the My Programs section, and the create form are all untouched. The compact Start button keeps its per-program accessible name via `aria-label={'Start ' + title}` even though its visible text is now just "Start," so `getByRole('button', { name: 'Start <title>' })` still resolves.

Out of scope for this slice (later PROD-237 slices): program-creation form changes, My Programs CRUD, start-from-any-session, ongoing weight adjustment, program queueing.

## How tested
Ran the `ProgramsPage` unit suite (13/13 pass) covering the compact-row rendering and aria-label-based Start button queries — updated from `getByText('Start <title>')` to `getByRole` since the visible text is now generic. Produced product-level visual evidence by rendering the actual `ProgramsPage` component in Storybook (react-query cache seeded with all six shared programs) and screenshotting it — confirms the single-`Card` divide-y compact list with truncated title/metadata, small Start buttons, and the unchanged My Programs section below it. Evidence below.

## Tradeoffs
Considered a full data-table (`MovementsPage`'s pattern) instead of a divide-y list, but that's heavier machinery than six rows of title+metadata need — the divide-y list is the app's existing lightweight-dense-list pattern and keeps this slice presentation-only rather than pulling in a new component.

- Evidence: ProgramsPage compact &#39;Browse programs&#39; list (rendered component) (local file: <code>/var/folders/2p/zdp7pmgx05z1k3dd8xyttrv80000gn/T/no-mistakes-evidence/01KXRDMGWJ3AM6RGTM4K62T5XM/programs-browse-compact-list.png</code>)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`npm test -- src/pages/ProgramsPage/ProgramsPage.test.tsx` — 13 tests pass, including the renamed compact-row test and getByRole(&#39;button&#39;,{name:&#39;Start &lt;title&gt;&#39;}) enroll assertions</code>
- `Rendered the real ProgramsPage in Storybook with a seeded react-query cache (6 shared programs) and captured a mobile-width screenshot of the compact 'Browse programs' list`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>



## Screenshots

_Compact "Browse programs" list — desktop_

![programs-list-desktop](https://github.com/user-attachments/assets/e44da44b-a27b-4680-a508-f7e58e1d18c5)

_Compact list — mobile (390×844)_

![programs-list-mobile](https://github.com/user-attachments/assets/3a5b8ae8-7c3b-4ee9-8bc3-c4cb7feff83f)
