### PR TITLE
fix(programs): apply enroll starting weight at workout time

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -289,11 +289,20 @@ session — atomic), and the PROD-219 editing pair `reorder_program_sessions` /
 - **Starting weight on enroll (PROD-TBD):** `enroll_in_program` takes four
   optional params mirroring `workout_options`' shared-weight shape —
   `p_shared_weight_one_value`/`_unit` + `p_shared_weight_two_value`/`_unit`. When
-  weight one is set, the clone's `sharedWeightOne/Two` fields (which
-  `resolveSharedWeights.ts` already prioritizes over a movement's own explicit
-  weight) are overridden on every cloned session whose source weight matches the
-  _modal_ weight across the program — i.e. the shared placeholder, not a
-  deliberately different session like DFW's W5D2 test day. If the program has
+  weight one is set, the clone is overridden on every cloned session whose source
+  weight matches the _modal_ weight across the program — i.e. the shared
+  placeholder, not a deliberately different session like DFW's W5D2 test day. The
+  override writes the chosen weight into **both** the session's
+  `sharedWeightOne/Two` fields (the `complexSet` runtime path —
+  `ComplexMovementDisplay` reads them) **and folds it onto every movement's own
+  `weightOne/Two` fields** (`*_enroll_in_program_fold_movement_weights.sql`,
+  PROD-TBD). The movement fold is what actually makes the choice take effect for
+  the common `complexSet: false` programs (DFW etc.): `sharedWeightOne/Two` is a
+  `complexSet`-only concept — the builder review screen and `ActiveWorkoutPage`
+  (`ActiveWorkoutPage.tsx`) read `movement.weightOneValue` directly and never run
+  `resolveSharedWeights` on the start path (that only runs on the log→repeat/history
+  path via `workoutLogToWorkoutOptions.ts`), so writing `sharedWeightOne/Two`
+  alone was inert and the workout ran at the seed placeholder. If the program has
   no numeric modal (bodyweight-first sessions or widely-varied first-movement
   weights make `v_placeholder_weight` NULL), the override falls back to _every_
   cloned session so the enrollee's chosen weight is never silently discarded. A

--- a/e2e/program-schema.spec.ts
+++ b/e2e/program-schema.spec.ts
@@ -717,7 +717,12 @@ test.describe('program schema — enroll_in_program (starting weight, PROD-TBD)'
       sharedWeightOneUnit: string | null;
       sharedWeightTwoValue: number | null;
       sharedWeightTwoUnit: string | null;
-      movements: Array<{ weightOneValue: number }>;
+      movements: Array<{
+        weightOneValue: number | null;
+        weightOneUnit: string | null;
+        weightTwoValue: number | null;
+        weightTwoUnit: string | null;
+      }>;
     };
   }
 
