### PR TITLE
fix(home): stop homepage crash from hooks-order violation

### DIFF
--- a/src/pages/StartWorkoutPage/StartWorkoutPage.hooksOrder.test.jsx
+++ b/src/pages/StartWorkoutPage/StartWorkoutPage.hooksOrder.test.jsx
@@ -1,0 +1,91 @@
+import { render, screen } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from 'react-query';
+import { MemoryRouter } from 'react-router-dom';
+
+import { DEFAULT_WORKOUT_OPTIONS, WorkoutOptionsContext } from '~/contexts';
+
+import { StartWorkoutPage } from './StartWorkoutPage';
+
+// Regression coverage for the prod homepage outage (React #310, "rendered more
+// hooks than during the previous render"). PR #138 added two hooks — an
+// `editSeeded` ref and a `seedBuilderForEdit` effect — BELOW the
+// `if (gatesPending) return <Loading />` early return. On a cold load the
+// active-program query starts pending (`gatesPending` true → bail before those
+// hooks), then resolves (`gatesPending` false → run them), so the hook count
+// changed between renders and the homepage crashed for every logged-in user.
+// The fix moves the guard below every hook; this test drives the same
+// pending→resolved transition on one component instance and asserts it never
+// throws.
+const { mockUseActiveProgram, mockUseFeatures } = vi.hoisted(() => ({
+  mockUseActiveProgram: vi.fn(),
+  mockUseFeatures: vi.fn(),
+}));
+vi.mock('~/api', async (importOriginal) => ({
+  ...(await importOriginal()),
+  useActiveProgram: mockUseActiveProgram,
+}));
+vi.mock('~/hooks', async (importOriginal) => ({
+  ...(await importOriginal()),
+  useFeatures: mockUseFeatures,
+}));
+
+const BASE_FEATURES = {
+  bottomNav: false,
+  complexMode: false,
+  explore: false,
+  premium: false,
+  programs: true,
+  weeklyBalance: false,
+};
+
+const makeQueryClient = () =>
+  new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+
+const renderPage = () =>
+  render(
+    <QueryClientProvider client={makeQueryClient()}>
+      <MemoryRouter initialEntries={[{ pathname: '/', state: null }]}>
+        <WorkoutOptionsContext.Provider
+          value={[DEFAULT_WORKOUT_OPTIONS, vi.fn()]}
+        >
+          <StartWorkoutPage />
+        </WorkoutOptionsContext.Provider>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+
+describe('StartWorkoutPage hooks-order stability', () => {
+  beforeEach(() => {
+    mockUseFeatures.mockReturnValue(BASE_FEATURES);
+  });
+
+  test('renders through the active-program pending→resolved transition without a hooks-order crash', () => {
+    mockUseActiveProgram.mockReturnValue({ data: undefined, isError: false });
+
+    const { rerender } = renderPage();
+
+    expect(screen.getByRole('status')).toBeInTheDocument();
+    expect(screen.queryByLabelText('Movement Input')).not.toBeInTheDocument();
+
+    mockUseActiveProgram.mockReturnValue({ data: null, isError: false });
+
+    expect(() =>
+      rerender(
+        <QueryClientProvider client={makeQueryClient()}>
+          <MemoryRouter initialEntries={[{ pathname: '/', state: null }]}>
+            <WorkoutOptionsContext.Provider
+              value={[DEFAULT_WORKOUT_OPTIONS, vi.fn()]}
+            >
+              <StartWorkoutPage />
+            </WorkoutOptionsContext.Provider>
+          </MemoryRouter>
+        </QueryClientProvider>,
+      ),
+    ).not.toThrow();
+
+    expect(screen.queryByRole('status')).not.toBeInTheDocument();
+    expect(screen.getByLabelText('Movement Input')).toBeInTheDocument();
+  });
+});

--- a/src/pages/StartWorkoutPage/StartWorkoutPage.tsx
+++ b/src/pages/StartWorkoutPage/StartWorkoutPage.tsx
@@ -319,10 +319,6 @@ export const StartWorkoutPage = ({
 
   const detailsRef = useRef<HTMLInputElement>(null);
 
-  // The program gate above hasn't settled, so the mode above is still derived
-  // from a forced `showBrowse` — withhold rendering rather than commit to it.
-  if (gatesPending) return <Loading />;
-
   const handleIncrementGoalValue = () => {
     if (workoutGoalUnits === 'kilograms') {
       setWorkoutGoal((prev) => prev + INCREMENT_VOLUME);
@@ -723,6 +719,12 @@ export const StartWorkoutPage = ({
     movements.some((movement) => movement.movementName.length === 0) ||
     isDifferentRepSchemes ||
     workoutGoal <= 0;
+
+  // Held below every hook so the pending→resolved gate transition can't change
+  // the hook count between renders (Rules of Hooks / React #310). The mode above
+  // is still derived from a forced `showBrowse` until the gate settles, so
+  // withhold the real UI rather than commit to it.
+  if (gatesPending) return <Loading />;
 
   return (
     <Page


### PR DESCRIPTION
## What
Move the `if (gatesPending) return <Loading />` guard in `StartWorkoutPage` (the homepage) from the middle of the hook list down to just before the final JSX, so no React hook is ever called after a conditional early return.

## Why
The homepage crashed on cold load for **every logged-in user** — React minified error #310 ("rendered more hooks than during the previous render"), caught by `RouteErrorBoundary` as "Something went wrong." This is a live prod outage introduced by #138.

Root cause: #138 added two hooks below the early return — `const editSeeded = useRef(false)` and a `useEffect(seedBuilderForEdit, …)`. On a cold load the active-program query starts pending (`gatesPending` true), so render 1 bails at the early return before those hooks; when the query resolves (`gatesPending` false) render 2 runs them, so the hook count changes between renders and React throws.

The guard is the only component-level early return; moving it below every hook (rather than moving the two hooks up — the offending effect calls `loadIntoBuilder`, defined later) is the smaller, behavior-preserving change.

## How tested
- New regression test `StartWorkoutPage.hooksOrder.test.jsx` drives the active-program pending→resolved transition on a single instance and asserts it renders both states without throwing. Confirmed it **fails with the exact #310 error** against the pre-fix code and passes after.
- `npm test` for `src/pages/StartWorkoutPage` — 10 files, 73 tests green.
- `npm run compile:ts` clean, `npm run lint` clean.

## Tradeoffs
Considered hoisting the two hooks above the guard instead. Rejected: the `seedBuilderForEdit` effect calls `loadIntoBuilder`, which is defined further down, so hoisting the hooks would have dragged handler definitions up too — a larger, riskier diff for a hotfix. Moving the single guard keeps behavior byte-identical (still `<Loading />` while pending, resolved UI otherwise) and touches the fewest lines.

This adds the regression coverage that was missing when #138 landed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)