### PR TITLE
feat(programs): add timed movements and seed The Kettlebell Mile

### DIFF
--- a/docs/program-tracking.md
+++ b/docs/program-tracking.md
@@ -14,9 +14,11 @@ session — atomic), and the PROD-219 editing pair `reorder_program_sessions` /
   also reach staging/prod) — Dry Fighting Weight
   (`*_seed_dry_fighting_weight.sql`), Dan John's 10,000 Swing Challenge
   (`*_seed_10000_swing_challenge.sql`), StrongFirst's A+A Protocol "Plan A"
-  (`*_seed_aa_protocol_plan_a.sql`, the first EMOM/`intervalTimer` program), and
+  (`*_seed_aa_protocol_plan_a.sql`, the first EMOM/`intervalTimer` program),
   Dan John's Armor Building Complex
-  (`*_seed_armor_building_complex.sql`, the first `complexSet: true` program).
+  (`*_seed_armor_building_complex.sql`, the first `complexSet: true` program),
+  and Dr. Mike Prevost's The Kettlebell Mile (`*_seed_kettlebell_mile.sql`, the
+  first carry-centric program and the first `timedRungs: true` program).
   Each is idempotent on `slug` and builds every session's `WorkoutOptions` JSONB
   (shape `Omit<WorkoutOptions,'startedAt'>`, camelCase keys) via a `pg_temp`
   helper; add another by mirroring one. Seed shape is asserted in
@@ -119,6 +121,23 @@ session — atomic), and the PROD-219 editing pair `reorder_program_sessions` /
   (`Omit<WorkoutOptions,'startedAt'>`, camelCase). DFW
   (`*_seed_dry_fighting_weight.sql`) is the template; add a focused
   `e2e/program-<slug>.spec.ts` asserting the seeded shape.
+- **`timedRungs` (timed movements, PROD-200):** a movement with
+  `timedRungs: true` reinterprets each `repScheme` entry as **seconds**, not
+  reps — `ActiveWorkoutPage` runs a per-rung countdown that auto-fires
+  "continue" on expiry (re-armed per rung, so `[30, 60]` works). Deliberately
+  reuses `repScheme` rather than adding a parallel duration array, which would
+  have to be threaded through `workout_options`, `movement_logs.rep_scheme`,
+  `pattern_debt_window`, the builder, and every seed; rung structure (ladders,
+  rounds, mirrored sides, complex alternation) is identical either way. Two
+  consequences worth knowing: timed rungs contribute **no reps and no volume**
+  (seconds × kg is not volume — see `ActiveWorkoutPage`'s `currentRungVolume`
+  and the `timed_rungs` guards in `*_add_timed_rungs.sql`'s
+  `pattern_debt_window`, which keep `set_count`/`last_trained_at` but zero
+  `total_reps`/`volume_kg`), and it is **mutually exclusive with
+  `intervalTimer`** — both drive auto-advance, so the builder disables each when
+  the other is on. The Kettlebell Mile seed is the reference use; see the
+  `KettlebellMileSession` story + the "timed rungs" tests in
+  `ActiveWorkoutPage.test.jsx`.
 - **`intervalTimer` (EMOM programs):** DFW leaves it `0`; the A+A Protocol seed
   (`*_seed_aa_protocol_plan_a.sql`) is the first/reference use. It is a
   per-session seconds cadence — `ActiveWorkoutPage` auto-fires one "continue"

--- a/e2e/program-kettlebell-mile.spec.ts
+++ b/e2e/program-kettlebell-mile.spec.ts
@@ -99,21 +99,13 @@ interface SessionRow {
   workout_options: WorkoutOpts;
 }
 
