### PR TITLE
feat(programs): fix loading mode in enroll starting-weight picker

### DIFF
--- a/src/pages/ProgramsPage/ProgramsPage.test.tsx
+++ b/src/pages/ProgramsPage/ProgramsPage.test.tsx
@@ -123,6 +123,20 @@ const snatchTest = {
   createdAt: '',
 };
 
+const swingChallenge = {
+  id: 'swing-1',
+  ownerId: null,
+  sourceProgramId: null,
+  slug: '10000-swing-challenge',
+  title: '10,000 Swing Challenge',
+  description: null,
+  authorName: 'Dan John',
+  numWeeks: 4,
+  daysPerWeek: 5,
+  isPublic: true,
+  createdAt: '',
+};
+
 // Minimal session whose first movement carries the given loading. `weightTwo`
 // null → two-hand, 0 → single, >0 → double.
 const sessionWith = (
@@ -173,6 +187,7 @@ const SESSIONS_BY_ID: Record<string, ReturnType<typeof sessionWith>[]> = {
     ...Array.from({ length: 11 }, () => sessionWith(24, 0)),
     ...Array.from({ length: 10 }, () => sessionWith(20, 0)),
   ],
+  'swing-1': Array.from({ length: 20 }, () => sessionWith(24, null)),
 };
 
 const renderPage = () =>
@@ -339,19 +354,16 @@ describe('ProgramsPage', () => {
     );
   });
 
