### PR TITLE
feat: adopt React 19 features across the app

### DIFF
--- a/src/api/useSelectRPE.ts
+++ b/src/api/useSelectRPE.ts
@@ -11,9 +11,8 @@ export const useSelectRPE = (workoutLogId: string) => {
     mutationFn: (selectedRpe: WorkoutLog['rpe']) => {
       return updateWorkoutLog(selectedRpe, workoutLogId);
     },
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: [QUERIES.WORKOUT_LOG] });
-    },
+    onSuccess: () =>
+      queryClient.invalidateQueries({ queryKey: [QUERIES.WORKOUT_LOG] }),
   });
 };
 

--- a/src/api/useSelectRPE.ts
+++ b/src/api/useSelectRPE.ts
@@ -12,7 +12,7 @@ export const useSelectRPE = (workoutLogId: string) => {
       return updateWorkoutLog(selectedRpe, workoutLogId);
     },
     onSuccess: () => {
-      queryClient.refetchQueries({ queryKey: [QUERIES.WORKOUT_LOG] });
+      queryClient.invalidateQueries({ queryKey: [QUERIES.WORKOUT_LOG] });
     },
   });
 };

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -41,52 +41,44 @@ export interface ButtonProps
     VariantProps<typeof buttonVariants> {
   asChild?: boolean;
   loading?: boolean;
+  ref?: React.Ref<HTMLButtonElement>;
 }
 
-const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
-  (
-    {
-      children,
-      className,
-      variant,
-      size,
-      loading = false,
-      asChild = false,
-      ...props
-    },
-    ref,
-  ) => {
-    const Comp = asChild ? Slot : 'button';
-    const loadingColor = () => {
-      switch (variant) {
-        case 'default':
-          return 'fill-primary/80';
-        case 'destructive':
-          return 'fill-destructive/80';
-        case 'outline':
-          return 'fill-accent-foreground/80';
-        case 'secondary':
-          return 'fill-secondary-foreground/80';
-        case 'ghost':
-          return 'fill-muted-foreground/80';
-        case 'link':
-          return 'fill-primary/80';
-        default:
-          return 'fill-primary-foreground/80';
-      }
-    };
+const Button = ({
+  children,
+  className,
+  variant,
+  size,
+  loading = false,
+  asChild = false,
+  ...props
+}: ButtonProps) => {
+  const Comp = asChild ? Slot : 'button';
+  const loadingColor = () => {
+    switch (variant) {
+      case 'default':
+        return 'fill-primary/80';
+      case 'destructive':
+        return 'fill-destructive/80';
+      case 'outline':
+        return 'fill-accent-foreground/80';
+      case 'secondary':
+        return 'fill-secondary-foreground/80';
+      case 'ghost':
+        return 'fill-muted-foreground/80';
+      case 'link':
+        return 'fill-primary/80';
+      default:
+        return 'fill-primary-foreground/80';
+    }
+  };
 
-    return (
-      <Comp
-        className={cn(buttonVariants({ variant, size, className }))}
-        ref={ref}
-        {...props}
-      >
-        {loading ? <Loading color={loadingColor()} /> : children}
-      </Comp>
-    );
-  },
-);
+  return (
+    <Comp className={cn(buttonVariants({ variant, size, className }))} {...props}>
+      {loading ? <Loading color={loadingColor()} /> : children}
+    </Comp>
+  );
+};
 Button.displayName = 'Button';
 
 // eslint-disable-next-line react-refresh/only-export-components -- co-locating the cva variants helper with its component is the shadcn/ui pattern; a separate module is out of scope for the lint pass

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -2,75 +2,49 @@ import * as React from 'react';
 
 import { cn } from '~/lib/utils';
 
-const Card = React.forwardRef<
-  HTMLDivElement,
-  React.HTMLAttributes<HTMLDivElement>
->(({ className, ...props }, ref) => (
+const Card = ({ className, ...props }: React.ComponentProps<'div'>) => (
   <div
-    ref={ref}
     className={cn(
       'rounded-md border bg-card text-card-foreground shadow',
       className,
     )}
     {...props}
   />
-));
+);
 Card.displayName = 'Card';
 
-const CardHeader = React.forwardRef<
-  HTMLDivElement,
-  React.HTMLAttributes<HTMLDivElement>
->(({ className, ...props }, ref) => (
-  <div
-    ref={ref}
-    className={cn('flex flex-col gap-y-0.5 p-2', className)}
-    {...props}
-  />
-));
+const CardHeader = ({ className, ...props }: React.ComponentProps<'div'>) => (
+  <div className={cn('flex flex-col gap-y-0.5 p-2', className)} {...props} />
+);
 CardHeader.displayName = 'CardHeader';
 
-const CardTitle = React.forwardRef<
-  HTMLParagraphElement,
-  React.HTMLAttributes<HTMLHeadingElement>
->(({ className, ...props }, ref) => (
+const CardTitle = ({ className, ...props }: React.ComponentProps<'h3'>) => (
   <h3
-    ref={ref}
     className={cn('font-semibold leading-none tracking-tight', className)}
     {...props}
   />
-));
+);
 CardTitle.displayName = 'CardTitle';
 
-const CardDescription = React.forwardRef<
-  HTMLParagraphElement,
-  React.HTMLAttributes<HTMLParagraphElement>
->(({ className, ...props }, ref) => (
+const CardDescription = ({
+  className,
+  ...props
+}: React.ComponentProps<'p'>) => (
   <p
-    ref={ref}
     className={cn('text-sm font-medium text-muted-foreground', className)}
     {...props}
   />
-));
+);
 CardDescription.displayName = 'CardDescription';
 
-const CardContent = React.forwardRef<
-  HTMLDivElement,
-  React.HTMLAttributes<HTMLDivElement>
->(({ className, ...props }, ref) => (
-  <div ref={ref} className={cn('p-2 pt-0', className)} {...props} />
-));
+const CardContent = ({ className, ...props }: React.ComponentProps<'div'>) => (
+  <div className={cn('p-2 pt-0', className)} {...props} />
+);
 CardContent.displayName = 'CardContent';
 
