### PR TITLE
feat(preview): auto-sign-in on deploy previews with all features on

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -37,3 +37,13 @@
   NODE_VERSION = "24"
   VITE_SUPABASE_URL = "https://obtrxswejclgxjfyddow.supabase.co"
   VITE_SUPABASE_ANON_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Im9idHJ4c3dlamNsZ3hqZnlkZG93Iiwicm9sZSI6ImFub24iLCJpYXQiOjE2OTk0Nzk2ODQsImV4cCI6MjAxNTA1NTY4NH0.insdjysFDW8dfU-IhgvN-Q3T2fNmeSL2FcejeM2KaGo"
+
+  # Deploy previews auto-sign-in as the seeded staging test user and force every
+  # feature flag on, so a PR preview is immediately usable with no email/OTP dance
+  # and no manual preview toggle. Scoped to this context ONLY — production never
+  # sets these, and the test user exists only in the staging project, so the
+  # auto-login path cannot activate on prod. The password is the same throwaway
+  # staging credential already committed in supabase/seed.sql.
+  VITE_DEPLOY_PREVIEW = "true"
+  VITE_PREVIEW_USER_EMAIL = "test@example.com"
+  VITE_PREVIEW_USER_PASSWORD = "testpassword123"

--- a/src/api/useFeatureFlags.test.ts
+++ b/src/api/useFeatureFlags.test.ts
@@ -3,7 +3,10 @@ import { HttpResponse, http } from 'msw';
 import React from 'react';
 import { QueryClient, QueryClientProvider } from 'react-query';
 
-import { SAFE_DEFAULT_FEATURES } from '~/config/experiments';
+import {
+  ALL_EXPERIMENT_FEATURES_ON,
+  SAFE_DEFAULT_FEATURES,
+} from '~/config/experiments';
 import { SessionProvider } from '~/contexts';
 import { server } from '~/mocks/server';
 