@@ -766,8 +771,9 @@ test.describe('program schema — enroll_in_program (starting weight, PROD-TBD)'
     expect(active[0].program_id).toBe(cloneId);
 
     // Every regular session (seq 0-12): sharedWeight overridden to the chosen
-    // per-slot value + unit (resolveSharedWeights then overrides every
-    // movement's own weight from these four fields).
+    // per-slot value + unit, AND the chosen weight folded onto every movement's
+    // own weight (the shape ActiveWorkoutPage / the builder read for non-complex
+    // sessions).
     const regularSessions = sessions.filter((s) => s.sequence_index < 13);
     expect(regularSessions).toHaveLength(13);
     for (const session of regularSessions) {
@@ -775,6 +781,12 @@ test.describe('program schema — enroll_in_program (starting weight, PROD-TBD)'
       expect(session.workout_options.sharedWeightOneUnit).toBe('pounds');
       expect(session.workout_options.sharedWeightTwoValue).toBe(16);
       expect(session.workout_options.sharedWeightTwoUnit).toBe('kilograms');
+      for (const movement of session.workout_options.movements) {
+        expect(movement.weightOneValue).toBe(20);
+        expect(movement.weightOneUnit).toBe('pounds');
+        expect(movement.weightTwoValue).toBe(16);
+        expect(movement.weightTwoUnit).toBe('kilograms');
+      }
     }
 
     // The W5D2 test day (seq 13) is left exactly as authored in the source:
@@ -807,6 +819,13 @@ test.describe('program schema — enroll_in_program (starting weight, PROD-TBD)'
       expect(session.workout_options.sharedWeightOneUnit).toBe('kilograms');
       expect(session.workout_options.sharedWeightTwoValue).toBeNull();
       expect(session.workout_options.sharedWeightTwoUnit).toBeNull();
+      // Folded onto every movement: double (seed 24/24) becomes two-hand 28.
+      for (const movement of session.workout_options.movements) {
+        expect(movement.weightOneValue).toBe(28);
+        expect(movement.weightOneUnit).toBe('kilograms');
+        expect(movement.weightTwoValue).toBeNull();
+        expect(movement.weightTwoUnit).toBeNull();
+      }
     }
 
     // The W5D2 test day is still untouched.
@@ -894,7 +913,12 @@ test.describe('program schema — enroll_in_program (starting weight, PROD-TBD)'
     expect(clones).toHaveLength(1);
 
     const sessions = await restJson<
-      Array<{ workout_options: { sharedWeightOneValue: number | null } }>
+      Array<{
+        workout_options: {
+          sharedWeightOneValue: number | null;
+          movements: Array<{ weightOneValue: number | null }>;
+        };
+      }>
     >(
       'GET',
       `program_sessions?program_id=eq.${clones[0].id}&select=workout_options&order=sequence_index.asc`,
@@ -903,6 +927,8 @@ test.describe('program schema — enroll_in_program (starting weight, PROD-TBD)'
     expect(sessions).toHaveLength(2);
     for (const session of sessions) {
       expect(session.workout_options.sharedWeightOneValue).toBe(16);
+      // Folded onto the bodyweight movement too (null -> chosen 16).
+      expect(session.workout_options.movements[0].weightOneValue).toBe(16);
     }
   });
 

--- a/supabase/migrations/20260721000001_enroll_in_program_fold_movement_weights.sql
+++ b/supabase/migrations/20260721000001_enroll_in_program_fold_movement_weights.sql
@@ -1,0 +1,150 @@
+-- Program Tracking: fold the enroll starting weight onto per-movement weights.
+--
+-- 20260714000001_enroll_in_program_starting_weight.sql wrote the enrollee's
+-- chosen weight only into each cloned session's sharedWeightOne/TwoValue/Unit,
+-- on the (mistaken) premise that resolveSharedWeights.ts overrides every
+-- movement's weight from those fields at start time. It does not: sharedWeight*
+-- is a complexSet-only concept. For a complexSet:false program (Dry Fighting
+-- Weight etc.) weights live per-movement in movements[i].weightOne/TwoValue, and
+-- both the builder review screen and ActiveWorkoutPage read those directly. So
+-- the enroll override was inert -- the workout ran at the seed's placeholder
+-- load (double 24kg) no matter what the enrollee picked.
+--
+-- Fix at the source: also fold the chosen weight onto every movement's
+-- per-movement weight fields in the overridden sessions, so a cloned session is
+-- immediately runnable in the shape the runtime already reads. sharedWeight* is
+-- still written (the complex-set path -- e.g. Armor Building Complex -- reads it
+-- via ComplexMovementDisplay; it is harmless and self-healing on non-complex
+-- sessions). No client change is needed.
+--
+-- Which sessions get overridden is unchanged: only sessions whose first
+-- movement's weightOneValue matches the *modal* weight across the source
+-- program (so DFW's deliberately heavier W5D2 test day is left as authored).
+-- A NULL weight-two folds JSON null onto each movement (double -> two-hand),
+-- mirroring the sharedWeight* behavior.
+--
+-- DROP + CREATE (forward-only, idempotent) mirrors the prior migration.
+DROP FUNCTION IF EXISTS public.enroll_in_program(UUID);
+DROP FUNCTION IF EXISTS public.enroll_in_program(UUID, NUMERIC, TEXT, NUMERIC, TEXT);
+
+CREATE FUNCTION public.enroll_in_program(
+  p_program_id UUID,
+  p_shared_weight_one_value NUMERIC DEFAULT NULL,
+  p_shared_weight_one_unit  TEXT    DEFAULT NULL,
+  p_shared_weight_two_value NUMERIC DEFAULT NULL,
+  p_shared_weight_two_unit  TEXT    DEFAULT NULL
+)
+RETURNS UUID
+LANGUAGE plpgsql
+SECURITY INVOKER
+SET search_path = public
+AS $$
+DECLARE
+  v_user_id            UUID    := auth.uid();
+  v_owner_id           UUID;
+  v_target_program     UUID;
+  v_user_program_id    UUID;
+  v_placeholder_weight NUMERIC;
+  v_override           BOOLEAN := p_shared_weight_one_value IS NOT NULL;
+BEGIN
+  IF v_user_id IS NULL THEN
+    RAISE EXCEPTION 'Not authenticated';
+  END IF;
+
+  -- RLS on this SELECT already restricts to public-or-own; a NOT FOUND result
+  -- means the program does not exist or is not visible to the caller.
+  SELECT owner_id INTO v_owner_id
+  FROM programs WHERE id = p_program_id;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Program % not found or not accessible', p_program_id;
+  END IF;
+
+  -- Abandon any existing active enrollment (keeps the partial unique index happy).
+  UPDATE user_programs
+    SET status = 'abandoned'
+    WHERE user_id = v_user_id AND status = 'active';
+
+  IF v_owner_id = v_user_id THEN
+    v_target_program := p_program_id;                     -- own program: no clone
+  ELSE
+    INSERT INTO programs
+      (owner_id, source_program_id, slug, title, description, author_name,
+       num_weeks, days_per_week, is_public)
+    SELECT v_user_id, id, NULL, title, description, author_name,
+           num_weeks, days_per_week, false
+    FROM programs WHERE id = p_program_id
+    RETURNING id INTO v_target_program;
+
+    IF v_override THEN
+      SELECT weight_val INTO v_placeholder_weight
+      FROM (
+        SELECT (workout_options->'movements'->0->>'weightOneValue')::NUMERIC AS weight_val,
+               COUNT(*) AS cnt
+        FROM program_sessions
+        WHERE program_id = p_program_id
+        GROUP BY weight_val
+        ORDER BY cnt DESC, weight_val
+        LIMIT 1
+      ) modal;
+    END IF;
+
+    INSERT INTO program_sessions
+      (program_id, sequence_index, week_number, day_number, title, workout_options, notes)
+    SELECT
+      v_target_program, sequence_index, week_number, day_number, title,
+      CASE
+        WHEN v_override
+         AND (v_placeholder_weight IS NULL
+              OR (workout_options->'movements'->0->>'weightOneValue')::NUMERIC = v_placeholder_weight)
+        -- COALESCE(..., 'null'::jsonb): jsonb_set is strict and to_jsonb(NULL)
+        -- is SQL NULL, so an unset slot (e.g. weight two in two-hand loading)
+        -- must be coerced to a JSON null or the whole workout_options nulls out.
+        --
+        -- The outermost jsonb_set rebuilds {movements}, folding the chosen weight
+        -- onto every movement (the shape ActiveWorkoutPage / the builder read for
+        -- non-complex sessions); the inner four set sharedWeight* (the complex
+        -- path). `m || jsonb_build_object(...)` overrides only the four weight
+        -- keys, preserving movementName / repScheme / etc.
+        THEN jsonb_set(
+               jsonb_set(
+                 jsonb_set(
+                   jsonb_set(
+                     jsonb_set(
+                       workout_options,
+                       '{sharedWeightOneValue}',
+                       COALESCE(to_jsonb(p_shared_weight_one_value), 'null'::jsonb)),
+                     '{sharedWeightOneUnit}',
+                     COALESCE(to_jsonb(p_shared_weight_one_unit), 'null'::jsonb)),
+                   '{sharedWeightTwoValue}',
+                   COALESCE(to_jsonb(p_shared_weight_two_value), 'null'::jsonb)),
+                 '{sharedWeightTwoUnit}',
+                 COALESCE(to_jsonb(p_shared_weight_two_unit), 'null'::jsonb)),
+               '{movements}',
+               (
+                 SELECT jsonb_agg(
+                          m || jsonb_build_object(
+                            'weightOneValue', COALESCE(to_jsonb(p_shared_weight_one_value), 'null'::jsonb),
+                            'weightOneUnit',  COALESCE(to_jsonb(p_shared_weight_one_unit),  'null'::jsonb),
+                            'weightTwoValue', COALESCE(to_jsonb(p_shared_weight_two_value), 'null'::jsonb),
+                            'weightTwoUnit',  COALESCE(to_jsonb(p_shared_weight_two_unit),  'null'::jsonb)
+                          )
+                        )
+                 FROM jsonb_array_elements(workout_options->'movements') AS m
+               ))
+        ELSE workout_options
+      END,
+      notes
+    FROM program_sessions WHERE program_id = p_program_id
+    ORDER BY sequence_index;
+  END IF;
+
+  INSERT INTO user_programs (user_id, program_id, status)
+  VALUES (v_user_id, v_target_program, 'active')
+  RETURNING id INTO v_user_program_id;
+
+  RETURN v_user_program_id;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.enroll_in_program(UUID, NUMERIC, TEXT, NUMERIC, TEXT) FROM public;
+GRANT EXECUTE ON FUNCTION public.enroll_in_program(UUID, NUMERIC, TEXT, NUMERIC, TEXT) TO authenticated;


### PR DESCRIPTION
## What

`enroll_in_program` now folds the enrollee's chosen starting weight onto each cloned session's per-movement `weightOne/Two` fields, so the choice is respected when the workout actually runs — first session and every next session.

## Why

The starting-weight picker flowed correctly into the RPC, but the RPC wrote the value **only** into each session's `sharedWeightOne/Two*` fields. That was built on a false premise: `sharedWeight*` is a `complexSet`-only concept. For the common `complexSet: false` programs (Dry Fighting Weight, 10K Swing, Snatch Test), weights live per-movement — the builder review screen and `ActiveWorkoutPage` read `movement.weightOneValue` directly and never run `resolveSharedWeights` on the start path (that only runs on the log→repeat/history path). So the override was inert: the workout ran at the seed's placeholder load (double 24 kg for DFW) no matter what the user picked.

The fix keeps all override logic in one place (the RPC already decides *which* sessions via the modal-match filter) and needs **zero client changes** — the folded per-movement weights are exactly what the builder, active workout, logging, and history already read. `sharedWeight*` is still written for the complex-set path (e.g. Armor Building Complex, read by `ComplexMovementDisplay`).

## How tested

- **New forward-only migration** `20260721000001_enroll_in_program_fold_movement_weights.sql` (DROP + CREATE, idempotent; no schema change).
- `supabase db reset --local` — applies cleanly.
- e2e (Playwright against local Supabase): `program-schema.spec.ts` (16, including extended per-movement assertions for mixed left/right, two-hand double→single conversion, and the null-modal bodyweight fallback), plus `program-in-program-flow.spec.ts` + `program-next-workout.spec.ts` (8) — all pass.
- Unit: `useEnrollProgram`, `deriveStartingWeight`, `ProgramsPage` (32) — all pass.
- `npm run compile:ts` and `npm run lint` — clean.
- Live RPC check: enrolling in DFW with a chosen two-hand 32 kg produced a cloned `complexSet: false` session whose every movement carries `weightOneValue: 32` (was 24 before), with the correct double→two-hand conversion (`weightTwoValue: null`).

## Tradeoffs

Considered fixing it client-side (folding shared→movement weights when a program session loads). Rejected: the RPC already writes `sharedWeight*` purely as a signal, and re-reading it on the client to fold would split the override logic across SQL (which sessions) and TS (how to apply). Fixing at the storage layer keeps the cloned session self-consistent and runnable with no new runtime transform. The client fold's one merit — unit-testability in Vitest/MSW — is covered here by the e2e assertions against real Postgres.