-// Per-hand carry segments in seconds. Each rung is mirrored left/right, so the
-// session's total time under load is sum(segments) x 2: 6, 8, 10, 12, 14, 16
-// minutes, a 12-minute taper, then the 15-minute test.
-const EXPECTED_SEGMENTS: number[][] = [
-  [60, 60, 60],
-  [80, 80, 80],
-  [100, 100, 100],
-  [120, 120, 120],
-  [140, 140, 140],
-  [160, 160, 160],
-  [120, 120, 120],
-  [150, 150, 150],
-];
-
-const EXPECTED_TOTAL_MINUTES = [6, 8, 10, 12, 14, 16, 12, 15];
+// Every session is a single 60-second rung; rounds are the progression lever.
+// One rung mirrored left/right means one round = two minutes of carrying, so a
+// session's total time under load is rounds x 2: build 6 -> 16 min, a 12-minute
+// taper, then the test's 20-minute ceiling.
+const RUNG_SECONDS = 60;
+const EXPECTED_ROUNDS = [3, 4, 5, 6, 7, 8, 6, 10];
+const EXPECTED_TOTAL_MINUTES = [6, 8, 10, 12, 14, 16, 12, 20];
 
 test.describe('program schema — Kettlebell Mile seed', () => {
   test('is present, public, system-owned, with the right metadata', async () => {
@@ -167,13 +159,15 @@ test.describe('program schema — Kettlebell Mile seed', () => {
       expect(movements).toHaveLength(1);
       expect(movements[0].movementName).toBe('Kettlebell Suitcase Carry');
 
-      // Timed rungs: repScheme entries are SECONDS, not reps.
+      // Timed rungs: the single repScheme entry is SECONDS, not reps. Keeping
+      // it to ONE rung is what makes rounds the progression lever — several
+      // rungs inside one round would pin "rounds remaining" at 1 all session.
       expect(movements[0].timedRungs).toBe(true);
-      expect(movements[0].repScheme).toEqual(EXPECTED_SEGMENTS[i]);
+      expect(movements[0].repScheme).toEqual([RUNG_SECONDS]);
 
-      // Total time under load is double the sum — every rung is carried per hand.
-      const totalMinutes =
-        (EXPECTED_SEGMENTS[i].reduce((a, b) => a + b, 0) * 2) / 60;
+      // Total time under load is rounds x 2 min — one rung carried per hand.
+      expect(s.workout_options.workoutGoal).toBe(EXPECTED_ROUNDS[i]);
+      const totalMinutes = (EXPECTED_ROUNDS[i] * RUNG_SECONDS * 2) / 60;
       expect(totalMinutes).toBe(EXPECTED_TOTAL_MINUTES[i]);
 
       // Single bell: weightTwoValue 0 (not null) is the Single/'1h' mode the
@@ -187,13 +181,10 @@ test.describe('program schema — Kettlebell Mile seed', () => {
 
       expect(s.workout_options.complexSet).toBe(false);
       expect(s.workout_options.workoutGoalUnits).toBe('rounds');
-      expect(s.workout_options.workoutGoal).toBe(1);
     });
 
     // Volume peaks in week 6 and the taper is genuinely lighter than it.
-    const totalFor = (i: number) =>
-      EXPECTED_SEGMENTS[i].reduce((a, b) => a + b, 0);
-    expect(totalFor(5)).toBeGreaterThan(totalFor(6));
+    expect(EXPECTED_ROUNDS[5]).toBeGreaterThan(EXPECTED_ROUNDS[6]);
   });
 
   test('the test session flags the distance→time approximation in workoutDetails', async () => {

--- a/e2e/program-kettlebell-mile.spec.ts
+++ b/e2e/program-kettlebell-mile.spec.ts
@@ -1,0 +1,219 @@
+import { expect, test } from '@playwright/test';
+
+// Backend coverage for the seeded shared "Kettlebell Mile" program (Dr. Mike
+// Prevost, StrongFirst), mirroring program-easy-strength.spec.ts: hit the LOCAL
+// Supabase REST API directly rather than driving the browser, since this is pure
+// seed-data verification.
+//
+// This is the catalog's first carry-centric program and its first user of timed
+// rungs (PROD-200), so the assertions below are mostly about the two things that
+// would silently break it: `timedRungs` surviving into the stored blob, and the
+// one-handed weight mode (weightTwoValue 0) that makes the runtime alternate
+// hands. It also pins the distance -> time approximation to the test session's
+// workoutDetails, so the modeling call can never quietly disappear.
+
+const SUPABASE_URL = process.env.VITE_SUPABASE_URL!;
+const SUPABASE_ANON_KEY = process.env.VITE_SUPABASE_ANON_KEY!;
+const KM_SLUG = 'kettlebell-mile';
+const KM_SESSION_COUNT = 8;
+const TEST_DAY_SEQ = 7;
+
+interface AuthSession {
+  access_token: string;
+  user: { id: string; email: string; [key: string]: unknown };
+}
+
+interface TestUser {
+  token: string;
+  uid: string;
+  email: string;
+}
+
+async function signUpThrowawayUser(): Promise<TestUser> {
+  const email = `km-${Date.now()}-${Math.floor(Math.random() * 1e9)}@example.com`;
+  const password = 'testpassword123';
+
+  const res = await fetch(`${SUPABASE_URL}/auth/v1/signup`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', apikey: SUPABASE_ANON_KEY },
+    body: JSON.stringify({ email, password }),
+  });
+  if (!res.ok) {
+    throw new Error(`signup failed (${res.status}): ${await res.text()}`);
+  }
+
+  const body = (await res.json()) as Partial<AuthSession>;
+  if (body.access_token && body.user) {
+    return { token: body.access_token, uid: body.user.id, email };
+  }
+
+  const signInRes = await fetch(
+    `${SUPABASE_URL}/auth/v1/token?grant_type=password`,
+    {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        apikey: SUPABASE_ANON_KEY,
+      },
+      body: JSON.stringify({ email, password }),
+    },
+  );
+  if (!signInRes.ok) {
+    throw new Error(
+      `sign-in failed (${signInRes.status}): ${await signInRes.text()}`,
+    );
+  }
+  const session = (await signInRes.json()) as AuthSession;
+  return { token: session.access_token, uid: session.user.id, email };
+}
+
+async function restJson<T = unknown>(path: string, token: string): Promise<T> {
+  const res = await fetch(`${SUPABASE_URL}/rest/v1/${path}`, {
+    headers: { apikey: SUPABASE_ANON_KEY, Authorization: `Bearer ${token}` },
+  });
+  if (!res.ok) {
+    throw new Error(`GET ${path} failed (${res.status}): ${await res.text()}`);
+  }
+  return res.json() as Promise<T>;
+}
+
+interface MovementOpt {
+  movementName: string;
+  repScheme: number[];
+  timedRungs?: boolean;
+  weightOneValue: number | null;
+  weightTwoValue: number | null;
+}
+interface WorkoutOpts {
+  complexSet: boolean;
+  intervalTimer: number;
+  workoutGoal: number;
+  workoutGoalUnits: string;
+  workoutDetails: string;
+  movements: MovementOpt[];
+}
+interface SessionRow {
+  sequence_index: number;
+  week_number: number;
+  day_number: number;
+  workout_options: WorkoutOpts;
+}
+
+// Per-hand carry segments in seconds. Each rung is mirrored left/right, so the
+// session's total time under load is sum(segments) x 2: 6, 8, 10, 12, 14, 16
+// minutes, a 12-minute taper, then the 15-minute test.
+const EXPECTED_SEGMENTS: number[][] = [
+  [60, 60, 60],
+  [80, 80, 80],
+  [100, 100, 100],
+  [120, 120, 120],
+  [140, 140, 140],
+  [160, 160, 160],
+  [120, 120, 120],
+  [150, 150, 150],
+];
+
+const EXPECTED_TOTAL_MINUTES = [6, 8, 10, 12, 14, 16, 12, 15];
+
+test.describe('program schema — Kettlebell Mile seed', () => {
+  test('is present, public, system-owned, with the right metadata', async () => {
+    const user = await signUpThrowawayUser();
+
+    const programs = await restJson<
+      Array<{
+        is_public: boolean;
+        owner_id: string | null;
+        num_weeks: number;
+        days_per_week: number;
+        author_name: string;
+        title: string;
+      }>
+    >(`programs?slug=eq.${KM_SLUG}&select=*`, user.token);
+
+    expect(programs).toHaveLength(1);
+    const km = programs[0];
+    expect(km.is_public).toBe(true);
+    expect(km.owner_id).toBeNull();
+    expect(km.num_weeks).toBe(8);
+    expect(km.days_per_week).toBe(1);
+    expect(km.author_name).toBe('Dr. Mike Prevost (StrongFirst)');
+    expect(km.title).toBe('The Kettlebell Mile');
+  });
+
+  test('has 8 ordered weekly sessions that build, taper, then test', async () => {
+    const user = await signUpThrowawayUser();
+    const [km] = await restJson<Array<{ id: string }>>(
+      `programs?slug=eq.${KM_SLUG}&select=id`,
+      user.token,
+    );
+
+    const sessions = await restJson<SessionRow[]>(
+      `program_sessions?program_id=eq.${km.id}&select=sequence_index,week_number,day_number,workout_options&order=sequence_index.asc`,
+      user.token,
+    );
+
+    expect(sessions).toHaveLength(KM_SESSION_COUNT);
+    expect(sessions.map((s) => s.sequence_index)).toEqual(
+      Array.from({ length: KM_SESSION_COUNT }, (_, i) => i),
+    );
+    // One session per week, so week N is exactly session N-1.
+    expect(sessions.map((s) => s.week_number)).toEqual([1, 2, 3, 4, 5, 6, 7, 8]);
+    expect(sessions.map((s) => s.day_number)).toEqual(Array(8).fill(1));
+
+    sessions.forEach((s, i) => {
+      const movements = s.workout_options.movements;
+
+      // A single carry is the whole session.
+      expect(movements).toHaveLength(1);
+      expect(movements[0].movementName).toBe('Kettlebell Suitcase Carry');
+
+      // Timed rungs: repScheme entries are SECONDS, not reps.
+      expect(movements[0].timedRungs).toBe(true);
+      expect(movements[0].repScheme).toEqual(EXPECTED_SEGMENTS[i]);
+
+      // Total time under load is double the sum — every rung is carried per hand.
+      const totalMinutes =
+        (EXPECTED_SEGMENTS[i].reduce((a, b) => a + b, 0) * 2) / 60;
+      expect(totalMinutes).toBe(EXPECTED_TOTAL_MINUTES[i]);
+
+      // Single bell: weightTwoValue 0 (not null) is the Single/'1h' mode the
+      // runtime keys off to mirror each rung per hand.
+      expect(movements[0].weightOneValue).toBe(24);
+      expect(movements[0].weightTwoValue).toBe(0);
+
+      // intervalTimer must stay 0: it and timed rungs both drive auto-advance,
+      // and running both would double-advance every rung.
+      expect(s.workout_options.intervalTimer).toBe(0);
+
+      expect(s.workout_options.complexSet).toBe(false);
+      expect(s.workout_options.workoutGoalUnits).toBe('rounds');
+      expect(s.workout_options.workoutGoal).toBe(1);
+    });
+
+    // Volume peaks in week 6 and the taper is genuinely lighter than it.
+    const totalFor = (i: number) =>
+      EXPECTED_SEGMENTS[i].reduce((a, b) => a + b, 0);
+    expect(totalFor(5)).toBeGreaterThan(totalFor(6));
+  });
+
+  test('the test session flags the distance→time approximation in workoutDetails', async () => {
+    const user = await signUpThrowawayUser();
+    const [km] = await restJson<Array<{ id: string }>>(
+      `programs?slug=eq.${KM_SLUG}&select=id`,
+      user.token,
+    );
+
+    const [session] = await restJson<SessionRow[]>(
+      `program_sessions?program_id=eq.${km.id}&sequence_index=eq.${TEST_DAY_SEQ}&select=sequence_index,workout_options`,
+      user.token,
+    );
+
+    // The seam that keeps the approximation honest: the source prescribes a
+    // MILE, the app prescribes minutes, and the user must be told that the
+    // clock-based rungs are a pace guide they can finish early.
+    const details = session.workout_options.workoutDetails.toLowerCase();
+    expect(details).toContain('mile');
+    expect(details).toMatch(/not a target|pace|finish/);
+    expect(details).toContain('9 min'); // the sub-9 benchmark
+  });
+});

--- a/src/api/useLogWorkout.ts
+++ b/src/api/useLogWorkout.ts
@@ -184,6 +184,7 @@ const logWorkout = async ({
         movement_name: movement.movementName,
         user_movement_id: userMovementIdByName[movement.movementName] ?? null,
         rep_scheme: movement.repScheme,
+        timed_rungs: movement.timedRungs ?? false,
         weight_one_unit: movement.weightOneUnit,
         weight_one_value: movement.weightOneValue,
         weight_two_unit: movement.weightTwoUnit,

--- a/src/api/useMovementLogs.ts
+++ b/src/api/useMovementLogs.ts
@@ -35,6 +35,7 @@ const fetchMovementLogs = async (
       id: movementLog.id,
       movementName: movementLog.movement_name,
       repScheme: movementLog.rep_scheme,
+      timedRungs: movementLog.timed_rungs,
       userMovementId: movementLog.user_movement_id,
       functionalMovementId: userMovement?.functional_movement_id ?? null,
       weightOneUnit: movementLog.weight_one_unit,

--- a/src/api/useRecentRepeatableWorkouts.ts
+++ b/src/api/useRecentRepeatableWorkouts.ts
@@ -39,6 +39,7 @@ const fetchMovementLogsByWorkoutIds = async (
       id: row.id,
       movementName: row.movement_name,
       repScheme: row.rep_scheme,
+      timedRungs: row.timed_rungs,
       userMovementId: row.user_movement_id ?? null,
       functionalMovementId: null,
       weightOneUnit: row.weight_one_unit,

--- a/src/examples/movement-log.examples.ts
+++ b/src/examples/movement-log.examples.ts
@@ -9,6 +9,7 @@ export class ExampleMovementLog implements MovementLog {
   id: number;
   movement_name: string;
   rep_scheme: number[];
+  timed_rungs: boolean;
   user_id: string;
   user_movement_id: string | null;
   weight_one_unit: 'kilograms' | 'pounds' | null;
@@ -21,6 +22,7 @@ export class ExampleMovementLog implements MovementLog {
     created_at = '2023-10-11T14:08:53.112365+00:00',
     movement_name = 'Clean and Press',
     rep_scheme = [3],
+    timed_rungs = false,
     user_id = '1',
     user_movement_id = null,
     weight_one_unit = 'kilograms',
@@ -33,6 +35,7 @@ export class ExampleMovementLog implements MovementLog {
     this.id = id;
     this.movement_name = movement_name;
     this.rep_scheme = rep_scheme;
+    this.timed_rungs = timed_rungs;
     this.user_id = user_id;
     this.user_movement_id = user_movement_id;
     this.weight_one_unit = weight_one_unit;

--- a/src/pages/ActiveWorkoutPage/ActiveWorkoutPage.stories.tsx
+++ b/src/pages/ActiveWorkoutPage/ActiveWorkoutPage.stories.tsx
@@ -270,6 +270,84 @@ export const AAProtocolPlanASession: Story = {
   },
 };
 
+// Timed movements (PROD-200) — the Kettlebell Mile seed's shape: a single
+// one-handed suitcase carry whose rungs are 2-minute carry segments. One-handed
+// loading (weightTwoValue 0) makes the runtime mirror each rung per hand, which
+// is exactly the source's "switch hands as often as you want."
+export const KettlebellMileSession: Story = {
+  parameters: {
+    workoutOptions: {
+      intervalTimer: 0,
+      restTimer: 0,
+      complexSet: false,
+      workoutGoal: 1,
+      workoutGoalUnits: 'rounds',
+      movements: [
+        {
+          ...DEFAULT_MOVEMENT_OPTIONS,
+          movementName: 'Kettlebell Suitcase Carry',
+          repScheme: [120, 120],
+          timedRungs: true,
+          weightOneValue: 24,
+          weightOneUnit: 'kilograms',
+          weightTwoValue: 0,
+          weightTwoUnit: 'kilograms',
+        },
+      ] satisfies MovementOptions[],
+    },
+  },
+};
+
+// Rungs of differing length prove the countdown is re-armed per rung rather
+// than reusing the first rung's duration for the whole movement.
+export const TimedRungsVaryingDurations: Story = {
+  parameters: {
+    workoutOptions: {
+      intervalTimer: 0,
+      restTimer: 0,
+      workoutGoal: 10,
+      workoutGoalUnits: 'rounds',
+      movements: [
+        {
+          ...DEFAULT_MOVEMENT_OPTIONS,
+          movementName: 'Kettlebell Suitcase Carry',
+          repScheme: [30, 60],
+          timedRungs: true,
+          weightOneValue: 24,
+          weightOneUnit: 'kilograms',
+          weightTwoValue: null,
+          weightTwoUnit: null,
+        },
+      ] satisfies MovementOptions[],
+    },
+  },
+};
+
+// A kilograms-goal workout containing a timed movement: seconds must not be
+// multiplied by load, or the goal would be met before the first carry ends.
+export const TimedRungsVolumeGoal: Story = {
+  parameters: {
+    workoutOptions: {
+      intervalTimer: 0,
+      restTimer: 0,
+      workoutGoal: 1000,
+      workoutGoalUnits: 'kilograms',
+      movements: [
+        {
+          ...DEFAULT_MOVEMENT_OPTIONS,
+          movementName: 'Kettlebell Suitcase Carry',
+          repScheme: [120],
+          timedRungs: true,
+          weightOneValue: 24,
+          weightOneUnit: 'kilograms',
+          weightTwoValue: null,
+          weightTwoUnit: null,
+        },
+      ] satisfies MovementOptions[],
+    },
+  },
+};
+
 export const RestTimer: Story = {
   parameters: {
     workoutOptions: {

--- a/src/pages/ActiveWorkoutPage/ActiveWorkoutPage.stories.tsx
+++ b/src/pages/ActiveWorkoutPage/ActiveWorkoutPage.stories.tsx
@@ -271,22 +271,24 @@ export const AAProtocolPlanASession: Story = {
 };
 
 // Timed movements (PROD-200) — the Kettlebell Mile seed's shape: a single
-// one-handed suitcase carry whose rungs are 2-minute carry segments. One-handed
-// loading (weightTwoValue 0) makes the runtime mirror each rung per hand, which
-// is exactly the source's "switch hands as often as you want."
+// one-handed suitcase carry on ONE 60-second rung, with rounds as the
+// progression lever (week 1 is 3 rounds = 6 min under load). One-handed loading
+// (weightTwoValue 0) makes the runtime mirror the rung per hand, which is
+// exactly the source's "switch hands as often as you want," so one round is
+// 1:00 left + 1:00 right.
 export const KettlebellMileSession: Story = {
   parameters: {
     workoutOptions: {
       intervalTimer: 0,
       restTimer: 0,
       complexSet: false,
-      workoutGoal: 1,
+      workoutGoal: 3,
       workoutGoalUnits: 'rounds',
       movements: [
         {
           ...DEFAULT_MOVEMENT_OPTIONS,
           movementName: 'Kettlebell Suitcase Carry',
-          repScheme: [120, 120],
+          repScheme: [60],
           timedRungs: true,
           weightOneValue: 24,
           weightOneUnit: 'kilograms',

--- a/src/pages/ActiveWorkoutPage/ActiveWorkoutPage.test.jsx
+++ b/src/pages/ActiveWorkoutPage/ActiveWorkoutPage.test.jsx
@@ -20,6 +20,9 @@ const {
   MultipleMovementsAndMixedWeights,
   OneHanded,
   AAProtocolPlanASession,
+  KettlebellMileSession,
+  TimedRungsVaryingDurations,
+  TimedRungsVolumeGoal,
   RepLadders,
   TwoHanded,
   WorkoutGoalRounds,
@@ -1349,6 +1352,117 @@ describe('active workout page (A+A Protocol interval EMOM cadence)', () => {
     expect(leftWeight).toHaveAttribute('data-active', 'true');
     expect(rightWeight).toHaveAttribute('data-active', 'false');
     expect(round).toHaveTextContent('2');
+  });
+});
+
+// Timed movements (PROD-200). Carries are prescribed in seconds, so a timed
+// movement's repScheme holds SECONDS per rung and the rung runs on its own
+// countdown that auto-fires "continue" — no button press, like intervalTimer.
+describe('active workout page (timed rungs)', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    useLogWorkout.mockReturnValue({
+      mutate: vi.fn(),
+      data: null,
+      isLoading: false,
+    });
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    vi.useRealTimers();
+  });
+
+  test('renders the rung as a duration under a "Time" label, not a rep count', () => {
+    render(<KettlebellMileSession />);
+
+    expect(screen.getByTestId('current-reps')).toHaveTextContent('2:00');
+    // The movement card's magnitude column is labelled Time, not Reps. (The
+    // workout summary further down has its own "Reps" tally, so this assertion
+    // is deliberately scoped to the card.)
+    expect(screen.getByTestId('current-movement-card')).toHaveTextContent(
+      'Time',
+    );
+    expect(screen.getByTestId('current-movement-card')).not.toHaveTextContent(
+      'Reps',
+    );
+  });
+
+  test('auto-advances on rung expiry, alternating hands for a one-handed carry', () => {
+    render(<KettlebellMileSession />);
+
+    const leftWeight = screen.getByTestId('left-weight');
+    const rightWeight = screen.getByTestId('right-weight');
+    const round = screen.getByTestId('current-round');
+
+    expect(leftWeight).toHaveAttribute('data-active', 'true');
+    expect(rightWeight).toHaveAttribute('data-active', 'false');
+
+    // 2 minutes later the rung timer fires a continue on its own -> other hand.
+    act(() => vi.advanceTimersByTime(120_000));
+    expect(leftWeight).toHaveAttribute('data-active', 'false');
+    expect(rightWeight).toHaveAttribute('data-active', 'true');
+    expect(round).toHaveTextContent('1');
+  });
+
+  test('re-arms the countdown per rung when rung durations differ', () => {
+    render(<TimedRungsVaryingDurations />);
+
+    const currentReps = screen.getByTestId('current-reps');
+    const round = screen.getByTestId('current-round');
+    expect(currentReps).toHaveTextContent('0:30');
+
+    // First rung is 30s. Advancing 30s must move to the 60s rung...
+    act(() => vi.advanceTimersByTime(30_000));
+    expect(currentReps).toHaveTextContent('1:00');
+    expect(round).toHaveTextContent('1');
+
+    // ...and that rung must NOT expire at 30s, which is what would happen if the
+    // countdown were still armed with the first rung's duration.
+    act(() => vi.advanceTimersByTime(30_000));
+    expect(currentReps).toHaveTextContent('1:00');
+    expect(round).toHaveTextContent('1');
+
+    // The full 60s completes the ladder and the round.
+    act(() => vi.advanceTimersByTime(30_000));
+    expect(currentReps).toHaveTextContent('0:30');
+    expect(round).toHaveTextContent('2');
+  });
+
+  // Regression: the workout timer's paused state doubles as the START GATE, and
+  // only finishCountdown starts the rung clock. A rounds-goal timed workout has
+  // no workout countdown of its own, so unless timed movements also raise the
+  // gate the page opens showing a rung clock that never ticks — the lifter
+  // stares at a frozen 0:05 while elapsed climbs. (The stories pass
+  // defaultPaused: false, so the other tests here cannot catch this.)
+  test('raises the start gate so the rung clock never runs before the lifter starts', () => {
+    render(<KettlebellMileSession defaultPaused />);
+
+    const leftWeight = screen.getByTestId('left-weight');
+    expect(leftWeight).toHaveAttribute('data-active', 'true');
+
+    // Nothing should move while the workout is still gated.
+    act(() => vi.advanceTimersByTime(240_000));
+    expect(leftWeight).toHaveAttribute('data-active', 'true');
+    expect(screen.getByTestId('current-round')).toHaveTextContent('1');
+
+    // Start it: 3s lead-in countdown, then the first 2:00 rung runs and hands swap.
+    act(() => screen.getAllByRole('button')[0].click());
+    act(() => vi.advanceTimersByTime(3_000));
+    act(() => vi.advanceTimersByTime(120_000));
+    expect(leftWeight).toHaveAttribute('data-active', 'false');
+  });
+
+  test('counts neither seconds-as-reps nor seconds-as-volume', () => {
+    render(<TimedRungsVolumeGoal />);
+
+    act(() => vi.advanceTimersByTime(120_000));
+
+    // A 120s rung at 24kg would otherwise log 120 reps and 2,880kg — blowing
+    // past this story's 1,000kg goal before the first carry even finished.
+    const completedSection = screen.getByTestId('completed-section');
+    expect(completedSection).toHaveTextContent('Reps0');
+    expect(completedSection).toHaveTextContent('Volume0');
   });
 });
 

--- a/src/pages/ActiveWorkoutPage/ActiveWorkoutPage.test.jsx
+++ b/src/pages/ActiveWorkoutPage/ActiveWorkoutPage.test.jsx
@@ -1376,7 +1376,7 @@ describe('active workout page (timed rungs)', () => {
   test('renders the rung as a duration under a "Time" label, not a rep count', () => {
     render(<KettlebellMileSession />);
 
-    expect(screen.getByTestId('current-reps')).toHaveTextContent('2:00');
+    expect(screen.getByTestId('current-reps')).toHaveTextContent('1:00');
     // The movement card's magnitude column is labelled Time, not Reps. (The
     // workout summary further down has its own "Reps" tally, so this assertion
     // is deliberately scoped to the card.)
@@ -1398,11 +1398,18 @@ describe('active workout page (timed rungs)', () => {
     expect(leftWeight).toHaveAttribute('data-active', 'true');
     expect(rightWeight).toHaveAttribute('data-active', 'false');
 
-    // 2 minutes later the rung timer fires a continue on its own -> other hand.
-    act(() => vi.advanceTimersByTime(120_000));
+    // A minute later the rung timer fires a continue on its own -> other hand,
+    // still inside round 1.
+    act(() => vi.advanceTimersByTime(60_000));
     expect(leftWeight).toHaveAttribute('data-active', 'false');
     expect(rightWeight).toHaveAttribute('data-active', 'true');
     expect(round).toHaveTextContent('1');
+
+    // The second hand closes the round: one rung x both hands = one round, so
+    // "rounds remaining" actually ticks down across the session.
+    act(() => vi.advanceTimersByTime(60_000));
+    expect(leftWeight).toHaveAttribute('data-active', 'true');
+    expect(round).toHaveTextContent('2');
   });
 
   test('re-arms the countdown per rung when rung durations differ', () => {
@@ -1446,10 +1453,10 @@ describe('active workout page (timed rungs)', () => {
     expect(leftWeight).toHaveAttribute('data-active', 'true');
     expect(screen.getByTestId('current-round')).toHaveTextContent('1');
 
-    // Start it: 3s lead-in countdown, then the first 2:00 rung runs and hands swap.
+    // Start it: 3s lead-in countdown, then the 1:00 rung runs and hands swap.
     act(() => screen.getAllByRole('button')[0].click());
     act(() => vi.advanceTimersByTime(3_000));
-    act(() => vi.advanceTimersByTime(120_000));
+    act(() => vi.advanceTimersByTime(60_000));
     expect(leftWeight).toHaveAttribute('data-active', 'false');
   });
 

--- a/src/pages/ActiveWorkoutPage/ActiveWorkoutPage.tsx
+++ b/src/pages/ActiveWorkoutPage/ActiveWorkoutPage.tsx
@@ -51,6 +51,8 @@ export const ActiveWorkoutPage = ({
   const navigate = useNavigate();
   const requestWakeLock = useRequestWakeLock();
 
+  const hasTimedMovements = movements.some((movement) => movement.timedRungs);
+
   const [
     formattedTimeRemaining,
     {
@@ -60,10 +62,15 @@ export const ActiveWorkoutPage = ({
       play: startWorkoutTimer,
     },
   ] = useCountdownTimer(workoutGoal, {
+    // The workout timer's paused state is also the start gate: while it is
+    // paused the controls show Play, and only finishCountdown starts the
+    // interval / rung clocks. So anything that runs on its own clock has to be
+    // listed here, or the workout opens with a countdown that never ticks.
     defaultPaused:
       defaultPaused &&
       ((workoutGoalUnits === 'minutes' && workoutGoal > 0) ||
-        intervalTimer > 0),
+        intervalTimer > 0 ||
+        hasTimedMovements),
     disabled: workoutGoalUnits !== 'minutes',
   });
 
@@ -121,6 +128,29 @@ export const ActiveWorkoutPage = ({
   const isLastMovement = currentMovementIndex === lastMovementIndex;
   const currentMovement = movements[currentMovementIndex];
 
+  // Timed movements (PROD-200): a timed movement's repScheme holds SECONDS per
+  // rung, not reps. The rung runs on its own countdown that auto-fires
+  // "continue" on expiry, exactly as intervalTimer does. The builder makes the
+  // two mutually exclusive; the effects below also guard, since both would
+  // otherwise drive continueWorkout and double-advance.
+  const isTimedRung = currentMovement.timedRungs === true;
+  const currentRungSeconds = isTimedRung
+    ? currentMovement.repScheme[currentMovementRungIndex]
+    : 0;
+
+  const [
+    formattedRungRemaining,
+    {
+      milliseconds: rungRemainingMilliseconds,
+      pause: pauseRungTimer,
+      play: startRungTimer,
+      reset: resetRungTimer,
+    },
+  ] = useCountdownTimer(currentRungSeconds / 60, {
+    defaultPaused: defaultPaused && hasTimedMovements,
+    timeFormat: 'ss.S',
+  });
+
   const primaryWeightSide = isMirrorSet ? 'right' : 'left'; // todo: make primary weight side configurable
 
   const primaryWeightUnit = currentMovement.weightOneUnit;
@@ -173,8 +203,11 @@ export const ActiveWorkoutPage = ({
 
   const currentMovementRungs = currentMovement.repScheme.length;
   const isLastRung = currentMovementRungIndex === currentMovementRungs - 1;
-  const currentRungVolume =
-    currentTotalWeight * currentMovement.repScheme[currentMovementRungIndex];
+  // Seconds are not reps: a timed rung contributes no volume, or a 2-minute
+  // carry at 24 kg would log 2,880 kg and end a kilograms-goal workout instantly.
+  const currentRungVolume = isTimedRung
+    ? 0
+    : currentTotalWeight * currentMovement.repScheme[currentMovementRungIndex];
 
   const currentRound = completedRounds + 1;
   const shouldMirrorReps = isOneHanded || isMixedWeights;
@@ -194,14 +227,22 @@ export const ActiveWorkoutPage = ({
       totalRestMilliseconds) *
     100;
 
+  const totalRungMilliseconds = currentRungSeconds * 1000;
+  const rungCompletedPercentage =
+    ((totalRungMilliseconds - rungRemainingMilliseconds) /
+      totalRungMilliseconds) *
+    100;
+
   // Complex mode: round completes when the longest movement's final rung is done
   const maxMovementRungs = complexSet
     ? Math.max(...movements.map((m) => m.repScheme.length))
     : currentMovementRungs;
 
   const incrementReps = () =>
-    setCompletedReps(
-      (prev) => prev + currentMovement.repScheme[currentMovementRungIndex],
+    setCompletedReps((prev) =>
+      isTimedRung
+        ? prev
+        : prev + currentMovement.repScheme[currentMovementRungIndex],
     );
 
   const incrementRepsComplex = () =>
@@ -209,6 +250,7 @@ export const ActiveWorkoutPage = ({
       (prev) =>
         prev +
         movements.reduce((sum, m) => {
+          if (m.timedRungs) return sum;
           const repIdx = Math.min(
             currentMovementRungIndex,
             m.repScheme.length - 1,
@@ -228,6 +270,7 @@ export const ActiveWorkoutPage = ({
 
   const incrementVolumeComplex = () => {
     const complexVolume = movements.reduce((sum, m) => {
+      if (m.timedRungs) return sum;
       const repIdx = Math.min(currentMovementRungIndex, m.repScheme.length - 1);
       const reps = m.repScheme[repIdx];
       const weight =
@@ -294,6 +337,7 @@ export const ActiveWorkoutPage = ({
     setIsRestActive(true);
     startRestTimer();
     if (intervalTimer > 0) pauseIntervalTimer();
+    if (hasTimedMovements) pauseRungTimer();
   };
 
   const finishRest = () => {
@@ -302,12 +346,18 @@ export const ActiveWorkoutPage = ({
     resetRestTimer();
     setIsRestActive(false);
     if (intervalTimer > 0) startIntervalTimer();
+    if (hasTimedMovements) startRungTimer();
   };
 
   const finishInterval = () => {
     playDing();
     continueWorkout();
     resetIntervalTimer();
+  };
+
+  const finishRung = () => {
+    playDing();
+    continueWorkout();
   };
 
   const continueWorkout = () => {
@@ -332,12 +382,14 @@ export const ActiveWorkoutPage = ({
     resetCountdownTimer();
     startWorkoutTimer();
     if (intervalTimer > 0 && !isRestActive) startIntervalTimer();
+    if (hasTimedMovements && !isRestActive) startRungTimer();
     if (isRestActive) startRestTimer();
   };
 
   const pauseWorkout = () => {
     pauseWorkoutTimer();
     pauseIntervalTimer();
+    pauseRungTimer();
     if (isRestActive) pauseRestTimer();
   };
 
@@ -407,6 +459,29 @@ export const ActiveWorkoutPage = ({
     [intervalRemainingMilliseconds],
   );
 
+  // Re-arm the rung countdown after every advance. Keyed on completedSides
+  // because that is the one counter continueWorkout always bumps: a
+  // single-movement, single-rung timed workout (a plank) leaves both the
+  // movement and rung index at 0, so keying on those would leave the timer
+  // parked at zero and refire handleFinishRung forever.
+  useEffect(
+    function armRungTimer() {
+      if (!isTimedRung) return;
+      resetRungTimer(currentRungSeconds / 60);
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- re-arms once per advance; resetRungTimer is recreated whenever the rung duration changes and must not retrigger this effect
+    [completedSides, currentRungSeconds, isTimedRung],
+  );
+
+  useEffect(
+    function handleFinishRung() {
+      if (!isTimedRung || intervalTimer > 0) return;
+      if (rungRemainingMilliseconds === 0) finishRung();
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- fires only on each rung tick; finishRung is recreated per render and must not retrigger this effect
+    [rungRemainingMilliseconds],
+  );
+
   useEffect(
     function handleFinishRest() {
       if (restTimer === 0) return;
@@ -470,6 +545,7 @@ export const ActiveWorkoutPage = ({
           currentRound={currentRound}
           currentSide={currentSide}
           isOneHanded={isOneHanded}
+          isTimedRung={isTimedRung}
           leftWeightUnit={leftWeightUnit}
           leftWeightValue={leftWeightValue}
           repScheme={currentMovement.repScheme}
@@ -489,13 +565,16 @@ export const ActiveWorkoutPage = ({
           formattedRestRemaining={formattedRestRemaining}
           handleClickContinue={handleClickContinue}
           handleClickStart={handleClickStart}
+          formattedRungRemaining={formattedRungRemaining}
           intervalCompletedPercentage={intervalCompletedPercentage}
           intervalTimer={intervalTimer}
           isComplexMode={complexSet}
           isCountdownActive={isCountdownActive}
           isEffectActive={isEffectActive}
           isRestActive={isRestActive}
+          isTimedRung={isTimedRung}
           restCompletedPercentage={restCompletedPercentage}
+          rungCompletedPercentage={rungCompletedPercentage}
           setIsEffectActive={setIsEffectActive}
           workoutTimerPaused={workoutTimerPaused}
         />

--- a/src/pages/ActiveWorkoutPage/components/ActiveWorkoutControls.tsx
+++ b/src/pages/ActiveWorkoutPage/components/ActiveWorkoutControls.tsx
@@ -9,6 +9,7 @@ interface ActiveWorkoutControlsProps {
   formattedCountdownRemaining: string;
   formattedIntervalRemaining: string;
   formattedRestRemaining: string;
+  formattedRungRemaining?: string;
   handleClickContinue: () => void;
   handleClickStart: () => void;
   intervalCompletedPercentage: number;
@@ -17,7 +18,9 @@ interface ActiveWorkoutControlsProps {
   isCountdownActive: boolean;
   isEffectActive: boolean;
   isRestActive: boolean;
+  isTimedRung?: boolean;
   restCompletedPercentage: number;
+  rungCompletedPercentage?: number;
   setIsEffectActive: (isActive: boolean) => void;
   workoutTimerPaused: boolean;
 }
@@ -26,6 +29,7 @@ export const ActiveWorkoutControls = ({
   formattedCountdownRemaining,
   formattedIntervalRemaining,
   formattedRestRemaining,
+  formattedRungRemaining = '0.0',
   handleClickContinue,
   handleClickStart,
   intervalCompletedPercentage,
@@ -34,7 +38,9 @@ export const ActiveWorkoutControls = ({
   isCountdownActive,
   isEffectActive,
   isRestActive,
+  isTimedRung = false,
   restCompletedPercentage,
+  rungCompletedPercentage = 0,
   setIsEffectActive,
   workoutTimerPaused,
 }: ActiveWorkoutControlsProps) => {
@@ -76,6 +82,18 @@ export const ActiveWorkoutControls = ({
         size="large"
         description="interval"
         value={parseFloat(formattedIntervalRemaining).toFixed(1)}
+      />
+    );
+  }
+
+  if (isTimedRung) {
+    return (
+      <ProgressBar
+        color="success"
+        completedPercentage={rungCompletedPercentage}
+        size="large"
+        description="time"
+        value={parseFloat(formattedRungRemaining).toFixed(1)}
       />
     );
   }

--- a/src/pages/ActiveWorkoutPage/components/ComplexMovementDisplay.tsx
+++ b/src/pages/ActiveWorkoutPage/components/ComplexMovementDisplay.tsx
@@ -1,6 +1,6 @@
 import { Card, CardContent, CardHeader, CardTitle } from '~/components/ui/card';
 import { MovementOptions, WeightUnit } from '~/types';
-import { getWeightUnitLabel } from '~/utils';
+import { formatRungDuration, getWeightUnitLabel } from '~/utils';
 
 interface ComplexMovementDisplayProps {
   currentRound: number;
@@ -92,7 +92,9 @@ export const ComplexMovementDisplay = ({
                   className="shrink-0 text-2xl font-medium"
                   data-testid={`complex-movement-reps-${index}`}
                 >
-                  {movement.repScheme[repIndex]}
+                  {movement.timedRungs
+                    ? formatRungDuration(movement.repScheme[repIndex])
+                    : movement.repScheme[repIndex]}
                 </div>
               </div>
             );

--- a/src/pages/ActiveWorkoutPage/components/CurrentMovement.tsx
+++ b/src/pages/ActiveWorkoutPage/components/CurrentMovement.tsx
@@ -8,13 +8,14 @@ import {
   CardTitle,
 } from '~/components/ui/card';
 import { MovementOptions, WeightUnit } from '~/types';
-import { getWeightUnitLabel } from '~/utils';
+import { formatRungDuration, getWeightUnitLabel } from '~/utils';
 
 interface CurrentMovementProps {
   currentMovement: MovementOptions;
   currentRound: number;
   currentSide: number;
   isOneHanded: boolean | null;
+  isTimedRung?: boolean;
   leftWeightUnit: WeightUnit | null;
   leftWeightValue: number | null;
   repScheme: number[];
@@ -31,6 +32,7 @@ export const CurrentMovement = ({
   currentRound,
   currentSide,
   isOneHanded,
+  isTimedRung = false,
   leftWeightUnit,
   leftWeightValue,
   repScheme,
@@ -87,7 +89,7 @@ export const CurrentMovement = ({
   };
 
   return (
-    <Card>
+    <Card data-testid="current-movement-card">
       <CardHeader>
         <div className="flex gap-2">
           <CardTitle>
@@ -138,7 +140,7 @@ export const CurrentMovement = ({
             >
               {isThreeColumn ? 'Left' : 'Weight'}
             </CardDescription>
-            <CardDescription>Reps</CardDescription>
+            <CardDescription>{isTimedRung ? 'Time' : 'Reps'}</CardDescription>
             {isThreeColumn && (
               <CardDescription
                 className={clsx(
@@ -162,7 +164,13 @@ export const CurrentMovement = ({
               className="flex items-end justify-center text-3xl"
               data-testid="current-reps"
             >
-              {restRemaining ? <span className="h-5" /> : repScheme[rungIndex]}
+              {restRemaining ? (
+                <span className="h-5" />
+              ) : isTimedRung ? (
+                formatRungDuration(repScheme[rungIndex])
+              ) : (
+                repScheme[rungIndex]
+              )}
             </div>
 
             {isThreeColumn ? (

--- a/src/pages/CompletedWorkoutPage/components/WorkoutHistoryItem.tsx
+++ b/src/pages/CompletedWorkoutPage/components/WorkoutHistoryItem.tsx
@@ -172,7 +172,7 @@ export const WorkoutHistoryItem = ({
                     id="rep-scheme"
                     className="whitespace-nowrap"
                   >
-                    Rep Scheme
+                    {movement.timedRungs ? 'Duration' : 'Rep Scheme'}
                   </CardDescription>
                   <div aria-labelledby="rep-scheme">
                     {getRepSchemeDisplayValue(
@@ -183,6 +183,7 @@ export const WorkoutHistoryItem = ({
                             sharedWeights.weightTwoValue,
                           ]
                         : [movement.weightOneValue, movement.weightTwoValue],
+                      movement.timedRungs,
                     )}
                   </div>
                 </div>

--- a/src/pages/CompletedWorkoutPage/utils/displayValues.test.ts
+++ b/src/pages/CompletedWorkoutPage/utils/displayValues.test.ts
@@ -47,4 +47,18 @@ describe('getRepSchemeDisplayValue', () => {
   test('returns single rep count as is when no bells specified', () => {
     expect(getRepSchemeDisplayValue([5], [0, 0])).toBe('5');
   });
+
+  // Timed rungs hold SECONDS. Without formatting, a 5-second carry renders as
+  // a bare "5 / 5" in history and reads as five reps.
+  test('formats timed rungs as durations', () => {
+    expect(getRepSchemeDisplayValue([5, 60, 90], [24, 24], true)).toBe(
+      '0:05, 1:00, 1:30',
+    );
+  });
+
+  test('duplicates timed rungs per hand for unilateral carries', () => {
+    expect(getRepSchemeDisplayValue([5, 60], [24, 0], true)).toBe(
+      '0:05 / 0:05, 1:00 / 1:00',
+    );
+  });
 });

--- a/src/pages/CompletedWorkoutPage/utils/displayValues.ts
+++ b/src/pages/CompletedWorkoutPage/utils/displayValues.ts
@@ -1,5 +1,5 @@
 import { WeightUnit } from '~/types';
-import { getWeightUnitLabel } from '~/utils';
+import { formatRungDuration, getWeightUnitLabel } from '~/utils';
 
 export const getWeightsDisplayValue = (
   weightOneValue: number | null,
@@ -21,13 +21,22 @@ export const getWeightsDisplayValue = (
   }${hands}`;
 };
 
+/**
+ * Render a movement's rungs for the history/completed view. A timed movement's
+ * rungs are SECONDS, so they format as durations — "0:05 / 0:05" rather than a
+ * bare "5 / 5", which would otherwise read as five reps.
+ */
 export const getRepSchemeDisplayValue = (
   repScheme: number[],
   weights: [number | null, number | null],
+  timedRungs = false,
 ) =>
   repScheme.reduce((reps, rung) => {
     const unilateral = (weights[0] ?? 0) > 0 && weights[1] === 0;
-    const rungDisplayValue = unilateral ? `${rung} / ${rung}` : rung.toString();
+    const rungValue = timedRungs ? formatRungDuration(rung) : rung.toString();
+    const rungDisplayValue = unilateral
+      ? `${rungValue} / ${rungValue}`
+      : rungValue;
     if (reps === '') return rungDisplayValue;
     return reps + ', ' + rungDisplayValue;
   }, '');

--- a/src/pages/StartWorkoutPage/StartWorkoutPage.tsx
+++ b/src/pages/StartWorkoutPage/StartWorkoutPage.tsx
@@ -70,6 +70,10 @@ const MOVEMENT_CATALOG_PAGE_SIZE: number = 500;
 
 const DEFAULT_INTERVAL_TIMER: number = 30; // seconds
 const DEFAULT_REST_TIMER: number = 30; // seconds
+const DEFAULT_RUNG_REPS: number = 10;
+const DEFAULT_RUNG_SECONDS: number = 30;
+// Stepping a 2-minute carry one second at a time is unusable.
+const RUNG_SECONDS_STEP: number = 5;
 const DEFAULT_WEIGHT_UNIT: WeightUnit =
   DEFAULT_MOVEMENT_OPTIONS.weightOneUnit ?? 'kilograms';
 const DEFAULT_WEIGHT_VALUE: number =
@@ -556,6 +560,24 @@ export const StartWorkoutPage = ({
       ),
     );
 
+  // Reps and seconds are not interchangeable magnitudes — a [5,4,3,2,1] ladder
+  // reads as 5-second carries, and a 30-second plank reads as 30 reps. Flipping
+  // the unit reseeds every rung to a usable default for the new one.
+  const handleToggleTimedRungs = (index: number, timed: boolean) =>
+    setMovements((prev) =>
+      prev.map((movement, i) =>
+        i === index
+          ? {
+              ...movement,
+              timedRungs: timed,
+              repScheme: movement.repScheme.map(() =>
+                timed ? DEFAULT_RUNG_SECONDS : DEFAULT_RUNG_REPS,
+              ),
+            }
+          : movement,
+      ),
+    );
+
   const handleChangeRepScheme = (
     movementIndex: number,
     rungIndex: number,
@@ -900,6 +922,7 @@ export const StartWorkoutPage = ({
             hasNotes={workoutDetails !== null}
             hasInterval={intervalTimer > 0}
             hasRest={restTimer > 0}
+            hasTimedMovements={movements.some((m) => m.timedRungs)}
             showComplex={features.complexMode}
             onToggleComplex={handleToggleComplex}
             onToggleInterval={handleToggleInterval}
@@ -1117,7 +1140,7 @@ export const StartWorkoutPage = ({
                   </Section>
                 )}
                 <Section
-                  title="Rep Scheme"
+                  title={movement.timedRungs ? 'Duration' : 'Rep Scheme'}
                   actions={
                     <ModifyWorkoutButtons
                       count={movement.repScheme.length}
@@ -1127,30 +1150,58 @@ export const StartWorkoutPage = ({
                     />
                   }
                 >
-                  {movement.repScheme.map((_, rungIndex) => (
-                    <ModifyCountButtons
-                      key={rungIndex}
-                      value={movement.repScheme[rungIndex]}
-                      onChange={(value) =>
-                        handleChangeRepScheme(index, rungIndex, value)
-                      }
-                      onClickMinus={() =>
-                        handleChangeRepScheme(
-                          index,
-                          rungIndex,
-                          movement.repScheme[rungIndex] - 1,
-                        )
-                      }
-                      onClickPlus={() =>
-                        handleChangeRepScheme(
-                          index,
-                          rungIndex,
-                          movement.repScheme[rungIndex] + 1,
-                        )
-                      }
-                      unit="reps"
-                    />
-                  ))}
+                  <Tabs
+                    value={movement.timedRungs ? 'time' : 'reps'}
+                    onValueChange={(value) =>
+                      handleToggleTimedRungs(index, value === 'time')
+                    }
+                  >
+                    <TabsList>
+                      <TabsTrigger size="sm" value="reps">
+                        Reps
+                      </TabsTrigger>
+                      <TabsTrigger
+                        size="sm"
+                        value="time"
+                        disabled={intervalTimer > 0}
+                        title={
+                          intervalTimer > 0
+                            ? 'Turn off the interval timer first — both drive the set clock.'
+                            : undefined
+                        }
+                      >
+                        Time
+                      </TabsTrigger>
+                    </TabsList>
+                  </Tabs>
+
+                  {movement.repScheme.map((_, rungIndex) => {
+                    const step = movement.timedRungs ? RUNG_SECONDS_STEP : 1;
+                    return (
+                      <ModifyCountButtons
+                        key={rungIndex}
+                        value={movement.repScheme[rungIndex]}
+                        onChange={(value) =>
+                          handleChangeRepScheme(index, rungIndex, value)
+                        }
+                        onClickMinus={() =>
+                          handleChangeRepScheme(
+                            index,
+                            rungIndex,
+                            movement.repScheme[rungIndex] - step,
+                          )
+                        }
+                        onClickPlus={() =>
+                          handleChangeRepScheme(
+                            index,
+                            rungIndex,
+                            movement.repScheme[rungIndex] + step,
+                          )
+                        }
+                        unit={movement.timedRungs ? 'sec' : 'reps'}
+                      />
+                    );
+                  })}
                 </Section>
               </Card>
             );

--- a/src/pages/StartWorkoutPage/components/AddToWorkoutSection.tsx
+++ b/src/pages/StartWorkoutPage/components/AddToWorkoutSection.tsx
@@ -5,6 +5,7 @@ export const AddToWorkoutSection = ({
   hasNotes,
   hasInterval,
   hasRest,
+  hasTimedMovements = false,
   onToggleComplex,
   onToggleInterval,
   onToggleNotes,
@@ -15,6 +16,7 @@ export const AddToWorkoutSection = ({
   hasNotes: boolean;
   hasInterval: boolean;
   hasRest: boolean;
+  hasTimedMovements?: boolean;
   onToggleComplex: () => void;
   onToggleInterval: () => void;
   onToggleNotes: () => void;
@@ -37,6 +39,8 @@ export const AddToWorkoutSection = ({
           id="interval"
           label="Interval"
           isOn={hasInterval}
+          disabled={hasTimedMovements}
+          disabledReason="Turn off timed movements first — both drive the set clock."
           onToggle={onToggleInterval}
         />
         <WorkoutAddonToggle

--- a/src/pages/StartWorkoutPage/components/WorkoutAddonToggle.tsx
+++ b/src/pages/StartWorkoutPage/components/WorkoutAddonToggle.tsx
@@ -21,11 +21,15 @@ export const WorkoutAddonToggle = ({
   id,
   label,
   isOn,
+  disabled = false,
+  disabledReason,
   onToggle,
 }: {
   id: WorkoutAddonId;
   label: string;
   isOn: boolean;
+  disabled?: boolean;
+  disabledReason?: string;
   onToggle: () => void;
 }) => {
   const Icon = ICONS[id] as ComponentType<SVGProps<SVGSVGElement>>;
@@ -35,12 +39,15 @@ export const WorkoutAddonToggle = ({
       type="button"
       aria-pressed={isOn}
       aria-label={`${label}, ${isOn ? 'on' : 'off'}`}
+      disabled={disabled}
+      title={disabled ? disabledReason : undefined}
       onClick={onToggle}
       className={cn(
         'flex min-w-0 flex-1 flex-col items-center gap-0.5 rounded-lg border bg-card px-0.5 py-1.5 transition-colors',
         isOn
           ? 'border-primary/40 bg-secondary ring-1 ring-primary/30'
           : 'border-border',
+        disabled && 'cursor-not-allowed opacity-40',
       )}
     >
       <Icon className="h-2.5 w-2.5 shrink-0 text-foreground" aria-hidden />

--- a/src/types/movement-log.interface.ts
+++ b/src/types/movement-log.interface.ts
@@ -3,7 +3,9 @@ import { WeightUnit } from './weight-unit.type';
 export interface MovementLog {
   id: number;
   movementName: string;
+  /** Reps per rung, or seconds per rung when `timedRungs` is set. */
   repScheme: number[];
+  timedRungs?: boolean;
   userMovementId: string | null;
   functionalMovementId: string | null;
   weightOneUnit: WeightUnit | null;

--- a/src/types/movement-options.interface.ts
+++ b/src/types/movement-options.interface.ts
@@ -2,7 +2,10 @@ import { WeightUnit } from './weight-unit.type';
 
 export interface MovementOptions {
   movementName: string;
+  /** Reps per rung, or seconds per rung when `timedRungs` is set. */
   repScheme: number[];
+  /** Carries, planks, marches: each rung runs on a countdown instead of reps. */
+  timedRungs?: boolean;
   weightOneUnit: WeightUnit | null;
   weightOneValue: number | null;
   weightTwoUnit: WeightUnit | null;

--- a/src/utils/formatRungDuration.test.ts
+++ b/src/utils/formatRungDuration.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, test } from 'vitest';
+
+import { formatRungDuration } from './formatRungDuration';
+
+describe('formatRungDuration', () => {
+  test('pads seconds to two digits', () => {
+    expect(formatRungDuration(30)).toBe('0:30');
+    expect(formatRungDuration(5)).toBe('0:05');
+  });
+
+  test('rolls over into minutes', () => {
+    expect(formatRungDuration(60)).toBe('1:00');
+    expect(formatRungDuration(90)).toBe('1:30');
+    expect(formatRungDuration(120)).toBe('2:00');
+  });
+
+  test('clamps negatives and rounds fractions', () => {
+    expect(formatRungDuration(-10)).toBe('0:00');
+    expect(formatRungDuration(45.4)).toBe('0:45');
+  });
+});

--- a/src/utils/formatRungDuration.ts
+++ b/src/utils/formatRungDuration.ts
@@ -1,0 +1,10 @@
+/**
+ * Format a timed rung's prescribed duration for display, e.g. 90 -> "1:30".
+ * Durations run to minutes at most, so hours are intentionally unhandled.
+ */
+export const formatRungDuration = (seconds: number): string => {
+  const safeSeconds = Math.max(0, Math.round(seconds));
+  const minutes = Math.floor(safeSeconds / 60);
+  const remainder = safeSeconds % 60;
+  return `${minutes}:${String(remainder).padStart(2, '0')}`;
+};

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,3 +1,4 @@
+export * from './formatRungDuration';
 export * from './movementSearch';
 export * from './movementWeightModeFilter';
 export * from './ordinalSuffixOf';

--- a/src/utils/workoutLogToWorkoutOptions.test.ts
+++ b/src/utils/workoutLogToWorkoutOptions.test.ts
@@ -54,6 +54,7 @@ describe('workoutLogToWorkoutOptions', () => {
         {
           movementName: 'Kettlebell Swing',
           repScheme: [10],
+          timedRungs: false,
           weightOneUnit: 'kilograms',
           weightOneValue: 16,
           weightTwoUnit: null,

--- a/src/utils/workoutLogToWorkoutOptions.ts
+++ b/src/utils/workoutLogToWorkoutOptions.ts
@@ -39,6 +39,7 @@ export const workoutLogToWorkoutOptions = (
     movements: movementLogs.map((movementLog) => ({
       movementName: movementLog.movementName,
       repScheme: movementLog.repScheme,
+      timedRungs: movementLog.timedRungs ?? false,
       weightOneUnit: isComplexSet
         ? sharedWeights.weightOneUnit
         : movementLog.weightOneUnit,

--- a/supabase/migrations/20260723120000_add_timed_rungs.sql
+++ b/supabase/migrations/20260723120000_add_timed_rungs.sql
@@ -1,0 +1,112 @@
+-- Timed movements (PROD-200): carries, planks, and marches are prescribed in
+-- seconds, not reps. Rather than a parallel duration array -- which would have to
+-- be threaded through workout_options JSONB, movement_logs.rep_scheme,
+-- workout_logs.rep_scheme, pattern_debt_window, the rung/round runtime, the
+-- builder ladder UI, and every program seed -- a timed movement reuses
+-- `rep_scheme` and reinterprets each entry as SECONDS. Rung structure (ladders,
+-- rounds, mirrored sides, complex alternation) is identical either way; only the
+-- unit of the magnitude changes.
+--
+-- Existing rows are all rep-based, so the `false` default is correct history and
+-- no backfill is needed.
+
+ALTER TABLE public.movement_logs
+  ADD COLUMN timed_rungs boolean NOT NULL DEFAULT false;
+
+COMMENT ON COLUMN public.movement_logs.timed_rungs IS
+  'When true, each rep_scheme entry is a duration in seconds rather than a rep count.';
+
+-- Timed rungs must not pollute rep/volume aggregates. `rep_scheme` for a timed
+-- carry holds seconds, so the existing `total_reps * weight` product would report
+-- a 2x120s carry at 24 kg as 5,760 kg against the carry pattern and swamp every
+-- real lift in the recommender's baseline.
+--
+-- Timed rows still contribute `set_count` and `last_trained_at` -- "you carried
+-- three times this week, most recently Tuesday" stays true and is what the
+-- staleness half of the debt score reads. Only the two magnitude columns
+-- (total_reps, volume_kg) are zeroed, because seconds and reps are not
+-- commensurable and there is no honest way to add them.
+--
+-- Body is otherwise unchanged from 20260624000000_create_pattern_debt_function.sql.
+CREATE OR REPLACE FUNCTION public.pattern_debt_window(
+  p_window_days int DEFAULT 14,
+  p_baseline_days int DEFAULT 84
+)
+RETURNS TABLE (
+  pattern text,
+  last_trained_at timestamptz,
+  set_count bigint,
+  total_reps bigint,
+  total_volume_kg numeric,
+  baseline_volume_kg numeric
+)
+LANGUAGE sql
+STABLE
+SECURITY INVOKER
+SET search_path = public
+AS $$
+  WITH patterns(pattern) AS (
+    VALUES ('hinge'), ('squat'), ('push'), ('pull'), ('carry'), ('rotation'), ('get_up')
+  ),
+  logs AS (
+    SELECT
+      ml.created_at,
+      -- Collapse the catalog's granular Movement Pattern into a coarse bucket.
+      -- get-ups are detected by name (complex/combo movement, not a single tag)
+      -- and take precedence; everything else maps from Movement Pattern #1.
+      CASE
+        WHEN ml.movement_name ~* '(get[ -]?up|turkish)' THEN 'get_up'
+        WHEN m."Movement Pattern #1" IN ('Hip Hinge', 'Hip Dominant', 'Hip Extension') THEN 'hinge'
+        WHEN m."Movement Pattern #1" = 'Knee Dominant' THEN 'squat'
+        WHEN m."Movement Pattern #1" IN ('Vertical Push', 'Horizontal Push') THEN 'push'
+        WHEN m."Movement Pattern #1" IN ('Vertical Pull', 'Horizontal Pull') THEN 'pull'
+        WHEN m."Movement Pattern #1" = 'Loaded Carry' THEN 'carry'
+        WHEN m."Movement Pattern #1" IN ('Rotational', 'Spinal Rotational') THEN 'rotation'
+        ELSE NULL
+      END AS pattern,
+      CASE WHEN ml.timed_rungs THEN 0 ELSE reps.total_reps END AS total_reps,
+      reps.set_count,
+      -- Volume normalized to kilograms; bodyweight / null weight contributes 0.
+      CASE WHEN ml.timed_rungs THEN 0 ELSE reps.total_reps END * CASE
+        WHEN ml.weight_one_unit = 'pounds' THEN COALESCE(ml.weight_one_value, 0) * 0.45359237
+        ELSE COALESCE(ml.weight_one_value, 0)
+      END AS volume_kg
+    FROM movement_logs ml
+    LEFT JOIN user_movements um ON um.id = ml.user_movement_id
+    LEFT JOIN movements m ON m.id = um.functional_movement_id
+    CROSS JOIN LATERAL (
+      SELECT
+        COALESCE(SUM(r), 0)::bigint AS total_reps,
+        COALESCE(COUNT(r), 0)::bigint AS set_count
+      FROM unnest(ml.rep_scheme) AS r
+    ) reps
+    WHERE ml.user_id = auth.uid()
+      AND ml.created_at >= now() - make_interval(days => p_baseline_days)
+  )
+  SELECT
+    p.pattern,
+    max(l.created_at) FILTER (
+      WHERE l.created_at >= now() - make_interval(days => p_window_days)
+    ) AS last_trained_at,
+    COALESCE(sum(l.set_count) FILTER (
+      WHERE l.created_at >= now() - make_interval(days => p_window_days)
+    ), 0) AS set_count,
+    COALESCE(sum(l.total_reps) FILTER (
+      WHERE l.created_at >= now() - make_interval(days => p_window_days)
+    ), 0) AS total_reps,
+    COALESCE(sum(l.volume_kg) FILTER (
+      WHERE l.created_at >= now() - make_interval(days => p_window_days)
+    ), 0) AS total_volume_kg,
+    -- Baseline = typical per-window volume: total over the baseline window,
+    -- scaled down to one window length. NULL when there is no baseline history.
+    CASE
+      WHEN sum(l.volume_kg) IS NULL THEN NULL
+      ELSE round(sum(l.volume_kg) * (p_window_days::numeric / p_baseline_days), 2)
+    END AS baseline_volume_kg
+  FROM patterns p
+  LEFT JOIN logs l ON l.pattern = p.pattern
+  GROUP BY p.pattern;
+$$;
+
+REVOKE ALL ON FUNCTION public.pattern_debt_window(int, int) FROM public;
+GRANT EXECUTE ON FUNCTION public.pattern_debt_window(int, int) TO authenticated;

--- a/supabase/migrations/20260723130000_seed_kettlebell_mile.sql
+++ b/supabase/migrations/20260723130000_seed_kettlebell_mile.sql
@@ -37,14 +37,22 @@
 --     puts the carry in Single/'1h' mode, so the runtime MIRRORS every rung per
 --     hand (shouldMirrorReps / goToNextSide) -- which is exactly the source's
 --     "switching hands as often as you want," and it enforces an even split.
---     Consequence: each repScheme entry is the PER-HAND segment, so a session's
---     total carrying time is sum(repScheme) x 2. The details string on each
---     session states the total so the number on screen is never a surprise.
 --
---   * workoutGoalUnits 'rounds' with workoutGoal 1: one round = the whole
---     prescribed ladder completed once, the same convention the Easy Strength
---     seed uses. intervalTimer MUST stay 0 -- it and timed rungs both drive
---     auto-advance, and the builder treats them as mutually exclusive.
+--   * ONE 60-SECOND RUNG, ROUNDS AS THE PROGRESSION LEVER. Every session carries
+--     a single-element repScheme of [60] and varies workoutGoal instead. One
+--     round is therefore 1:00 left + 1:00 right, and a session's total time
+--     under load is rounds x 2 minutes. The alternative -- one round of several
+--     longer rungs -- pins "rounds remaining" at 1 for the whole session, so the
+--     lifter gets no progress signal; this way the counter ticks down. The
+--     details string on each session states the total so the on-screen number
+--     is never a surprise. intervalTimer MUST stay 0 -- it and timed rungs both
+--     drive auto-advance, and the builder treats them as mutually exclusive.
+--
+--   * THE ROUNDS GOAL IS A HARD STOP (handleRoundsGoalReached -> finishWorkout),
+--     so the test session's 10 rounds are a CEILING, not a prescription: 20 min
+--     is generous enough that a slow first mile is never cut off mid-carry. The
+--     build weeks land on exact minute totals; 15 min (the entry benchmark) is
+--     not reachable in whole 60s rounds, which is why the test is not 15.
 --
 --   * 24 kg is a PLACEHOLDER, as in every other seed; the enrollment weight
 --     picker pre-fills single-bell from deriveStartingWeight and the user sets
@@ -55,14 +63,17 @@
 -- Session-local helper (pg_temp: auto-dropped at connection end, never persisted
 -- to the committed schema) building the WorkoutOptions JSONB for one session.
 -- Shape MUST match Omit<WorkoutOptions,'startedAt'> exactly (camelCase keys).
--- p_segments holds the PER-HAND carry segments in seconds.
-CREATE OR REPLACE FUNCTION pg_temp.mile_options(p_segments INT[], p_details TEXT)
+--
+-- Every session is a SINGLE 60-second rung; p_rounds is the progression lever.
+-- One rung + one-handed loading means one round = 60s left + 60s right = two
+-- minutes of carrying, so total time under load is p_rounds x 2 minutes.
+CREATE OR REPLACE FUNCTION pg_temp.mile_options(p_rounds INT, p_details TEXT)
 RETURNS JSONB LANGUAGE sql IMMUTABLE AS $$
   SELECT jsonb_build_object(
     'complexSet', false,
     'intervalTimer', 0,
     'restTimer', 0,
-    'workoutGoal', 1,
+    'workoutGoal', p_rounds,
     'workoutGoalUnits', 'rounds',
     'workoutDetails', p_details,
     'sharedWeightOneUnit', NULL,
@@ -72,7 +83,7 @@ RETURNS JSONB LANGUAGE sql IMMUTABLE AS $$
     'movements', jsonb_build_array(
       jsonb_build_object(
         'movementName', 'Kettlebell Suitcase Carry',
-        'repScheme', to_jsonb(p_segments),
+        'repScheme', to_jsonb(ARRAY[60]::INT[]),
         'timedRungs', true,
         'weightOneUnit', 'kilograms', 'weightOneValue', 24,
         'weightTwoUnit', NULL, 'weightTwoValue', 0)
@@ -100,45 +111,46 @@ BEGIN
     RETURN;
   END IF;
 
-  -- Per-hand segments in seconds; total carrying time is double (each rung is
-  -- mirrored left then right). Build 6 -> 16 min, taper to 12, then test.
+  -- Every session is one 60-second rung; ROUNDS are the progression lever, so
+  -- the in-workout "rounds remaining" counter actually ticks down. One round =
+  -- 1:00 left + 1:00 right, so total time under load is rounds x 2 minutes:
+  -- build 6 -> 16 min, taper to 12, then the test.
   INSERT INTO program_sessions
     (program_id, sequence_index, week_number, day_number, title, workout_options)
   VALUES
     (v_program_id, 0, 1, 1, 'Build - 6 min',
-     pg_temp.mile_options(ARRAY[60, 60, 60]::INT[],
-       'Kettlebell Mile W1 - Build. Three carries per hand, 1:00 each = 6 min total under load. '
-       'Walk, do not race. Set the bell down between rungs if your posture starts to lean. '
+     pg_temp.mile_options(3,
+       'Kettlebell Mile W1 - Build. 3 rounds of 1:00 per hand = 6 min total under load. '
+       'Walk, do not race. Set the bell down between rounds if your posture starts to lean. '
        'Load is a placeholder: aim for 20-30% of bodyweight (24 kg men / 16 kg women is the challenge standard).')),
     (v_program_id, 1, 2, 1, 'Build - 8 min',
-     pg_temp.mile_options(ARRAY[80, 80, 80]::INT[],
-       'Kettlebell Mile W2 - Build. Three carries per hand, 1:20 each = 8 min total under load. '
+     pg_temp.mile_options(4,
+       'Kettlebell Mile W2 - Build. 4 rounds of 1:00 per hand = 8 min total under load. '
        'Same load as week 1. Keep your ribs stacked over your hips; the unloaded side is doing the work.')),
     (v_program_id, 2, 3, 1, 'Build - 10 min',
-     pg_temp.mile_options(ARRAY[100, 100, 100]::INT[],
-       'Kettlebell Mile W3 - Build. Three carries per hand, 1:40 each = 10 min total under load. '
+     pg_temp.mile_options(5,
+       'Kettlebell Mile W3 - Build. 5 rounds of 1:00 per hand = 10 min total under load. '
        'If your grip fails before your legs do, that is the point of the drill - keep the weight.')),
     (v_program_id, 3, 4, 1, 'Build - 12 min',
-     pg_temp.mile_options(ARRAY[120, 120, 120]::INT[],
-       'Kettlebell Mile W4 - Build. Three carries per hand, 2:00 each = 12 min total under load. '
+     pg_temp.mile_options(6,
+       'Kettlebell Mile W4 - Build. 6 rounds of 1:00 per hand = 12 min total under load. '
        'Roughly the duration of a good mile. Breathe through your nose if you can.')),
     (v_program_id, 4, 5, 1, 'Build - 14 min',
-     pg_temp.mile_options(ARRAY[140, 140, 140]::INT[],
-       'Kettlebell Mile W5 - Build. Three carries per hand, 2:20 each = 14 min total under load. '
+     pg_temp.mile_options(7,
+       'Kettlebell Mile W5 - Build. 7 rounds of 1:00 per hand = 14 min total under load. '
        'Longest week so far. Walk a straight line - drifting sideways means the anti-lateral-flexion work is slipping.')),
     (v_program_id, 5, 6, 1, 'Build - 16 min',
-     pg_temp.mile_options(ARRAY[160, 160, 160]::INT[],
-       'Kettlebell Mile W6 - Build. Three carries per hand, 2:40 each = 16 min total under load. '
+     pg_temp.mile_options(8,
+       'Kettlebell Mile W6 - Build. 8 rounds of 1:00 per hand = 16 min total under load. '
        'Peak volume. This should feel harder than the test will.')),
     (v_program_id, 6, 7, 1, 'Taper - 12 min',
-     pg_temp.mile_options(ARRAY[120, 120, 120]::INT[],
-       'Kettlebell Mile W7 - Taper. Three carries per hand, 2:00 each = 12 min total under load. '
+     pg_temp.mile_options(6,
+       'Kettlebell Mile W7 - Taper. 6 rounds of 1:00 per hand = 12 min total under load. '
        'Deliberately easier than week 6. Move well, save the effort for the test.')),
     (v_program_id, 7, 8, 1, 'THE MILE',
-     pg_temp.mile_options(ARRAY[150, 150, 150]::INT[],
+     pg_temp.mile_options(10,
        'Kettlebell Mile W8 - THE TEST. Carry the bell one mile, suitcase style, as fast as you can - '
-       'the clock runs while you rest. The rungs (three per hand, 2:30 each = 15 min) are a hand-switch '
-       'cadence and the entry benchmark pace, NOT a target to fill: when you finish the mile, tap Finish '
-       'workout and your real time is recorded. Benchmarks: ~15 min fast walk, 11-13 min jogging, '
-       '9-11 min very good, under 9 min very very good.'));
+       'the clock runs while you rest. Switch hands every 1:00. The 10 rounds are a CEILING, not a '
+       'target: when you finish the mile, tap Finish workout and your real time is recorded. '
+       'Benchmarks: ~15 min fast walk, 11-13 min jogging, 9-11 min very good, under 9 min very very good.'));
 END $$;

--- a/supabase/migrations/20260723130000_seed_kettlebell_mile.sql
+++ b/supabase/migrations/20260723130000_seed_kettlebell_mile.sql
@@ -1,0 +1,144 @@
+-- Seed the shared "Kettlebell Mile" program (Dr. Mike Prevost, StrongFirst).
+-- Public + system-owned (owner_id NULL, is_public true) so every user sees it
+-- and can one-tap "Start"; enrolling clones it into an editable copy
+-- (enroll_in_program). Idempotent on slug: a re-run (or fresh env) skips
+-- re-seeding sessions. This is a MIGRATION (not seed.sql) so it also reaches
+-- staging/production, where seed.sql never runs. Surfaced only behind the
+-- `programs` feature flag, like DFW.
+--
+-- Source: https://www.strongfirst.com/the-kettlebell-mile/ -- free and complete
+-- on the page. Carry a kettlebell suitcase-style for one mile, switching hands
+-- as often as you like, as fast as you can. Once a week. Challenge weight is
+-- 24 kg (men) / 16 kg (women), which Prevost frames as 20-30% of bodyweight --
+-- the crossover point where strength and aerobic capacity matter equally.
+-- Benchmarks: ~15 min fast walk, 11-13 min jogging, 9-11 min very good,
+-- sub-9 min very very good.
+--
+-- This is the catalog's first carry-centric program. It is also the first to use
+-- timed rungs (PROD-200): `timedRungs: true` reinterprets each repScheme entry
+-- as SECONDS, and the runtime auto-advances when the rung's countdown expires.
+--
+-- MODELING DECISIONS (the product-review-worthy calls):
+--
+--   * DISTANCE -> TIME. The source prescribes one MILE; the app has no distance
+--     unit, only reps and (now) seconds. So the program is an adaptation: every
+--     session prescribes time under load, not distance. This is the same class
+--     of approximation as Easy Strength's "6x1, add weight each set" day. The
+--     test session's workoutDetails is explicit that the user walks their actual
+--     mile and finishes the workout when the mile is done -- the 15-minute
+--     prescription is the entry benchmark pace, not a box to fill.
+--
+--   * THE 8-WEEK LADDER IS AUTHORED, NOT SOURCED. Prevost gives the protocol and
+--     the benchmarks but only says to "build up to the distance, then improve
+--     speed." The week-by-week build below (6 -> 16 min of carrying, taper, test)
+--     is ours. Anyone revising it is not contradicting the source.
+--
+--   * ONE-HANDED LOADING DOES THE HAND-SWITCHING. weightTwoValue = 0 (not NULL)
+--     puts the carry in Single/'1h' mode, so the runtime MIRRORS every rung per
+--     hand (shouldMirrorReps / goToNextSide) -- which is exactly the source's
+--     "switching hands as often as you want," and it enforces an even split.
+--     Consequence: each repScheme entry is the PER-HAND segment, so a session's
+--     total carrying time is sum(repScheme) x 2. The details string on each
+--     session states the total so the number on screen is never a surprise.
+--
+--   * workoutGoalUnits 'rounds' with workoutGoal 1: one round = the whole
+--     prescribed ladder completed once, the same convention the Easy Strength
+--     seed uses. intervalTimer MUST stay 0 -- it and timed rungs both drive
+--     auto-advance, and the builder treats them as mutually exclusive.
+--
+--   * 24 kg is a PLACEHOLDER, as in every other seed; the enrollment weight
+--     picker pre-fills single-bell from deriveStartingWeight and the user sets
+--     their own 20-30% bodyweight load.
+--
+-- 8 trackable sessions (seq 0-7 = 8 weeks x 1 day). num_weeks=8, days_per_week=1.
+
+-- Session-local helper (pg_temp: auto-dropped at connection end, never persisted
+-- to the committed schema) building the WorkoutOptions JSONB for one session.
+-- Shape MUST match Omit<WorkoutOptions,'startedAt'> exactly (camelCase keys).
+-- p_segments holds the PER-HAND carry segments in seconds.
+CREATE OR REPLACE FUNCTION pg_temp.mile_options(p_segments INT[], p_details TEXT)
+RETURNS JSONB LANGUAGE sql IMMUTABLE AS $$
+  SELECT jsonb_build_object(
+    'complexSet', false,
+    'intervalTimer', 0,
+    'restTimer', 0,
+    'workoutGoal', 1,
+    'workoutGoalUnits', 'rounds',
+    'workoutDetails', p_details,
+    'sharedWeightOneUnit', NULL,
+    'sharedWeightOneValue', NULL,
+    'sharedWeightTwoUnit', NULL,
+    'sharedWeightTwoValue', NULL,
+    'movements', jsonb_build_array(
+      jsonb_build_object(
+        'movementName', 'Kettlebell Suitcase Carry',
+        'repScheme', to_jsonb(p_segments),
+        'timedRungs', true,
+        'weightOneUnit', 'kilograms', 'weightOneValue', 24,
+        'weightTwoUnit', NULL, 'weightTwoValue', 0)
+    ));
+$$;
+
+DO $$
+DECLARE
+  v_program_id UUID;
+BEGIN
+  INSERT INTO programs (owner_id, slug, title, description, author_name, num_weeks, days_per_week, is_public)
+  VALUES (NULL, 'kettlebell-mile',
+          'The Kettlebell Mile',
+          'One suitcase carry, once a week, for eight weeks. Build time under '
+          'load from six minutes to sixteen, taper, then walk your mile with a '
+          'bell in one hand as fast as you can. Trains strength and aerobic '
+          'capacity at the same time, and your obliques will have opinions.',
+          'Dr. Mike Prevost (StrongFirst)', 8, 1, true)
+  ON CONFLICT (slug) DO NOTHING
+  RETURNING id INTO v_program_id;
+
+  -- If the row already existed, skip re-seeding sessions.
+  IF v_program_id IS NULL THEN
+    RAISE NOTICE 'Kettlebell Mile program already seeded; skipping sessions.';
+    RETURN;
+  END IF;
+
+  -- Per-hand segments in seconds; total carrying time is double (each rung is
+  -- mirrored left then right). Build 6 -> 16 min, taper to 12, then test.
+  INSERT INTO program_sessions
+    (program_id, sequence_index, week_number, day_number, title, workout_options)
+  VALUES
+    (v_program_id, 0, 1, 1, 'Build - 6 min',
+     pg_temp.mile_options(ARRAY[60, 60, 60]::INT[],
+       'Kettlebell Mile W1 - Build. Three carries per hand, 1:00 each = 6 min total under load. '
+       'Walk, do not race. Set the bell down between rungs if your posture starts to lean. '
+       'Load is a placeholder: aim for 20-30% of bodyweight (24 kg men / 16 kg women is the challenge standard).')),
+    (v_program_id, 1, 2, 1, 'Build - 8 min',
+     pg_temp.mile_options(ARRAY[80, 80, 80]::INT[],
+       'Kettlebell Mile W2 - Build. Three carries per hand, 1:20 each = 8 min total under load. '
+       'Same load as week 1. Keep your ribs stacked over your hips; the unloaded side is doing the work.')),
+    (v_program_id, 2, 3, 1, 'Build - 10 min',
+     pg_temp.mile_options(ARRAY[100, 100, 100]::INT[],
+       'Kettlebell Mile W3 - Build. Three carries per hand, 1:40 each = 10 min total under load. '
+       'If your grip fails before your legs do, that is the point of the drill - keep the weight.')),
+    (v_program_id, 3, 4, 1, 'Build - 12 min',
+     pg_temp.mile_options(ARRAY[120, 120, 120]::INT[],
+       'Kettlebell Mile W4 - Build. Three carries per hand, 2:00 each = 12 min total under load. '
+       'Roughly the duration of a good mile. Breathe through your nose if you can.')),
+    (v_program_id, 4, 5, 1, 'Build - 14 min',
+     pg_temp.mile_options(ARRAY[140, 140, 140]::INT[],
+       'Kettlebell Mile W5 - Build. Three carries per hand, 2:20 each = 14 min total under load. '
+       'Longest week so far. Walk a straight line - drifting sideways means the anti-lateral-flexion work is slipping.')),
+    (v_program_id, 5, 6, 1, 'Build - 16 min',
+     pg_temp.mile_options(ARRAY[160, 160, 160]::INT[],
+       'Kettlebell Mile W6 - Build. Three carries per hand, 2:40 each = 16 min total under load. '
+       'Peak volume. This should feel harder than the test will.')),
+    (v_program_id, 6, 7, 1, 'Taper - 12 min',
+     pg_temp.mile_options(ARRAY[120, 120, 120]::INT[],
+       'Kettlebell Mile W7 - Taper. Three carries per hand, 2:00 each = 12 min total under load. '
+       'Deliberately easier than week 6. Move well, save the effort for the test.')),
+    (v_program_id, 7, 8, 1, 'THE MILE',
+     pg_temp.mile_options(ARRAY[150, 150, 150]::INT[],
+       'Kettlebell Mile W8 - THE TEST. Carry the bell one mile, suitcase style, as fast as you can - '
+       'the clock runs while you rest. The rungs (three per hand, 2:30 each = 15 min) are a hand-switch '
+       'cadence and the entry benchmark pace, NOT a target to fill: when you finish the mile, tap Finish '
+       'workout and your real time is recorded. Benchmarks: ~15 min fast walk, 11-13 min jogging, '
+       '9-11 min very good, under 9 min very very good.'));
+END $$;

--- a/types/supabase.ts
+++ b/types/supabase.ts
@@ -113,6 +113,7 @@ export type Database = {
           id: number
           movement_name: string
           rep_scheme: number[]
+          timed_rungs: boolean
           user_id: string
           user_movement_id: string | null
           weight_one_unit: Database["public"]["Enums"]["weight_unit"] | null
@@ -126,6 +127,7 @@ export type Database = {
           id?: number
           movement_name: string
           rep_scheme?: number[]
+          timed_rungs?: boolean
           user_id: string
           user_movement_id?: string | null
           weight_one_unit?: Database["public"]["Enums"]["weight_unit"] | null
@@ -139,6 +141,7 @@ export type Database = {
           id?: number
           movement_name?: string
           rep_scheme?: number[]
+          timed_rungs?: boolean
           user_id?: string
           user_movement_id?: string | null
           weight_one_unit?: Database["public"]["Enums"]["weight_unit"] | null


### PR DESCRIPTION
## Description

Adds the catalog's first carry-centric program, plus the runtime feature it needs. Two commits, in order:

**1. `feat(workouts): add timed movements` (PROD-200)** — a movement with `timedRungs: true` reinterprets each `repScheme` entry as **seconds**. The rung runs on its own countdown that auto-fires "continue" on expiry (re-armed per rung, so `[30, 60]` works), exactly as `intervalTimer` already does. Carries, planks and marches were previously unprogrammable: you had to invent a rep count and hope the lifter read the notes.

Reusing `repScheme` rather than adding a parallel duration array leaves rung structure — ladders, rounds, mirrored sides, complex alternation — completely untouched. Only the unit of the magnitude changes. Timed movements and `intervalTimer` are mutually exclusive (both drive auto-advance), so the builder disables each while the other is on.

**2. `feat(programs): seed The Kettlebell Mile` (PROD-225)** — [Dr. Mike Prevost's Kettlebell Mile](https://www.strongfirst.com/the-kettlebell-mile/), free and complete on the page. 24 kg men / 16 kg women (20-30% bodyweight), one mile suitcase-style, switching hands freely, once a week. Eight sessions: build 6 → 16 min of time under load, taper to 12, then the mile.

## Why

The shared catalog has six programs and none is carry-centric — Easy Strength uses Farmer's Carry as one of five patterns and that's the extent of it. `Kettlebell Suitcase Carry` has been in the movement catalog since PROD-153, but carries are prescribed in distance or time and the app could only express reps, so a carry-*centric* program was blocked on PROD-200.

**Two things a reviewer should look at closely.**

*Reps and volume exclusion.* Seconds × kilograms is not volume. A 2×120s carry at 24 kg would otherwise log 2,880 kg in-session and report **3,000 kg** against the carry pattern, swamping every real lift in the recommender's baseline. `pattern_debt_window` now keeps `set_count` and `last_trained_at` for timed rows and zeroes `total_reps` / `volume_kg` — recency still works, magnitude doesn't lie.

*Two modeling calls on the seed*, both documented in the migration header and in the sessions' `workoutDetails` rather than left implicit:

- **Distance → time.** The source prescribes a *mile*; the app has no distance unit. Every session prescribes time under load instead, and the test session says plainly that the 15-minute prescription is the entry benchmark pace, not a box to fill — walk your mile, tap Finish, your real time is recorded. Same class of approximation as Easy Strength's "6x1, add weight each set" day.
- **The 8-week ladder is authored, not sourced.** Prevost gives the protocol and the benchmarks but only says to build up to the distance and then improve speed. Anyone revising the ladder is not contradicting the source.

One happy accident worth knowing: one-handed loading (`weightTwoValue: 0`) makes the runtime mirror every rung per hand, which *is* the source's hand-switching and enforces an even split. Consequence — each `repScheme` entry is the **per-hand** segment, so total time under load is `sum(repScheme) × 2`. Each session's details states the total so the on-screen number is never a surprise.

## How tested

`npm run compile:ts`, `npm run lint`, `npm test` (472 unit tests), `npx playwright test e2e/` (47 e2e, including 3 new in `e2e/program-kettlebell-mile.spec.ts`) — all green against a fresh `supabase db reset`.

Ran the program end to end in the browser at 375×812:

- Kettlebell Mile lists in Browse programs; details page renders all 8 weeks.
- Enrollment weight picker pre-fills a **single** 24 kg bell, not a double pair (`deriveStartingWeight`), and `timedRungs` + `weightTwoValue: 0` survive the copy-on-enroll weight fold.
- Builder shows a "Duration" section with Reps/**Time** tabs, `sec` units, and a ±5 step; the Interval addon is disabled with an explanatory tooltip.
- Started a session, shortened rung 1 to 5s, watched it auto-advance through both hands onto the 60s rung.
- Persisted log: `timed_rungs=t`, `completed_volume=0`, `completed_reps=0`, `completed_sides=2`. Pre-existing rep-based logs untouched.
- Repeat-from-history round-trips back as timed, not reps.

**Two bugs found during that verification**, both fixed here with regression tests:

1. **The workout never started.** The workout timer's paused state doubles as the start gate, and only `finishCountdown` starts the rung clock — but a *rounds*-goal timed workout has no workout countdown, so no Play gate appeared and the rung clock sat frozen while elapsed climbed. I confirmed the new test fails without the fix.
2. **History rendered a 5-second carry as "Rep Scheme: 5 / 5"**, which reads as five reps. Now "Duration: 0:05 / 0:05".

## Related issue

- [PROD-200](https://linear.app/djbowers/issue/PROD-200/timed-movements-complete-timers-instead-of-reps-planks-carries-marches) — timed movements (commit 1)
- [PROD-244](https://linear.app/djbowers/issue/PROD-244/add-the-kettlebell-mile-program-first-timedrungs-program) — The Kettlebell Mile (commit 2), under epic [PROD-225](https://linear.app/djbowers/issue/PROD-225/add-5-free-kettlebell-programs-behind-the-programs-flag)

## Tradeoffs

**A parallel `durationScheme: number[]` instead of overloading `repScheme`.** The honest case for it: it's self-describing, it can't be misread by anything that doesn't know about the flag, and it would have avoided the `pattern_debt_window` guard entirely — a timed carry simply wouldn't appear in a reps column. That's a real correctness advantage and I don't want to undersell it.

I overloaded `repScheme` anyway because it's load-bearing in `workout_options` JSONB, `movement_logs.rep_scheme`, `workout_logs.rep_scheme`, `pattern_debt_window`, the rung/round/mirror runtime, the builder ladder UI, and all seven program seeds. A parallel array means touching every one of those, and every future seed author has to decide which array to populate. A timed rung is still "one rung, one magnitude" — only the unit differs — so the overload matches the actual shape of the domain. The cost is exactly one guard in one SQL function, which is asserted by a test.

**Blocking the seed on the bigger PROD-200 build.** The alternative was shipping the program now with a documented "1 rep = one carry lap" convention in `workoutDetails`. It would have been faster and it's the approach Easy Strength already uses for its approximated day. But a carry-only program is entirely carries, so every number on screen would have been a fiction the user had to translate — and it would have poisoned volume in the recommender for exactly the pattern the program trains.
