### PR TITLE
feat(ui): swipe to select weights and reps

### DIFF
--- a/src/components/ModifyCountButtons.stories.tsx
+++ b/src/components/ModifyCountButtons.stories.tsx
@@ -1,0 +1,80 @@
+import { useState } from 'react';
+
+import { WeightUnit } from '~/types';
+import { getWeightRange, getWeightUnitLabel } from '~/utils';
+
+import { ModifyCountButtons } from './ModifyCountButtons';
+import { WeightUnitTabs } from './WeightUnitTabs';
+
+export default {
+  component: ModifyCountButtons,
+  parameters: { viewport: { defaultViewport: 'mobile1' } },
+};
+
+const Weight = ({ initialUnit }: { initialUnit: WeightUnit }) => {
+  const [unit, setUnit] = useState<WeightUnit>(initialUnit);
+  const [value, setValue] = useState(unit === 'pounds' ? 53 : 24);
+  const range = getWeightRange(unit);
+
+  return (
+    <div className="w-full max-w-sm bg-card p-2">
+      <ModifyCountButtons
+        {...range}
+        bellUnit={unit}
+        value={value}
+        onChange={setValue}
+        onClickMinus={() => setValue((prev) => Math.max(range.min, prev - 1))}
+        onClickPlus={() => setValue((prev) => prev + 1)}
+        unit={getWeightUnitLabel(unit)}
+        unitTabs={<WeightUnitTabs value={unit} onChange={setUnit} />}
+      />
+    </div>
+  );
+};
+
+const Plain = ({
+  unit,
+  initialValue,
+  min,
+  max,
+  step,
+}: {
+  initialValue: number;
+  max: number;
+  min: number;
+  step: number;
+  unit: string;
+}) => {
+  const [value, setValue] = useState(initialValue);
+
+  return (
+    <div className="w-full max-w-sm bg-card p-2">
+      <ModifyCountButtons
+        min={min}
+        max={max}
+        step={step}
+        value={value}
+        onChange={setValue}
+        onClickMinus={() => setValue((prev) => Math.max(min, prev - step))}
+        onClickPlus={() => setValue((prev) => Math.min(max, prev + step))}
+        unit={unit}
+      />
+    </div>
+  );
+};
+
+export const Kilograms = { render: () => <Weight initialUnit="kilograms" /> };
+
+export const Pounds = { render: () => <Weight initialUnit="pounds" /> };
+
+export const Reps = {
+  render: () => (
+    <Plain unit="reps" initialValue={5} min={1} max={50} step={1} />
+  ),
+};
+
+export const Timer = {
+  render: () => (
+    <Plain unit="sec" initialValue={30} min={5} max={300} step={5} />
+  ),
+};

--- a/src/components/ModifyCountButtons.test.tsx
+++ b/src/components/ModifyCountButtons.test.tsx
@@ -1,0 +1,89 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { WeightUnitTabs } from '~/components/WeightUnitTabs';
+
+import { ModifyCountButtons } from './ModifyCountButtons';
+
+const setup = (overrides = {}) => {
+  const props = {
+    onChange: vi.fn(),
+    onClickMinus: vi.fn(),
+    onClickPlus: vi.fn(),
+    unit: 'reps',
+    value: 5,
+    ...overrides,
+  };
+  return { ...render(<ModifyCountButtons {...props} />), props };
+};
+
+describe('ModifyCountButtons', () => {
+  it('labels the step buttons with the unit', () => {
+    const { props } = setup({ unit: 'kg' });
+
+    fireEvent.click(screen.getByRole('button', { name: '- kg' }));
+    fireEvent.click(screen.getByRole('button', { name: '+ kg' }));
+
+    expect(props.onClickMinus).toHaveBeenCalledOnce();
+    expect(props.onClickPlus).toHaveBeenCalledOnce();
+  });
+
+  it('exposes exactly one number field, showing the value', () => {
+    setup({ value: 24 });
+
+    const inputs = screen.getAllByRole('spinbutton');
+    expect(inputs).toHaveLength(1);
+    expect(inputs[0]).toHaveValue(24);
+  });
+
+  it('reports typed values', () => {
+    const { props } = setup();
+
+    fireEvent.change(screen.getByRole('spinbutton'), {
+      target: { value: '12' },
+    });
+
+    expect(props.onChange).toHaveBeenCalledWith(12);
+  });
+
+  it('selects a value swiped to on the strip', () => {
+    const { props } = setup({ min: 1, max: 10, value: 5 });
+
+    fireEvent.click(screen.getByText('8').closest('button')!);
+
+    expect(props.onChange).toHaveBeenCalledWith(8);
+  });
+
+  it('renders the unit as a label by default', () => {
+    setup({ unit: 'sec' });
+
+    expect(screen.getByText('sec')).toBeInTheDocument();
+  });
+
+  it('renders unit tabs in place of the label when given', () => {
+    setup({
+      unit: 'kg',
+      unitTabs: <WeightUnitTabs value="kilograms" onChange={vi.fn()} />,
+    });
+
+    expect(screen.getByRole('tab', { name: 'kg' })).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: 'lb' })).toBeInTheDocument();
+  });
+
+  it('color-codes the strip only when a bell unit is given', () => {
+    const { container, unmount } = setup({
+      min: 20,
+      max: 28,
+      value: 24,
+      unit: 'kg',
+      bellUnit: 'kilograms',
+    });
+    expect(container.querySelectorAll('[style*="background"]').length).toBe(3);
+    unmount();
+
+    const plain = setup({ min: 20, max: 28, value: 24, unit: 'reps' });
+    expect(
+      plain.container.querySelectorAll('[style*="background"]'),
+    ).toHaveLength(0);
+  });
+});

--- a/src/components/ModifyCountButtons.tsx
+++ b/src/components/ModifyCountButtons.tsx
@@ -1,51 +1,107 @@
 import { MinusIcon, PlusIcon } from '@heroicons/react/24/outline';
-import { ReactNode } from 'react';
+import { ReactNode, useCallback, useRef, useState } from 'react';
 
