### PR TITLE
chore(repo): add minimal PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,15 @@
+## Description
+
+<!-- What changed and why. Link context. -->
+
+## How tested
+
+<!-- Commands run, cases covered, screenshots if UI. -->
+
+## Related issue
+
+<!-- Closes # -->
+
+## Tradeoffs
+
+<!-- Optional — what you considered and rejected, and what the rejected option did well. Delete if none. -->


### PR DESCRIPTION
## Description

Adds `.github/pull_request_template.md` using the common minimal PR-template convention — a single **Description** block, **How tested**, **Related issue** (`Closes #`), and an optional **Tradeoffs** section. Replaces an earlier untracked draft that was a verbatim transcription of my personal dev-writing style guide (separate What/Why headings).

The prose voice now fills a standard skeleton rather than dictating the headings. Type-of-change checkboxes and a pre-merge checklist were deliberately left out — overkill for a solo repo.

## How tested

Not app code — GitHub metadata only, so no build/test impact. Rendered the file locally (`cat .github/pull_request_template.md`) to confirm structure. GitHub auto-applies it to new PRs once it lands on `main`.

## Related issue

<!-- Closes # -->

## Tradeoffs

Considered the fuller common standard (Type-of-change checkboxes + pre-merge checklist). That version is better for team repos where a cold reviewer benefits from the scaffolding and self-review gates — but it adds ceremony this solo repo doesn't need, so I kept the lean prose shape.