### PR TITLE
fix(programs): de-collide archived_at migration skipped on prod

### DIFF
--- a/supabase/migrations/20260720120000_add_program_archived_at.sql
+++ b/supabase/migrations/20260720120000_add_program_archived_at.sql
@@ -1,5 +1,13 @@
 -- Program Tracking (PROD-237, slice 3): soft-archive for owned programs.
 --
+-- Forward re-add of the archived_at column. The original migration
+-- (20260717000000_add_program_archived_at.sql) collided on version with
+-- 20260717000000_relink_deployed_dfw_to_catalog.sql; prod's schema_migrations
+-- recorded only the relink at that version, so the column was silently skipped
+-- on prod and the Archive feature (src/api/useSetProgramArchived.ts) broke. The
+-- colliding file is removed to de-collide history; this idempotent forward
+-- migration is what actually reaches prod.
+--
 -- "My Programs" accumulates program definitions the user owns — both
 -- hand-authored programs and the copy-on-enroll clones minted every time they
 -- start a shared program. To let users tidy that list without losing history,
@@ -11,4 +19,4 @@
 -- "Users can update own programs" policy, and reads are unchanged. Delete stays
 -- the separate irreversible cascade (existing DELETE policy + ON DELETE CASCADE);
 -- archive is the reversible, history-preserving alternative.
-ALTER TABLE programs ADD COLUMN archived_at TIMESTAMPTZ;
+ALTER TABLE programs ADD COLUMN IF NOT EXISTS archived_at TIMESTAMPTZ;


### PR DESCRIPTION
## What
Two merged migrations were given the same version `20260717000000` —
`add_program_archived_at` (#138) and `relink_deployed_dfw_to_catalog` (#142).
This removes the colliding `add_program_archived_at` file and re-adds the column
as a forward, idempotent migration (`20260720120000_add_program_archived_at.sql`,
`ADD COLUMN IF NOT EXISTS archived_at TIMESTAMPTZ`).

## Why
No Linear ticket — full context here.

Prod's `schema_migrations` recorded only `relink_deployed_dfw_to_catalog` at
version `20260717000000`, so Postgres treated that version as already applied and
**silently skipped** the sibling `add_program_archived_at` migration. Verified
against prod: `programs.archived_at` does not exist there, which breaks the
Archive feature — `src/api/useSetProgramArchived.ts` writes `programs.archived_at`
on every archive/restore. The duplicate version also aborts `supabase db reset`
locally, so the collision blocks both prod and local dev.

Because prod already recorded the *other* file at `20260717000000`, deleting the
`add_program_archived_at` file de-collides migration history with no
`supabase migration repair` needed. The column reaches prod through the new
forward migration, timestamped above prod's applied ceiling so `db push` accepts
it. `relink_deployed_dfw_to_catalog` is left exactly as applied.

The re-add is idempotent (`IF NOT EXISTS`) and additive-only — a pure nullable
column, no data re-key, so no prod survival count applies. On merge, CI
`db push` applies the column to prod.

## How tested
- `npx supabase db reset` completes cleanly — no duplicate-version abort (the key proof).
- `programs.archived_at` (`timestamp with time zone`) confirmed present via
  `information_schema.columns` after reset.
- `npm run gen:types`: no diff — `types/supabase.ts` already carried `archived_at`
  from #138's generation, so the types were correct while the prod column was not.
- Unit: `ProgramsPage.test.tsx` (18) + `useSetProgramArchived.test.ts` (3) — all green.
- e2e: full `e2e/program-*.spec.ts` suite (39 tests) green, including
  `program-crud` archive/restore and the owner-only archive-protection paths.
- `npm run compile:ts` + `npm run lint` clean.

## Tradeoffs
Considered `supabase migration repair` to reconcile history in place instead of
deleting the file. Repair keeps both filenames on disk, which reads as intentional
history — but prod never applied `add_program_archived_at`, so there is nothing to
repair *to*; a forward migration is the honest record of what actually reaches
prod. Delete + forward-re-add also fixes `supabase db reset` for every developer,
which repair alone would not.

Note on rebase: PR #145 (in flight) also regenerated `types/supabase.ts` and adds
`20260720000000_resume_program.sql` (a distinct timestamp from this PR's
`20260720120000`). Expect a trivial `types/supabase.ts` rebase depending on merge
order; the migration filenames do not collide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)