### PR TITLE
fix(recommender): open two-bell movements as Double, not 2H

### DIFF
--- a/src/api/useMovements.ts
+++ b/src/api/useMovements.ts
@@ -1,4 +1,4 @@
-import { useQuery } from 'react-query';
+import { UseQueryOptions, useQuery } from 'react-query';
 
 import { QUERIES } from '~/constants';
 import { DifficultyLevel, Equipment, Movement, MuscleGroup } from '~/types';
@@ -27,8 +27,18 @@ interface MovementsResponse {
   hasPreviousPage: boolean;
 }
 
-export const useMovements = (options: UseMovementsOptions = {}) =>
-  useQuery([QUERIES.MOVEMENTS, options], () => fetchMovements(options));
+export const useMovements = (
+  options: UseMovementsOptions = {},
+  queryOptions?: Omit<
+    UseQueryOptions<MovementsResponse>,
+    'queryKey' | 'queryFn'
+  >,
+) =>
+  useQuery(
+    [QUERIES.MOVEMENTS, options],
+    () => fetchMovements(options),
+    queryOptions,
+  );
 
 const fetchMovements = async ({
   page = 1,

--- a/src/pages/StartWorkoutPage/StartWorkoutPage.tsx
+++ b/src/pages/StartWorkoutPage/StartWorkoutPage.tsx
@@ -30,7 +30,6 @@ import type { WorkoutStartSource } from '~/hooks';
 import { getWeightsDisplayValue } from '~/pages/CompletedWorkoutPage/utils/displayValues';
 import {
   CuratedWorkout,
-  Movement,
   MovementOptions,
   Recommendation,
   WeightTabValue,
@@ -60,6 +59,7 @@ import {
 import { useRecommendedWorkouts } from './hooks';
 import {
   RecommendationCatalog,
+  buildRecommendationCatalog,
   recommendationToWorkoutOptions,
 } from './utils/recommendationToMovements';
 
@@ -178,14 +178,14 @@ export const StartWorkoutPage = ({
     { limit: MOVEMENT_CATALOG_PAGE_SIZE },
     { enabled: showRecommender },
   );
-  const recommendationCatalog = useMemo<RecommendationCatalog>(() => {
-    const entries: [string, Movement][] = [];
-    for (const movement of movementCatalogQuery.data?.movements ?? []) {
-      if (movement.movementName)
-        entries.push([movement.movementName, movement]);
-    }
-    return new Map(entries);
-  }, [movementCatalogQuery.data]);
+  const recommendationCatalog = useMemo<RecommendationCatalog>(
+    () =>
+      buildRecommendationCatalog(
+        movementCatalogQuery.data?.movements ?? [],
+        movementCatalogQuery.data?.hasNextPage,
+      ),
+    [movementCatalogQuery.data],
+  );
 
   // Browse mode shows recommendations plus a Build-custom button; the builder
   // opens directly when there's nothing to browse or when history's "Repeat"

--- a/src/pages/StartWorkoutPage/StartWorkoutPage.tsx
+++ b/src/pages/StartWorkoutPage/StartWorkoutPage.tsx
@@ -1,5 +1,5 @@
 import { ArrowLeftIcon, XMarkIcon } from '@heroicons/react/24/outline';
-import { ReactNode, useEffect, useRef, useState } from 'react';
+import { ReactNode, useEffect, useMemo, useRef, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 
 import {
@@ -9,6 +9,7 @@ import {
   useActiveProgram,
   useCompleteProgramSession,
   useFeatureFlags,
+  useMovements,
   useWorkoutLogs,
 } from '~/api';
 import { Loading, Page } from '~/components';
@@ -29,6 +30,7 @@ import type { WorkoutStartSource } from '~/hooks';
 import { getWeightsDisplayValue } from '~/pages/CompletedWorkoutPage/utils/displayValues';
 import {
   CuratedWorkout,
+  Movement,
   MovementOptions,
   Recommendation,
   WeightTabValue,
@@ -56,7 +58,14 @@ import {
   WeightUnitTabs,
 } from './components';
 import { useRecommendedWorkouts } from './hooks';
-import { recommendationToWorkoutOptions } from './utils/recommendationToMovements';
+import {
+  RecommendationCatalog,
+  recommendationToWorkoutOptions,
+} from './utils/recommendationToMovements';
+
+// One page comfortably covers the whole ~250-row catalog, so the recommender
+// can infer each movement's loading mode without paginating.
+const MOVEMENT_CATALOG_PAGE_SIZE: number = 500;
 
 const DEFAULT_INTERVAL_TIMER: number = 30; // seconds
 const DEFAULT_REST_TIMER: number = 30; // seconds
@@ -160,6 +169,23 @@ export const StartWorkoutPage = ({
   const showRepeat = shellOn && population === 'returning';
   const showRecommender =
     shellOn && population === 'returning' && experimentFeatures.recommender;
+
+  // The recommender prescribes a single weight per movement; the catalog's
+  // primary-item count + arm split tell us whether that load means two-hand,
+  // single, or two-bell so an accepted recommendation opens in the right mode
+  // (PROD-238). Only fetched when the recommender surface is actually shown.
+  const movementCatalogQuery = useMovements(
+    { limit: MOVEMENT_CATALOG_PAGE_SIZE },
+    { enabled: showRecommender },
+  );
+  const recommendationCatalog = useMemo<RecommendationCatalog>(() => {
+    const entries: [string, Movement][] = [];
+    for (const movement of movementCatalogQuery.data?.movements ?? []) {
+      if (movement.movementName)
+        entries.push([movement.movementName, movement]);
+    }
+    return new Map(entries);
+  }, [movementCatalogQuery.data]);
 
   // Browse mode shows recommendations plus a Build-custom button; the builder
   // opens directly when there's nothing to browse or when history's "Repeat"
@@ -581,7 +607,9 @@ export const StartWorkoutPage = ({
     recommendation: Recommendation,
     recommendationId: string,
   ) => {
-    loadIntoBuilder(recommendationToWorkoutOptions(recommendation));
+    loadIntoBuilder(
+      recommendationToWorkoutOptions(recommendation, recommendationCatalog),
+    );
     setStartSource('recommender');
     setStartSourceProps({ recommendation_id: recommendationId });
     setPendingProgramSession(null);

--- a/src/pages/StartWorkoutPage/utils/recommendationToMovements.test.ts
+++ b/src/pages/StartWorkoutPage/utils/recommendationToMovements.test.ts
@@ -1,13 +1,26 @@
-import { describe, expect, test } from 'vitest';
+import { afterEach, describe, expect, test, vi } from 'vitest';
 
-import type { Recommendation } from '~/types';
+import type { Movement, Recommendation } from '~/types';
 import { type MovementWeightModeFields, getWeightTabValue } from '~/utils';
 
 import {
   RecommendationCatalog,
+  buildRecommendationCatalog,
   recommendationToMovements,
   recommendationToWorkoutOptions,
 } from './recommendationToMovements';
+
+const catalogRow = (fields: Partial<Movement>): Movement => ({
+  id: fields.movementName ?? 'id',
+  movementName: null,
+  primaryEquipment: 'Kettlebell',
+  primaryItemCount: 2,
+  singleOrDoubleArm: 'Double Arm',
+  targetMuscleGroup: null,
+  difficultyLevel: null,
+  movementPattern1: null,
+  ...fields,
+});
 
 const DOUBLE_KB_FRONT_SQUAT = 'Front Squat With Two Kettlebells';
 const TWO_HAND_SWING = 'Kettlebell Swing';
@@ -136,5 +149,48 @@ describe('recommendationToWorkoutOptions', () => {
     expect(getWeightTabValue(options.movements[0])).toBe('double');
     expect(options.workoutGoal).toBe(20);
     expect(options.workoutGoalUnits).toBe('minutes');
+  });
+});
+
+describe('buildRecommendationCatalog', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test('keys catalog rows by name and skips null-named rows', () => {
+    const built = buildRecommendationCatalog([
+      catalogRow({ movementName: DOUBLE_KB_FRONT_SQUAT }),
+      catalogRow({ movementName: null }),
+    ]);
+
+    expect(built.get(DOUBLE_KB_FRONT_SQUAT)).toMatchObject({
+      primaryItemCount: 2,
+      singleOrDoubleArm: 'Double Arm',
+    });
+    expect(built.size).toBe(1);
+  });
+
+  test('warns loudly when the catalog paginated past one page', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    buildRecommendationCatalog(
+      [catalogRow({ movementName: DOUBLE_KB_FRONT_SQUAT })],
+      true,
+    );
+
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining('movement catalog exceeded'),
+    );
+  });
+
+  test('stays silent when a single page holds the whole catalog', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    buildRecommendationCatalog(
+      [catalogRow({ movementName: DOUBLE_KB_FRONT_SQUAT })],
+      false,
+    );
+
+    expect(warn).not.toHaveBeenCalled();
   });
 });

--- a/src/pages/StartWorkoutPage/utils/recommendationToMovements.test.ts
+++ b/src/pages/StartWorkoutPage/utils/recommendationToMovements.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, test } from 'vitest';
+
+import type { Recommendation } from '~/types';
+import { type MovementWeightModeFields, getWeightTabValue } from '~/utils';
+
+import {
+  RecommendationCatalog,
+  recommendationToMovements,
+  recommendationToWorkoutOptions,
+} from './recommendationToMovements';
+
+const DOUBLE_KB_FRONT_SQUAT = 'Front Squat With Two Kettlebells';
+const TWO_HAND_SWING = 'Kettlebell Swing';
+const SINGLE_ARM_PRESS = 'One-Arm Kettlebell Military Press';
+
+const catalog: RecommendationCatalog = new Map<
+  string,
+  MovementWeightModeFields
+>([
+  [
+    DOUBLE_KB_FRONT_SQUAT,
+    {
+      primaryEquipment: 'Kettlebell',
+      primaryItemCount: 2,
+      singleOrDoubleArm: 'Double Arm',
+    },
+  ],
+  [
+    TWO_HAND_SWING,
+    {
+      primaryEquipment: 'Kettlebell',
+      primaryItemCount: 1,
+      singleOrDoubleArm: 'Double Arm',
+    },
+  ],
+  [
+    SINGLE_ARM_PRESS,
+    {
+      primaryEquipment: 'Kettlebell',
+      primaryItemCount: 1,
+      singleOrDoubleArm: 'Single Arm',
+    },
+  ],
+]);
+
+const block = (movementName: string, weightKg: number) => ({
+  user_movement_id: `id-${movementName}`,
+  movement_name: movementName,
+  weight_kg: weightKg,
+  rep_scheme: [5],
+  notes: '',
+});
+
+const recommendation = (movementNames: [string, number][]): Recommendation => ({
+  rationale: 'test',
+  duration_minutes: 20,
+  format: 'Straight Sets',
+  confidence: 'high',
+  blocks: movementNames.map(([name, weight]) => block(name, weight)),
+});
+
+describe('recommendationToMovements', () => {
+  test('a genuine two-bell movement resolves to Double, carrying the prescribed load', () => {
+    const [movement] = recommendationToMovements(
+      recommendation([[DOUBLE_KB_FRONT_SQUAT, 24]]),
+      catalog,
+    );
+
+    expect(movement.weightOneValue).toBe(24);
+    expect(movement.weightTwoValue).toBe(24);
+    expect(movement.weightTwoUnit).toBe('kilograms');
+    expect(getWeightTabValue(movement)).toBe('double');
+  });
+
+  test('a one-bell two-hand movement is unaffected and resolves to 2H', () => {
+    const [movement] = recommendationToMovements(
+      recommendation([[TWO_HAND_SWING, 32]]),
+      catalog,
+    );
+
+    expect(movement.weightOneValue).toBe(32);
+    expect(movement.weightTwoValue).toBeNull();
+    expect(movement.weightTwoUnit).toBeNull();
+    expect(getWeightTabValue(movement)).toBe('2h');
+  });
+
+  test('a single-arm movement pins weight two to 0 and resolves to 1H', () => {
+    const [movement] = recommendationToMovements(
+      recommendation([[SINGLE_ARM_PRESS, 16]]),
+      catalog,
+    );
+
+    expect(movement.weightOneValue).toBe(16);
+    expect(movement.weightTwoValue).toBe(0);
+    expect(getWeightTabValue(movement)).toBe('1h');
+  });
+
+  test('without catalog metadata the second weight stays unset (2H), matching prior behavior', () => {
+    const [noCatalog] = recommendationToMovements(
+      recommendation([[DOUBLE_KB_FRONT_SQUAT, 24]]),
+    );
+    expect(noCatalog.weightTwoValue).toBeNull();
+    expect(getWeightTabValue(noCatalog)).toBe('2h');
+
+    const [unknownMovement] = recommendationToMovements(
+      recommendation([['Not In Catalog', 24]]),
+      catalog,
+    );
+    expect(unknownMovement.weightTwoValue).toBeNull();
+    expect(getWeightTabValue(unknownMovement)).toBe('2h');
+  });
+
+  test('maps each block to a movement, preserving name and rep scheme', () => {
+    const movements = recommendationToMovements(
+      recommendation([
+        [DOUBLE_KB_FRONT_SQUAT, 24],
+        [SINGLE_ARM_PRESS, 16],
+      ]),
+      catalog,
+    );
+
+    expect(movements).toHaveLength(2);
+    expect(movements[0].movementName).toBe(DOUBLE_KB_FRONT_SQUAT);
+    expect(movements[0].repScheme).toEqual([5]);
+    expect(movements[1].movementName).toBe(SINGLE_ARM_PRESS);
+  });
+});
+
+describe('recommendationToWorkoutOptions', () => {
+  test('threads the catalog through so movements carry inferred loading modes', () => {
+    const options = recommendationToWorkoutOptions(
+      recommendation([[DOUBLE_KB_FRONT_SQUAT, 24]]),
+      catalog,
+    );
+
+    expect(getWeightTabValue(options.movements[0])).toBe('double');
+    expect(options.workoutGoal).toBe(20);
+    expect(options.workoutGoalUnits).toBe('minutes');
+  });
+});

--- a/src/pages/StartWorkoutPage/utils/recommendationToMovements.ts
+++ b/src/pages/StartWorkoutPage/utils/recommendationToMovements.ts
@@ -1,21 +1,48 @@
 import type { MovementOptions, Recommendation, WorkoutOptions } from '~/types';
+import {
+  type MovementWeightModeFields,
+  movementMatchesWeightMode,
+} from '~/utils';
+
+/** Catalog weight-mode metadata keyed by canonical movement name. */
+export type RecommendationCatalog = ReadonlyMap<
+  string,
+  MovementWeightModeFields
+>;
+
+// Fills the second weight slot from catalog metadata so the builder opens in the
+// loading mode the movement implies (getWeightTabValue): a genuine two-bell
+// movement carries the prescribed load (Double), a single-arm movement pins it
+// to 0 (1H), and everything else stays unset (2H, the pre-catalog default).
+const inferSecondWeight = (
+  fields: MovementWeightModeFields | undefined,
+  weightKg: number,
+): Pick<MovementOptions, 'weightTwoUnit' | 'weightTwoValue'> => {
+  if (fields && movementMatchesWeightMode(fields, 'double')) {
+    return { weightTwoUnit: 'kilograms', weightTwoValue: weightKg };
+  }
+  if (fields && movementMatchesWeightMode(fields, '1h')) {
+    return { weightTwoUnit: null, weightTwoValue: 0 };
+  }
+  return { weightTwoUnit: null, weightTwoValue: null };
+};
 
 /**
  * Maps a recommendation's blocks onto the app's MovementOptions. The recommender
  * prescribes a single weight in kilograms per movement, which becomes weight one;
- * the second weight slot is left unset for the user to fill if they want offset
- * or double-bell loading.
+ * the second weight slot is inferred from the movement's catalog metadata so
+ * two-bell movements open as Double rather than defaulting to two-hand.
  */
 export const recommendationToMovements = (
   recommendation: Recommendation,
+  catalog?: RecommendationCatalog,
 ): MovementOptions[] =>
   recommendation.blocks.map((block) => ({
     movementName: block.movement_name,
     repScheme: block.rep_scheme,
     weightOneUnit: 'kilograms',
     weightOneValue: block.weight_kg,
-    weightTwoUnit: null,
-    weightTwoValue: null,
+    ...inferSecondWeight(catalog?.get(block.movement_name), block.weight_kg),
   }));
 
 /**
@@ -25,10 +52,11 @@ export const recommendationToMovements = (
  */
 export const recommendationToWorkoutOptions = (
   recommendation: Recommendation,
+  catalog?: RecommendationCatalog,
 ): Omit<WorkoutOptions, 'startedAt'> => ({
   complexSet: false,
   intervalTimer: 0,
-  movements: recommendationToMovements(recommendation),
+  movements: recommendationToMovements(recommendation, catalog),
   restTimer: 0,
   sharedWeightOneUnit: null,
   sharedWeightOneValue: null,

--- a/src/pages/StartWorkoutPage/utils/recommendationToMovements.ts
+++ b/src/pages/StartWorkoutPage/utils/recommendationToMovements.ts
@@ -1,4 +1,9 @@
-import type { MovementOptions, Recommendation, WorkoutOptions } from '~/types';
+import type {
+  Movement,
+  MovementOptions,
+  Recommendation,
+  WorkoutOptions,
+} from '~/types';
 import {
   type MovementWeightModeFields,
   movementMatchesWeightMode,
@@ -9,6 +14,28 @@ export type RecommendationCatalog = ReadonlyMap<
   string,
   MovementWeightModeFields
 >;
+
+/**
+ * Builds the name→metadata lookup the recommender maps against. A single catalog
+ * page is meant to hold every movement; if the source query reports another page
+ * (`hasNextPage`), movements past page one are absent from the map and silently
+ * fall back to 2H — the exact silent-revert PROD-238 killed — so warn loudly.
+ */
+export const buildRecommendationCatalog = (
+  movements: Movement[],
+  hasNextPage = false,
+): RecommendationCatalog => {
+  if (hasNextPage) {
+    console.warn(
+      'movement catalog exceeded MOVEMENT_CATALOG_PAGE_SIZE; recommended weight-mode inference may be incomplete',
+    );
+  }
+  const entries: [string, Movement][] = [];
+  for (const movement of movements) {
+    if (movement.movementName) entries.push([movement.movementName, movement]);
+  }
+  return new Map(entries);
+};
 
 // Fills the second weight slot from catalog metadata so the builder opens in the
 // loading mode the movement implies (getWeightTabValue): a genuine two-bell


### PR DESCRIPTION
## What
The AI recommender now opens each accepted movement in the loading mode it actually implies: a genuine two-bell movement (e.g. "Front Squat With Two Kettlebells") lands on **Double**, a single-arm movement on **1H**, and one-bell two-hand movements stay on **2H**. Previously *every* recommended movement opened as 2H.

## Why
`recommendationToMovements` hardcoded `weightTwoValue: null` for every block, so `getWeightTabValue` (`src/utils/movementWeightModeFilter.ts`) resolved every accepted recommendation to 2H — the double-KB front squat came through as a single two-hand bell. Fixes PROD-238.

## How tested
- New `src/pages/StartWorkoutPage/utils/recommendationToMovements.test.ts` (the util was untested): asserts the double-KB front squat → `double`, a one-bell two-hand movement → `2h` (unchanged), and a single-arm movement → `1h`; plus the no-catalog / unknown-movement path still yields `2h`, and that `recommendationToWorkoutOptions` threads the catalog through.
- `buildRecommendationCatalog` tests cover the null-name skip and, critically, that it **warns** when the source query reports `hasNextPage` and stays silent otherwise.
- `npm test` — 455 passing, including the StartWorkoutPage recommendations suite.
- `npm run compile:ts` clean; `npm run lint` clean; `prettier --check` clean on touched files.

## Implementation notes
- The mapping infers the second weight by reusing the existing `movementMatchesWeightMode` `double`/`1h` predicates rather than re-deriving the rule — the fix generalizes to any two-bell vs. single-bell/two-hand movement.
- The caller `handleAcceptRecommendation` in `StartWorkoutPage.tsx` passes a name→catalog-fields map built from `useMovements`; that catalog query is gated (`enabled: showRecommender`) so non-recommender users fire zero extra requests. `useMovements` gained an optional react-query options passthrough to support the gate. Only `handleAcceptRecommendation` was touched in that file, leaving `handleStartProgram` (PROD-237, in flight) alone.
- **Pagination guard:** inference relies on `MOVEMENT_CATALOG_PAGE_SIZE` (500) holding the whole ~250-row catalog in a single page. If the catalog ever outgrows that, `buildRecommendationCatalog` emits a `console.warn` (triggered off the query's `hasNextPage`) so movements on later pages don't *silently* revert to 2H — the exact failure PROD-238 exists to kill surfaces loudly instead.

## Tradeoffs
- **Accepting before the catalog resolves degrades to 2H, by design.** The catalog query is async; if a user accepts a recommendation before it settles, `recommendationCatalog` is empty and inference falls back to 2H (the old behavior) rather than blocking the accept on `isSuccess`. This is intentional graceful degradation — the accept flow stays responsive, and the far more common path (catalog resolves well before the user reviews and accepts) gets correct inference. Gating the accept on the query would trade a rare, self-correcting miss for a guaranteed latency hit on every accept.
- The plan referenced a "now-wrong fixture" at `StartWorkoutPage.recommendations.test.jsx:216-217`; in the current `origin/main` that location is a repeat-from-history fixture ("Clean and Press") that never routes through `recommendationToMovements`, so it is genuinely unaffected and was left untouched rather than edited to a wrong value. The behavior is instead covered directly by the new util test.
- Fetching the whole ~250-row catalog (one page, `limit: 500`) to infer loading mode is heavier than a targeted per-movement lookup, but it's gated to the recommender surface and cached by react-query; a bespoke lookup endpoint buys nothing at this catalog size.

🤖 Generated with [Claude Code](https://claude.com/claude-code)