-const CardFooter = React.forwardRef<
-  HTMLDivElement,
-  React.HTMLAttributes<HTMLDivElement>
->(({ className, ...props }, ref) => (
-  <div
-    ref={ref}
-    className={cn('flex items-center p-2 pt-0', className)}
-    {...props}
-  />
-));
+const CardFooter = ({ className, ...props }: React.ComponentProps<'div'>) => (
+  <div className={cn('flex items-center p-2 pt-0', className)} {...props} />
+);
 CardFooter.displayName = 'CardFooter';
 
 export {

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -12,29 +12,28 @@ const DialogPortal = DialogPrimitive.Portal;
 
 const DialogClose = DialogPrimitive.Close;
 
-const DialogOverlay = React.forwardRef<
-  React.ElementRef<typeof DialogPrimitive.Overlay>,
-  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
->(({ className, ...props }, ref) => (
+const DialogOverlay = ({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Overlay>) => (
   <DialogPrimitive.Overlay
-    ref={ref}
     className={cn(
       'fixed inset-0 z-50 bg-black/80  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
       className,
     )}
     {...props}
   />
-));
+);
 DialogOverlay.displayName = DialogPrimitive.Overlay.displayName;
 
-const DialogContent = React.forwardRef<
-  React.ElementRef<typeof DialogPrimitive.Content>,
-  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
->(({ className, children, ...props }, ref) => (
+const DialogContent = ({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Content>) => (
   <DialogPortal>
     <DialogOverlay />
     <DialogPrimitive.Content
-      ref={ref}
       className={cn(
         'fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-2 border bg-background p-3 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%]',
         className,
@@ -48,7 +47,7 @@ const DialogContent = React.forwardRef<
       </DialogPrimitive.Close>
     </DialogPrimitive.Content>
   </DialogPortal>
-));
+);
 DialogContent.displayName = DialogPrimitive.Content.displayName;
 
 const DialogHeader = ({
@@ -79,31 +78,29 @@ const DialogFooter = ({
 );
 DialogFooter.displayName = 'DialogFooter';
 
-const DialogTitle = React.forwardRef<
-  React.ElementRef<typeof DialogPrimitive.Title>,
-  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Title>
->(({ className, ...props }, ref) => (
+const DialogTitle = ({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Title>) => (
   <DialogPrimitive.Title
-    ref={ref}
     className={cn(
       'text-lg font-semibold leading-none tracking-tight',
       className,
     )}
     {...props}
   />
-));
+);
 DialogTitle.displayName = DialogPrimitive.Title.displayName;
 
-const DialogDescription = React.forwardRef<
-  React.ElementRef<typeof DialogPrimitive.Description>,
-  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Description>
->(({ className, ...props }, ref) => (
+const DialogDescription = ({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Description>) => (
   <DialogPrimitive.Description
-    ref={ref}
     className={cn('text-sm text-muted-foreground', className)}
     {...props}
   />
-));
+);
 DialogDescription.displayName = DialogPrimitive.Description.displayName;
 
 export {

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -3,27 +3,26 @@ import * as React from 'react';
 import { cn } from '~/lib/utils';
 
 export interface InputProps
-  extends React.InputHTMLAttributes<HTMLInputElement> {}
+  extends React.InputHTMLAttributes<HTMLInputElement> {
+  ref?: React.Ref<HTMLInputElement>;
+}
 
-const Input = React.forwardRef<HTMLInputElement, InputProps>(
-  ({ className, type, ...props }, ref) => {
-    return (
-      <input
-        type={type}
-        className={cn(
-          'flex h-4 w-full rounded-md border border-input bg-transparent px-1 py-0.5 text-base shadow-sm transition-colors',
-          'disabled:cursor-not-allowed disabled:opacity-50',
-          'file:border-0 file:bg-transparent file:text-sm file:font-medium',
-          'focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring',
-          'placeholder:text-muted-foreground',
-          className,
-        )}
-        ref={ref}
-        {...props}
-      />
-    );
-  },
-);
+const Input = ({ className, type, ...props }: InputProps) => {
+  return (
+    <input
+      type={type}
+      className={cn(
+        'flex h-4 w-full rounded-md border border-input bg-transparent px-1 py-0.5 text-base shadow-sm transition-colors',
+        'disabled:cursor-not-allowed disabled:opacity-50',
+        'file:border-0 file:bg-transparent file:text-sm file:font-medium',
+        'focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring',
+        'placeholder:text-muted-foreground',
+        className,
+      )}
+      {...props}
+    />
+  );
+};
 Input.displayName = 'Input';
 
 export { Input };

--- a/src/components/ui/label.tsx
+++ b/src/components/ui/label.tsx
@@ -19,17 +19,17 @@ const labelVariants = cva(
   },
 );
 
-const Label = React.forwardRef<
-  React.ElementRef<typeof LabelPrimitive.Root>,
-  React.ComponentPropsWithoutRef<typeof LabelPrimitive.Root> &
-    VariantProps<typeof labelVariants>
->(({ className, size, ...props }, ref) => (
+const Label = ({
+  className,
+  size,
+  ...props
+}: React.ComponentProps<typeof LabelPrimitive.Root> &
+  VariantProps<typeof labelVariants>) => (
   <LabelPrimitive.Root
-    ref={ref}
     className={cn(labelVariants({ size }), className)}
     {...props}
   />
-));
+);
 Label.displayName = LabelPrimitive.Root.displayName;
 
 export { Label };

--- a/src/components/ui/navigation-menu.tsx
+++ b/src/components/ui/navigation-menu.tsx
@@ -5,12 +5,12 @@ import * as React from 'react';
 
 import { cn } from '~/lib/utils';
 
-const NavigationMenu = React.forwardRef<
-  React.ElementRef<typeof NavigationMenuPrimitive.Root>,
-  React.ComponentPropsWithoutRef<typeof NavigationMenuPrimitive.Root>
->(({ className, children, ...props }, ref) => (
+const NavigationMenu = ({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof NavigationMenuPrimitive.Root>) => (
   <NavigationMenuPrimitive.Root
-    ref={ref}
     className={cn(
       'relative z-10 flex w-full items-center justify-between px-1 py-0.5',
       className,
@@ -20,22 +20,21 @@ const NavigationMenu = React.forwardRef<
     {children}
     <NavigationMenuViewport />
   </NavigationMenuPrimitive.Root>
-));
+);
 NavigationMenu.displayName = NavigationMenuPrimitive.Root.displayName;
 
-const NavigationMenuList = React.forwardRef<
-  React.ElementRef<typeof NavigationMenuPrimitive.List>,
-  React.ComponentPropsWithoutRef<typeof NavigationMenuPrimitive.List>
->(({ className, ...props }, ref) => (
+const NavigationMenuList = ({
+  className,
+  ...props
+}: React.ComponentProps<typeof NavigationMenuPrimitive.List>) => (
   <NavigationMenuPrimitive.List
-    ref={ref}
     className={cn(
       'group flex flex-1 list-none items-center justify-center space-x-0.5',
       className,
     )}
     {...props}
   />
-));
+);
 NavigationMenuList.displayName = NavigationMenuPrimitive.List.displayName;
 
 const NavigationMenuItem = NavigationMenuPrimitive.Item;
@@ -44,12 +43,12 @@ const navigationMenuTriggerStyle = cva(
   'cursor-pointer group inline-flex w-full items-center rounded-md bg-background px-1.5 py-1 text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground focus:outline-none disabled:pointer-events-none disabled:opacity-50 data-[active]:bg-accent/50 data-[state=open]:bg-accent/50',
 );
 
-const NavigationMenuTrigger = React.forwardRef<
-  React.ElementRef<typeof NavigationMenuPrimitive.Trigger>,
-  React.ComponentPropsWithoutRef<typeof NavigationMenuPrimitive.Trigger>
->(({ className, children, ...props }, ref) => (
+const NavigationMenuTrigger = ({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof NavigationMenuPrimitive.Trigger>) => (
   <NavigationMenuPrimitive.Trigger
-    ref={ref}
     className={cn(navigationMenuTriggerStyle(), 'group', className)}
     onPointerEnter={(event) => event.preventDefault()}
     onPointerLeave={(event) => event.preventDefault()}
@@ -62,15 +61,14 @@ const NavigationMenuTrigger = React.forwardRef<
       aria-hidden="true"
     />
   </NavigationMenuPrimitive.Trigger>
-));
+);
 NavigationMenuTrigger.displayName = NavigationMenuPrimitive.Trigger.displayName;
 
-const NavigationMenuContent = React.forwardRef<
-  React.ElementRef<typeof NavigationMenuPrimitive.Content>,
-  React.ComponentPropsWithoutRef<typeof NavigationMenuPrimitive.Content>
->(({ className, ...props }, ref) => (
+const NavigationMenuContent = ({
+  className,
+  ...props
+}: React.ComponentProps<typeof NavigationMenuPrimitive.Content>) => (
   <NavigationMenuPrimitive.Content
-    ref={ref}
     className={cn(
       'left-0 top-0 w-full min-w-[200px] p-0.5 md:absolute md:w-auto',
       'data-[motion^=from-]:animate-in data-[motion^=to-]:animate-out data-[motion^=from-]:fade-in data-[motion^=to-]:fade-out',
@@ -79,35 +77,33 @@ const NavigationMenuContent = React.forwardRef<
     )}
     {...props}
   />
-));
+);
 NavigationMenuContent.displayName = NavigationMenuPrimitive.Content.displayName;
 
 const NavigationMenuLink = NavigationMenuPrimitive.Link;
 
-const NavigationMenuViewport = React.forwardRef<
-  React.ElementRef<typeof NavigationMenuPrimitive.Viewport>,
-  React.ComponentPropsWithoutRef<typeof NavigationMenuPrimitive.Viewport>
->(({ className, ...props }, ref) => (
+const NavigationMenuViewport = ({
+  className,
+  ...props
+}: React.ComponentProps<typeof NavigationMenuPrimitive.Viewport>) => (
   <div className={cn('absolute left-0 top-full flex justify-center')}>
     <NavigationMenuPrimitive.Viewport
       className={cn(
         'origin-top-center relative mt-1 h-[var(--radix-navigation-menu-viewport-height)] w-full overflow-hidden border bg-popover text-popover-foreground shadow data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-90 md:w-[var(--radix-navigation-menu-viewport-width)]',
         className,
       )}
-      ref={ref}
       {...props}
     />
   </div>
-));
+);
 NavigationMenuViewport.displayName =
   NavigationMenuPrimitive.Viewport.displayName;
 
-const NavigationMenuIndicator = React.forwardRef<
-  React.ElementRef<typeof NavigationMenuPrimitive.Indicator>,
-  React.ComponentPropsWithoutRef<typeof NavigationMenuPrimitive.Indicator>
->(({ className, ...props }, ref) => (
+const NavigationMenuIndicator = ({
+  className,
+  ...props
+}: React.ComponentProps<typeof NavigationMenuPrimitive.Indicator>) => (
   <NavigationMenuPrimitive.Indicator
-    ref={ref}
     className={cn(
       'top-full z-[1] flex h-1 items-end justify-center overflow-hidden data-[state=visible]:animate-in data-[state=hidden]:animate-out data-[state=hidden]:fade-out data-[state=visible]:fade-in',
       className,
@@ -116,7 +112,7 @@ const NavigationMenuIndicator = React.forwardRef<
   >
     <div className="relative top-[60%] h-0.5 w-0.5 rotate-45 bg-border shadow-md" />
   </NavigationMenuPrimitive.Indicator>
-));
+);
 NavigationMenuIndicator.displayName =
   NavigationMenuPrimitive.Indicator.displayName;
 

--- a/src/components/ui/otp-input.tsx
+++ b/src/components/ui/otp-input.tsx
@@ -9,93 +9,97 @@ export interface OtpInputProps {
   length?: number;
   className?: string;
   disabled?: boolean;
+  ref?: React.Ref<HTMLDivElement>;
 }
 
-const OtpInput = React.forwardRef<HTMLDivElement, OtpInputProps>(
-  (
-    { value, onChange, onComplete, length = 6, className, disabled = false },
-    ref,
+const OtpInput = ({
+  value,
+  onChange,
+  onComplete,
+  length = 6,
+  className,
+  disabled = false,
+  ref,
+}: OtpInputProps) => {
+  const inputRefs = React.useRef<(HTMLInputElement | null)[]>([]);
+
+  const handleChange = (index: number, inputValue: string) => {
+    const digit = inputValue.replace(/\D/g, '').slice(-1);
+
+    const newValue = value.split('');
+    newValue[index] = digit;
+    const updatedValue = newValue.join('');
+
+    onChange(updatedValue);
+
+    if (digit && index < length - 1) {
+      inputRefs.current[index + 1]?.focus();
+    }
+
+    if (updatedValue.length === length && onComplete) {
+      onComplete(updatedValue);
+    }
+  };
+
+  const handleKeyDown = (
+    index: number,
+    e: React.KeyboardEvent<HTMLInputElement>,
   ) => {
-    const inputRefs = React.useRef<(HTMLInputElement | null)[]>([]);
+    if (e.key === 'Backspace' && !value[index] && index > 0) {
+      inputRefs.current[index - 1]?.focus();
+    } else if (e.key === 'ArrowLeft' && index > 0) {
+      inputRefs.current[index - 1]?.focus();
+    } else if (e.key === 'ArrowRight' && index < length - 1) {
+      inputRefs.current[index + 1]?.focus();
+    }
+  };
 
-    const handleChange = (index: number, inputValue: string) => {
-      const digit = inputValue.replace(/\D/g, '').slice(-1);
+  const handlePaste = (e: React.ClipboardEvent) => {
+    e.preventDefault();
+    const pastedData = e.clipboardData.getData('text').replace(/\D/g, '');
+    const newValue = pastedData.slice(0, length);
+    onChange(newValue);
 
-      const newValue = value.split('');
-      newValue[index] = digit;
-      const updatedValue = newValue.join('');
+    const focusIndex = Math.min(newValue.length, length - 1);
+    setTimeout(() => {
+      inputRefs.current[focusIndex]?.focus();
+    }, 0);
 
-      onChange(updatedValue);
+    if (newValue.length === length && onComplete) {
+      onComplete(newValue);
+    }
+  };
 
-      if (digit && index < length - 1) {
-        inputRefs.current[index + 1]?.focus();
-      }
-
-      if (updatedValue.length === length && onComplete) {
-        onComplete(updatedValue);
-      }
-    };
-
-    const handleKeyDown = (
-      index: number,
-      e: React.KeyboardEvent<HTMLInputElement>,
-    ) => {
-      if (e.key === 'Backspace' && !value[index] && index > 0) {
-        inputRefs.current[index - 1]?.focus();
-      } else if (e.key === 'ArrowLeft' && index > 0) {
-        inputRefs.current[index - 1]?.focus();
-      } else if (e.key === 'ArrowRight' && index < length - 1) {
-        inputRefs.current[index + 1]?.focus();
-      }
-    };
-
-    const handlePaste = (e: React.ClipboardEvent) => {
-      e.preventDefault();
-      const pastedData = e.clipboardData.getData('text').replace(/\D/g, '');
-      const newValue = pastedData.slice(0, length);
-      onChange(newValue);
-
-      const focusIndex = Math.min(newValue.length, length - 1);
-      setTimeout(() => {
-        inputRefs.current[focusIndex]?.focus();
-      }, 0);
-
-      if (newValue.length === length && onComplete) {
-        onComplete(newValue);
-      }
-    };
-
-    return (
-      <div
-        ref={ref}
-        className={cn('flex justify-center gap-2', className)}
-        onPaste={handlePaste}
-      >
-        {Array.from({ length }, (_, index) => (
-          <input
-            key={index}
-            ref={(el) => {
-              inputRefs.current[index] = el;
-            }}
-            type="text"
-            inputMode="numeric"
-            maxLength={1}
-            value={value[index] || ''}
-            onChange={(e) => handleChange(index, e.target.value)}
-            onKeyDown={(e) => handleKeyDown(index, e)}
-            disabled={disabled}
-            className={cn(
-              'h-5 w-5 rounded-md border border-input bg-transparent text-center text-base font-semibold shadow-sm transition-colors',
-              'focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring',
-              'disabled:cursor-not-allowed disabled:opacity-50',
-              value[index] ? 'border-primary' : 'border-input',
-            )}
-          />
-        ))}
-      </div>
-    );
-  },
-);
+  return (
+    <div
+      ref={ref}
+      className={cn('flex justify-center gap-2', className)}
+      onPaste={handlePaste}
+    >
+      {Array.from({ length }, (_, index) => (
+        <input
+          key={index}
+          ref={(el) => {
+            inputRefs.current[index] = el;
+          }}
+          type="text"
+          inputMode="numeric"
+          maxLength={1}
+          value={value[index] || ''}
+          onChange={(e) => handleChange(index, e.target.value)}
+          onKeyDown={(e) => handleKeyDown(index, e)}
+          disabled={disabled}
+          className={cn(
+            'h-5 w-5 rounded-md border border-input bg-transparent text-center text-base font-semibold shadow-sm transition-colors',
+            'focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring',
+            'disabled:cursor-not-allowed disabled:opacity-50',
+            value[index] ? 'border-primary' : 'border-input',
+          )}
+        />
+      ))}
+    </div>
+  );
+};
 
 OtpInput.displayName = 'OtpInput';
 

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -37,12 +37,12 @@ const SelectGroup = SelectPrimitive.Group;
 
 const SelectValue = SelectPrimitive.Value;
 
-const SelectTrigger = React.forwardRef<
-  React.ElementRef<typeof SelectPrimitive.Trigger>,
-  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Trigger>
->(({ className, children, ...props }, ref) => (
+const SelectTrigger = ({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Trigger>) => (
   <SelectPrimitive.Trigger
-    ref={ref}
     className={cn(
       'flex h-4 w-full items-center justify-between whitespace-nowrap rounded-md border border-input bg-transparent px-1 py-0.5 text-sm shadow-sm ring-offset-background',
       'focus:outline-none focus:ring-1 focus:ring-ring',
@@ -56,15 +56,14 @@ const SelectTrigger = React.forwardRef<
       <ChevronDownIcon className="h-2.5 w-2.5 opacity-50" />
     </SelectPrimitive.Icon>
   </SelectPrimitive.Trigger>
-));
+);
 SelectTrigger.displayName = SelectPrimitive.Trigger.displayName;
 
-const SelectScrollUpButton = React.forwardRef<
-  React.ElementRef<typeof SelectPrimitive.ScrollUpButton>,
-  React.ComponentPropsWithoutRef<typeof SelectPrimitive.ScrollUpButton>
->(({ className, ...props }, ref) => (
+const SelectScrollUpButton = ({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.ScrollUpButton>) => (
   <SelectPrimitive.ScrollUpButton
-    ref={ref}
     className={cn(
       'flex cursor-default items-center justify-center py-1',
       className,
@@ -73,15 +72,14 @@ const SelectScrollUpButton = React.forwardRef<
   >
     <ChevronUpIcon className="h-2.5 w-2.5" />
   </SelectPrimitive.ScrollUpButton>
-));
+);
 SelectScrollUpButton.displayName = SelectPrimitive.ScrollUpButton.displayName;
 
-const SelectScrollDownButton = React.forwardRef<
-  React.ElementRef<typeof SelectPrimitive.ScrollDownButton>,
-  React.ComponentPropsWithoutRef<typeof SelectPrimitive.ScrollDownButton>
->(({ className, ...props }, ref) => (
+const SelectScrollDownButton = ({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.ScrollDownButton>) => (
   <SelectPrimitive.ScrollDownButton
-    ref={ref}
     className={cn(
       'flex cursor-default items-center justify-center py-1',
       className,
@@ -90,17 +88,18 @@ const SelectScrollDownButton = React.forwardRef<
   >
     <ChevronDownIcon className="h-2.5 w-2.5" />
   </SelectPrimitive.ScrollDownButton>
-));
+);
 SelectScrollDownButton.displayName =
   SelectPrimitive.ScrollDownButton.displayName;
 
-const SelectContent = React.forwardRef<
-  React.ElementRef<typeof SelectPrimitive.Content>,
-  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Content>
->(({ className, children, position = 'popper', ...props }, ref) => (
+const SelectContent = ({
+  className,
+  children,
+  position = 'popper',
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Content>) => (
   <SelectPrimitive.Portal>
     <SelectPrimitive.Content
-      ref={ref}
       className={cn(
         'relative z-50 max-h-[--radix-select-content-available-height] min-w-[8rem] origin-[--radix-select-content-transform-origin] overflow-y-auto overflow-x-hidden rounded-md border bg-popover text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
         position === 'popper' &&
@@ -123,27 +122,26 @@ const SelectContent = React.forwardRef<
       <SelectScrollDownButton />
     </SelectPrimitive.Content>
   </SelectPrimitive.Portal>
-));
+);
 SelectContent.displayName = SelectPrimitive.Content.displayName;
 
-const SelectLabel = React.forwardRef<
-  React.ElementRef<typeof SelectPrimitive.Label>,
-  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Label>
->(({ className, ...props }, ref) => (
+const SelectLabel = ({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Label>) => (
   <SelectPrimitive.Label
-    ref={ref}
     className={cn('px-2 py-1 text-sm font-semibold', className)}
     {...props}
   />
-));
+);
 SelectLabel.displayName = SelectPrimitive.Label.displayName;
 
-const SelectItem = React.forwardRef<
-  React.ElementRef<typeof SelectPrimitive.Item>,
-  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Item>
->(({ className, children, ...props }, ref) => (
+const SelectItem = ({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Item>) => (
   <SelectPrimitive.Item
-    ref={ref}
     className={cn(
       'relative flex w-full cursor-default select-none items-center rounded-sm p-1 text-sm outline-none',
       'focus:bg-accent focus:text-accent-foreground',
@@ -159,19 +157,18 @@ const SelectItem = React.forwardRef<
     </span>
     <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
   </SelectPrimitive.Item>
-));
+);
 SelectItem.displayName = SelectPrimitive.Item.displayName;
 
-const SelectSeparator = React.forwardRef<
-  React.ElementRef<typeof SelectPrimitive.Separator>,
-  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Separator>
->(({ className, ...props }, ref) => (
+const SelectSeparator = ({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Separator>) => (
   <SelectPrimitive.Separator
-    ref={ref}
     className={cn('-mx-1 my-1 h-px bg-muted', className)}
     {...props}
   />
-));
+);
 SelectSeparator.displayName = SelectPrimitive.Separator.displayName;
 
 export {

--- a/src/components/ui/separator.tsx
+++ b/src/components/ui/separator.tsx
@@ -3,28 +3,24 @@ import * as React from 'react';
 
 import { cn } from '~/lib/utils';
 
-const Separator = React.forwardRef<
-  React.ElementRef<typeof SeparatorPrimitive.Root>,
-  React.ComponentPropsWithoutRef<typeof SeparatorPrimitive.Root>
->(
-  (
-    { className, orientation = 'horizontal', decorative = true, ...props },
-    ref,
-  ) => (
-    <SeparatorPrimitive.Root
-      ref={ref}
-      decorative={decorative}
-      orientation={orientation}
-      className={cn(
-        'shrink-0 bg-border',
-        orientation === 'horizontal'
-          ? 'my-0.5 h-[1px] w-full'
-          : 'mx-0.5 h-full w-[1px]',
-        className,
-      )}
-      {...props}
-    />
-  ),
+const Separator = ({
+  className,
+  orientation = 'horizontal',
+  decorative = true,
+  ...props
+}: React.ComponentProps<typeof SeparatorPrimitive.Root>) => (
+  <SeparatorPrimitive.Root
+    decorative={decorative}
+    orientation={orientation}
+    className={cn(
+      'shrink-0 bg-border',
+      orientation === 'horizontal'
+        ? 'my-0.5 h-[1px] w-full'
+        : 'mx-0.5 h-full w-[1px]',
+      className,
+    )}
+    {...props}
+  />
 );
 Separator.displayName = SeparatorPrimitive.Root.displayName;
 

--- a/src/components/ui/table.tsx
+++ b/src/components/ui/table.tsx
@@ -2,110 +2,79 @@ import * as React from 'react';
 
 import { cn } from '~/lib/utils';
 
-const Table = React.forwardRef<
-  HTMLTableElement,
-  React.HTMLAttributes<HTMLTableElement>
->(({ className, ...props }, ref) => (
+const Table = ({ className, ...props }: React.ComponentProps<'table'>) => (
   <div className="relative w-full overflow-auto">
     <table
-      ref={ref}
       className={cn('w-full caption-bottom text-sm', className)}
       {...props}
     />
   </div>
-));
+);
 Table.displayName = 'Table';
 
-const TableHeader = React.forwardRef<
-  HTMLTableSectionElement,
-  React.HTMLAttributes<HTMLTableSectionElement>
->(({ className, ...props }, ref) => (
-  <thead ref={ref} className={cn('[&_tr]:border-b', className)} {...props} />
-));
+const TableHeader = ({ className, ...props }: React.ComponentProps<'thead'>) => (
+  <thead className={cn('[&_tr]:border-b', className)} {...props} />
+);
 TableHeader.displayName = 'TableHeader';
 
-const TableBody = React.forwardRef<
-  HTMLTableSectionElement,
-  React.HTMLAttributes<HTMLTableSectionElement>
->(({ className, ...props }, ref) => (
-  <tbody
-    ref={ref}
-    className={cn('[&_tr:last-child]:border-0', className)}
-    {...props}
-  />
-));
+const TableBody = ({ className, ...props }: React.ComponentProps<'tbody'>) => (
+  <tbody className={cn('[&_tr:last-child]:border-0', className)} {...props} />
+);
 TableBody.displayName = 'TableBody';
 
-const TableFooter = React.forwardRef<
-  HTMLTableSectionElement,
-  React.HTMLAttributes<HTMLTableSectionElement>
->(({ className, ...props }, ref) => (
+const TableFooter = ({ className, ...props }: React.ComponentProps<'tfoot'>) => (
   <tfoot
-    ref={ref}
     className={cn(
       'border-t bg-muted/50 font-medium [&>tr]:last:border-b-0',
       className,
     )}
     {...props}
   />
-));
+);
 TableFooter.displayName = 'TableFooter';
 
-const TableRow = React.forwardRef<
-  HTMLTableRowElement,
-  React.HTMLAttributes<HTMLTableRowElement>
->(({ className, ...props }, ref) => (
+const TableRow = ({ className, ...props }: React.ComponentProps<'tr'>) => (
   <tr
-    ref={ref}
     className={cn(
       'border-b transition-colors hover:bg-muted/50 data-[state=selected]:bg-muted',
       className,
     )}
     {...props}
   />
-));
+);
 TableRow.displayName = 'TableRow';
 
-const TableHead = React.forwardRef<
-  HTMLTableCellElement,
-  React.ThHTMLAttributes<HTMLTableCellElement>
->(({ className, ...props }, ref) => (
+const TableHead = ({ className, ...props }: React.ComponentProps<'th'>) => (
   <th
-    ref={ref}
     className={cn(
       'h-4 px-1 text-left align-middle font-medium text-muted-foreground [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]',
       className,
     )}
     {...props}
   />
-));
+);
 TableHead.displayName = 'TableHead';
 
-const TableCell = React.forwardRef<
-  HTMLTableCellElement,
-  React.TdHTMLAttributes<HTMLTableCellElement>
->(({ className, ...props }, ref) => (
+const TableCell = ({ className, ...props }: React.ComponentProps<'td'>) => (
   <td
-    ref={ref}
     className={cn(
       'p-1 align-middle [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]',
       className,
     )}
     {...props}
   />
-));
+);
 TableCell.displayName = 'TableCell';
 
-const TableCaption = React.forwardRef<
-  HTMLTableCaptionElement,
-  React.HTMLAttributes<HTMLTableCaptionElement>
->(({ className, ...props }, ref) => (
+const TableCaption = ({
+  className,
+  ...props
+}: React.ComponentProps<'caption'>) => (
   <caption
-    ref={ref}
     className={cn('mt-2 text-sm text-muted-foreground', className)}
     {...props}
   />
-));
+);
 TableCaption.displayName = 'TableCaption';
 
 export {

--- a/src/components/ui/tabs.tsx
+++ b/src/components/ui/tabs.tsx
@@ -5,29 +5,28 @@ import { cn } from '~/lib/utils';
 
 const Tabs = TabsPrimitive.Root;
 
-const TabsList = React.forwardRef<
-  React.ElementRef<typeof TabsPrimitive.List>,
-  React.ComponentPropsWithoutRef<typeof TabsPrimitive.List>
->(({ className, ...props }, ref) => (
+const TabsList = ({
+  className,
+  ...props
+}: React.ComponentProps<typeof TabsPrimitive.List>) => (
   <TabsPrimitive.List
-    ref={ref}
     className={cn(
       'inline-flex items-center justify-center rounded-md bg-muted p-0.5 text-muted-foreground',
       className,
     )}
     {...props}
   />
-));
+);
 TabsList.displayName = TabsPrimitive.List.displayName;
 
-const TabsTrigger = React.forwardRef<
-  React.ElementRef<typeof TabsPrimitive.Trigger>,
-  React.ComponentPropsWithoutRef<typeof TabsPrimitive.Trigger> & {
-    size?: 'default' | 'sm';
-  }
->(({ className, size = 'default', ...props }, ref) => (
+const TabsTrigger = ({
+  className,
+  size = 'default',
+  ...props
+}: React.ComponentProps<typeof TabsPrimitive.Trigger> & {
+  size?: 'default' | 'sm';
+}) => (
   <TabsPrimitive.Trigger
-    ref={ref}
     className={cn(
       { 'px-2 py-1 text-sm': size === 'default' },
       { 'px-1 py-0.5 text-xs': size === 'sm' },
@@ -38,22 +37,21 @@ const TabsTrigger = React.forwardRef<
     )}
     {...props}
   />
-));
+);
 TabsTrigger.displayName = TabsPrimitive.Trigger.displayName;
 
-const TabsContent = React.forwardRef<
-  React.ElementRef<typeof TabsPrimitive.Content>,
-  React.ComponentPropsWithoutRef<typeof TabsPrimitive.Content>
->(({ className, ...props }, ref) => (
+const TabsContent = ({
+  className,
+  ...props
+}: React.ComponentProps<typeof TabsPrimitive.Content>) => (
   <TabsPrimitive.Content
-    ref={ref}
     className={cn(
       'mt-2 rounded-md ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
       className,
     )}
     {...props}
   />
-));
+);
 TabsContent.displayName = TabsPrimitive.Content.displayName;
 
 export { Tabs, TabsList, TabsTrigger, TabsContent };

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -3,22 +3,21 @@ import * as React from 'react';
 import { cn } from '~/lib/utils';
 
 export interface TextareaProps
-  extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
+  extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {
+  ref?: React.Ref<HTMLTextAreaElement>;
+}
 
-const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
-  ({ className, ...props }, ref) => {
-    return (
-      <textarea
-        className={cn(
-          'flex min-h-[60px] w-full rounded-md border border-input bg-transparent px-2 py-1 text-sm shadow-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50',
-          className,
-        )}
-        ref={ref}
-        {...props}
-      />
-    );
-  },
-);
+const Textarea = ({ className, ...props }: TextareaProps) => {
+  return (
+    <textarea
+      className={cn(
+        'flex min-h-[60px] w-full rounded-md border border-input bg-transparent px-2 py-1 text-sm shadow-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50',
+        className,
+      )}
+      {...props}
+    />
+  );
+};
 Textarea.displayName = 'Textarea';
 
 export { Textarea };

--- a/src/components/ui/toast.tsx
+++ b/src/components/ui/toast.tsx
@@ -7,54 +7,57 @@ import { cn } from '~/lib/utils';
  * (`pointer-events-none`) so it never blocks the page when empty; individual
  * toasts re-enable pointer events for their dismiss button.
  */
-const ToastViewport = React.forwardRef<
-  HTMLDivElement,
-  React.HTMLAttributes<HTMLDivElement>
->(({ className, ...props }, ref) => (
+const ToastViewport = ({
+  className,
+  ...props
+}: React.ComponentProps<'div'>) => (
   <div
-    ref={ref}
     className={cn(
       'pointer-events-none fixed inset-x-0 bottom-0 z-50 flex flex-col items-center gap-1 p-2',
       className,
     )}
     {...props}
   />
-));
+);
 ToastViewport.displayName = 'ToastViewport';
 
 export interface ToastProps extends React.HTMLAttributes<HTMLDivElement> {
   variant?: 'default' | 'destructive';
   onDismiss?: () => void;
+  ref?: React.Ref<HTMLDivElement>;
 }
 
 /** A single toast card. `destructive` uses the error color tokens. */
-const Toast = React.forwardRef<HTMLDivElement, ToastProps>(
-  ({ className, variant = 'default', onDismiss, children, ...props }, ref) => (
-    <div
-      ref={ref}
-      role="alert"
-      className={cn(
-        'pointer-events-auto flex w-full max-w-sm items-center justify-between gap-2 rounded-md border px-2 py-1.5 text-sm shadow-lg',
-        variant === 'destructive'
-          ? 'border-destructive bg-destructive text-destructive-foreground'
-          : 'border-border bg-background text-foreground',
-        className,
-      )}
-      {...props}
-    >
-      <span>{children}</span>
-      {onDismiss && (
-        <button
-          type="button"
-          onClick={onDismiss}
-          aria-label="Dismiss"
-          className="shrink-0 opacity-80 transition-opacity hover:opacity-100"
-        >
-          ✕
-        </button>
-      )}
-    </div>
-  ),
+const Toast = ({
+  className,
+  variant = 'default',
+  onDismiss,
+  children,
+  ...props
+}: ToastProps) => (
+  <div
+    role="alert"
+    className={cn(
+      'pointer-events-auto flex w-full max-w-sm items-center justify-between gap-2 rounded-md border px-2 py-1.5 text-sm shadow-lg',
+      variant === 'destructive'
+        ? 'border-destructive bg-destructive text-destructive-foreground'
+        : 'border-border bg-background text-foreground',
+      className,
+    )}
+    {...props}
+  >
+    <span>{children}</span>
+    {onDismiss && (
+      <button
+        type="button"
+        onClick={onDismiss}
+        aria-label="Dismiss"
+        className="shrink-0 opacity-80 transition-opacity hover:opacity-100"
+      >
+        ✕
+      </button>
+    )}
+  </div>
 );
 Toast.displayName = 'Toast';
 

--- a/src/contexts/EntitlementContext.tsx
+++ b/src/contexts/EntitlementContext.tsx
@@ -36,7 +36,7 @@ export const EntitlementProvider = ({ ...props }) => {
     },
   };
 
-  return <EntitlementContext.Provider value={value} {...props} />;
+  return <EntitlementContext value={value} {...props} />;
 };
 
 // eslint-disable-next-line react-refresh/only-export-components -- consumer hook is intentionally co-located with its Provider; splitting the module is out of scope for the lint pass

--- a/src/contexts/ProgramSessionContext.tsx
+++ b/src/contexts/ProgramSessionContext.tsx
@@ -32,7 +32,7 @@ export const ProgramSessionProvider = ({ ...props }) => {
     useState<PendingProgramSession | null>(null);
 
   return (
-    <ProgramSessionContext.Provider
+    <ProgramSessionContext
       value={[programSession, setProgramSession]}
       {...props}
     />

--- a/src/contexts/SessionContext.tsx
+++ b/src/contexts/SessionContext.tsx
@@ -3,6 +3,6 @@ import { createContext, useContext } from 'react';
 
 // eslint-disable-next-line react-refresh/only-export-components -- context object is intentionally co-located with its Provider; splitting the module is out of scope for the lint pass
 export const SessionContext = createContext<Session>(undefined!);
-export const SessionProvider = SessionContext.Provider;
+export const SessionProvider = SessionContext;
 // eslint-disable-next-line react-refresh/only-export-components -- consumer hook is intentionally co-located with its Provider; splitting the module is out of scope for the lint pass
 export const useSession = () => useContext(SessionContext);

--- a/src/contexts/ToastContext.tsx
+++ b/src/contexts/ToastContext.tsx
@@ -65,7 +65,7 @@ export const ToastProvider = ({ children }: { children: ReactNode }) => {
   );
 
   return (
-    <ToastContext.Provider value={{ showToast }}>
+    <ToastContext value={{ showToast }}>
       {children}
       {createPortal(
         <ToastViewport>
@@ -81,7 +81,7 @@ export const ToastProvider = ({ children }: { children: ReactNode }) => {
         </ToastViewport>,
         document.body,
       )}
-    </ToastContext.Provider>
+    </ToastContext>
   );
 };
 

--- a/src/contexts/WorkoutOptionsContext.tsx
+++ b/src/contexts/WorkoutOptionsContext.tsx
@@ -41,7 +41,7 @@ export const WorkoutOptionsProvider = ({ ...props }) => {
   );
 
   return (
-    <WorkoutOptionsContext.Provider
+    <WorkoutOptionsContext
       value={[workoutOptions, setWorkoutOptions]}
       {...props}
     />

--- a/src/pages/AccountPage/AccountPage.tsx
+++ b/src/pages/AccountPage/AccountPage.tsx
@@ -1,9 +1,5 @@
-import {
-  ChangeEventHandler,
-  FormEventHandler,
-  useEffect,
-  useState,
-} from 'react';
+import { ChangeEventHandler, useActionState, useEffect, useState } from 'react';
+import { useFormStatus } from 'react-dom';
 
 import {
   SubscriptionState,
@@ -25,21 +21,22 @@ import { isSoundEnabled, setSoundEnabled } from '~/utils';
 
 export const AccountPage = () => {
   const session = useSession();
-  const { isPremium, isTrialing, refetch: refetchEntitlement } =
-    useEntitlement();
+  const {
+    isPremium,
+    isTrialing,
+    refetch: refetchEntitlement,
+  } = useEntitlement();
   const { mutate: openPortal, isPending: portalLoading } =
     useCreatePortalSession();
   const { mutate: setSubscription, isPending: settingSubscription } =
     useSetSubscription();
 
-  const [loading, setLoading] = useState<boolean>(true);
   const [username, setUsername] = useState<string>('');
   const [previewEnabled, setPreviewEnabled] = useState<boolean>(
     isPreviewOverrideEnabled(),
   );
-  const [soundEnabled, setSoundEnabledState] = useState<boolean>(
-    isSoundEnabled(),
-  );
+  const [soundEnabled, setSoundEnabledState] =
+    useState<boolean>(isSoundEnabled());
 
   const handleToggleSound = () => {
     const next = !soundEnabled;
@@ -77,10 +74,9 @@ export const AccountPage = () => {
 
   useEffect(() => {
     async function getProfile() {
-      setLoading(true);
       const { user } = session;
 
-      let { data, error } = await supabase
+      const { data, error } = await supabase
         .from('profiles')
         .select('username')
         .eq('id', user.id)
@@ -91,32 +87,23 @@ export const AccountPage = () => {
       } else if (data) {
         setUsername(data.username || '');
       }
-
-      setLoading(false);
     }
 
     getProfile();
   }, [session]);
 
-  const updateProfile: FormEventHandler<HTMLFormElement> = async (e) => {
-    e.preventDefault();
+  const [updateError, updateProfile] = useActionState<string | null>(
+    async () => {
+      const { error } = await supabase.from('profiles').upsert({
+        id: session.user.id,
+        username,
+        updated_at: new Date().toISOString(),
+      });
 
-    setLoading(true);
-    const { user } = session;
-
-    const updates = {
-      id: user.id,
-      username,
-      updated_at: new Date().toISOString(),
-    };
-
-    let { error } = await supabase.from('profiles').upsert(updates);
-
-    if (error) {
-      alert(error.message);
-    }
-    setLoading(false);
-  };
+      return error ? error.message : null;
+    },
+    null,
+  );
 
   const handleChangeUsername: ChangeEventHandler<HTMLInputElement> = (e) => {
     setUsername(e.target.value);
@@ -126,17 +113,19 @@ export const AccountPage = () => {
     <Page title="Account">
       <TrialStatusPill />
 
-      <form onSubmit={updateProfile} className="flex flex-col space-y-2">
+      <form action={updateProfile} className="flex flex-col space-y-2">
         <Label htmlFor="email">Email</Label>
         <Input id="email" value={session.user.email} disabled={true} />
 
         <Label htmlFor="name">Name</Label>
         <Input id="name" value={username} onChange={handleChangeUsername} />
 
+        {updateError && (
+          <p className="text-sm text-destructive">{updateError}</p>
+        )}
+
         <div className="flex justify-end">
-          <Button type="submit" loading={loading}>
-            Update
-          </Button>
+          <SubmitButton />
         </div>
       </form>
 
@@ -204,5 +193,15 @@ export const AccountPage = () => {
         </div>
       )}
     </Page>
+  );
+};
+
+const SubmitButton = () => {
+  const { pending } = useFormStatus();
+
+  return (
+    <Button type="submit" loading={pending}>
+      Update
+    </Button>
   );
 };

--- a/src/pages/CompletedWorkoutPage/CompletedWorkoutPage.tsx
+++ b/src/pages/CompletedWorkoutPage/CompletedWorkoutPage.tsx
@@ -1,5 +1,5 @@
 import { ArrowRightIcon, TrashIcon } from '@heroicons/react/24/outline';
-import { useEffect, useRef } from 'react';
+import { startTransition, useEffect, useOptimistic, useRef } from 'react';
 import { useLocation, useNavigate, useParams } from 'react-router-dom';
 
 import {
@@ -53,8 +53,12 @@ export const CompletedWorkoutPage = () => {
     data: deletedWorkoutLogId,
     isPending: isDeletingWorkoutLog,
   } = useDeleteWorkoutLog(id);
-  const { mutate: selectRPE } = useSelectRPE(id);
+  const { mutateAsync: selectRPE } = useSelectRPE(id);
   const { mutate: updateWorkoutNotes } = useUpdateWorkoutNotes(id);
+
+  const [optimisticRpe, setOptimisticRpe] = useOptimistic(
+    workoutLog?.rpe ?? null,
+  );
 
   const notesRef = useRef<HTMLTextAreaElement>(null);
 
@@ -70,7 +74,10 @@ export const CompletedWorkoutPage = () => {
   const handleClickDelete = () => deleteWorkoutLog();
 
   const handleSelectRPE = (selectedRPE: WorkoutLog['rpe']) =>
-    selectRPE(selectedRPE);
+    startTransition(async () => {
+      setOptimisticRpe(selectedRPE);
+      await selectRPE(selectedRPE);
+    });
 
   const handleAddNotes = () => updateWorkoutNotes('');
   const handleClearNotes = () => updateWorkoutNotes(null);
@@ -122,7 +129,7 @@ export const CompletedWorkoutPage = () => {
       >
         <HeadlineStats workoutLog={workoutLog} />
 
-        <RPESelector onSelectRPE={handleSelectRPE} rpeValue={workoutLog.rpe} />
+        <RPESelector onSelectRPE={handleSelectRPE} rpeValue={optimisticRpe} />
 
         <WorkoutHistoryItem
           completedAt={workoutLog.completedAt}


### PR DESCRIPTION
## Description

React 19.2 already landed on `main` (#159); this PR adopts the actual React 19 idioms in real code. Four changes, each a distinct feature:

- **`useOptimistic`** — tapping an exertion (RPE) rating on the completed-workout page now highlights **instantly** instead of waiting on the Supabase update + refetch round-trip. `useSelectRPE` switches to `invalidateQueries`; the page drives the selection through `startTransition` + `useOptimistic`, so it reconciles cleanly on success and snaps back on error.
- **`ref` as a prop** — removed all **43** `React.forwardRef` wrappers across the 13 shadcn `src/components/ui/` files, using `React.ComponentProps<…>` (the pattern shadcn itself adopted for React 19). Pure boilerplate reduction, no behavior change.
- **Actions** — the AccountPage "Update username" form uses `useActionState` + a `SubmitButton` reading `useFormStatus`, replacing a hand-rolled `loading` boolean that awkwardly double-dutied for both the initial profile fetch and the submit spinner. Errors render inline instead of `alert()`.
- **`<Context>` as provider** — the 5 `src/contexts/` render `<Ctx value>` instead of `<Ctx.Provider value>`.

Net: −483 / +413 lines across 21 files, mostly boilerplate removed. The SignupPage auth form is deliberately left untouched.

## How tested

- `npm run compile:ts` — clean.
- `npx eslint src` — clean. (`npm run lint` also flags a local, gitignored `storybook-static/` build artifact; unrelated to this change.)
- `npm test` — **462/462 pass**, including `AccountPage`, `RPESelector`, `ToastContext`, and the many page tests that render the converted `Button`/`Dialog`/`Select`/`Tabs`.
- Live dev server (local Supabase) boots with **zero console errors**; the sign-in page renders the converted `Input`/`Button`/`Label` correctly and the 5-deep context-provider tree mounts cleanly.
- Not verified live: the authenticated RPE-tap and Account-form-submit flows — reaching them needs the SignupPage OTP login, whose blocking `alert()` calls stall headless-browser automation. Both behaviors are covered by the passing unit tests above.

## Related issue

<!-- none -->

## Tradeoffs

- Considered the **React Compiler** and **native `<title>`/`<meta>`** too, but skipped both: the app barely memoizes (0 `React.memo`), and it has no per-page title management today, making metadata a greenfield addition better suited to its own PR.
- For `useOptimistic` on RPE I kept React Query as the source of truth (optimistic layer on top of the existing invalidate/refetch) rather than migrating to React Query's own `onMutate` optimistic updates — this keeps the change contained and demonstrates the React 19 hook, at the cost of not unifying the two optimistic-update mechanisms.
