### PR TITLE
fix(programs): reconcile A+A Plan A with its source protocol

### DIFF
--- a/docs/program-tracking.md
+++ b/docs/program-tracking.md
@@ -125,14 +125,28 @@ session — atomic), and the PROD-219 editing pair `reorder_program_sessions` /
   every `intervalTimer` seconds. On a **one-handed** movement (`weightTwoValue: 0`)
   each auto-fire alternates sides, so `intervalTimer: 30` gives "left on the
   minute, right 30s later." See the `AAProtocolPlanASession` story +
-  `ActiveWorkoutPage.test.jsx` EMOM-cadence test.
+  `ActiveWorkoutPage.test.jsx` EMOM-cadence test. The program itself is 8 weeks
+  × 2 days (16 sessions) — a +2 min duration ramp toward the source's 30-minute
+  target, with weeks 4 and 8 deloaded one bell size lighter (24 → 16 kg) at the
+  preceding week's duration. `*_reshape_aa_protocol_plan_a.sql` is the forward
+  data fix that reconciled the original seed with the source article; the
+  original seed migration is applied in prod and is left untouched.
 - **Starting weight on enroll (PROD-TBD):** `enroll_in_program` takes four
   optional params mirroring `workout_options`' shared-weight shape —
   `p_shared_weight_one_value`/`_unit` + `p_shared_weight_two_value`/`_unit`. When
-  weight one is set, the clone is overridden on every cloned session whose source
-  weight matches the _modal_ weight across the program — i.e. the shared
-  placeholder, not a deliberately different session like DFW's W5D2 test day. The
-  override writes the chosen weight into **both** the session's
+  weight one is set, **every** cloned session is overridden, each shifted by its
+  own authored offset from the program's _modal_ (weightOne, weightTwo)
+  placeholder pair (`*_enroll_in_program_relative_weights.sql`). A modal session
+  has delta 0 and clones exactly as before; a deliberately different one keeps
+  its relationship to the working load — DFW's W5D2 test day stays +4 kg, A+A's
+  deload weeks stay −8 kg, rather than being frozen at an absolute number that
+  could land _above_ a light enrollee's working sets. A delta applies only when
+  the session's authored unit for that slot matches the chosen unit (all seeds
+  author kg); on a mismatch the slot falls back to the flat override rather than
+  inventing a converted, non-kettlebell number. A zero delta passes the chosen
+  value through untouched — notably it must skip the `GREATEST(..., 1)` clamp,
+  since single-bell loading legitimately carries weight two = 0. The
+  override writes the resolved weight into **both** the session's
   `sharedWeightOne/Two` fields (the `complexSet` runtime path —
   `ComplexMovementDisplay` reads them) **and folds it onto every movement's own
   `weightOne/Two` fields** (`*_enroll_in_program_fold_movement_weights.sql`,
@@ -143,9 +157,9 @@ session — atomic), and the PROD-219 editing pair `reorder_program_sessions` /
   `resolveSharedWeights` on the start path (that only runs on the log→repeat/history
   path via `workoutLogToWorkoutOptions.ts`), so writing `sharedWeightOne/Two`
   alone was inert and the workout ran at the seed placeholder. If the program has
-  no numeric modal (bodyweight-first sessions or widely-varied first-movement
-  weights make `v_placeholder_weight` NULL), the override falls back to _every_
-  cloned session so the enrollee's chosen weight is never silently discarded. A
+  no numeric modal (bodyweight-first sessions make `v_modal_one` NULL), every
+  delta resolves to 0 and the override degrades to a flat one across all
+  sessions, so the enrollee's chosen weight is never silently discarded. A
   null weight-two slot means two-hand loading; `jsonb_set` is strict, so each override value is
   `COALESCE(to_jsonb(x), 'null'::jsonb)` (unset slots become JSON null, not a
   nulled-out column). Passing no weight params (the default) is byte-identical

--- a/e2e/program-aa-protocol.spec.ts
+++ b/e2e/program-aa-protocol.spec.ts
@@ -7,21 +7,42 @@ import { expect, test } from '@playwright/test';
 // e2e/program-schema.spec.ts it hits the LOCAL Supabase REST API directly rather
 // than driving the browser; programs REVOKE anon, so it authenticates as a
 // throwaway user (public rows are readable by any authenticated user).
+//
+// The layout asserted here is the reshaped one from
+// *_reshape_aa_protocol_plan_a.sql, which reconciles the seed with the source
+// article: twice a week for eight weeks, a duration ramp toward 30 minutes, and
+// every fourth week deloaded one bell size lighter at the SAME duration.
 
 const SUPABASE_URL = process.env.VITE_SUPABASE_URL!;
 const SUPABASE_ANON_KEY = process.env.VITE_SUPABASE_ANON_KEY!;
 const AA_SLUG = 'aa-protocol-plan-a';
 const MOVEMENT = 'One-Arm Kettlebell Clean and Jerk';
 const EMOM_INTERVAL_SECONDS = 30;
+const NUM_WEEKS = 8;
+const DAYS_PER_WEEK = 2;
+const WORKING_WEIGHT = 24;
+// "-8kg for gentlemen" from the 24 kg placeholder.
+const DELOAD_WEIGHT = 16;
+const DELOAD_WEEKS = [4, 8];
 