-  it('omits the Bodyweight mode from the starting-weight prompt', () => {
+  it('offers no loading-mode tabs — the program fixes the mode', () => {
     renderPage();
 
     fireEvent.click(
       screen.getByRole('button', { name: 'Start Dry Fighting Weight' }),
     );
 
-    expect(
-      screen.queryByRole('tab', { name: 'Bodyweight' }),
-    ).not.toBeInTheDocument();
-    expect(screen.getByRole('tab', { name: 'Two-Hand' })).toBeInTheDocument();
-    expect(screen.getByRole('tab', { name: 'Single' })).toBeInTheDocument();
-    expect(screen.getByRole('tab', { name: 'Double' })).toBeInTheDocument();
+    expect(screen.queryByRole('tab', { name: 'Two-Hand' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('tab', { name: 'Single' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('tab', { name: 'Double' })).not.toBeInTheDocument();
   });
 
   it('enrolls with mixed independent left/right weights', () => {
@@ -378,22 +390,26 @@ describe('ProgramsPage', () => {
     );
   });
 
-  it('enrolls with a single two-hand weight when the Two-Hand mode is selected', async () => {
+  it('enrolls with a single two-hand weight for a two-hand program', () => {
+    mockUsePrograms.mockReturnValue({
+      data: [swingChallenge, myProgram],
+      isLoading: false,
+    });
+
     renderPage();
 
     fireEvent.click(
-      screen.getByRole('button', { name: 'Start Dry Fighting Weight' }),
+      screen.getByRole('button', { name: 'Start 10,000 Swing Challenge' }),
     );
-    await userEvent.click(screen.getByRole('tab', { name: 'Two-Hand' }));
 
-    // Two-hand loading collapses to one weight input; weight two clears.
+    // A two-hand program collapses to one weight input; weight two stays null.
     expect(screen.getAllByRole('spinbutton')).toHaveLength(1);
 
     fireEvent.click(screen.getByRole('button', { name: 'Start program' }));
 
     expect(enrollMutate).toHaveBeenCalledWith(
       {
-        programId: 'dfw-1',
+        programId: 'swing-1',
         sharedWeightOneValue: 24,
         sharedWeightOneUnit: 'kilograms',
         sharedWeightTwoValue: null,
@@ -420,28 +436,6 @@ describe('ProgramsPage', () => {
         sharedWeightOneUnit: 'pounds',
         sharedWeightTwoValue: 24,
         sharedWeightTwoUnit: 'kilograms',
-      },
-      expect.anything(),
-    );
-  });
-
-  it('preserves the selected unit (lb) across a loading-mode switch', async () => {
-    renderPage();
-
-    fireEvent.click(
-      screen.getByRole('button', { name: 'Start Dry Fighting Weight' }),
-    );
-    await userEvent.click(screen.getAllByRole('tab', { name: 'lb' })[0]);
-    await userEvent.click(screen.getByRole('tab', { name: 'Two-Hand' }));
-    fireEvent.click(screen.getByRole('button', { name: 'Start program' }));
-
-    expect(enrollMutate).toHaveBeenCalledWith(
-      {
-        programId: 'dfw-1',
-        sharedWeightOneValue: 24,
-        sharedWeightOneUnit: 'pounds',
-        sharedWeightTwoValue: null,
-        sharedWeightTwoUnit: null,
       },
       expect.anything(),
     );

--- a/src/pages/ProgramsPage/ProgramsPage.tsx
+++ b/src/pages/ProgramsPage/ProgramsPage.tsx
@@ -17,7 +17,6 @@ import {
   useSetProgramArchived,
 } from '~/api';
 import { ModifyCountButtons, Page, WeightUnitTabs } from '~/components';
-import { WeightModeTabs } from '~/components/MovementAutocomplete';
 import { Button } from '~/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '~/components/ui/card';
 import {
@@ -32,7 +31,7 @@ import { Input } from '~/components/ui/input';
 import { Label } from '~/components/ui/label';
 import { useSession } from '~/contexts';
 import { Program, WeightUnit } from '~/types';
-import { getWeightTabValue, getWeightUnitLabel } from '~/utils';
+import { getWeightUnitLabel } from '~/utils';
 
 import { deriveStartingWeight } from './utils/deriveStartingWeight';
 
@@ -158,32 +157,6 @@ export const ProgramsPage = () => {
       { programId, ...weights },
       { onSuccess: () => navigate('/') },
     );
-
-  const sharedWeightTabValue = getWeightTabValue({
-    weightOneValue: sharedWeightOneValue,
-    weightTwoValue: sharedWeightTwoValue,
-  });
-
-  const handleChangeSharedWeightTab = (value: string) => {
-    setSharedWeightOneValue(
-      value === 'none'
-        ? null
-        : sharedWeightOneValue || DEFAULT_STARTING_WEIGHT_VALUE,
-    );
-    setSharedWeightOneUnit(
-      value === 'none' ? null : sharedWeightOneUnit || DEFAULT_WEIGHT_UNIT,
-    );
-    setSharedWeightTwoValue(
-      value === 'double'
-        ? sharedWeightTwoValue || DEFAULT_STARTING_WEIGHT_VALUE
-        : value === '1h'
-          ? 0
-          : null,
-    );
-    setSharedWeightTwoUnit(
-      value === 'double' ? sharedWeightTwoUnit || DEFAULT_WEIGHT_UNIT : null,
-    );
-  };
 
   const handleChangeSharedWeightOneValue = (value: number) =>
     setSharedWeightOneValue(Math.max(1, value));
@@ -661,13 +634,6 @@ export const ProgramsPage = () => {
           <div className="flex flex-col gap-1">
             {!startingWeightReady && (
               <p className="text-sm text-muted-foreground">Loading…</p>
-            )}
-            {startingWeightReady && (
-              <WeightModeTabs
-                value={sharedWeightTabValue}
-                onValueChange={handleChangeSharedWeightTab}
-                hideNone
-              />
             )}
             {startingWeightReady && sharedWeightOneValue !== null && (
               <ModifyCountButtons


### PR DESCRIPTION
## What
Remove the Two-Hand / Single / Double loading-mode tabs from the "Starting weight" dialog shown when enrolling in a shared program. The program now fixes the loading mode; only the weight values stay editable.

## Why
The picker let the enrollee override the loading mode, but the program's own sessions already dictate it — a two-hand swing program shouldn't be switchable to double bells, and a single-bell program shouldn't offer a phantom second weight. The mode was only ever a sensible default anyway: the dialog seeds it from `deriveStartingWeight(program.sessions)`. Dropping the tabs freezes the mode to that seed while leaving the weight steppers (kg/lb, independent left/right) fully editable.

No change to `deriveStartingWeight`, `resolveSharedWeights`, the `useEnrollProgram` hook, or the `enroll_in_program` RPC — the RPC already round-trips all four weight shapes; the client just stops offering the override.

## How tested
- `npm run compile:ts` — clean (removed the now-unused `WeightModeTabs` / `getWeightTabValue` imports).
- `npx vitest run src/pages/ProgramsPage` — 26/26 pass. Updated the suite to assert the mode tabs are absent and that enrollment still sends the program-determined `sharedWeight*` params (single input → `sharedWeightTwoValue: null` for a two-hand program; two inputs for DFW's double). Added a `10,000 Swing Challenge` two-hand fixture to drive the mode from the program instead of a tab click, and dropped the mode-switch unit test (kg/lb is covered by the per-slot-unit test).
- `npm run lint` not run here — this worktree can't resolve `@typescript-eslint/parser`; CI installs it fresh.

## Tradeoffs
Kept the existing `deriveStartingWeight` seeding as the single source of the mode rather than adding an explicit program-level mode field. It already derives the modal weight and mode from the program's sessions, so a separate field would be redundant state to keep in sync.