### PR TITLE
chore(dev): default .env.development to local Supabase

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -2,3 +2,10 @@ VITE_FEATURE_COMPLEX_MODE=true
 VITE_FEATURE_EXPLORE=true
 VITE_FEATURE_PREMIUM=true
 VITE_FEATURE_WEEKLY_BALANCE=true
+
+# Local Supabase defaults for `npm run dev` (Vite `development` mode).
+# Requires the local stack running: `npm run start:server` (`supabase start`).
+# Override in a gitignored `.env.local` to point at your own project.
+# The anon key is Supabase's public static local demo JWT — safe to commit.
+VITE_SUPABASE_URL=http://localhost:54321
+VITE_SUPABASE_ANON_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,7 +30,7 @@ One folder per route under `src/pages/` (`Page.tsx`, `.test.tsx`, `.stories.tsx`
 - Testing: Vitest + React Testing Library, MSW mocking (`src/mocks/`), tests collocated as `*.test.tsx`.
 
 ## Commands
-`npm run dev` · `npm test` / `test-watch` · `compile:ts` · `lint` · `storybook` · `start:server` (local Supabase, before `gen:types`) · `diff-db`. Full list in `package.json`.
+`npm run dev` · `npm test` / `test-watch` · `compile:ts` · `lint` · `storybook` · `start:server` (local Supabase, before `gen:types`) · `diff-db`. Full list in `package.json`. `npm run dev` reads local Supabase defaults (`VITE_SUPABASE_URL` / `VITE_SUPABASE_ANON_KEY`) from `.env.development`, so run `start:server` first; override via a gitignored `.env.local`.
 
 ## Deeper docs (read when working in these areas)
 - Movement catalog (CSV source, ingest, migration reload): `docs/movement-catalog.md`


### PR DESCRIPTION
**What:** Commit local Supabase defaults (`VITE_SUPABASE_URL` + the public static demo anon key) to the git-tracked `.env.development`, plus a one-line pointer in `AGENTS.md`.

**Why:** `.env.development` held only feature flags, so a fresh worktree running `npm run dev` got `undefined` for both Supabase vars and had to rediscover the local setup by hand. This gives dev a working default that "just works" against a local stack.

Targets the **local** stack (`localhost:54321`), not the cloud dev/staging project (`obtrxswejclgxjfyddow`) — that one is shared and disposable (CI wipes it via `supabase db reset --linked`), so pointing worktrees there would trample shared state and PR-preview testing. The anon key is Supabase's public static demo JWT, safe to commit (same class as the cloud anon keys already in `netlify.toml`). Uses the `localhost` hostname to match the auth-token convention documented in `.env.e2e.example`.

**How tested:**
- Local REST reachable with the committed anon key → `200`
- `npm run dev` boots and the sign-in screen renders (proves the client constructed with a valid URL/key — supabase-js throws on `undefined`)
- Real auth OTP call from the app origin (`localhost:5173` → `54321`) → `200`
- No Supabase console errors; `git status` scoped to `.env.development` + `AGENTS.md`

**Tradeoffs / notes:**
- Non-breaking by Vite precedence: a present `.env.local` still overrides these defaults.
- No prod/CI impact — `vite build` uses `production` mode (`.env.production` + `netlify.toml`), which is untouched; tests read `.env.e2e`/`process.env`.
- The default only works when the local stack is up (`npm run start:server`), hence the AGENTS.md pointer.
- Touches `.env*`, an off-limits path in AGENTS.md — done under explicit human direction and kept low-risk (public local values, dev-only).