### PR TITLE
docs: require UI screenshots in PRs

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,14 +1,27 @@
-## Description
+## Why
 
-<!-- What changed and why. Link context. -->
+<!-- The problem or motivation — the section a reviewer six months from now needs. Closes # -->
 
-## How tested
+## What
 
-<!-- Commands run, cases covered, screenshots if UI. -->
+<!-- One or two sentences. The elevator version of the diff. -->
 
-## Related issue
+## How to test
 
-<!-- Closes # -->
+<!-- Concrete: commands run, cases covered. "Ran the ladder against a 5-rung scheme" beats "tested thoroughly." -->
+
+## Gallery
+
+<!--
+Required for any change with visible UI.
+- Changed UI: before and after.
+- New UI: after is enough.
+Delete this section for backend-only changes.
+-->
+
+## Deploy notes
+
+<!-- Migrations, feature flags to flip, env vars, `npm run gen:types`. Delete if none. -->
 
 ## Tradeoffs
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,6 +29,11 @@ One folder per route under `src/pages/` (`Page.tsx`, `.test.tsx`, `.stories.tsx`
 - Custom Tailwind spacing is **larger** than defaults — check `tailwind.config.js` and existing `src/components/ui/` before sizing new components.
 - Testing: Vitest + React Testing Library, MSW mocking (`src/mocks/`), tests collocated as `*.test.tsx`.
 
+## PR screenshots
+Any PR with visible UI work needs screenshots in the template's **Gallery** section: before *and* after for changed UI, after alone for new UI.
+- **Capture:** `preview_start` the `bellskill-dev` config in `.claude/launch.json` (port 5173; run `start:server` first), drive to the affected screen, and use the browser `computer {action: "screenshot"}` tool, saving to the session scratchpad. For a "before", capture on `main` or stash the change first. `bellskill-storybook` (port 6006) is the cheaper surface for isolated components.
+- **Embed:** run the `uploading-attachments` skill on the saved files for GitHub CDN URLs, then put those in Gallery — don't commit screenshots. If browser login for that skill isn't set up, save to the scratchpad and ask DJ to drag-drop instead. Flag that CDN uploads are permanent; GitHub can't delete them.
+
 ## Commands
 `npm run dev` · `npm test` / `test-watch` · `compile:ts` · `lint` · `storybook` · `start:server` (local Supabase, before `gen:types`) · `diff-db`. Full list in `package.json`. `npm run dev` reads local Supabase defaults (`VITE_SUPABASE_URL` / `VITE_SUPABASE_ANON_KEY`) from `.env.development`, so run `start:server` first; override via a gitignored `.env.local`.
 


### PR DESCRIPTION
## Why

Bellskill is a UI-heavy PWA, but nothing in the repo asked a PR to *show* the change. The template only mentioned screenshots in a parenthetical inside "How tested", so frontend PRs landed as prose descriptions of pixels — reviewing them meant checking out the branch and running the app.

## What

Two changes. The PR template gets a dedicated **Gallery** section and is reordered to Why / What / How to test / Gallery / Deploy notes / Tradeoffs (Why before What front-loads the section a reviewer six months out actually needs; the standalone "Related issue" section folds its `Closes #` hint into Why). `AGENTS.md` (surfaced as `CLAUDE.md`) gets the screenshot rule plus the capture-and-embed mechanism, so agent-authored PRs produce shots without being asked: before *and* after for changed UI, after alone for new UI. Deploy notes is also new — this repo has real post-merge steps worth flagging (migrations, feature flags, `gen:types`).

## How to test

- `grep '^## ' .github/pull_request_template.md` — confirms six headings in order; every hint is inside an HTML comment, so a fresh PR shows only the headings.
- This PR body itself was written against the new template — see the section structure above.

## Gallery

N/A — no visible UI. Docs and repo-config only.

## Deploy notes

None. No migrations, flags, or type regen.

## Tradeoffs

Gallery is convention, not a CI gate — no check enforces it. Enforcement can come later if PRs skip it. The Why-before-What ordering inverts my dev-writing guide's PR template, a deliberate call to prioritize reviewer context.