+import { ITEM_WIDTH, ValueCarousel } from '~/components/ValueCarousel';
 import { Button } from '~/components/ui/button';
 import { Input } from '~/components/ui/input';
+import { cn } from '~/lib/utils';
+import { WeightUnit } from '~/types';
+import { getBellColor } from '~/utils';
 
 interface ModifyCountButtonsProps {
+  /** Color the strip with the competition bell code for this unit. */
+  bellUnit?: WeightUnit | null;
+  max?: number;
+  min?: number;
   onChange: (value: number) => void;
   onClickMinus: () => void;
   onClickPlus: () => void;
+  step?: number;
   unit: string;
   unitTabs?: ReactNode;
   value: number;
 }
 
 export const ModifyCountButtons = ({
+  bellUnit,
+  max = 100,
+  min = 0,
   onChange,
   onClickMinus,
   onClickPlus,
+  step = 1,
   unit,
   unitTabs,
   value,
 }: ModifyCountButtonsProps) => {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [editing, setEditing] = useState(false);
+
+  // The strip scrolls under the input, so the input shows where the finger is
+  // rather than the last committed value.
+  const [displayValue, setDisplayValue] = useState(value);
+  const [committedValue, setCommittedValue] = useState(value);
+  if (committedValue !== value) {
+    setCommittedValue(value);
+    setDisplayValue(value);
+  }
+
   const handleChangeValue = (e: React.ChangeEvent<HTMLInputElement>) =>
     onChange(Number(e.target.value));
 
+  const startEditing = useCallback(() => {
+    setEditing(true);
+    inputRef.current?.focus();
+    inputRef.current?.select();
+  }, []);
+
+  const chipColor = useCallback(
+    (current: number) => getBellColor(current, bellUnit ?? null),
+    [bellUnit],
+  );
+
   return (
-    <div className="grid grid-cols-3 gap-5">
-      <div className="flex items-center justify-end">
+    <div className="flex flex-col gap-1">
+      <div className="flex items-center gap-1">
         <Button size="icon" onClick={onClickMinus} aria-label={`- ${unit}`}>
           <MinusIcon className="h-2.5 w-2.5" />
         </Button>
-      </div>
-      <div className="flex flex-col items-center justify-center gap-1">
-        <Input
-          value={value}
-          onChange={handleChangeValue}
-          className="text-center [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
-          type="number"
-        />
-        {unitTabs ?? (
-          <div className="text-center text-sm text-foreground">{unit}</div>
-        )}
-      </div>
-      <div className="flex items-center justify-start">
+
+        <div className="relative min-w-0 flex-1">
+          <ValueCarousel
+            chipColor={bellUnit ? chipColor : undefined}
+            max={max}
+            min={min}
+            onChange={onChange}
+            onFocusChange={setDisplayValue}
+            onSelectCenter={startEditing}
+            step={step}
+            value={value}
+          />
+          <div className="pointer-events-none absolute inset-x-0 top-0.5 flex justify-center">
+            <Input
+              ref={inputRef}
+              type="number"
+              value={displayValue}
+              onChange={handleChangeValue}
+              onBlur={() => setEditing(false)}
+              style={{ width: ITEM_WIDTH }}
+              className={cn(
+                'h-3 border-0 bg-transparent px-0 py-0 text-center font-medium shadow-none',
+                '[&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none',
+                editing && 'pointer-events-auto',
+              )}
+            />
+          </div>
+        </div>
+
         <Button size="icon" onClick={onClickPlus} aria-label={`+ ${unit}`}>
           <PlusIcon className="h-2.5 w-2.5" />
         </Button>
+      </div>
+
+      <div className="flex justify-center">
+        {unitTabs ?? <div className="text-sm text-foreground">{unit}</div>}
       </div>
     </div>
   );

--- a/src/components/ValueCarousel/ValueCarousel.test.tsx
+++ b/src/components/ValueCarousel/ValueCarousel.test.tsx
@@ -1,0 +1,195 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { ITEM_WIDTH, ValueCarousel } from './ValueCarousel';
+
+const clickValue = (value: number) => {
+  const button = screen.getByText(String(value)).closest('button');
+  fireEvent.click(button!);
+};
+
+/** jsdom has no layout, so give the track just enough of one to scroll. */
+const layoutTrack = (container: HTMLElement) => {
+  const track = container.querySelector<HTMLDivElement>(
+    '[aria-hidden="true"]',
+  )!;
+  Object.defineProperty(track, 'clientWidth', {
+    value: ITEM_WIDTH * 5,
+    configurable: true,
+  });
+  return track;
+};
+
+const settleAt = (track: HTMLDivElement, index: number) => {
+  track.scrollLeft = index * ITEM_WIDTH;
+  fireEvent.scroll(track);
+  fireEvent(track, new Event('scrollend'));
+  vi.advanceTimersByTime(200);
+};
+
+describe('ValueCarousel', () => {
+  it('renders every value in the range', () => {
+    render(
+      <ValueCarousel min={1} max={5} step={1} value={3} onChange={vi.fn()} />,
+    );
+
+    [1, 2, 3, 4, 5].forEach((value) => {
+      expect(screen.getByText(String(value))).toBeInTheDocument();
+    });
+  });
+
+  it('walks the range by step', () => {
+    render(
+      <ValueCarousel min={5} max={20} step={5} value={10} onChange={vi.fn()} />,
+    );
+
+    expect(screen.getByText('15')).toBeInTheDocument();
+    expect(screen.queryByText('11')).not.toBeInTheDocument();
+  });
+
+  it('selects a value that is tapped', () => {
+    const onChange = vi.fn();
+    render(
+      <ValueCarousel min={1} max={5} step={1} value={3} onChange={onChange} />,
+    );
+
+    clickValue(5);
+
+    expect(onChange).toHaveBeenCalledWith(5);
+  });
+
+  it('hands a tap on the centered value to the center display', () => {
+    const onChange = vi.fn();
+    const onSelectCenter = vi.fn();
+    render(
+      <ValueCarousel
+        min={1}
+        max={5}
+        step={1}
+        value={3}
+        onChange={onChange}
+        onSelectCenter={onSelectCenter}
+      />,
+    );
+
+    clickValue(3);
+
+    expect(onSelectCenter).toHaveBeenCalled();
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('leaves an out-of-range value alone instead of snapping it in', () => {
+    const onChange = vi.fn();
+    render(
+      <ValueCarousel
+        min={1}
+        max={5}
+        step={1}
+        value={500}
+        onChange={onChange}
+      />,
+    );
+
+    expect(screen.getByText('5')).toBeInTheDocument();
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('chips the values a color is given for, and only those', () => {
+    const { container } = render(
+      <ValueCarousel
+        min={1}
+        max={3}
+        step={1}
+        value={2}
+        onChange={vi.fn()}
+        chipColor={(value) => (value === 2 ? '#3fa45b' : null)}
+      />,
+    );
+
+    const chips = container.querySelectorAll('[style*="background"]');
+    expect(chips).toHaveLength(1);
+    expect(chips[0]).toHaveStyle({ background: '#3fa45b' });
+  });
+
+  it('renders no chip row when no colors are supplied', () => {
+    const { container } = render(
+      <ValueCarousel min={1} max={3} step={1} value={2} onChange={vi.fn()} />,
+    );
+
+    expect(container.querySelectorAll('button span')).toHaveLength(3);
+  });
+
+  describe('settling', () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it('commits the value the user swiped to', () => {
+      const onChange = vi.fn();
+      const { container } = render(
+        <ValueCarousel
+          min={1}
+          max={40}
+          step={1}
+          value={24}
+          onChange={onChange}
+        />,
+      );
+      const track = layoutTrack(container);
+
+      fireEvent.pointerDown(track);
+      settleAt(track, 31);
+
+      expect(onChange).toHaveBeenCalledWith(32);
+    });
+
+    it('ignores a settle the user did not cause', () => {
+      const onChange = vi.fn();
+      const { container } = render(
+        <ValueCarousel
+          min={1}
+          max={40}
+          step={1}
+          value={24}
+          onChange={onChange}
+        />,
+      );
+
+      // The browser fires one of these at position 0 before the strip is
+      // placed; committing it would collapse the value to the minimum.
+      settleAt(layoutTrack(container), 0);
+
+      expect(onChange).not.toHaveBeenCalled();
+    });
+
+    it('does not re-commit a value it was just given', () => {
+      const onChange = vi.fn();
+      const { container } = render(
+        <ValueCarousel
+          min={1}
+          max={40}
+          step={1}
+          value={24}
+          onChange={onChange}
+        />,
+      );
+      const track = layoutTrack(container);
+
+      fireEvent.pointerDown(track);
+      settleAt(track, 23);
+
+      expect(onChange).not.toHaveBeenCalled();
+    });
+  });
+
+  it('keeps the strip out of the accessibility tree', () => {
+    render(
+      <ValueCarousel min={1} max={3} step={1} value={2} onChange={vi.fn()} />,
+    );
+
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+  });
+});

--- a/src/components/ValueCarousel/ValueCarousel.test.tsx
+++ b/src/components/ValueCarousel/ValueCarousel.test.tsx
@@ -38,6 +38,32 @@ describe('ValueCarousel', () => {
     });
   });
 
+  it('keeps a long range out of the DOM, holding its width with spacers', () => {
+    const { container } = render(
+      <ValueCarousel
+        min={10}
+        max={3000}
+        step={10}
+        value={1000}
+        onChange={vi.fn()}
+      />,
+    );
+
+    const rendered = container.querySelectorAll('button');
+    expect(rendered.length).toBeLessThan(30);
+    expect(screen.getByText('1000')).toBeInTheDocument();
+    expect(screen.queryByText('2000')).not.toBeInTheDocument();
+
+    const track = container.querySelector('[aria-hidden="true"]')!;
+    const spacers = track.querySelectorAll(':scope > div');
+    const spacerWidth = [...spacers].reduce(
+      (total, spacer) =>
+        total + Number((spacer as HTMLElement).style.width.replace('px', '')),
+      0,
+    );
+    expect(spacerWidth + rendered.length * ITEM_WIDTH).toBe(300 * ITEM_WIDTH);
+  });
+
   it('walks the range by step', () => {
     render(
       <ValueCarousel min={5} max={20} step={5} value={10} onChange={vi.fn()} />,

--- a/src/components/ValueCarousel/ValueCarousel.tsx
+++ b/src/components/ValueCarousel/ValueCarousel.tsx
@@ -1,0 +1,115 @@
+import { useMemo } from 'react';
+
+import { cn } from '~/lib/utils';
+
+import { useSnapScrollValue } from './useSnapScrollValue';
+
+export const ITEM_WIDTH = 48; // px
+
+const FADE_BY_DISTANCE = [1, 0.7, 0.42, 0.24];
+
+interface ValueCarouselProps {
+  /** Return a color to chip a value with, or null to leave it uncoded. */
+  chipColor?: (value: number) => string | null;
+  max: number;
+  min: number;
+  onChange: (value: number) => void;
+  /** Fires continuously as the strip scrolls, before the value commits. */
+  onFocusChange?: (value: number) => void;
+  /** Tapping the already-centered value, as opposed to swiping to a new one. */
+  onSelectCenter?: () => void;
+  step: number;
+  value: number;
+}
+
+/**
+ * A center-snapping strip of values. The centered numeral is hidden and the
+ * caliper marks where the consumer's own center display sits on top.
+ */
+export const ValueCarousel = ({
+  chipColor,
+  max,
+  min,
+  onChange,
+  onFocusChange,
+  onSelectCenter,
+  step,
+  value,
+}: ValueCarouselProps) => {
+  const values = useMemo(() => {
+    const range: number[] = [];
+    for (let current = min; current <= max; current += step)
+      range.push(current);
+    return range;
+  }, [max, min, step]);
+
+  const { focusedIndex, trackRef } = useSnapScrollValue({
+    itemWidth: ITEM_WIDTH,
+    onChange,
+    onFocusChange,
+    value,
+    values,
+  });
+
+  if (values.length === 0) return null;
+
+  return (
+    <div className="relative">
+      <div
+        ref={trackRef}
+        aria-hidden="true"
+        className="no-select flex snap-x snap-mandatory overflow-x-auto py-0.5 [-ms-overflow-style:none] [overscroll-behavior-x:contain] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+        style={{ paddingInline: `calc(50% - ${ITEM_WIDTH / 2}px)` }}
+      >
+        {values.map((current, index) => {
+          const distance = Math.abs(index - focusedIndex);
+          const centered = distance === 0;
+          const color = chipColor?.(current) ?? null;
+
+          return (
+            <button
+              key={current}
+              type="button"
+              tabIndex={-1}
+              onClick={() =>
+                centered ? onSelectCenter?.() : onChange(current)
+              }
+              className="flex shrink-0 snap-center flex-col items-center gap-0.5"
+              style={{
+                width: ITEM_WIDTH,
+                opacity: FADE_BY_DISTANCE[Math.min(distance, 3)],
+              }}
+            >
+              <span
+                className={cn(
+                  'text-base tabular-nums',
+                  centered
+                    ? 'invisible font-medium text-foreground'
+                    : 'text-muted-foreground',
+                )}
+              >
+                {current}
+              </span>
+              {chipColor &&
+                (color ? (
+                  <span
+                    className="h-[5px] w-2.5 rounded-sm border border-foreground/25"
+                    style={{ background: color }}
+                  />
+                ) : (
+                  <span className="h-[2px] w-1 rounded-sm bg-border" />
+                ))}
+            </button>
+          );
+        })}
+      </div>
+
+      <div
+        className="pointer-events-none absolute inset-y-0 left-1/2 -translate-x-1/2 rounded-sm border-x-2 border-primary"
+        style={{ width: ITEM_WIDTH + 4 }}
+      />
+      <div className="pointer-events-none absolute inset-y-0 left-0 w-4 bg-gradient-to-r from-card to-transparent" />
+      <div className="pointer-events-none absolute inset-y-0 right-0 w-4 bg-gradient-to-l from-card to-transparent" />
+    </div>
+  );
+};

--- a/src/components/ValueCarousel/ValueCarousel.tsx
+++ b/src/components/ValueCarousel/ValueCarousel.tsx
@@ -8,6 +8,10 @@ export const ITEM_WIDTH = 48; // px
 
 const FADE_BY_DISTANCE = [1, 0.7, 0.42, 0.24];
 
+/** Values kept in the DOM either side of center. Wide enough that a fling
+ * cannot outrun a re-render before the next scroll event lands. */
+const WINDOW_RADIUS = 12;
+
 interface ValueCarouselProps {
   /** Return a color to chip a value with, or null to leave it uncoded. */
   chipColor?: (value: number) => string | null;
@@ -53,6 +57,12 @@ export const ValueCarousel = ({
 
   if (values.length === 0) return null;
 
+  // Ranges run to a few hundred values (volume goes to 3000 by 10). Rendering
+  // them all costs a full reconcile on every step, so keep the DOM to the
+  // window either side of center and hold the scroll geometry open with spacers.
+  const first = Math.max(0, focusedIndex - WINDOW_RADIUS);
+  const last = Math.min(values.length - 1, focusedIndex + WINDOW_RADIUS);
+
   return (
     <div className="relative">
       <div
@@ -61,7 +71,9 @@ export const ValueCarousel = ({
         className="no-select flex snap-x snap-mandatory overflow-x-auto py-0.5 [-ms-overflow-style:none] [overscroll-behavior-x:contain] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
         style={{ paddingInline: `calc(50% - ${ITEM_WIDTH / 2}px)` }}
       >
-        {values.map((current, index) => {
+        <div className="shrink-0" style={{ width: first * ITEM_WIDTH }} />
+        {values.slice(first, last + 1).map((current, offset) => {
+          const index = first + offset;
           const distance = Math.abs(index - focusedIndex);
           const centered = distance === 0;
           const color = chipColor?.(current) ?? null;
@@ -102,6 +114,10 @@ export const ValueCarousel = ({
             </button>
           );
         })}
+        <div
+          className="shrink-0"
+          style={{ width: (values.length - 1 - last) * ITEM_WIDTH }}
+        />
       </div>
 
       <div

--- a/src/components/ValueCarousel/index.ts
+++ b/src/components/ValueCarousel/index.ts
@@ -1,0 +1,1 @@
+export * from './ValueCarousel';

--- a/src/components/ValueCarousel/useSnapScrollValue.ts
+++ b/src/components/ValueCarousel/useSnapScrollValue.ts
@@ -1,0 +1,157 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+const SETTLE_DELAY = 150; // ms
+
+/** Gestures that mean the scroll about to happen came from the user. */
+const USER_SCROLL_EVENTS = [
+  'pointerdown',
+  'touchstart',
+  'wheel',
+  'keydown',
+] as const;
+
+const supportsScrollEnd =
+  typeof window !== 'undefined' && 'onscrollend' in window;
+
+const clamp = (value: number, min: number, max: number) =>
+  Math.min(max, Math.max(min, value));
+
+const nearestIndex = (values: number[], value: number) => {
+  let nearest = 0;
+  let shortest = Infinity;
+  values.forEach((candidate, index) => {
+    const distance = Math.abs(candidate - value);
+    if (distance < shortest) {
+      shortest = distance;
+      nearest = index;
+    }
+  });
+  return nearest;
+};
+
+const prefersReducedMotion = () =>
+  typeof window !== 'undefined' &&
+  Boolean(window.matchMedia?.('(prefers-reduced-motion: reduce)').matches);
+
+interface UseSnapScrollValueOptions {
+  itemWidth: number;
+  onChange: (value: number) => void;
+  onFocusChange?: (value: number) => void;
+  value: number;
+  values: number[];
+}
+
+/**
+ * Two-way sync between a scroll-snap track and a controlled numeric value.
+ *
+ * A settle only commits when the user caused the scroll *and* it landed
+ * somewhere other than where the value prop put us. Both halves matter: the
+ * first keeps our own scrolling from echoing back through `onChange`, and the
+ * second leaves an out-of-range value alone rather than silently snapping it in.
+ *
+ * `values` and `onFocusChange` must be referentially stable — memoize them, or
+ * the sync effect will fight every render.
+ */
+export const useSnapScrollValue = ({
+  itemWidth,
+  onChange,
+  onFocusChange,
+  value,
+  values,
+}: UseSnapScrollValueOptions) => {
+  const trackRef = useRef<HTMLDivElement>(null);
+  const settleTimer = useRef<ReturnType<typeof setTimeout>>(undefined);
+  const syncedIndex = useRef(nearestIndex(values, value));
+  const hasPositioned = useRef(false);
+  const pendingUserScroll = useRef(false);
+  const [focusedIndex, setFocusedIndex] = useState(syncedIndex.current);
+
+  // Reported live during a swipe so the consumer's center display can track the
+  // finger rather than lagging until the scroll settles.
+  const focus = useCallback(
+    (index: number) => {
+      setFocusedIndex(index);
+      onFocusChange?.(values[index]);
+    },
+    [onFocusChange, values],
+  );
+
+  const indexFromScroll = useCallback(() => {
+    const track = trackRef.current;
+    // jsdom has no layout, so there is no scroll position to read.
+    if (!track || track.clientWidth === 0) return null;
+    return clamp(
+      Math.round(track.scrollLeft / itemWidth),
+      0,
+      values.length - 1,
+    );
+  }, [itemWidth, values.length]);
+
+  useEffect(() => {
+    const index = nearestIndex(values, value);
+    syncedIndex.current = index;
+    setFocusedIndex(index);
+
+    const scrollToSynced = (behavior: ScrollBehavior) =>
+      trackRef.current?.scrollTo?.({ left: index * itemWidth, behavior });
+
+    // On the first commit the track has no laid-out width yet, so scrollTo is a
+    // no-op — place it on the next frame instead, and instantly, since there is
+    // nothing to animate away from.
+    if (!hasPositioned.current) {
+      hasPositioned.current = true;
+      const frame = requestAnimationFrame(() => scrollToSynced('auto'));
+      return () => cancelAnimationFrame(frame);
+    }
+
+    scrollToSynced(prefersReducedMotion() ? 'auto' : 'smooth');
+  }, [itemWidth, value, values]);
+
+  const handleSettle = useCallback(() => {
+    const index = indexFromScroll();
+    if (index === null) return;
+    focus(index);
+    // A settle the user did not cause is the tail of our own scroll, or a
+    // browser-fired one at position 0 before the strip was placed. Committing
+    // either would overwrite the real value with whatever happens to be centered.
+    const userDriven = pendingUserScroll.current;
+    pendingUserScroll.current = false;
+    if (!userDriven || index === syncedIndex.current) return;
+    syncedIndex.current = index;
+    onChange(values[index]);
+  }, [focus, indexFromScroll, onChange, values]);
+
+  useEffect(() => {
+    const track = trackRef.current;
+    if (!track) return;
+
+    const markUserScroll = () => {
+      pendingUserScroll.current = true;
+    };
+
+    const handleScroll = () => {
+      const index = indexFromScroll();
+      if (index !== null) focus(index);
+      if (supportsScrollEnd) return;
+      clearTimeout(settleTimer.current);
+      settleTimer.current = setTimeout(handleSettle, SETTLE_DELAY);
+    };
+
+    USER_SCROLL_EVENTS.forEach((type) =>
+      track.addEventListener(type, markUserScroll, { passive: true }),
+    );
+    track.addEventListener('scroll', handleScroll, { passive: true });
+    if (supportsScrollEnd) track.addEventListener('scrollend', handleSettle);
+
+    return () => {
+      clearTimeout(settleTimer.current);
+      USER_SCROLL_EVENTS.forEach((type) =>
+        track.removeEventListener(type, markUserScroll),
+      );
+      track.removeEventListener('scroll', handleScroll);
+      track.removeEventListener('scrollend', handleSettle);
+    };
+  }, [focus, handleSettle, indexFromScroll]);
+
+  return { focusedIndex, trackRef };
+};

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -8,5 +8,6 @@ export * from './Page';
 export * from './PremiumGate';
 export * from './SafeAreaWrapper';
 export * from './TrialStatusPill';
+export * from './ValueCarousel';
 export * from './WeeklyBalance';
 export * from './WeightUnitTabs';

--- a/src/pages/ProgramDetailsPage/ProgramDetailsPage.tsx
+++ b/src/pages/ProgramDetailsPage/ProgramDetailsPage.tsx
@@ -26,7 +26,7 @@ import {
   WeightUnit,
   WorkoutGoalUnits,
 } from '~/types';
-import { getWeightUnitLabel } from '~/utils';
+import { getWeightRange, getWeightUnitLabel } from '~/utils';
 
 import { deriveStartingWeight } from './utils/deriveStartingWeight';
 
@@ -257,6 +257,8 @@ export const ProgramDetailsPage = () => {
         {!seeded && <p className="text-sm text-muted-foreground">Loading…</p>}
         {seeded && sharedWeightOneValue !== null && (
           <ModifyCountButtons
+            {...getWeightRange(sharedWeightOneUnit)}
+            bellUnit={sharedWeightOneUnit}
             onClickMinus={() =>
               handleChangeSharedWeightOneValue(sharedWeightOneValue - 1)
             }
@@ -278,6 +280,8 @@ export const ProgramDetailsPage = () => {
           sharedWeightTwoValue !== null &&
           sharedWeightTwoValue > 0 && (
             <ModifyCountButtons
+              {...getWeightRange(sharedWeightTwoUnit)}
+              bellUnit={sharedWeightTwoUnit}
               onClickMinus={() =>
                 handleChangeSharedWeightTwoValue(sharedWeightTwoValue - 1)
               }

--- a/src/pages/StartWorkoutPage/StartWorkoutPage.tsx
+++ b/src/pages/StartWorkoutPage/StartWorkoutPage.tsx
@@ -714,7 +714,8 @@ export const StartWorkoutPage = ({
   // Skip the next session: writes a `skipped` completion (no workout_log), which
   // advances the cursor to the following session without leaving the home card.
   const handleSkipProgram = () => {
-    if (!primaryProgram?.nextSession || completeProgramSession.isPending) return;
+    if (!primaryProgram?.nextSession || completeProgramSession.isPending)
+      return;
     completeProgramSession.mutate({
       userProgramId: primaryProgram.enrollment.id,
       programSessionId: primaryProgram.nextSession.session.id,

--- a/src/pages/StartWorkoutPage/StartWorkoutPage.tsx
+++ b/src/pages/StartWorkoutPage/StartWorkoutPage.tsx
@@ -40,6 +40,7 @@ import {
 } from '~/types';
 import {
   WEIGHT_MODE_LABELS,
+  getWeightRange,
   getWeightTabValue,
   getWeightUnitLabel,
 } from '~/utils';
@@ -59,6 +60,7 @@ import {
   WeightUnitTabs,
 } from './components';
 import { useRecommendedWorkouts } from './hooks';
+import { INCREMENT_VOLUME, getGoalRange } from './utils/goalRange';
 import {
   RecommendationCatalog,
   buildRecommendationCatalog,
@@ -83,7 +85,8 @@ const DEFAULT_WEIGHT_VALUE: number =
 const INCREMENT_DURATION: number = 1; // minutes
 const INCREMENT_INTERVAL_TIMER: number = 5; // seconds
 const INCREMENT_REST_TIMER: number = 5; // seconds
-const INCREMENT_VOLUME: number = 10; // kg
+const TIMER_BOUNDS = { min: 5, max: 300 }; // seconds
+const REPS_RANGE = { min: 1, max: 50, step: 1 };
 const DEFAULT_VOLUME: number = 1000; // kg
 const DEFAULT_MINUTES: number = 10; // minutes
 const DEFAULT_ROUNDS: number = 10; // rounds
@@ -360,7 +363,10 @@ export const StartWorkoutPage = ({
   // the eventual start attributes to `program` and the log step advances that
   // enrollment on completion. Shared by the home "next" card and the progress
   // page's per-session picker (which routes through nav state below).
-  const applyProgramStart = (session: ProgramSession, userProgramId: string) => {
+  const applyProgramStart = (
+    session: ProgramSession,
+    userProgramId: string,
+  ) => {
     loadIntoBuilder(session.workoutOptions);
     setStartSource('program');
     setStartSourceProps({
@@ -930,6 +936,7 @@ export const StartWorkoutPage = ({
               }
             >
               <ModifyCountButtons
+                {...getGoalRange(workoutGoalUnits)}
                 onClickMinus={handleDecrementGoalValue}
                 onClickPlus={handleIncrementGoalValue}
                 onChange={setWorkoutGoal}
@@ -964,6 +971,8 @@ export const StartWorkoutPage = ({
                 />
                 {sharedWeightOneValue !== null && (
                   <ModifyCountButtons
+                    {...getWeightRange(sharedWeightOneUnit)}
+                    bellUnit={sharedWeightOneUnit}
                     onClickMinus={() =>
                       handleChangeSharedWeightOneValue(sharedWeightOneValue - 1)
                     }
@@ -985,6 +994,8 @@ export const StartWorkoutPage = ({
                 )}
                 {sharedWeightTwoValue !== null && sharedWeightTwoValue > 0 && (
                   <ModifyCountButtons
+                    {...getWeightRange(sharedWeightTwoUnit)}
+                    bellUnit={sharedWeightTwoUnit}
                     onClickMinus={() =>
                       handleChangeSharedWeightTwoValue(sharedWeightTwoValue - 1)
                     }
@@ -1026,6 +1037,8 @@ export const StartWorkoutPage = ({
             <Card>
               <Section title="Interval Timer">
                 <ModifyCountButtons
+                  {...TIMER_BOUNDS}
+                  step={INCREMENT_INTERVAL_TIMER}
                   onClickMinus={handleDecrementInterval}
                   onClickPlus={handleIncrementInterval}
                   unit="sec"
@@ -1040,6 +1053,8 @@ export const StartWorkoutPage = ({
             <Card>
               <Section title="Rest Timer">
                 <ModifyCountButtons
+                  {...TIMER_BOUNDS}
+                  step={INCREMENT_REST_TIMER}
                   onClickMinus={handleDecrementRest}
                   onClickPlus={handleIncrementRest}
                   unit="sec"
@@ -1103,6 +1118,8 @@ export const StartWorkoutPage = ({
                 {!complexSet && weightTabValue !== 'none' && (
                   <Section title="Load">
                     <ModifyCountButtons
+                      {...getWeightRange(movement.weightOneUnit)}
+                      bellUnit={movement.weightOneUnit}
                       onClickMinus={() =>
                         handleChangeWeightOneValue(
                           index,
@@ -1132,6 +1149,8 @@ export const StartWorkoutPage = ({
                     {movement.weightTwoValue !== null &&
                       movement.weightTwoValue > 0 && (
                         <ModifyCountButtons
+                          {...getWeightRange(movement.weightTwoUnit)}
+                          bellUnit={movement.weightTwoUnit}
                           onClickMinus={() =>
                             handleChangeWeightTwoValue(
                               index,
@@ -1198,10 +1217,13 @@ export const StartWorkoutPage = ({
                   </Tabs>
 
                   {movement.repScheme.map((_, rungIndex) => {
-                    const step = movement.timedRungs ? RUNG_SECONDS_STEP : 1;
+                    const range = movement.timedRungs
+                      ? { ...TIMER_BOUNDS, step: RUNG_SECONDS_STEP }
+                      : REPS_RANGE;
                     return (
                       <ModifyCountButtons
                         key={rungIndex}
+                        {...range}
                         value={movement.repScheme[rungIndex]}
                         onChange={(value) =>
                           handleChangeRepScheme(index, rungIndex, value)
@@ -1210,14 +1232,14 @@ export const StartWorkoutPage = ({
                           handleChangeRepScheme(
                             index,
                             rungIndex,
-                            movement.repScheme[rungIndex] - step,
+                            movement.repScheme[rungIndex] - range.step,
                           )
                         }
                         onClickPlus={() =>
                           handleChangeRepScheme(
                             index,
                             rungIndex,
-                            movement.repScheme[rungIndex] + step,
+                            movement.repScheme[rungIndex] + range.step,
                           )
                         }
                         unit={movement.timedRungs ? 'sec' : 'reps'}

--- a/src/pages/StartWorkoutPage/utils/goalRange.ts
+++ b/src/pages/StartWorkoutPage/utils/goalRange.ts
@@ -3,8 +3,10 @@ import { ValueRange, WorkoutGoalUnits } from '~/types';
 export const INCREMENT_VOLUME = 10; // kg
 
 export const getGoalRange = (units: WorkoutGoalUnits): ValueRange => {
+  // The minus button floors volume at 1kg, below the step grid; the strip shows
+  // the grid and leaves that last value to the button.
   if (units === 'kilograms')
-    return { min: 100, max: 3000, step: INCREMENT_VOLUME };
+    return { min: INCREMENT_VOLUME, max: 3000, step: INCREMENT_VOLUME };
   if (units === 'rounds') return { min: 1, max: 100, step: 1 };
   return { min: 1, max: 120, step: 1 };
 };

--- a/src/pages/StartWorkoutPage/utils/goalRange.ts
+++ b/src/pages/StartWorkoutPage/utils/goalRange.ts
@@ -1,0 +1,10 @@
+import { ValueRange, WorkoutGoalUnits } from '~/types';
+
+export const INCREMENT_VOLUME = 10; // kg
+
+export const getGoalRange = (units: WorkoutGoalUnits): ValueRange => {
+  if (units === 'kilograms')
+    return { min: 100, max: 3000, step: INCREMENT_VOLUME };
+  if (units === 'rounds') return { min: 1, max: 100, step: 1 };
+  return { min: 1, max: 120, step: 1 };
+};

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -9,6 +9,7 @@ export * from './program.interface';
 export * from './program-session.interface';
 export * from './program-session-completion.interface';
 export * from './user-program.interface';
+export * from './value-range.type';
 export * from './recommendation.interface';
 export * from './rpe-options.type';
 export * from './weight-tab.type';

--- a/src/types/value-range.type.ts
+++ b/src/types/value-range.type.ts
@@ -1,0 +1,5 @@
+export interface ValueRange {
+  min: number;
+  max: number;
+  step: number;
+}

--- a/src/utils/bellColors.test.ts
+++ b/src/utils/bellColors.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+
+import { getBellColor } from './bellColors';
+
+describe('getBellColor', () => {
+  it('gives the two names of one bell the same color', () => {
+    expect(getBellColor(24, 'kilograms')).toBe(getBellColor(53, 'pounds'));
+    expect(getBellColor(16, 'kilograms')).toBe(getBellColor(35, 'pounds'));
+  });
+
+  it('returns null for sizes outside the competition standard', () => {
+    expect(getBellColor(25, 'kilograms')).toBeNull();
+    expect(getBellColor(54, 'pounds')).toBeNull();
+  });
+
+  it('does not color a pound value using the kilogram table', () => {
+    expect(getBellColor(24, 'pounds')).toBeNull();
+  });
+
+  it('returns null when the unit is unknown', () => {
+    expect(getBellColor(24, null)).toBeNull();
+  });
+});

--- a/src/utils/bellColors.ts
+++ b/src/utils/bellColors.ts
@@ -1,0 +1,31 @@
+import { WeightUnit } from '~/types';
+
+/**
+ * Competition kettlebells are color-coded by size, so a lifter picks a bell out
+ * of a rack by color before reading its number. Pound sizes name the same
+ * physical bells — a 35 lb bell *is* the 16 kg bell — so both names of one bell
+ * live on the same row rather than being derived by unit conversion.
+ */
+const BELLS = [
+  { kilograms: 8, pounds: 18, color: '#e8639b' },
+  { kilograms: 12, pounds: 26, color: '#3a7bd5' },
+  { kilograms: 16, pounds: 35, color: '#e8c33a' },
+  { kilograms: 20, pounds: 44, color: '#7b4fb5' },
+  { kilograms: 24, pounds: 53, color: '#3fa45b' },
+  { kilograms: 28, pounds: 62, color: '#e88b2e' },
+  { kilograms: 32, pounds: 70, color: '#d64545' },
+  { kilograms: 36, pounds: 79, color: '#8a8f94' },
+  { kilograms: 40, pounds: 88, color: '#efede8' },
+  { kilograms: 44, pounds: 97, color: '#4a4f55' },
+  { kilograms: 48, pounds: 106, color: '#2e6f8e' },
+];
+
+const COLORS_BY_UNIT: Record<WeightUnit, Map<number, string>> = {
+  kilograms: new Map(BELLS.map(({ kilograms, color }) => [kilograms, color])),
+  pounds: new Map(BELLS.map(({ pounds, color }) => [pounds, color])),
+};
+
+export const getBellColor = (
+  value: number,
+  unit: WeightUnit | null,
+): string | null => (unit ? (COLORS_BY_UNIT[unit].get(value) ?? null) : null);

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,3 +1,4 @@
+export * from './bellColors';
 export * from './formatRungDuration';
 export * from './movementSearch';
 export * from './movementWeightModeFilter';

--- a/src/utils/weightUnits.ts
+++ b/src/utils/weightUnits.ts
@@ -1,7 +1,12 @@
-import { WeightUnit } from '~/types';
+import { ValueRange, WeightUnit } from '~/types';
 
 export const getWeightUnitLabel = (unit: WeightUnit | null) => {
   if (unit === 'kilograms') return 'kg';
   if (unit === 'pounds') return 'lb';
   return '';
 };
+
+export const getWeightRange = (unit: WeightUnit | null): ValueRange =>
+  unit === 'pounds'
+    ? { min: 1, max: 220, step: 1 }
+    : { min: 1, max: 100, step: 1 };


### PR DESCRIPTION
## Description

`ModifyCountButtons` becomes a center-snapping carousel across all ten call sites, so weights, reps, goal, and both timers can be set with a horizontal swipe instead of repeated tapping.

Three parts:

**The strip.** New `ValueCarousel` — a CSS scroll-snap track, no new dependency (no embla). Native momentum and snap on mobile, trackpad and wheel on desktop for free. The scroll↔value sync is isolated in `useSnapScrollValue`. Callers pass `min`/`max`/`step`, which keeps the swipe increment matched to each site's existing `-`/`+` step (`INCREMENT_VOLUME` is 10, the timers are 5, everything else 1).

**The color code.** Standard bells carry their competition color under the numeral, off-sizes get a neutral hairline. The point is aiming, not decoration — you can see the green 24 coming three values out. Pounds map through a lookup table, not a unit conversion, because a 53 lb bell *is* the 24 kg bell. Reps, timers, and goal use the identical strip with no color channel, so nothing is claimed that isn't true.

**What didn't change.** The `-`/`+` buttons and the typeable number field both stay. Tapping the centered number opens it for typing; swiping scrolls instead, because a drag that scrolls doesn't fire `click`. The strip is `aria-hidden` with `tabIndex={-1}` items — the spinbutton and the labelled step buttons remain the accessible path, and color is never the only carrier of meaning.

## Screenshots

Captured from the deploy preview's Storybook at a mobile width.

| Weight (kg) | Weight (kg), dark |
|---|---|
| ![kg light](https://github.com/user-attachments/assets/845a77e7-089e-4140-aa6f-ea48d11377df) | ![kg dark](https://github.com/user-attachments/assets/3aa464e4-1d9e-4ba7-98a0-d8cc0075e09a) |

`24` sits centered in the caliper with its green competition-bell chip; the chip stays legible against the dark card.

| Weight (lb) | Reps |
|---|---|
| ![lb](https://github.com/user-attachments/assets/23142a08-a927-49c6-8546-2beae1f239b9) | ![reps](https://github.com/user-attachments/assets/9a027027-610b-4940-b1cc-c3c6e0a1fee2) |

`53 lb` carries the same green as `24 kg` — the same physical bell. Reps use the identical strip with no color channel, one row shorter.

**Wider view — the color guides the swipe:**

![kg wide](https://github.com/user-attachments/assets/5ee66fa9-dc29-4c05-8ca3-d564678d783d)

`20` purple, `24` green, `28` orange — you can see the bell you want coming several values before you reach it.

## How tested

`npm test` — **484 passed, 74/74 files**. The regression bar was that no existing test gets edited: `StartWorkoutPage.test.jsx` (which clicks `+ reps`, `- kilograms`, `- lb` by aria-label) and `ProgramDetailsPage.test.tsx` (which asserts `getAllByRole('spinbutton')` has exactly length 2 and 1) both pass untouched.

`npm run compile:ts` 0 errors · `npm run lint` clean · `prettier --check` clean on every touched file.

New coverage: `bellColors.test.ts` (24 kg and 53 lb resolve to the same color; 25 kg and a null unit return null), `ValueCarousel.test.tsx` (range/step rendering, tap-to-select, out-of-range values, chip presence, and the three settle cases below), `ModifyCountButtons.test.tsx` (aria-labels, single spinbutton, typing, unit tabs).

Storybook at 375px, verified in light and dark: correct initial position (`scrollLeft 1104 = 23 × 48`), kg, lb, reps, and a step-5 timer. Dark mode holds — 20 purple, 24 green, 28 orange all legible against `--card`.

**Two bugs the browser caught, both now covered by tests:**

1. The strip collapsed to the minimum on mount. A `scrollend` fired at position 0 before the initial scroll landed, and the settle handler committed it — the kg picker opened on `1` instead of `24`. Settles now only commit when the user caused the scroll (`pointerdown`/`touchstart`/`wheel`/`keydown`). I confirmed the guard test genuinely fails without the guard rather than passing vacuously.
2. The initial `scrollTo` was a no-op because the track has no laid-out width on first commit. It's now placed on the next frame, instantly.

## Related issue

None.

## Tradeoffs

**Drag-to-scrub over the number** was the compact alternative — it keeps the current layout and needs no strip. It loses the preview of nearby values, which is most of the benefit, and it means hand-rolling pointer and momentum math that the browser already does well.

**Snapping weights to real bell sizes only** is faster and feels physical, and for a competition lifter it would be strictly better. Rejected because it blocks the odd values people legitimately use — dumbbells, plate-loaded, banded. The color chips give the same "find your bell fast" affordance without removing anything.

**A paged carousel with arrow buttons** is the most literal reading of "carousel" and would have let the arrows double as `-`/`+`. It traverses a large range slowly and would likely have meant adding embla.

## Notes for review

Two things outside the diff worth knowing:

- **This worktree had React 18.3.1 installed against React 19 source.** That was masking 154 failing tests and 41 type errors on a *clean* checkout. I ran `npm ci` to sync it — `package.json` and the lockfile are untouched, so there's no repo change, but it's worth checking your own install.
- **`e2e/workout-flow.spec.ts` did not run.** There's no `.env.e2e` and `.env*` is off-limits per `CLAUDE.md`, so I didn't create one. Running it with local Supabase values passed inline fails at line 170 looking for "Start workout" — but it **fails identically on a clean tree**, so it's an auth/seed environment gap rather than this change. The nine `- rounds` clicks it covers are exercised by the passing unit tests, but that real-browser path is unverified here.

I also couldn't drive a real swipe through the browser tooling — the preview pane runs hidden and the renderer is throttled, so no scroll events fire. That's why the commit logic is pinned by mocked-layout unit tests instead. **The gesture itself is worth a quick check on an actual phone before merging.**

