### PR TITLE
fix(seed): map DFW movements to catalog names so logs bucket correctly

### DIFF
--- a/supabase/migrations/20260706170001_seed_dry_fighting_weight.sql
+++ b/supabase/migrations/20260706170001_seed_dry_fighting_weight.sql
@@ -42,12 +42,12 @@ RETURNS JSONB LANGUAGE sql IMMUTABLE AS $$
     'sharedWeightTwoValue', NULL,
     'movements', jsonb_build_array(
       jsonb_build_object(
-        'movementName', 'Clean and Press',
+        'movementName', 'Double Kettlebell Clean and Press',
         'repScheme', to_jsonb(p_reps),
         'weightOneUnit', 'kilograms', 'weightOneValue', 24,
         'weightTwoUnit', 'kilograms', 'weightTwoValue', 24),
       jsonb_build_object(
-        'movementName', 'Front Squat',
+        'movementName', 'Front Squat With Two Kettlebells',
         'repScheme', to_jsonb(p_reps),
         'weightOneUnit', 'kilograms', 'weightOneValue', 24,
         'weightTwoUnit', 'kilograms', 'weightTwoValue', 24)
@@ -70,7 +70,7 @@ RETURNS JSONB LANGUAGE sql IMMUTABLE AS $$
     'sharedWeightTwoValue', NULL,
     'movements', jsonb_build_array(
       jsonb_build_object(
-        'movementName', 'Clean and Press',
+        'movementName', 'Double Kettlebell Clean and Press',
         'repScheme', to_jsonb(ARRAY[5]::INT[]),
         'weightOneUnit', 'kilograms', 'weightOneValue', 28,
         'weightTwoUnit', 'kilograms', 'weightTwoValue', 28)

--- a/supabase/migrations/20260717000000_relink_deployed_dfw_to_catalog.sql
+++ b/supabase/migrations/20260717000000_relink_deployed_dfw_to_catalog.sql
@@ -1,0 +1,71 @@
+-- Reconcile the DEPLOYED Dry Fighting Weight program data to the movements
+-- catalog. Follow-up to the DFW seed name fix, modeled on the PROD-234 relink
+-- (20260716090000_relink_orphaned_user_movements.sql).
+--
+-- The DFW seed (20260706170001_seed_dry_fighting_weight.sql) wrote two movement
+-- names that do not exist in the 252-row catalog: 'Clean and Press' and
+-- 'Front Squat'. That seed migration is already applied in production, so
+-- correcting the seed file itself is inert there (forward-only `db push` skips
+-- applied versions). This migration fixes the data the applied seed left behind.
+--
+-- Correct catalog targets are the DOUBLE-bell variants, consistent with DFW's
+-- two-bell weight structure (every seeded movement sets both weightOne AND
+-- weightTwo). Both targets are Double Arm / 2 primary items in the catalog:
+--   'Clean and Press' -> 'Double Kettlebell Clean and Press'
+--   'Front Squat'     -> 'Front Squat With Two Kettlebells'
+--
+-- Two idempotent, DFW-scoped parts:
+--   1. Rewrite the stored movementName in program_sessions.workout_options for
+--      the DFW system template AND its copy-on-enroll clones (source_program_id
+--      -> DFW). enroll_in_program copies workout_options verbatim, so each of
+--      the 7 existing enrollees holds an active clone carrying the old names;
+--      left unfixed, their future logged sessions would keep orphaning.
+--   2. Relink user_movements that enrollees already logged under the old names
+--      (NULL functional_movement_id) to the catalog rows, exactly as PROD-234
+--      does -- writing only where the FK IS NULL, so already-linked rows are
+--      untouched and a re-run is a no-op. Both old names are absent from the
+--      catalog, so any such row is already unbucketed; both catalog targets
+--      share the same movement pattern as any single-bell variant
+--      (Vertical Push / Knee Dominant), so the pattern_debt_window bucket is
+--      correct regardless of bell count.
+
+-- Part 1 — correct the already-seeded (and cloned) DFW template rows.
+UPDATE public.program_sessions ps
+SET workout_options = jsonb_set(
+  ps.workout_options,
+  '{movements}',
+  (
+    SELECT jsonb_agg(
+      CASE elem->>'movementName'
+        WHEN 'Clean and Press'
+          THEN jsonb_set(elem, '{movementName}', '"Double Kettlebell Clean and Press"'::jsonb)
+        WHEN 'Front Squat'
+          THEN jsonb_set(elem, '{movementName}', '"Front Squat With Two Kettlebells"'::jsonb)
+        ELSE elem
+      END
+      ORDER BY ord
+    )
+    FROM jsonb_array_elements(ps.workout_options->'movements') WITH ORDINALITY AS m(elem, ord)
+  )
+)
+FROM public.programs p
+WHERE p.id = ps.program_id
+  AND (
+    p.slug = 'dry-fighting-weight'
+    OR p.source_program_id = (SELECT id FROM public.programs WHERE slug = 'dry-fighting-weight')
+  )
+  AND (
+    ps.workout_options->'movements' @> '[{"movementName": "Clean and Press"}]'::jsonb
+    OR ps.workout_options->'movements' @> '[{"movementName": "Front Squat"}]'::jsonb
+  );
+
+-- Part 2 — relink enrollee logs orphaned under the old names (PROD-234 pattern).
+UPDATE public.user_movements u
+SET functional_movement_id = m.id
+FROM (VALUES
+  ('Clean and Press', 'Double Kettlebell Clean and Press'),
+  ('Front Squat',     'Front Squat With Two Kettlebells')
+) AS map(orphan_name, catalog_name)
+JOIN public.movements m ON lower(m."Movement") = lower(map.catalog_name)
+WHERE lower(u.canonical_name) = lower(map.orphan_name)
+  AND u.functional_movement_id IS NULL;


### PR DESCRIPTION
## What

Fix the Dry Fighting Weight movement names that never existed in the catalog, in two parts:

1. **Seed correction** (`20260706170001_seed_dry_fighting_weight.sql`) — map the three bad `movementName` strings to catalog rows, so fresh/staging environments seed consistently:
   - `Clean and Press` -> `Double Kettlebell Clean and Press` (x2: standard sessions + W5D2 test day)
   - `Front Squat` -> `Front Squat With Two Kettlebells`
2. **Forward data-fix** (new `20260717000000_relink_deployed_dfw_to_catalog.sql`) — repair the data the already-applied seed left in production.

## Why

Neither `Clean and Press` nor `Front Squat` exists in the 252-row movements catalog. When a DFW enrollee starts a session without hand-picking from the dropdown, `createOrReuseUserMovement` resolves no catalog id, so `user_movements.functional_movement_id` is left NULL and the log is silently excluded from every `pattern_debt_window` bucket. DFW already has **7 enrollments**, so this is a latent production bug.

The seed edit alone does not fix production: migration `20260706170001` is already applied, and forward-only `supabase db push` skips applied versions. Prod's seeded template rows, the 7 enrollees' copy-on-enroll clones (`enroll_in_program` copies `workout_options` verbatim), and any logs already written under the old names all still carry the bad names. The new migration is the follow-up data-fix, modeled on the PROD-234 relink (`20260716090000_relink_orphaned_user_movements.sql`):

- **Part 1** rewrites `movementName` in `program_sessions.workout_options` for the DFW template *and* its clones (`source_program_id -> DFW`), so enrollees' future logged sessions carry catalog names.
- **Part 2** relinks `user_movements` orphaned under the old names to the catalog rows, writing only where the FK `IS NULL`.

Double-bell is unambiguous: every seeded movement sets both `weightOneValue` and `weightTwoValue` (24/24 standard, 28/28 test day), the seed comment and program description name the "Double Clean and Press" / "Double Front Squat", and both catalog targets are `Double Arm` / 2 primary items. Both targets also share the same movement pattern as any single-bell variant (Vertical Push / Knee Dominant), so the pattern-debt bucket is correct regardless of bell count. Both migration parts are idempotent (guarded/`NULL`-only) and scoped to DFW.

## How tested

- `grep` confirmed both new names are byte-exact matches in the catalog sources (`scripts/data/movements.csv`, `20260709000000_slim_movements_catalog.sql`) and the old names have zero exact matches.
- `npm run movements:check` -> `252 movements valid`.
- `npx supabase db reset` replayed the full chain including the new migration cleanly.
- Post-reset survival queries: 0 DFW-scoped sessions reference the old names; both DFW template names resolve to catalog rows (`matches_catalog = t`); 0 `user_movements` orphaned under the old names (fresh DB has no enrollee logs).
- Ran both migration statements inside a **rolled-back transaction** against synthetic pre-migration data (a DFW clone with old names + two orphaned `user_movements`): Part 1 rewrote both names to the Double variants, Part 2 relinked both rows to `Double Arm` catalog rows, and the Part 1 idempotency guard then matched 0 rows.
- Confirmed no e2e/unit assertion is pinned to the old DFW seed names (`program-schema.spec.ts` asserts weights/counts, not name strings).

Local `db reset` cannot verify production row counts. The captain runs the survival check below **after merge** against prod.

### Post-merge prod survival check

```sql
-- (a) No DFW-scoped session (template or enrolled clone) still references the old names. Expect 0.
SELECT count(*) AS dfw_sessions_with_old_names
FROM program_sessions ps
JOIN programs p ON p.id = ps.program_id
WHERE (p.slug = 'dry-fighting-weight'
       OR p.source_program_id = (SELECT id FROM programs WHERE slug = 'dry-fighting-weight'))
  AND (ps.workout_options->'movements' @> '[{"movementName":"Clean and Press"}]'::jsonb
       OR ps.workout_options->'movements' @> '[{"movementName":"Front Squat"}]'::jsonb);

-- (b) No DFW log remains orphaned under the old names. Expect 0.
SELECT count(*) AS orphaned_old_name_user_movements
FROM user_movements
WHERE canonical_name IN ('Clean and Press', 'Front Squat')
  AND functional_movement_id IS NULL;

-- (context) How many rows the relink touched — the prod orphan set this fix recovered.
SELECT canonical_name, count(*) AS relinked_rows
FROM user_movements
WHERE canonical_name IN ('Clean and Press', 'Front Squat')
  AND functional_movement_id IS NOT NULL
GROUP BY canonical_name ORDER BY canonical_name;
```

## Tradeoffs

- The seed edit is kept (not reverted) even though it is inert in prod, because it keeps fresh/staging environments internally consistent — the data-fix migration then handles the already-deployed rows. The alternative, a single migration that only fixes prod data, would leave the seed file itself wrong and re-seed the bad names into any brand-new environment.
- Part 2 relinks by name globally (`NULL`-FK only), matching the PROD-234 precedent, rather than joining through `user_programs` to restrict to DFW enrollees. Since the catalog contains neither old name, any such row is already unbucketed, and both targets map to the same movement pattern as any single-bell variant, so the relink is strictly an improvement and cannot mis-bucket. Scoping to enrollees would add complexity for no correctness gain.
- I could not query production, so this PR does not assert a specific prod orphan count. The mechanism (a non-catalog name orphans every enrollee log) plus 7 known enrollments justifies the relink; the survival check above confirms the actual count post-merge. If prod happens to have zero such rows, both parts are safe no-ops.

🤖 Generated with [Claude Code](https://claude.com/claude-code)