### PR TITLE
fix(movements): rename Front Squat With Two Kettlebells to Double Kettlebell Front Squat

### DIFF
--- a/e2e/program-armor-building-complex.spec.ts
+++ b/e2e/program-armor-building-complex.spec.ts
@@ -20,7 +20,7 @@ const ABC_SESSION_COUNT = 20;
 const EXPECTED_MOVEMENTS = [
   { movementName: 'Two-Arm Kettlebell Clean', repScheme: [2] },
   { movementName: 'Two-Arm Kettlebell Military Press', repScheme: [1] },
-  { movementName: 'Front Squat With Two Kettlebells', repScheme: [3] },
+  { movementName: 'Double Kettlebell Front Squat', repScheme: [3] },
 ];
 
 // Round-progression ramp (progression = add rounds, not weight), by sequence.

--- a/e2e/program-easy-strength.spec.ts
+++ b/e2e/program-easy-strength.spec.ts
@@ -112,7 +112,7 @@ const EXPECTED_MOVEMENTS = [
   'Two-Arm Kettlebell Military Press',
   'Pull-Up',
   'Kettlebell Swing',
-  'Front Squat With Two Kettlebells',
+  'Double Kettlebell Front Squat',
   "Kettlebell Farmer's Carry",
 ];
 
@@ -189,7 +189,7 @@ test.describe('program schema — Easy Strength seed', () => {
       expect(byName['Two-Arm Kettlebell Military Press'].weightTwoValue).toBe(
         24,
       );
-      expect(byName['Front Squat With Two Kettlebells'].weightTwoValue).toBe(
+      expect(byName['Double Kettlebell Front Squat'].weightTwoValue).toBe(
         24,
       );
       expect(byName["Kettlebell Farmer's Carry"].weightTwoValue).toBe(24);

--- a/scripts/data/movements.csv
+++ b/scripts/data/movements.csv
@@ -35,7 +35,7 @@ Kettlebell Single-Leg Romanian Deadlift,Kettlebell,1,Single Arm,Hamstrings,Inter
 Kettlebell Staggered Deadlift,Kettlebell,1,Single Arm,Hamstrings,Intermediate,Hip Hinge
 Kettlebell Good Morning,Kettlebell,1,Double Arm,Hamstrings,Intermediate,Hip Hinge
 Goblet Squat,Kettlebell,1,Double Arm,Quadriceps,Beginner,Knee Dominant
-Front Squat With Two Kettlebells,Kettlebell,2,Double Arm,Quadriceps,Intermediate,Knee Dominant
+Double Kettlebell Front Squat,Kettlebell,2,Double Arm,Quadriceps,Intermediate,Knee Dominant
 Kettlebell Pistol Squat,Kettlebell,1,Double Arm,Quadriceps,Expert,Knee Dominant
 One-Arm Overhead Kettlebell Squat,Kettlebell,1,Single Arm,Quadriceps,Expert,Knee Dominant
 Kettlebell Front Rack Squat,Kettlebell,1,Single Arm,Quadriceps,Intermediate,Knee Dominant

--- a/src/pages/ActiveWorkoutPage/ActiveWorkoutPage.stories.tsx
+++ b/src/pages/ActiveWorkoutPage/ActiveWorkoutPage.stories.tsx
@@ -753,7 +753,7 @@ const ARMOR_BUILDING_COMPLEX_MOVEMENTS = [
   },
   {
     ...DEFAULT_MOVEMENT_OPTIONS,
-    movementName: 'Front Squat With Two Kettlebells',
+    movementName: 'Double Kettlebell Front Squat',
     repScheme: [3],
     weightOneValue: 24,
     weightOneUnit: 'kilograms',

--- a/src/pages/ActiveWorkoutPage/ActiveWorkoutPage.test.jsx
+++ b/src/pages/ActiveWorkoutPage/ActiveWorkoutPage.test.jsx
@@ -1364,7 +1364,7 @@ describe('active workout page (Armor Building Complex seed session)', () => {
     expect(workoutOptions.movements.map((m) => m.movementName)).toEqual([
       'Two-Arm Kettlebell Clean',
       'Two-Arm Kettlebell Military Press',
-      'Front Squat With Two Kettlebells',
+      'Double Kettlebell Front Squat',
     ]);
     workoutOptions.movements.forEach((movement, index) => {
       expect(

--- a/supabase/migrations/20260709000000_slim_movements_catalog.sql
+++ b/supabase/migrations/20260709000000_slim_movements_catalog.sql
@@ -137,7 +137,7 @@ INSERT INTO public.movements ("Movement", "Primary Equipment", "# Primary Items"
   ('Kettlebell Staggered Deadlift', 'Kettlebell', 1, 'Single Arm', 'Hamstrings', 'Intermediate', 'Hip Hinge'),
   ('Kettlebell Good Morning', 'Kettlebell', 1, 'Double Arm', 'Hamstrings', 'Intermediate', 'Hip Hinge'),
   ('Goblet Squat', 'Kettlebell', 1, 'Double Arm', 'Quadriceps', 'Beginner', 'Knee Dominant'),
-  ('Front Squat With Two Kettlebells', 'Kettlebell', 2, 'Double Arm', 'Quadriceps', 'Intermediate', 'Knee Dominant'),
+  ('Double Kettlebell Front Squat', 'Kettlebell', 2, 'Double Arm', 'Quadriceps', 'Intermediate', 'Knee Dominant'),
   ('Kettlebell Pistol Squat', 'Kettlebell', 1, 'Double Arm', 'Quadriceps', 'Expert', 'Knee Dominant'),
   ('One-Arm Overhead Kettlebell Squat', 'Kettlebell', 1, 'Single Arm', 'Quadriceps', 'Expert', 'Knee Dominant'),
   ('Kettlebell Front Rack Squat', 'Kettlebell', 1, 'Single Arm', 'Quadriceps', 'Intermediate', 'Knee Dominant'),

--- a/supabase/migrations/20260720150000_rename_front_squat_double_kb.sql
+++ b/supabase/migrations/20260720150000_rename_front_squat_double_kb.sql
@@ -29,12 +29,16 @@ BEGIN
   WHERE "Movement" = 'Front Squat With Two Kettlebells';
   GET DIAGNOSTICS v_catalog_renamed = ROW_COUNT;
 
-  -- 2. Rewrite the stored movementName in program_sessions.workout_options for
-  --    the shared-program TEMPLATES that reference it (Dry Fighting Weight,
-  --    Armor Building Complex, Easy Strength) AND their copy-on-enroll CLONES
-  --    (source_program_id -> a template). enroll_in_program copies
-  --    workout_options verbatim, so every enrollee holds a clone carrying the
-  --    old name; left unfixed their future logged sessions would orphan.
+  -- 2. Rewrite the stored movementName in EVERY program_sessions row that
+  --    carries the old name. The seeded shared templates (Dry Fighting Weight,
+  --    Armor Building Complex, Easy Strength) and their copy-on-enroll clones
+  --    carry it, but so can a SELF-AUTHORED program: this is a real catalog
+  --    movement any user could have placed in a program via the PROD-237
+  --    builder. Left unfixed, that session's next logged workout spawns a fresh
+  --    user_movements row (old canonical_name, NULL FK) — the exact PROD-234
+  --    orphan class this rename exists to prevent. Scope solely by the
+  --    containment guard: it already touches only sessions holding the old name,
+  --    so broadening past the shared programs is strictly correct.
   UPDATE public.program_sessions ps
   SET workout_options = jsonb_set(
     ps.workout_options,
@@ -51,16 +55,7 @@ BEGIN
       FROM jsonb_array_elements(ps.workout_options->'movements') WITH ORDINALITY AS m(elem, ord)
     )
   )
-  FROM public.programs p
-  WHERE p.id = ps.program_id
-    AND (
-      p.slug IN ('dry-fighting-weight', 'armor-building-complex', 'easy-strength')
-      OR p.source_program_id IN (
-        SELECT id FROM public.programs
-        WHERE slug IN ('dry-fighting-weight', 'armor-building-complex', 'easy-strength')
-      )
-    )
-    AND ps.workout_options->'movements' @> '[{"movementName": "Front Squat With Two Kettlebells"}]'::jsonb;
+  WHERE ps.workout_options->'movements' @> '[{"movementName": "Front Squat With Two Kettlebells"}]'::jsonb;
   GET DIAGNOSTICS v_sessions_fixed = ROW_COUNT;
 
   -- 3. Rename the denormalized canonical_name on user_movements rows already

--- a/supabase/migrations/20260720150000_rename_front_squat_double_kb.sql
+++ b/supabase/migrations/20260720150000_rename_front_squat_double_kb.sql
@@ -1,0 +1,96 @@
+-- PROD-239: Rename the catalog movement
+--   'Front Squat With Two Kettlebells' -> 'Double Kettlebell Front Squat'
+-- everywhere the old string is denormalized, so nothing splits or orphans.
+--
+-- The reload migration (20260709000000_slim_movements_catalog.sql) and the CSV
+-- source of truth now emit the new name, so a fresh `db reset` reproduces the
+-- catalog correctly. But that reload is already applied in production
+-- (forward-only `db push` skips applied versions), and the old name is also
+-- baked into seeded program JSON and denormalized user rows. This forward
+-- data-fix reconciles the DEPLOYED data. Modeled on #142
+-- (20260717000000_relink_deployed_dfw_to_catalog.sql).
+--
+-- All four parts are idempotent, guarded, and NULL-safe: a re-run (or a fresh
+-- env where the reload/seeds already carry the new name) matches nothing.
+-- Row counts are surfaced via RAISE NOTICE for the post-merge prod survival
+-- check.
+
+DO $$
+DECLARE
+  v_catalog_renamed  INT;
+  v_sessions_fixed   INT;
+  v_canonical_fixed  INT;
+  v_orphans_relinked INT;
+BEGIN
+  -- 1. Rename the catalog row in place. The id is untouched, so every FK
+  --    (user_movements.functional_movement_id) stays valid.
+  UPDATE public.movements
+  SET "Movement" = 'Double Kettlebell Front Squat'
+  WHERE "Movement" = 'Front Squat With Two Kettlebells';
+  GET DIAGNOSTICS v_catalog_renamed = ROW_COUNT;
+
+  -- 2. Rewrite the stored movementName in program_sessions.workout_options for
+  --    the shared-program TEMPLATES that reference it (Dry Fighting Weight,
+  --    Armor Building Complex, Easy Strength) AND their copy-on-enroll CLONES
+  --    (source_program_id -> a template). enroll_in_program copies
+  --    workout_options verbatim, so every enrollee holds a clone carrying the
+  --    old name; left unfixed their future logged sessions would orphan.
+  UPDATE public.program_sessions ps
+  SET workout_options = jsonb_set(
+    ps.workout_options,
+    '{movements}',
+    (
+      SELECT jsonb_agg(
+        CASE elem->>'movementName'
+          WHEN 'Front Squat With Two Kettlebells'
+            THEN jsonb_set(elem, '{movementName}', '"Double Kettlebell Front Squat"'::jsonb)
+          ELSE elem
+        END
+        ORDER BY ord
+      )
+      FROM jsonb_array_elements(ps.workout_options->'movements') WITH ORDINALITY AS m(elem, ord)
+    )
+  )
+  FROM public.programs p
+  WHERE p.id = ps.program_id
+    AND (
+      p.slug IN ('dry-fighting-weight', 'armor-building-complex', 'easy-strength')
+      OR p.source_program_id IN (
+        SELECT id FROM public.programs
+        WHERE slug IN ('dry-fighting-weight', 'armor-building-complex', 'easy-strength')
+      )
+    )
+    AND ps.workout_options->'movements' @> '[{"movementName": "Front Squat With Two Kettlebells"}]'::jsonb;
+  GET DIAGNOSTICS v_sessions_fixed = ROW_COUNT;
+
+  -- 3. Rename the denormalized canonical_name on user_movements rows already
+  --    linked to the (now renamed) catalog id. Without this, a future log under
+  --    the new catalog name would create a SECOND user_movements row and split
+  --    the lifter's history across two rows.
+  UPDATE public.user_movements u
+  SET canonical_name = 'Double Kettlebell Front Squat'
+  FROM public.movements m
+  WHERE m."Movement" = 'Double Kettlebell Front Squat'
+    AND u.functional_movement_id = m.id
+    AND u.canonical_name = 'Front Squat With Two Kettlebells';
+  GET DIAGNOSTICS v_canonical_fixed = ROW_COUNT;
+
+  -- 4. Re-relink the PROD-234 orphan target. The applied relink
+  --    (20260716090000_relink_orphaned_user_movements.sql) mapped
+  --    'Double Kettlebell Front Rack Squat' -> 'Front Squat With Two Kettlebells'.
+  --    After the reload emits the new name, that JOIN matches nothing on a fresh
+  --    reset, re-stranding those rows; in prod any still-NULL row (e.g. logged
+  --    after the relink) is likewise unmatched. Relink them to the new name.
+  --    Writes only where functional_movement_id IS NULL, so already-linked rows
+  --    are untouched and a re-run is a no-op.
+  UPDATE public.user_movements u
+  SET functional_movement_id = m.id
+  FROM public.movements m
+  WHERE m."Movement" = 'Double Kettlebell Front Squat'
+    AND lower(u.canonical_name) = lower('Double Kettlebell Front Rack Squat')
+    AND u.functional_movement_id IS NULL;
+  GET DIAGNOSTICS v_orphans_relinked = ROW_COUNT;
+
+  RAISE NOTICE 'PROD-239 rename: catalog rows renamed=%, program_sessions rewritten=%, user_movements canonical renamed=%, orphans relinked=%',
+    v_catalog_renamed, v_sessions_fixed, v_canonical_fixed, v_orphans_relinked;
+END $$;


### PR DESCRIPTION
## What
Rename the catalog movement `Front Squat With Two Kettlebells` → `Double Kettlebell Front Squat` everywhere the old string is denormalized — the CSV source of truth, the regenerated catalog reload, every program's session JSON, and denormalized user rows — so nothing splits or orphans (PROD-239).

## Why
This is not a catalog-only rename. The old name is baked into shared-program session JSON, self-authored program sessions, and `user_movements.canonical_name`. Renaming only the catalog row would (1) leave deployed program JSON pointing at a name that no longer exists, so future logged sessions orphan, (2) split a lifter's history when a future log matches the new catalog name and creates a *second* `user_movements` row, and (3) re-strand the PROD-234 orphan target, which `20260716090000_relink_orphaned_user_movements.sql` pins to the old name — after the reload emits the new name that JOIN matches nothing on a fresh reset.

The change is in two layers:

1. **Source of truth (inert in prod, keeps fresh/staging consistent):** `scripts/data/movements.csv` and the regenerated reload block in `20260709000000_slim_movements_catalog.sql` (via `npm run movements:emit-sql`).
2. **Forward data-fix migration** `20260720150000_rename_front_squat_double_kb.sql` (timestamp above origin/main's ceiling `20260720120000`). Idempotent, guarded, NULL-safe, and it reports each statement's row count via `RAISE NOTICE`:
   - a. Rename the catalog row in place — id stays stable so every FK stays valid.
   - b. `jsonb_set` the stored `movementName` old→new across **every** `program_sessions` row carrying the old name — shared templates (DFW, ABC, Easy Strength), their copy-on-enroll clones, **and self-authored programs**, since this is a real catalog movement any user could place via the PROD-237 builder. Scoped solely by the `workout_options->'movements' @> [{"movementName": ...}]` containment guard.
   - c. Rename `user_movements.canonical_name` old→new for rows linked to the renamed id, preventing a future duplicate-row split.
   - d. Re-relink `Double Kettlebell Front Rack Squat` orphans (FK still NULL) to the new name.

`movement_logs.movement_name` is intentionally left as-logged: it is a historical record of what was performed, and pattern-debt bucketing joins on `user_movements.functional_movement_id`, not that raw text label — so rewriting it would falsify history for no functional gain.

## How tested
- `npm run movements:check` → 252 valid; `npm run gen:types` → no diff (rename is a data value, not a schema change).
- `npx supabase db reset` replays the full chain clean. The new migration's NOTICE: `catalog rows renamed=0, program_sessions rewritten=43, user_movements canonical renamed=0, orphans relinked=0` (0 catalog/user rows on a fresh reset because the reload/seeds already carry the new name; 43 = the shared-program template sessions rewritten from old→new).
- Post-reset survival queries: catalog resolves 0 old / 1 new; **0** program_sessions (any program) reference the old name; new-name sessions = ABC 20, DFW 13, Easy Strength 10; **0** `user_movements` under the old canonical name.
- Affected fixtures updated and green: `e2e/program-easy-strength.spec.ts`, `e2e/program-armor-building-complex.spec.ts` (5 Playwright tests pass), `ActiveWorkoutPage.test.jsx` (60 tests pass), `ActiveWorkoutPage.stories.tsx`. `npm run compile:ts` and `npm run lint` clean.

## Post-merge prod survival check (captain runs against prod after merge)
A local `db reset` regenerates both sides together and cannot verify a re-key against real prod data. Run this after merge — expect **0** rows referencing the old name; note the relinked/renamed `user_movements` counts:

```sql
-- 1. Catalog: old name gone, new name present (expect 0 old, 1 new).
SELECT
  count(*) FILTER (WHERE "Movement" = 'Front Squat With Two Kettlebells') AS old_name,
  count(*) FILTER (WHERE "Movement" = 'Double Kettlebell Front Squat')    AS new_name
FROM public.movements;

-- 2. No program_sessions (any program — shared, clones, self-authored) reference the old name (expect 0).
SELECT count(*) AS sessions_referencing_old_name
FROM public.program_sessions
WHERE workout_options->'movements' @> '[{"movementName": "Front Squat With Two Kettlebells"}]'::jsonb;

-- 3. New-name sessions, by program (sanity — DFW/ABC/Easy Strength templates + clones + any self-authored).
SELECT p.slug, count(*)
FROM public.program_sessions ps
JOIN public.programs p ON p.id = ps.program_id
WHERE ps.workout_options->'movements' @> '[{"movementName": "Double Kettlebell Front Squat"}]'::jsonb
GROUP BY p.slug ORDER BY p.slug;

-- 4. No user_movements left under the old canonical_name (expect 0).
SELECT count(*) AS user_movements_old_canonical
FROM public.user_movements
WHERE canonical_name = 'Front Squat With Two Kettlebells';

-- 5. The renamed catalog id has no NULL-FK orphans left under the old front-rack name (expect 0).
SELECT count(*) AS unrelinked_front_rack_orphans
FROM public.user_movements
WHERE lower(canonical_name) = lower('Double Kettlebell Front Rack Squat')
  AND functional_movement_id IS NULL;
```

## Tradeoffs
I considered editing the three seed migrations' JSON in place (as #142 did for the DFW seed) so a fresh reset needs no rewrite. That keeps the seed files self-consistent, but it means editing already-applied migrations for the ABC/Easy Strength seeds — inert in prod and a wider blast radius than the guardrails want. The forward data-fix rewrites both fresh and prod from a single additive migration, so the seed files stay untouched and prod and fresh converge through the same code path. It also naturally covers self-authored programs, which a seed-file edit never could.

🤖 Generated with [Claude Code](https://claude.com/claude-code)