-// Per-session expectations, in sequence order: 4 progression stages building to
-// 30 minutes, then the monthly deload (lighter + shorter).
+// Per-session expectations, in sequence order.
 const EXPECTED_SESSIONS = [
-  { seq: 0, goal: 8, weight: 24 },
-  { seq: 1, goal: 15, weight: 24 },
-  { seq: 2, goal: 22, weight: 24 },
-  { seq: 3, goal: 30, weight: 24 },
-  { seq: 4, goal: 15, weight: 20 }, // deload
+  { seq: 0, week: 1, day: 1, goal: 10, weight: WORKING_WEIGHT },
+  { seq: 1, week: 1, day: 2, goal: 12, weight: WORKING_WEIGHT },
+  { seq: 2, week: 2, day: 1, goal: 14, weight: WORKING_WEIGHT },
+  { seq: 3, week: 2, day: 2, goal: 16, weight: WORKING_WEIGHT },
+  { seq: 4, week: 3, day: 1, goal: 18, weight: WORKING_WEIGHT },
+  { seq: 5, week: 3, day: 2, goal: 20, weight: WORKING_WEIGHT },
+  { seq: 6, week: 4, day: 1, goal: 20, weight: DELOAD_WEIGHT },
+  { seq: 7, week: 4, day: 2, goal: 20, weight: DELOAD_WEIGHT },
+  { seq: 8, week: 5, day: 1, goal: 22, weight: WORKING_WEIGHT },
+  { seq: 9, week: 5, day: 2, goal: 24, weight: WORKING_WEIGHT },
+  { seq: 10, week: 6, day: 1, goal: 26, weight: WORKING_WEIGHT },
+  { seq: 11, week: 6, day: 2, goal: 28, weight: WORKING_WEIGHT },
+  { seq: 12, week: 7, day: 1, goal: 30, weight: WORKING_WEIGHT },
+  { seq: 13, week: 7, day: 2, goal: 30, weight: WORKING_WEIGHT },
+  { seq: 14, week: 8, day: 1, goal: 30, weight: DELOAD_WEIGHT },
+  { seq: 15, week: 8, day: 2, goal: 30, weight: DELOAD_WEIGHT },
 ];
 
 interface MovementOption {
@@ -106,13 +127,18 @@ test.describe('program schema — A+A Protocol "Plan A" seed', () => {
     expect(aa.author_name).toBe('Pavel Tsatsouline / StrongFirst');
     expect(aa.is_public).toBe(true);
     expect(aa.owner_id).toBeNull();
-    expect(aa.num_weeks).toBe(4);
-    expect(aa.days_per_week).toBe(3);
+    expect(aa.num_weeks).toBe(NUM_WEEKS);
+    expect(aa.days_per_week).toBe(DAYS_PER_WEEK);
 
     const sessions = await restJson<
-      Array<{ sequence_index: number; workout_options: WorkoutOptions }>
+      Array<{
+        sequence_index: number;
+        week_number: number;
+        day_number: number;
+        workout_options: WorkoutOptions;
+      }>
     >(
-      `program_sessions?program_id=eq.${aa.id}&select=sequence_index,workout_options&order=sequence_index.asc`,
+      `program_sessions?program_id=eq.${aa.id}&select=sequence_index,week_number,day_number,workout_options&order=sequence_index.asc`,
       token,
     );
 
@@ -125,6 +151,10 @@ test.describe('program schema — A+A Protocol "Plan A" seed', () => {
     sessions.forEach((s, i) => {
       const expected = EXPECTED_SESSIONS[i];
       const wo = s.workout_options;
+
+      // Twice a week for eight weeks — the cadence the program advertises.
+      expect(s.week_number).toBe(expected.week);
+      expect(s.day_number).toBe(expected.day);
 
       // The defining feature: every session is EMOM-paced by a non-zero interval,
       // with no separate between-set rest.
@@ -147,9 +177,35 @@ test.describe('program schema — A+A Protocol "Plan A" seed', () => {
       expect(movement.weightTwoValue).toBe(0);
     });
 
-    // Stages build monotonically to the 30-minute target, then the deload drops.
+    // Every session belongs to exactly one of eight weeks, two days apiece.
+    expect(new Set(sessions.map((s) => s.week_number)).size).toBe(NUM_WEEKS);
+    for (let week = 1; week <= NUM_WEEKS; week++) {
+      const inWeek = sessions.filter((s) => s.week_number === week);
+      expect(inWeek).toHaveLength(DAYS_PER_WEEK);
+      expect(inWeek.map((s) => s.day_number)).toEqual([1, 2]);
+    }
+
+    // Duration never regresses: the ramp builds toward the 30-minute target and
+    // each deload week HOLDS the preceding week's duration rather than cutting
+    // it — the source deloads by dropping a bell size, nothing else.
     const goals = sessions.map((s) => s.workout_options.workoutGoal);
-    expect(goals.slice(0, 4)).toEqual([8, 15, 22, 30]);
-    expect(goals[4]).toBeLessThan(goals[3]);
+    for (let i = 1; i < goals.length; i++) {
+      expect(goals[i]).toBeGreaterThanOrEqual(goals[i - 1]);
+    }
+    expect(goals[goals.length - 1]).toBe(30);
+
+    for (const week of DELOAD_WEEKS) {
+      const deload = sessions.filter((s) => s.week_number === week);
+      const priorWeek = sessions.filter((s) => s.week_number === week - 1);
+      const priorDuration = priorWeek[priorWeek.length - 1].workout_options
+        .workoutGoal;
+      for (const s of deload) {
+        expect(s.workout_options.workoutGoal).toBe(priorDuration);
+        // "-8kg for gentlemen" — one kettlebell size below the working load.
+        expect(s.workout_options.movements[0].weightOneValue).toBe(
+          WORKING_WEIGHT - 8,
+        );
+      }
+    }
   });
 });

--- a/e2e/program-schema.spec.ts
+++ b/e2e/program-schema.spec.ts
@@ -17,6 +17,9 @@ const SWING10K_SLUG = '10000-swing-challenge';
 const SWING10K_SESSION_COUNT = 20;
 const SNATCH_SLUG = 'strongfirst-snatch-test-plan';
 const SNATCH_SESSION_COUNT = 30; // 10 weeks x 3 days
+const AA_SLUG = 'aa-protocol-plan-a';
+const AA_SESSION_COUNT = 16; // 8 weeks x 2 days
+const AA_DELOAD_WEEKS = [4, 8]; // authored one bell size below the placeholder
 
 // ── Types ────────────────────────────────────────────────────────────────────
 
@@ -747,7 +750,7 @@ test.describe('program schema — enroll_in_program (starting weight, PROD-TBD)'
     return { cloneId, sessions };
   }
 
-  test('a shared weight override sets every placeholder session (mixed left/right value + unit) but leaves the W5D2 test day exactly as authored', async () => {
+  test('a shared weight override sets every placeholder session (mixed left/right value + unit) and shifts the W5D2 test day by its authored offset', async () => {
     const user = await signUpThrowawayUser();
     const dfwId = await getDfwProgramId(user.token);
 
@@ -789,14 +792,20 @@ test.describe('program schema — enroll_in_program (starting weight, PROD-TBD)'
       }
     }
 
-    // The W5D2 test day (seq 13) is left exactly as authored in the source:
-    // no sharedWeight override, and its own heavier 28kg movement weight
-    // untouched.
+    // The W5D2 test day (seq 13) is authored 4 kg ABOVE the modal placeholder,
+    // and keeps that offset relative to the enrollee's choice rather than
+    // staying frozen at its absolute 28 kg. Slot one's authored unit
+    // (kilograms) differs from the chosen unit (pounds), so that slot falls
+    // back to the flat override instead of doing cross-unit arithmetic; slot
+    // two matches units and picks up the +4.
     const testDay = sessions.find((s) => s.sequence_index === 13);
     expect(testDay?.title).toBe('Test - new press max');
-    expect(testDay?.workout_options.sharedWeightOneValue).toBeNull();
-    expect(testDay?.workout_options.sharedWeightTwoValue).toBeNull();
-    expect(testDay?.workout_options.movements[0].weightOneValue).toBe(28);
+    expect(testDay?.workout_options.sharedWeightOneValue).toBe(20);
+    expect(testDay?.workout_options.sharedWeightOneUnit).toBe('pounds');
+    expect(testDay?.workout_options.sharedWeightTwoValue).toBe(20);
+    expect(testDay?.workout_options.sharedWeightTwoUnit).toBe('kilograms');
+    expect(testDay?.workout_options.movements[0].weightOneValue).toBe(20);
+    expect(testDay?.workout_options.movements[0].weightTwoValue).toBe(20);
   });
 
   test('a single two-hand override writes weight one and clears weight two on every placeholder session', async () => {
@@ -828,10 +837,14 @@ test.describe('program schema — enroll_in_program (starting weight, PROD-TBD)'
       }
     }
 
-    // The W5D2 test day is still untouched.
+    // Same units this time (kilograms both sides), so the test day keeps its
+    // authored +4 kg offset from the modal: 28 chosen -> 32.
     const testDay = sessions.find((s) => s.sequence_index === 13);
-    expect(testDay?.workout_options.sharedWeightOneValue).toBeNull();
-    expect(testDay?.workout_options.movements[0].weightOneValue).toBe(28);
+    expect(testDay?.workout_options.sharedWeightOneValue).toBe(32);
+    expect(testDay?.workout_options.sharedWeightOneUnit).toBe('kilograms');
+    expect(testDay?.workout_options.sharedWeightTwoValue).toBeNull();
+    expect(testDay?.workout_options.movements[0].weightOneValue).toBe(32);
+    expect(testDay?.workout_options.movements[0].weightTwoValue).toBeNull();
   });
 
   test('enrolling with no starting weight clones sharedWeight* byte-identically to the source (unchanged behavior)', async () => {
@@ -929,6 +942,52 @@ test.describe('program schema — enroll_in_program (starting weight, PROD-TBD)'
       expect(session.workout_options.sharedWeightOneValue).toBe(16);
       // Folded onto the bodyweight movement too (null -> chosen 16).
       expect(session.workout_options.movements[0].weightOneValue).toBe(16);
+    }
+  });
+
+  test("A+A Plan A's deload weeks stay one bell size below the chosen starting weight", async () => {
+    const user = await signUpThrowawayUser();
+
+    const [aa] = await restJson<Array<{ id: string }>>(
+      'GET',
+      `programs?slug=eq.${AA_SLUG}&select=id`,
+      user.token,
+    );
+
+    // Single-bell loading, 8 kg below the 24 kg seed placeholder. Before the
+    // relative-weight fix the deload weeks kept their absolute authored load,
+    // so this enrollee's "deload" came out HEAVIER than their working sets.
+    await rpc<string>('enroll_in_program', user.token, {
+      p_program_id: aa.id,
+      p_shared_weight_one_value: 16,
+      p_shared_weight_one_unit: 'kilograms',
+      p_shared_weight_two_value: 0,
+    });
+
+    const clones = await restJson<Array<{ id: string }>>(
+      'GET',
+      `programs?source_program_id=eq.${aa.id}&owner_id=eq.${user.uid}&select=id`,
+      user.token,
+    );
+    expect(clones).toHaveLength(1);
+
+    const sessions = await restJson<
+      Array<{
+        week_number: number;
+        workout_options: { movements: Array<{ weightOneValue: number }> };
+      }>
+    >(
+      'GET',
+      `program_sessions?program_id=eq.${clones[0].id}&select=week_number,workout_options&order=sequence_index.asc`,
+      user.token,
+    );
+    expect(sessions).toHaveLength(AA_SESSION_COUNT);
+
+    for (const session of sessions) {
+      const isDeloadWeek = AA_DELOAD_WEEKS.includes(session.week_number);
+      expect(session.workout_options.movements[0].weightOneValue).toBe(
+        isDeloadWeek ? 8 : 16,
+      );
     }
   });
 

--- a/src/pages/ActiveWorkoutPage/ActiveWorkoutPage.stories.tsx
+++ b/src/pages/ActiveWorkoutPage/ActiveWorkoutPage.stories.tsx
@@ -243,10 +243,10 @@ export const IntervalTimer: Story = {
   },
 };
 
-// Mirrors the seeded A+A Protocol "Plan A" session (Stage 4): single-KB one-arm
-// clean & jerk, EMOM-paced at a 30s interval so consecutive auto-fires alternate
-// hands (left on the minute, right 30s later). First shipped program to use
-// intervalTimer.
+// Mirrors a seeded A+A Protocol "Plan A" session at the program's 30-minute
+// target: single-KB one-arm clean & jerk, EMOM-paced at a 30s interval so
+// consecutive auto-fires alternate hands (left on the minute, right 30s later).
+// First shipped program to use intervalTimer.
 export const AAProtocolPlanASession: Story = {
   parameters: {
     workoutOptions: {

--- a/src/pages/ProgramDetailsPage/utils/deriveStartingWeight.test.ts
+++ b/src/pages/ProgramDetailsPage/utils/deriveStartingWeight.test.ts
@@ -105,13 +105,11 @@ describe('deriveStartingWeight', () => {
   });
 
   it('derives single loading and the modal weight (A+A Protocol)', () => {
-    // Four sessions at 24kg, one at 20kg — 24 is modal.
+    // Twelve working sessions at 24kg, four deload sessions at 16kg — 24 is
+    // modal, so the deload weeks don't drag the pre-fill down.
     const sessions = [
-      single(24),
-      single(24),
-      single(24),
-      single(24),
-      single(20),
+      ...Array.from({ length: 12 }, () => single(24)),
+      ...Array.from({ length: 4 }, () => single(16)),
     ];
     expect(deriveStartingWeight(sessions)).toEqual({
       sharedWeightOneValue: 24,

--- a/supabase/migrations/20260723000000_enroll_in_program_relative_weights.sql
+++ b/supabase/migrations/20260723000000_enroll_in_program_relative_weights.sql
@@ -1,0 +1,193 @@
+-- Program Tracking: make the enroll starting weight RELATIVE, not modal-only.
+--
+-- 20260721000001_enroll_in_program_fold_movement_weights.sql folds the
+-- enrollee's chosen weight onto every session whose first movement matches the
+-- program's *modal* placeholder, and copies every other session verbatim. That
+-- leaves a deliberately-different session frozen at its authored absolute load:
+--
+--   * A+A Protocol "Plan A" authors its deload week one bell size below the
+--     working weight. An enrollee starting at 16 kg got a "deload" HEAVIER than
+--     their working sets; one starting at 32 kg got a 16 kg cliff.
+--   * Dry Fighting Weight's W5D2 test day authors +4 kg over the working load,
+--     and stayed at a flat 28 kg no matter what the enrollee picked.
+--
+-- Fix: override EVERY cloned session, offsetting each weight slot by that
+-- session's own authored distance from the modal placeholder. A session
+-- authored at the modal weight has delta 0 and clones byte-identically to
+-- before; a session authored -8 kg stays -8 kg below whatever the enrollee
+-- chose. Passing no weight params is still a verbatim clone.
+--
+-- Unit handling: a delta is applied only when the session's authored unit for
+-- that slot equals the enrollee's chosen unit for that slot. Every seeded
+-- program authors kilograms, so the common path offsets correctly; a pounds
+-- enrollee falls back to the previous flat override rather than having us
+-- invent a converted, non-kettlebell number. The seeds' workoutDetails carry
+-- the "go down one bell size" instruction in prose for that case.
+--
+-- The modal is now the (weightOne, weightTwo) PAIR rather than weight one
+-- alone, matching how the client's deriveStartingWeight keys the mode. When a
+-- program has no numeric modal at all (bodyweight-first sessions), every delta
+-- resolves to 0 and the behavior collapses to the prior flat override of every
+-- session -- the same fallback as before, now implicit rather than a branch.
+--
+-- DROP + CREATE (forward-only, idempotent) mirrors the prior migrations.
+DROP FUNCTION IF EXISTS public.enroll_in_program(UUID);
+DROP FUNCTION IF EXISTS public.enroll_in_program(UUID, NUMERIC, TEXT, NUMERIC, TEXT);
+
+CREATE FUNCTION public.enroll_in_program(
+  p_program_id UUID,
+  p_shared_weight_one_value NUMERIC DEFAULT NULL,
+  p_shared_weight_one_unit  TEXT    DEFAULT NULL,
+  p_shared_weight_two_value NUMERIC DEFAULT NULL,
+  p_shared_weight_two_unit  TEXT    DEFAULT NULL
+)
+RETURNS UUID
+LANGUAGE plpgsql
+SECURITY INVOKER
+SET search_path = public
+AS $$
+DECLARE
+  v_user_id         UUID    := auth.uid();
+  v_owner_id        UUID;
+  v_target_program  UUID;
+  v_user_program_id UUID;
+  v_modal_one       NUMERIC;
+  v_modal_two       NUMERIC;
+  v_override        BOOLEAN := p_shared_weight_one_value IS NOT NULL;
+BEGIN
+  IF v_user_id IS NULL THEN
+    RAISE EXCEPTION 'Not authenticated';
+  END IF;
+
+  -- RLS on this SELECT already restricts to public-or-own; a NOT FOUND result
+  -- means the program does not exist or is not visible to the caller.
+  SELECT owner_id INTO v_owner_id
+  FROM programs WHERE id = p_program_id;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Program % not found or not accessible', p_program_id;
+  END IF;
+
+  -- Abandon any existing active enrollment (keeps the partial unique index happy).
+  UPDATE user_programs
+    SET status = 'abandoned'
+    WHERE user_id = v_user_id AND status = 'active';
+
+  IF v_owner_id = v_user_id THEN
+    v_target_program := p_program_id;                     -- own program: no clone
+  ELSE
+    INSERT INTO programs
+      (owner_id, source_program_id, slug, title, description, author_name,
+       num_weeks, days_per_week, is_public)
+    SELECT v_user_id, id, NULL, title, description, author_name,
+           num_weeks, days_per_week, false
+    FROM programs WHERE id = p_program_id
+    RETURNING id INTO v_target_program;
+
+    IF v_override THEN
+      -- The modal (weightOne, weightTwo) pair across the program's sessions:
+      -- the shared placeholder load every deliberately-different session is
+      -- offset from. Ties break toward the lighter pair, mirroring
+      -- deriveStartingWeight.
+      SELECT one_val, two_val INTO v_modal_one, v_modal_two
+      FROM (
+        SELECT (workout_options->'movements'->0->>'weightOneValue')::NUMERIC AS one_val,
+               (workout_options->'movements'->0->>'weightTwoValue')::NUMERIC AS two_val,
+               COUNT(*) AS cnt
+        FROM program_sessions
+        WHERE program_id = p_program_id
+        GROUP BY one_val, two_val
+        ORDER BY cnt DESC, one_val, two_val
+        LIMIT 1
+      ) modal;
+    END IF;
+
+    INSERT INTO program_sessions
+      (program_id, sequence_index, week_number, day_number, title, workout_options, notes)
+    SELECT
+      v_target_program, ps.sequence_index, ps.week_number, ps.day_number, ps.title,
+      CASE
+        WHEN NOT v_override THEN ps.workout_options
+        -- COALESCE(..., 'null'::jsonb): jsonb_set is strict and to_jsonb(NULL)
+        -- is SQL NULL, so an unset slot (e.g. weight two in two-hand loading)
+        -- must be coerced to a JSON null or the whole workout_options nulls out.
+        --
+        -- The outermost jsonb_set rebuilds {movements}, folding the resolved
+        -- weight onto every movement (the shape ActiveWorkoutPage / the builder
+        -- read for non-complex sessions); the inner four set sharedWeight* (the
+        -- complex path). `m || jsonb_build_object(...)` overrides only the four
+        -- weight keys, preserving movementName / repScheme / etc.
+        ELSE jsonb_set(
+               jsonb_set(
+                 jsonb_set(
+                   jsonb_set(
+                     jsonb_set(
+                       ps.workout_options,
+                       '{sharedWeightOneValue}',
+                       COALESCE(to_jsonb(w.one_value), 'null'::jsonb)),
+                     '{sharedWeightOneUnit}',
+                     COALESCE(to_jsonb(p_shared_weight_one_unit), 'null'::jsonb)),
+                   '{sharedWeightTwoValue}',
+                   COALESCE(to_jsonb(w.two_value), 'null'::jsonb)),
+                 '{sharedWeightTwoUnit}',
+                 COALESCE(to_jsonb(p_shared_weight_two_unit), 'null'::jsonb)),
+               '{movements}',
+               (
+                 SELECT jsonb_agg(
+                          m || jsonb_build_object(
+                            'weightOneValue', COALESCE(to_jsonb(w.one_value), 'null'::jsonb),
+                            'weightOneUnit',  COALESCE(to_jsonb(p_shared_weight_one_unit),  'null'::jsonb),
+                            'weightTwoValue', COALESCE(to_jsonb(w.two_value), 'null'::jsonb),
+                            'weightTwoUnit',  COALESCE(to_jsonb(p_shared_weight_two_unit),  'null'::jsonb)
+                          )
+                        )
+                 FROM jsonb_array_elements(ps.workout_options->'movements') AS m
+               ))
+      END,
+      ps.notes
+    FROM program_sessions ps
+    -- Per-session resolved weights: the enrollee's choice shifted by this
+    -- session's authored offset from the modal. A zero delta passes the chosen
+    -- value through untouched -- notably it must NOT hit the >= 1 clamp, since a
+    -- single-bell enrollment legitimately carries weight two = 0.
+    CROSS JOIN LATERAL (
+      SELECT
+        CASE
+          WHEN p_shared_weight_one_value IS NULL OR d.one_delta = 0
+            THEN p_shared_weight_one_value
+          ELSE GREATEST(p_shared_weight_one_value + d.one_delta, 1)
+        END AS one_value,
+        CASE
+          WHEN p_shared_weight_two_value IS NULL OR d.two_delta = 0
+            THEN p_shared_weight_two_value
+          ELSE GREATEST(p_shared_weight_two_value + d.two_delta, 1)
+        END AS two_value
+      FROM (
+        SELECT
+          COALESCE(
+            CASE WHEN ps.workout_options->'movements'->0->>'weightOneUnit'
+                      IS NOT DISTINCT FROM p_shared_weight_one_unit
+                 THEN (ps.workout_options->'movements'->0->>'weightOneValue')::NUMERIC
+                      - v_modal_one
+            END, 0) AS one_delta,
+          COALESCE(
+            CASE WHEN ps.workout_options->'movements'->0->>'weightTwoUnit'
+                      IS NOT DISTINCT FROM p_shared_weight_two_unit
+                 THEN (ps.workout_options->'movements'->0->>'weightTwoValue')::NUMERIC
+                      - v_modal_two
+            END, 0) AS two_delta
+      ) d
+    ) w
+    WHERE ps.program_id = p_program_id
+    ORDER BY ps.sequence_index;
+  END IF;
+
+  INSERT INTO user_programs (user_id, program_id, status)
+  VALUES (v_user_id, v_target_program, 'active')
+  RETURNING id INTO v_user_program_id;
+
+  RETURN v_user_program_id;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.enroll_in_program(UUID, NUMERIC, TEXT, NUMERIC, TEXT) FROM public;
+GRANT EXECUTE ON FUNCTION public.enroll_in_program(UUID, NUMERIC, TEXT, NUMERIC, TEXT) TO authenticated;

--- a/supabase/migrations/20260723000001_reshape_aa_protocol_plan_a.sql
+++ b/supabase/migrations/20260723000001_reshape_aa_protocol_plan_a.sql
@@ -1,0 +1,149 @@
+-- Reshape the seeded StrongFirst "A+A Protocol, Plan A" program to match its
+-- source: https://www.strongfirst.com/the-best-all-around-training-method-ever/
+--
+-- 20260713181819_seed_aa_protocol_plan_a.sql shipped a program that advertised
+-- days_per_week=3 / "2-3x per week" but laid its five sessions out one per week
+-- (W1D1, W2D1, W3D1, W4D1, W4D2), and diverged from the source in five more
+-- ways. Corrected here:
+--
+--   1. Cadence      3x/wk (and really 1x/wk) -> "Train twice a week, on Mondays
+--                   and Thursdays": 8 weeks x 2 days = 16 sessions.
+--   2. Progression   4 invented stages (8/15/22/30) -> a duration ramp toward
+--                   the source's 30 min / 30 sets per arm target, +2 min per
+--                   session. Volume is talk-test autoregulated in the source;
+--                   the ramp is the trackable modeling of it, and the details
+--                   tell the athlete to stop early when the talk test fails.
+--   3. Deload week  A single shortened 15-min session -> the WHOLE fourth week
+--                   (weeks 4 and 8), at the previous week's duration, per
+--                   "maintaining the rest of the load parameters of the last
+--                   training session (the same sets, reps, and rest periods)".
+--   4. Deload load  24 -> 20 kg (a 4 kg ladies' step) -> 24 -> 16 kg, per
+--                   "-4kg per kettlebell for ladies, -8kg for gentlemen".
+--   5. Load choice  "24 kg (men's standard)" -> the 6-12RM on the WEAKER arm,
+--                   which is what the source has you test for. 24 kg stays the
+--                   placeholder the enrollee overrides at start.
+--   6. Rep density  The source's post-30-min progression (C+J -> C+J+C ->
+--                   C+J+C+J, up to three C&J per 30s) is described in the
+--                   program description rather than modeled as more sessions;
+--                   every seeded session stays at repScheme [1].
+--
+-- Unchanged and still correct: intervalTimer 30 with a one-handed movement, so
+-- consecutive auto-fires alternate arms -- left on the minute, right 30s later.
+--
+-- This is a forward DATA FIX over deployed rows (the original seed is applied
+-- in production and is ON CONFLICT DO NOTHING, so re-running it changes
+-- nothing). Modeled on 20260720150000_rename_front_squat_double_kb.sql:
+-- guarded, idempotent, RAISE NOTICE row counts for the post-merge prod check.
+--
+-- Every statement is scoped to the SYSTEM-OWNED template
+-- (slug = 'aa-protocol-plan-a' AND owner_id IS NULL). Copy-on-enroll clones
+-- carry slug NULL and a real owner_id, so existing enrollees keep the program
+-- they started, and deleting the template's sessions cascades no completions
+-- (completions point at the enrollee's cloned session rows, never these).
+
+-- Session-local helper (pg_temp: auto-dropped at connection end, never
+-- persisted to the committed schema). Shape MUST match
+-- Omit<WorkoutOptions,'startedAt'> exactly (camelCase keys), matching the
+-- original seed's helper.
+CREATE OR REPLACE FUNCTION pg_temp.aa_options(
+  p_minutes INT, p_weight INT, p_details TEXT
+)
+RETURNS JSONB LANGUAGE sql IMMUTABLE AS $$
+  SELECT jsonb_build_object(
+    'complexSet', false,
+    'intervalTimer', 30,
+    'restTimer', 0,
+    'workoutGoal', p_minutes,
+    'workoutGoalUnits', 'minutes',
+    'workoutDetails', p_details,
+    'sharedWeightOneUnit', NULL,
+    'sharedWeightOneValue', NULL,
+    'sharedWeightTwoUnit', NULL,
+    'sharedWeightTwoValue', NULL,
+    'movements', jsonb_build_array(
+      jsonb_build_object(
+        'movementName', 'One-Arm Kettlebell Clean and Jerk',
+        'repScheme', to_jsonb(ARRAY[1]::INT[]),
+        'weightOneUnit', 'kilograms', 'weightOneValue', p_weight,
+        'weightTwoUnit', 'kilograms', 'weightTwoValue', 0)
+    ));
+$$;
+
+-- A working session: the ramp toward 30 minutes at the placeholder load.
+CREATE OR REPLACE FUNCTION pg_temp.aa_work(p_minutes INT)
+RETURNS JSONB LANGUAGE sql IMMUTABLE AS $$
+  SELECT pg_temp.aa_options(p_minutes, 24, format(
+    '%s min of one-arm clean & jerk. One set every 30s: left arm on the minute, '
+    'right arm 30s later. Stop early any time you cannot pass the talk test '
+    'right before the next set.', p_minutes));
+$$;
+
+-- A deload session: same duration as the week before, one bell size lighter.
+CREATE OR REPLACE FUNCTION pg_temp.aa_deload(p_minutes INT)
+RETURNS JSONB LANGUAGE sql IMMUTABLE AS $$
+  SELECT pg_temp.aa_options(p_minutes, 16, format(
+    'Deload week - %s min, one kettlebell size lighter (-8 kg gentlemen, -4 kg '
+    'ladies) with every other parameter held: same 30s left/right cadence, same '
+    'duration as last week. Explode, and keep it easy.', p_minutes));
+$$;
+
+DO $$
+DECLARE
+  v_program_id       UUID;
+  v_sessions_deleted INT;
+  v_sessions_seeded  INT;
+BEGIN
+  SELECT id INTO v_program_id
+  FROM programs
+  WHERE slug = 'aa-protocol-plan-a' AND owner_id IS NULL;
+
+  IF v_program_id IS NULL THEN
+    RAISE NOTICE 'A+A Protocol template not found; nothing to reshape.';
+    RETURN;
+  END IF;
+
+  UPDATE programs
+  SET num_weeks   = 8,
+      days_per_week = 2,
+      description =
+        'A single-kettlebell alactic+aerobic conditioning protocol built on the '
+        'one-arm clean & jerk. One set every 30 seconds - left arm on the '
+        'minute, right arm 30 seconds later - with the bell you can clean & '
+        'jerk 6-12 times with your WEAKER arm. Train twice a week (the source '
+        'prescribes Monday and Thursday), building from 10 up to 30 minutes of '
+        'work across eight weeks, with every fourth week deloaded one bell size '
+        'lighter at the same duration. Cut any session short when you cannot '
+        'pass the talk test before the next set. Once 30 minutes feels strong, '
+        'repeat the block adding a second clean to each set (C+J+C), then a '
+        'second jerk (C+J+C+J), up to three clean & jerks every 30 seconds.'
+  WHERE id = v_program_id;
+
+  DELETE FROM program_sessions WHERE program_id = v_program_id;
+  GET DIAGNOSTICS v_sessions_deleted = ROW_COUNT;
+
+  -- Weeks 1-3 and 5-7 ramp +2 min per session toward the 30-minute target;
+  -- weeks 4 and 8 hold the preceding week's final duration at the lighter bell.
+  INSERT INTO program_sessions
+    (program_id, sequence_index, week_number, day_number, title, workout_options)
+  VALUES
+    (v_program_id,  0, 1, 1, '10 min',          pg_temp.aa_work(10)),
+    (v_program_id,  1, 1, 2, '12 min',          pg_temp.aa_work(12)),
+    (v_program_id,  2, 2, 1, '14 min',          pg_temp.aa_work(14)),
+    (v_program_id,  3, 2, 2, '16 min',          pg_temp.aa_work(16)),
+    (v_program_id,  4, 3, 1, '18 min',          pg_temp.aa_work(18)),
+    (v_program_id,  5, 3, 2, '20 min',          pg_temp.aa_work(20)),
+    (v_program_id,  6, 4, 1, 'Deload - 20 min', pg_temp.aa_deload(20)),
+    (v_program_id,  7, 4, 2, 'Deload - 20 min', pg_temp.aa_deload(20)),
+    (v_program_id,  8, 5, 1, '22 min',          pg_temp.aa_work(22)),
+    (v_program_id,  9, 5, 2, '24 min',          pg_temp.aa_work(24)),
+    (v_program_id, 10, 6, 1, '26 min',          pg_temp.aa_work(26)),
+    (v_program_id, 11, 6, 2, '28 min',          pg_temp.aa_work(28)),
+    (v_program_id, 12, 7, 1, '30 min',          pg_temp.aa_work(30)),
+    (v_program_id, 13, 7, 2, '30 min',          pg_temp.aa_work(30)),
+    (v_program_id, 14, 8, 1, 'Deload - 30 min', pg_temp.aa_deload(30)),
+    (v_program_id, 15, 8, 2, 'Deload - 30 min', pg_temp.aa_deload(30));
+  GET DIAGNOSTICS v_sessions_seeded = ROW_COUNT;
+
+  RAISE NOTICE 'A+A Protocol reshaped: % sessions deleted, % seeded.',
+    v_sessions_deleted, v_sessions_seeded;
+END $$;


### PR DESCRIPTION
## Description

The seeded shared program `aa-protocol-plan-a` advertised `days_per_week = 3` / "2-3x per week" but laid its five sessions out `W1D1, W2D1, W3D1, W4D1, W4D2` — one workout per week for three of the four weeks. Auditing it against the [StrongFirst article it cites](https://www.strongfirst.com/the-best-all-around-training-method-ever/) turned up five more divergences, plus an enrollment bug the deload exposed. Three parts:

**1. Reshaped the program** (`20260723000001_reshape_aa_protocol_plan_a.sql`)

| | Before | After |
|---|---|---|
| Cadence | `days_per_week 3`, sessions 1/week | 8 weeks × 2 days, 16 sessions ("Train twice a week, on Mondays and Thursdays") |
| Progression | 4 invented stages 8/15/22/30 | +2 min per session, 10 → 30 min toward the source's 30 min / 30 sets per arm |
| Deload | one session shortened to 15 min | weeks 4 and 8, holding the prior week's duration ("maintaining the rest of the load parameters") |
| Deload load | 24 → 20 kg (a 4 kg ladies' step) | 24 → 16 kg ("−4kg per kettlebell for ladies, −8kg for gentlemen") |
| Load guidance | "24 kg placeholder (men's standard)" | your 6–12RM on the weaker arm |
| Rep density | absent | described in the program copy (C+J → C+J+C → C+J+C+J, up to 3 per 30s) |

`intervalTimer: 30` on a one-handed movement is unchanged — the left-on-the-minute / right-at-:30 EMOM alternation was already correct and is the one thing the original seed got exactly right.

**2. Fixed the enrollment weight bug it exposed** (`20260723000000_enroll_in_program_relative_weights.sql`)

`enroll_in_program` overrode the enrollee's chosen starting weight only onto sessions matching the program's *modal* weight, copying the rest verbatim. So A+A's deload kept its hardcoded absolute load: a 16 kg enrollee got a "deload" **heavier** than their working sets, and a 32 kg enrollee got a 16 kg cliff. DFW's W5D2 test day had the same flaw at a flat 28 kg.

Every cloned session is now overridden, each shifted by its own authored offset from the modal `(weightOne, weightTwo)` pair. A modal session has delta 0 and clones byte-identically to before; a deload authored −8 kg stays −8 kg below whatever the enrollee picks. Two details worth a reviewer's eye: a zero delta deliberately skips the `GREATEST(…, 1)` clamp, because single-bell loading legitimately carries weight two = 0; and a delta applies only when the session's authored unit for that slot matches the chosen unit (see Tradeoffs).

**3. Tests and docs** — rebuilt `e2e/program-aa-protocol.spec.ts` around the new 16-session layout, reworked the three W5D2 assertions in `e2e/program-schema.spec.ts` from "left exactly as authored" to "shifted by its authored offset," added a case proving a 16 kg A+A enrollee's deload weeks clone at 8 kg, and updated `docs/program-tracking.md`.

The reshape is a forward data fix over deployed rows (the original seed is applied in prod and is `ON CONFLICT DO NOTHING`), modeled on `20260720150000_rename_front_squat_double_kb.sql`. Every statement is scoped to `slug = 'aa-protocol-plan-a' AND owner_id IS NULL`, so copy-on-enroll clones are untouched and existing enrollees keep the program they started; deleting the template's sessions cascades no completions, which point at cloned rows.

## How tested

- `supabase db reset` twice from scratch (`5 sessions deleted, 16 seeded`), then re-ran the reshape migration against an already-reshaped DB (`16 deleted, 16 seeded`) to confirm idempotency
- Queried the result directly: `num_weeks 8 / days_per_week 2`, 16 rows covering weeks 1–8 × days 1–2, deloads at 16 kg holding 20 and 30 min, `intervalTimer 30` on every row
- `npm run test:e2e` — 45 passed, including the new A+A deload-offset case and the reworked DFW test-day assertions
- `npm test` — 462 passed (the EMOM cadence test and `deriveStartingWeight`'s A+A case both still green; the modal stays 24 kg under the 12×24 / 4×16 split)
- `npm run compile:ts`, `npm run lint` — clean

Not done: the browser click-through of the program details page, which sits behind the auth gate. The rendering path is untouched by this change — `cadenceLabel` and `groupByWeek` are pure functions of data verified directly in the DB, and `ProgramDetailsPage.test.tsx` already covers both.

## Tradeoffs

**Unit-matched offsets vs. converting across units.** Converting a −8 kg delta into pounds (≈ −18 lb) would give a pounds enrollee a real relative deload, and ~18 lb is genuinely close to a US bell size step (35 → 53). I went with a flat fallback on unit mismatch instead: it never invents a weight that isn't a bell you own, and the deload instruction is spelled out in each session's `workoutDetails` so the athlete can drop a size manually. Every seeded program authors kilograms today, so this only affects enrollees who switch the picker to pounds.

**Describing the rep progression vs. modeling it.** The source's real long-term progression after 30 minutes is rep density, not duration — C+J → C+J+C → C+J+C+J, up to three C&J per 30 s. Modeling that as additional `repScheme` blocks would be the most faithful thing and would make the whole arc trackable. It would also push the program well past ~20 sessions for something most people won't reach for months, so it lives in the program description for now.

**Fixing the RPC vs. authoring the deload at working weight.** Setting the deload sessions to the same 24 kg placeholder would have made the enroll override apply uniformly with no RPC change, leaving "go down one bell size" as a prose instruction. That's a smaller diff and keeps a shared RPC untouched. But the same bug was already silently wrong for DFW's test day, and it will be wrong for every future program with a deliberately different session — worth fixing at the source.