@@ -138,6 +141,28 @@ describe('useFeatureFlags', () => {
     expect(result.current.features).toEqual(SAFE_DEFAULT_FEATURES);
     await waitFor(() => expect(result.current.isPending).toBe(false));
     expect(result.current.features).toEqual(SAFE_DEFAULT_FEATURES);
+  });
+
+  test('forces every experiment feature on for a deploy preview without calling the RPC', async () => {
+    vi.stubEnv('VITE_DEPLOY_PREVIEW', 'true');
+    let called = false;
+    server.use(
+      http.post(RPC_URL, () => {
+        called = true;
+        return HttpResponse.json([]);
+      }),
+    );
+
+    const { result } = renderHook(() => useFeatureFlags(), {
+      wrapper: makeWrapper(),
+    });
+
+    // Deploy previews short-circuit to all-on immediately, bypassing the RPC.
+    expect(result.current.features).toEqual(ALL_EXPERIMENT_FEATURES_ON);
+    expect(result.current.isPending).toBe(false);
+    expect(called).toBe(false);
+
+    vi.unstubAllEnvs();
   });
 
   test('resolves to the safe default without calling the RPC when unauthenticated', async () => {

--- a/src/api/useFeatureFlags.ts
+++ b/src/api/useFeatureFlags.ts
@@ -8,7 +8,7 @@ import {
   SAFE_DEFAULT_FEATURES,
   resolveExperimentFeatures,
 } from '~/config/experiments';
-import { isPreviewingAllFeatures } from '~/config/features';
+import { isDeployPreview, isPreviewingAllFeatures } from '~/config/features';
 import { QUERIES } from '~/constants';
 import { useSession } from '~/contexts';
 
@@ -89,9 +89,10 @@ export const useFeatureFlags = (): FeatureFlagsResult => {
     },
   );
 
-  // Owner preview override: force every experiment feature on so owners can
-  // preview in-progress surfaces in production, matching getFeatures().
-  if (isPreviewingAllFeatures(session)) {
+  // Force every experiment feature on for deploy previews and for owners who
+  // enabled the preview override, so in-progress surfaces are visible — matching
+  // getFeatures().
+  if (isDeployPreview() || isPreviewingAllFeatures(session)) {
     return { features: ALL_EXPERIMENT_FEATURES_ON, isPending: false };
   }
 

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -9,8 +9,12 @@ import { ToastProvider } from '~/contexts/ToastContext';
 import { WorkoutOptionsProvider } from '~/contexts/WorkoutOptionsContext';
 import { resolveAuthSession } from '~/utils';
 
-import { getFeatures } from '../config/features';
+import { getFeatures, isDeployPreview } from '../config/features';
 import { SessionProvider } from '../contexts';
+import {
+  VITE_PREVIEW_USER_EMAIL,
+  VITE_PREVIEW_USER_PASSWORD,
+} from '../env';
 import { Signup } from '../pages';
 import { supabase } from '../supabaseClient';
 import '../tailwind.css';
@@ -21,13 +25,38 @@ export function App() {
   const [session, setSession] = useState<Session | null | undefined>(undefined);
 
   useEffect(() => {
+    // Deploy previews auto-sign-in as the seeded staging test user so a PR
+    // preview is usable with no email/OTP. Gated on the preview build flag —
+    // inert in production and local builds (see netlify.toml / features.ts).
+    const previewAutoLogin =
+      isDeployPreview() &&
+      !!VITE_PREVIEW_USER_EMAIL &&
+      !!VITE_PREVIEW_USER_PASSWORD;
+
     supabase.auth.getSession().then(({ data: { session } }) => {
+      if (!session && previewAutoLogin) {
+        // Keep the Loading splash up while sign-in is in flight; success
+        // arrives via onAuthStateChange (SIGNED_IN). Only surface a failure.
+        supabase.auth
+          .signInWithPassword({
+            email: VITE_PREVIEW_USER_EMAIL,
+            password: VITE_PREVIEW_USER_PASSWORD,
+          })
+          .then(({ error }) => {
+            if (error) setSession(null);
+          });
+        return;
+      }
       resolveAuthSession(session).then(setSession);
     });
 
     const {
       data: { subscription },
     } = supabase.auth.onAuthStateChange((_event, session) => {
+      // On a preview, ignore the transient null (INITIAL_SESSION / pre-login)
+      // so the Signup screen doesn't flash before auto-login resolves — a real
+      // sign-in failure is surfaced by the error handler above instead.
+      if (previewAutoLogin && !session) return;
       resolveAuthSession(session).then(setSession);
     });
 

--- a/src/config/features.test.ts
+++ b/src/config/features.test.ts
@@ -1,0 +1,40 @@
+import { features, getFeatures, isDeployPreview } from './features';
+
+const ALL_ON = {
+  bottomNav: true,
+  complexMode: true,
+  explore: true,
+  premium: true,
+  programs: true,
+  weeklyBalance: true,
+};
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe('isDeployPreview', () => {
+  test('true only when VITE_DEPLOY_PREVIEW is exactly "true"', () => {
+    vi.stubEnv('VITE_DEPLOY_PREVIEW', 'true');
+    expect(isDeployPreview()).toBe(true);
+  });
+
+  test('false when the flag is unset or anything other than "true"', () => {
+    vi.stubEnv('VITE_DEPLOY_PREVIEW', '');
+    expect(isDeployPreview()).toBe(false);
+    vi.stubEnv('VITE_DEPLOY_PREVIEW', 'false');
+    expect(isDeployPreview()).toBe(false);
+  });
+});
+
+describe('getFeatures', () => {
+  test('forces every feature on for a deploy preview, even with no session', () => {
+    vi.stubEnv('VITE_DEPLOY_PREVIEW', 'true');
+    expect(getFeatures()).toEqual(ALL_ON);
+  });
+
+  test('returns the base build-time flags outside a deploy preview', () => {
+    vi.stubEnv('VITE_DEPLOY_PREVIEW', 'false');
+    expect(getFeatures()).toEqual(features);
+  });
+});

--- a/src/config/features.ts
+++ b/src/config/features.ts
@@ -47,6 +47,16 @@ export const isOwner = (session?: Session | null): boolean => {
   return !!email && OWNER_EMAILS.includes(email);
 };
 
+/**
+ * Whether this build is a Netlify deploy preview. Set to 'true' only in the
+ * deploy-preview Netlify context (see netlify.toml) — never in production or
+ * local builds. Deploy previews force every feature flag on (and auto-sign-in,
+ * see App.tsx) so a PR preview is immediately usable, independent of the
+ * owner/localStorage preview override below.
+ */
+export const isDeployPreview = (): boolean =>
+  import.meta.env.VITE_DEPLOY_PREVIEW === 'true';
+
 export const isPreviewOverrideEnabled = (): boolean => {
   try {
     return localStorage.getItem(PREVIEW_STORAGE_KEY) === 'true';
@@ -73,12 +83,12 @@ export const isPreviewingAllFeatures = (session?: Session | null): boolean =>
 
 /**
  * Effective feature flags for the current session. Returns the base (env)
- * flags for everyone, except owners who have enabled the preview override —
- * they get every flag forced on so they can view in-progress features in
- * production even when those flags are disabled.
+ * flags for everyone, except (a) deploy previews and (b) owners who have enabled
+ * the preview override — both get every flag forced on so in-progress features
+ * are visible even when those flags are disabled.
  */
 export const getFeatures = (session?: Session | null): Features => {
-  if (isPreviewingAllFeatures(session)) {
+  if (isDeployPreview() || isPreviewingAllFeatures(session)) {
     return {
       bottomNav: true,
       complexMode: true,

--- a/src/env.js
+++ b/src/env.js
@@ -1,1 +1,7 @@
-export const { VITE_SUPABASE_URL, VITE_SUPABASE_ANON_KEY } = import.meta.env;
+export const {
+  VITE_SUPABASE_URL,
+  VITE_SUPABASE_ANON_KEY,
+  VITE_DEPLOY_PREVIEW,
+  VITE_PREVIEW_USER_EMAIL,
+  VITE_PREVIEW_USER_PASSWORD,
+} = import.meta.env;


### PR DESCRIPTION
## What
Deploy previews now auto-sign-in and render with every feature flag on, so a PR preview is immediately usable — no email/OTP dance and no manual owner preview toggle. Driven by one build-time flag, `VITE_DEPLOY_PREVIEW`, set **only** in the deploy-preview Netlify context.

## Why
Opening a Netlify deploy preview cost two passwordless round-trips (signup implicitly creates the user, a second email/OTP authenticates) *plus* flipping the owner localStorage toggle on the Account page before in-progress features showed. Every preview review started with that friction.

## How
- **`netlify.toml`** — `VITE_DEPLOY_PREVIEW=true` + the seeded staging test credentials (`test@example.com` / `testpassword123`, already public in `supabase/seed.sql`) added to `[context.deploy-preview.environment]` only.
- **`src/env.js`** — exports the three new vars.
- **`src/config/features.ts`** — new `isDeployPreview()`; `getFeatures` returns all-on for previews.
- **`src/api/useFeatureFlags.ts`** — experiment-flag override also fires on previews (launchpad, recommender, etc.).
- **`src/app/App.tsx`** — on a preview with no session, bootstrap calls `signInWithPassword` and holds the Loading splash until it resolves (no Signup flash); a genuine failure still falls back to Signup.

## How tested
- `npm run compile:ts` clean; 19 relevant unit tests pass (new `features.test.ts`, deploy-preview case in `useFeatureFlags.test.ts`, plus app tests).
- **Local preview sim** (dev server with `VITE_DEPLOY_PREVIEW=true` against local Supabase): loaded straight into the signed-in home with full feature nav (Programs, Explore, AI, Balance) and the recommender — no email prompt, no auth console errors.
- **Negative check** (flag off, session cleared): normal "Sign up or Log in" screen — the auto-login path is inert outside preview builds.

## Reviewer notes
- **Touches auth/session handling** (off-limits per `CLAUDE.md`) — approved by the owner before implementing. Defense in depth: the path is gated on `VITE_DEPLOY_PREVIEW === 'true'` (never set in prod/local), and even if the flag leaked to prod, `test@example.com` doesn't exist in the prod Supabase project, so sign-in would just fail → normal Signup.
- This is a **shared** preview account — Netlify deploy-preview URLs have no per-viewer identity, which is the intended behavior for reviewing one's own PR previews.
- `npm run lint` couldn't run locally (`Cannot find module '@typescript-eslint/parser'` — a pre-existing worktree `node_modules` resolution issue, unrelated to these changes).