### PR TITLE
docs: fix stale type-generation command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,9 +78,10 @@ The production app at [app.bellskill.com](https://app.bellskill.com) is the reco
 
 3. Configure Supabase environment variables. Create a `.env.local` file in the project root with credentials for your own Supabase project.
 
-4. Fetch the latest types from the backend:
+4. Generate TypeScript types from your Supabase schema (requires the local
+   Supabase stack running — `npm run start:server`):
    ```bash
-   npm run fetch-types
+   npm run gen:types
    ```
 
 5. Start the development server:


### PR DESCRIPTION
**What:** Update the local-setup step in `README.md` that referenced `npm run fetch-types` to use `npm run gen:types`.

**Why:** `fetch-types` is not a script in `package.json` — the type-generation command is `gen:types`, which reads the local Supabase schema. Following the README as written fails at step 4.

**How tested:** Verified `gen:types` exists (and `fetch-types` does not) in `package.json`; noted the command needs the local Supabase stack running (`npm run start:server`) and reflected that in the step. Docs-only change.