### PR TITLE
feat(history): redesign workout history around a weekly view

### DIFF
--- a/src/components/WeeklyBalance/patternDisplay.ts
+++ b/src/components/WeeklyBalance/patternDisplay.ts
@@ -55,5 +55,4 @@ export const lastTrainedLabel = (lastTrained: Date | null): string => {
   return DateTime.fromJSDate(lastTrained).toRelative() ?? 'Recently';
 };
 
-export const formatVolume = (kg: number): string =>
-  `${Math.round(kg).toLocaleString()} kg`;
+export { formatVolume } from '~/utils';

--- a/src/pages/CompletedWorkoutPage/components/RPESelector.tsx
+++ b/src/pages/CompletedWorkoutPage/components/RPESelector.tsx
@@ -85,6 +85,8 @@ export const RpeBadge = ({ rpeValue }: { rpeValue: RpeOptions }) => {
   );
 };
 
+// Colors come from the shared exertion ramp (--intensity-0…4 in tailwind.css),
+// so the selector, the badge, and the History week strip read as one scale.
 // eslint-disable-next-line react-refresh/only-export-components -- RPE config constant is intentionally co-located with its selector component; splitting the module is out of scope for the lint pass
 export const RPE_CONFIG: {
   [key: string]: {
@@ -92,42 +94,36 @@ export const RPE_CONFIG: {
     description: string;
     ringColor: string;
     text: string;
-    textColor: string;
   };
 } = {
   noEffort: {
-    bgColor: 'bg-gray-300',
+    bgColor: 'bg-intensity-0',
     description: 'Felt like no workout at all.',
-    ringColor: 'ring-gray-300',
+    ringColor: 'ring-intensity-0',
     text: 'No Effort',
-    textColor: 'text-gray-500',
   },
   easy: {
-    bgColor: 'bg-green-400',
+    bgColor: 'bg-intensity-1',
     description: 'Comfortable and sustainable effort.',
-    ringColor: 'ring-green-400',
+    ringColor: 'ring-intensity-1',
     text: 'Easy',
-    textColor: 'text-green-500',
   },
   ideal: {
-    bgColor: 'bg-yellow-400',
+    bgColor: 'bg-intensity-2',
     description: 'Challenging yet manageable workout.',
-    ringColor: 'ring-yellow-400',
+    ringColor: 'ring-intensity-2',
     text: 'Ideal',
-    textColor: 'text-yellow-500',
   },
   hard: {
-    bgColor: 'bg-orange-400',
+    bgColor: 'bg-intensity-3',
     description: 'Pushed near your limits, quite tough.',
-    ringColor: 'ring-orange-400',
+    ringColor: 'ring-intensity-3',
     text: 'Hard',
-    textColor: 'text-orange-500',
   },
   maxEffort: {
-    bgColor: 'bg-red-500',
+    bgColor: 'bg-intensity-4',
     description: 'Peak exertion, pushed to the absolute limit.',
-    ringColor: 'ring-red-500',
+    ringColor: 'ring-intensity-4',
     text: 'Max Effort',
-    textColor: 'text-red-600',
   },
 };

--- a/src/pages/HistoryPage/HistoryPage.test.jsx
+++ b/src/pages/HistoryPage/HistoryPage.test.jsx
@@ -25,25 +25,43 @@ describe('workout history page', () => {
   });
 
   test('renders workout volume', async () => {
-    await screen.findByText('1000 kg');
+    await screen.findByText('1,000 kg');
   });
 
   test('renders workout date', async () => {
-    await screen.findByText('Thu Nov 09 2023');
+    // Two sessions share Nov 9; each row carries its own date.
+    expect(await screen.findAllByText('Thu 9')).toHaveLength(2);
   });
 
   test('renders rep count for bodyweight workouts', async () => {
     await screen.findByText('50 reps');
   });
 
-  test('renders Complex badge for workouts with complex_set true', async () => {
-    await screen.findByText('Complex');
+  test('marks complex sets on the session row', async () => {
+    await screen.findByText(/Complex/);
   });
 
-  test('does not render Complex badge for workouts without complex_set', async () => {
+  test('does not mark workouts without complex_set', async () => {
     await screen.findByText('50 reps');
-    const badges = screen.getAllByText('Complex');
-    expect(badges).toHaveLength(1);
+    expect(screen.getAllByText(/Complex/)).toHaveLength(1);
+  });
+
+  test('summarizes each week by session count and volume', async () => {
+    await screen.findByText('3 sessions · 1,000 kg');
+  });
+
+  test('omits volume from the summary of a bodyweight-only week', async () => {
+    // Weeks of Oct 16 and Oct 23 log reps only, so volume is left off.
+    expect(await screen.findAllByText('3 sessions')).toHaveLength(2);
+  });
+
+  test('describes the week strip for screen readers', async () => {
+    const strips = await screen.findAllByRole('img');
+    expect(
+      strips.some((strip) =>
+        strip.getAttribute('aria-label')?.includes('not trained'),
+      ),
+    ).toBe(true);
   });
 });
 

--- a/src/pages/HistoryPage/HistoryPage.tsx
+++ b/src/pages/HistoryPage/HistoryPage.tsx
@@ -1,24 +1,21 @@
-import { DateTime } from 'luxon';
 import { Link } from 'react-router-dom';
 
 import { useInfiniteWorkoutLogs } from '~/api';
 import { Loading, Page } from '~/components';
-import { Badge } from '~/components/ui/badge';
 import { Button } from '~/components/ui/button';
-import { Card, CardContent, CardHeader, CardTitle } from '~/components/ui/card';
-import { WorkoutLog } from '~/types';
+import { Card, CardContent } from '~/components/ui/card';
+import { Separator } from '~/components/ui/separator';
+import { formatVolume } from '~/utils';
 
-import { RpeBadge } from '../CompletedWorkoutPage/components';
-import { getDuration } from '../CompletedWorkoutPage/utils';
+import { SessionRow, WeekStrip } from './components';
+import { WorkoutWeek, getWeekLabel, groupByDate, groupByWeek } from './utils';
 
 export const HistoryPage = () => {
   const { data, isLoading, fetchNextPage, hasNextPage, isFetchingNextPage } =
     useInfiniteWorkoutLogs();
 
   const workoutLogs = data?.pages.flatMap((page) => page.workoutLogs) ?? [];
-
-  const workoutDays = groupByDate(workoutLogs);
-  const workoutWeeks = groupByWeek(workoutDays);
+  const workoutWeeks = groupByWeek(groupByDate(workoutLogs));
 
   return (
     <Page title="Workout History">
@@ -26,7 +23,7 @@ export const HistoryPage = () => {
         <Card>
           <CardContent className="flex flex-col items-center gap-2 p-3 text-center">
             <div className="text-muted-foreground">
-              Your finished workouts will show up here.
+              Finished workouts show up here, newest first.
             </div>
             <Button asChild>
               <Link to="/">Start your first workout</Link>
@@ -35,14 +32,9 @@ export const HistoryPage = () => {
         </Card>
       )}
 
-      <div className="flex flex-col gap-4">
-        {workoutWeeks.map(({ weekKey, weekYear, weekNumber, workoutDays }) => (
-          <WorkoutWeekGroup
-            key={weekKey}
-            weekYear={weekYear}
-            weekNumber={weekNumber}
-            workoutDays={workoutDays}
-          />
+      <div className="flex flex-col gap-3">
+        {workoutWeeks.map((workoutWeek) => (
+          <WorkoutWeekGroup key={workoutWeek.weekKey} {...workoutWeek} />
         ))}
       </div>
 
@@ -64,182 +56,52 @@ export const HistoryPage = () => {
   );
 };
 
-const WorkoutLogItem = ({ workoutLog }: { workoutLog: WorkoutLog }) => {
-  const workoutDetailsPath = '/history/' + workoutLog.id;
-  const workoutVolume = workoutLog.completedVolume ?? 0;
-  const displayText =
-    workoutVolume > 0
-      ? `${workoutVolume.toFixed(0)} kg`
-      : `${workoutLog.completedReps} reps`;
-  const duration = getDuration(workoutLog.startedAt, workoutLog.completedAt);
-
-  // The lifter's own name for the session is the most scannable line; fall
-  // back to the movement list when the workout wasn't named.
-  const title = workoutLog.title?.trim() || '';
-  const movementsLine = workoutLog.movements.join(' · ');
-
-  return (
-    <Link
-      className="flex justify-between gap-1 rounded-md px-2 py-1 hover:cursor-pointer hover:bg-accent hover:text-accent-foreground"
-      to={workoutDetailsPath}
-    >
-      <div className="min-w-0">
-        <div className="font-medium">{title || movementsLine}</div>
-        {title && (
-          <div className="text-sm text-muted-foreground">{movementsLine}</div>
-        )}
-      </div>
-      <div className="flex shrink-0 items-center justify-end gap-1">
-        {workoutLog.complexSet === true && (
-          <Badge variant="secondary">Complex</Badge>
-        )}
-        {workoutLog.rpe !== null && <RpeBadge rpeValue={workoutLog.rpe} />}
-        <div className="text-right">
-          <div>{displayText}</div>
-          <div className="text-sm text-muted-foreground">{duration}</div>
-        </div>
-      </div>
-    </Link>
-  );
-};
-
-const WorkoutDayCard = ({
-  date,
-  workoutLogs = [],
-}: {
-  date: string;
-  workoutLogs: WorkoutLog[];
-}) => (
-  <Card>
-    <CardHeader>
-      <CardTitle>{date}</CardTitle>
-    </CardHeader>
-    <CardContent>
-      {workoutLogs.map((workoutLog) => (
-        <WorkoutLogItem key={workoutLog.id} workoutLog={workoutLog} />
-      ))}
-    </CardContent>
-  </Card>
-);
-
 const WorkoutWeekGroup = ({
   weekYear,
   weekNumber,
   workoutDays,
-}: {
-  weekYear: number;
-  weekNumber: number;
-  workoutDays: WorkoutDay[];
-}) => {
-  let weekVolume = 0;
+}: Omit<WorkoutWeek, 'weekKey'>) => {
+  const sessions = workoutDays.flatMap(({ workoutLogs }) => workoutLogs);
+  const weekVolume = sessions.reduce(
+    (total, { completedVolume }) => total + (completedVolume ?? 0),
+    0,
+  );
 
-  workoutDays.forEach(({ workoutLogs }) => {
-    let dayVolume = 0;
-    workoutLogs.forEach((workoutLog) => {
-      dayVolume += workoutLog.completedVolume ?? 0;
-    });
-    weekVolume += dayVolume;
-  });
-
-  const displayText = weekVolume > 0 && `${weekVolume.toFixed(0)} kg total`;
+  // Volume is meaningless for a bodyweight-only week, so the session count
+  // carries the summary on its own rather than leaving the line half empty.
+  const summary = [
+    `${sessions.length} ${sessions.length === 1 ? 'session' : 'sessions'}`,
+    weekVolume > 0 ? formatVolume(weekVolume) : null,
+  ]
+    .filter(Boolean)
+    .join(' · ');
 
   return (
-    <div className="flex flex-col gap-2">
-      <div className="flex items-center justify-between gap-1 px-1 text-sm font-medium">
-        <div>{getWeekLabel(weekYear, weekNumber)}</div>
-        <div>{displayText}</div>
+    <div className="flex flex-col gap-1">
+      <div className="flex items-baseline justify-between gap-1 px-1 text-sm">
+        <div className="font-medium">{getWeekLabel(weekYear, weekNumber)}</div>
+        <div className="tabular-nums text-muted-foreground">{summary}</div>
       </div>
-      {workoutDays.map(({ date, workoutLogs }) => (
-        <WorkoutDayCard
-          key={date.toISOString()}
-          workoutLogs={workoutLogs}
-          date={date.toDateString()}
-        />
-      ))}
+
+      <Card>
+        <CardContent className="px-1.5 pb-1.5 pt-1">
+          <WeekStrip
+            weekYear={weekYear}
+            weekNumber={weekNumber}
+            workoutDays={workoutDays}
+          />
+        </CardContent>
+
+        <Separator />
+
+        <div className="divide-y">
+          {workoutDays.flatMap(({ workoutLogs }) =>
+            workoutLogs.map((workoutLog) => (
+              <SessionRow key={workoutLog.id} workoutLog={workoutLog} />
+            )),
+          )}
+        </div>
+      </Card>
     </div>
   );
-};
-
-// "Week 27" means nothing to a human — label weeks relative to today, then by
-// date range once they're further back.
-const getWeekLabel = (weekYear: number, weekNumber: number): string => {
-  const now = DateTime.now();
-  if (weekYear === now.weekYear && weekNumber === now.weekNumber) {
-    return 'This week';
-  }
-
-  const lastWeek = now.minus({ weeks: 1 });
-  if (weekYear === lastWeek.weekYear && weekNumber === lastWeek.weekNumber) {
-    return 'Last week';
-  }
-
-  const start = DateTime.fromObject({ weekYear, weekNumber, weekday: 1 });
-  const end = start.plus({ days: 6 });
-  const range =
-    start.month === end.month
-      ? `${start.toFormat('MMM d')} – ${end.toFormat('d')}`
-      : `${start.toFormat('MMM d')} – ${end.toFormat('MMM d')}`;
-
-  return start.year === now.year ? range : `${range}, ${start.year}`;
-};
-
-interface WorkoutDay {
-  date: Date;
-  workoutLogs: WorkoutLog[];
-}
-
-interface WorkoutWeek {
-  weekKey: string;
-  weekYear: number;
-  weekNumber: number;
-  workoutDays: WorkoutDay[];
-}
-
-const groupByDate = (workoutLogs: WorkoutLog[] = []): WorkoutDay[] => {
-  const groupedByDate: { [dateKey: string]: WorkoutLog[] } = {};
-
-  workoutLogs.forEach((log) => {
-    const dateKey = log.startedAt.toDateString();
-    if (!groupedByDate[dateKey]) {
-      groupedByDate[dateKey] = [];
-    }
-    groupedByDate[dateKey].push(log);
-    groupedByDate[dateKey].sort(
-      (a, b) => a.startedAt.getTime() - b.startedAt.getTime(),
-    );
-  });
-
-  return Object.entries(groupedByDate)
-    .sort(([a], [b]) => new Date(b).getTime() - new Date(a).getTime())
-    .map(([dateKey, workoutLogs]) => ({
-      date: new Date(dateKey),
-      workoutLogs,
-    }));
-};
-
-const groupByWeek = (workoutDays: WorkoutDay[]): WorkoutWeek[] => {
-  const groupedByWeek: { [weekKey: string]: WorkoutDay[] } = {};
-
-  workoutDays.forEach((workoutDay) => {
-    const year = DateTime.fromJSDate(workoutDay.date).weekYear;
-    const weekNumber = DateTime.fromJSDate(workoutDay.date).weekNumber;
-    const weekKey = `${year}-W${weekNumber}`;
-    if (!groupedByWeek[weekKey]) {
-      groupedByWeek[weekKey] = [];
-    }
-    groupedByWeek[weekKey].push(workoutDay);
-    groupedByWeek[weekKey].sort((a, b) => b.date.getTime() - a.date.getTime());
-  });
-
-  return Object.entries(groupedByWeek)
-    .map(([weekKey, workoutDays]) => ({
-      weekKey,
-      weekYear: Number(weekKey.split('-W')[0]),
-      weekNumber: Number(weekKey.split('-W')[1]),
-      workoutDays,
-    }))
-    .sort(
-      (a, b) =>
-        b.workoutDays[0].date.getTime() - a.workoutDays[0].date.getTime(),
-    );
 };

--- a/src/pages/HistoryPage/components/SessionRow.tsx
+++ b/src/pages/HistoryPage/components/SessionRow.tsx
@@ -1,0 +1,80 @@
+import { Link } from 'react-router-dom';
+
+import { cn } from '~/lib/utils';
+import { WorkoutLog } from '~/types';
+import { formatVolume } from '~/utils';
+
+import { getDuration } from '../../CompletedWorkoutPage/utils';
+import {
+  INTENSITY_BG,
+  INTENSITY_LABEL,
+  RPE_INTENSITY,
+  getRowDateLabel,
+} from '../utils';
+
+export interface SessionRowProps {
+  workoutLog: WorkoutLog;
+}
+
+export const SessionRow = ({ workoutLog }: SessionRowProps) => {
+  const {
+    completedReps,
+    completedVolume,
+    complexSet,
+    id,
+    movements,
+    rpe,
+    startedAt,
+  } = workoutLog;
+
+  const movementsLine = movements.join(' · ');
+  // The lifter's own name for the session is the most scannable line; fall
+  // back to the movement list when the workout wasn't named.
+  const title = workoutLog.title?.trim() || movementsLine;
+
+  const volume = completedVolume ?? 0;
+  const metric = volume > 0 ? formatVolume(volume) : `${completedReps} reps`;
+
+  const meta = [
+    getRowDateLabel(startedAt),
+    complexSet === true ? 'Complex' : null,
+    // Already the headline when the session went unnamed.
+    title === movementsLine ? null : movementsLine,
+  ].filter(Boolean);
+
+  return (
+    <Link
+      to={`/history/${id}`}
+      className="flex min-h-[44px] items-center gap-1 px-1.5 py-1 hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset"
+    >
+      <div className="min-w-0 flex-1">
+        <div className="truncate text-sm font-medium">{title}</div>
+        <div className="flex items-center gap-0.5 text-xs text-muted-foreground">
+          {rpe && (
+            <span
+              className={cn(
+                'h-[6px] w-[6px] shrink-0 rounded-full',
+                INTENSITY_BG[RPE_INTENSITY[rpe]],
+              )}
+            >
+              <span className="sr-only">
+                {INTENSITY_LABEL[RPE_INTENSITY[rpe]]}
+              </span>
+            </span>
+          )}
+          <span className="truncate">
+            <span className="text-foreground">{meta[0]}</span>
+            {meta.length > 1 && ` · ${meta.slice(1).join(' · ')}`}
+          </span>
+        </div>
+      </div>
+
+      <div className="shrink-0 text-right">
+        <div className="text-sm tabular-nums">{metric}</div>
+        <div className="text-xs tabular-nums text-muted-foreground">
+          {getDuration(startedAt, workoutLog.completedAt)}
+        </div>
+      </div>
+    </Link>
+  );
+};

--- a/src/pages/HistoryPage/components/WeekStrip.stories.tsx
+++ b/src/pages/HistoryPage/components/WeekStrip.stories.tsx
@@ -1,0 +1,100 @@
+import { Meta } from '@storybook/react';
+import { DateTime, WeekdayNumbers } from 'luxon';
+
+import { RpeOptions, WorkoutLog } from '~/types';
+
+import { WorkoutDay } from '../utils';
+import { WeekStrip } from './WeekStrip';
+
+const now = DateTime.now();
+
+const sessionOn = (date: Date, rpe: RpeOptions | null): WorkoutLog => ({
+  completedAt: date,
+  completedReps: 60,
+  completedRounds: 10,
+  completedRungs: 10,
+  completedSides: null,
+  completedVolume: 900,
+  complexSet: false,
+  id: date.getTime(),
+  intervalTimer: 0,
+  movements: ['Clean and Press'],
+  restTimer: 0,
+  rpe,
+  sharedWeightOneUnit: null,
+  sharedWeightOneValue: null,
+  sharedWeightTwoUnit: null,
+  sharedWeightTwoValue: null,
+  startedAt: date,
+  title: 'The Giant 3.0 W1D2',
+  preWorkoutNotes: null,
+  workoutGoal: 20,
+  workoutGoalUnits: 'minutes',
+  postWorkoutNotes: null,
+});
+
+const dayIn = (
+  week: DateTime,
+  weekday: WeekdayNumbers,
+  rpe: RpeOptions | null,
+): WorkoutDay => {
+  const date = DateTime.fromObject({
+    weekYear: week.weekYear,
+    weekNumber: week.weekNumber,
+    weekday,
+  }).toJSDate();
+
+  return { date, workoutLogs: [sessionOn(date, rpe)] };
+};
+
+export default {
+  component: WeekStrip,
+  args: { weekYear: now.weekYear, weekNumber: now.weekNumber },
+  decorators: [
+    (Story) => (
+      <div className="max-w-md bg-card p-2">
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof WeekStrip>;
+
+/** The full exertion ramp, no-effort through max-effort. */
+export const FullWeek = {
+  args: {
+    workoutDays: [
+      dayIn(now, 1, 'easy'),
+      dayIn(now, 2, 'ideal'),
+      dayIn(now, 3, 'hard'),
+      dayIn(now, 4, 'noEffort'),
+      dayIn(now, 5, 'maxEffort'),
+      dayIn(now, 6, 'ideal'),
+      dayIn(now, 7, 'easy'),
+    ],
+  },
+};
+
+export const SingleSession = {
+  args: { workoutDays: [dayIn(now, 3, 'hard')] },
+};
+
+/** Logged but never rated — filled, but off the exertion ramp. */
+export const Unrated = {
+  args: { workoutDays: [dayIn(now, 2, null), dayIn(now, 4, 'ideal')] },
+};
+
+export const NothingLogged = {
+  args: { workoutDays: [] },
+};
+
+/** A past week has no "not yet" days — every untrained day reads as skipped. */
+export const PastWeek = (() => {
+  const past = now.minus({ weeks: 6 });
+  return {
+    args: {
+      weekYear: past.weekYear,
+      weekNumber: past.weekNumber,
+      workoutDays: [dayIn(past, 2, 'maxEffort'), dayIn(past, 5, 'easy')],
+    },
+  };
+})();

--- a/src/pages/HistoryPage/components/WeekStrip.tsx
+++ b/src/pages/HistoryPage/components/WeekStrip.tsx
@@ -1,0 +1,122 @@
+import { DateTime } from 'luxon';
+
+import { cn } from '~/lib/utils';
+
+import {
+  INTENSITY_BG,
+  INTENSITY_LABEL,
+  RPE_INTENSITY,
+  WorkoutDay,
+  hardestRpe,
+  startOfWeek,
+} from '../utils';
+
+const WEEKDAY_LETTERS = ['M', 'T', 'W', 'T', 'F', 'S', 'S'];
+
+export interface WeekStripProps {
+  weekYear: number;
+  weekNumber: number;
+  workoutDays: WorkoutDay[];
+}
+
+interface DayCell {
+  weekday: DateTime;
+  trained: boolean;
+  isFuture: boolean;
+  fill: string;
+  /** Exertion wording for the day, or null when trained but never rated. */
+  intensityLabel: string | null;
+}
+
+/**
+ * Seven segments, one per day of the ISO week, tinted by that day's hardest
+ * exertion rating. Gives the week its shape before you read a single row.
+ */
+export const WeekStrip = ({
+  weekYear,
+  weekNumber,
+  workoutDays,
+}: WeekStripProps) => {
+  const cells = buildCells(weekYear, weekNumber, workoutDays);
+
+  return (
+    <div role="img" aria-label={describeWeek(cells)}>
+      <div aria-hidden className="flex gap-0.5">
+        {WEEKDAY_LETTERS.map((letter, index) => (
+          <div
+            key={index}
+            className="flex-1 text-center text-[10px] uppercase tracking-wider text-muted-foreground"
+          >
+            {letter}
+          </div>
+        ))}
+      </div>
+
+      <div aria-hidden className="mt-0.5 flex gap-0.5">
+        {cells.map(({ fill }, index) => (
+          <div key={index} className={cn('h-1 flex-1 rounded-full', fill)} />
+        ))}
+      </div>
+    </div>
+  );
+};
+
+const buildCells = (
+  weekYear: number,
+  weekNumber: number,
+  workoutDays: WorkoutDay[],
+): DayCell[] => {
+  const monday = startOfWeek(weekYear, weekNumber);
+  const today = DateTime.now().startOf('day');
+
+  return WEEKDAY_LETTERS.map((_, index) => {
+    const weekday = monday.plus({ days: index });
+    const day = workoutDays.find(({ date }) =>
+      DateTime.fromJSDate(date).hasSame(weekday, 'day'),
+    );
+    const rpe = day ? hardestRpe(day.workoutLogs) : null;
+
+    return {
+      weekday,
+      trained: Boolean(day),
+      isFuture: weekday > today,
+      intensityLabel: rpe ? INTENSITY_LABEL[RPE_INTENSITY[rpe]] : null,
+      fill: resolveFill(Boolean(day), rpe, weekday > today),
+    };
+  });
+};
+
+const resolveFill = (
+  trained: boolean,
+  rpe: ReturnType<typeof hardestRpe>,
+  isFuture: boolean,
+): string => {
+  // A logged-but-unrated day still happened, so it reads as filled — just
+  // without a place on the exertion ramp.
+  if (trained) {
+    return rpe ? INTENSITY_BG[RPE_INTENSITY[rpe]] : 'bg-muted-foreground/50';
+  }
+  // A day that hasn't arrived yet isn't a day you skipped.
+  return isFuture ? 'bg-muted/40' : 'bg-muted';
+};
+
+const describeWeek = (cells: DayCell[]): string => {
+  const trained = cells.filter((cell) => cell.trained);
+
+  if (trained.length === 0) return 'No workouts this week.';
+
+  const sessions = trained
+    .map(
+      ({ weekday, intensityLabel }) =>
+        `${weekday.toFormat('cccc')}${intensityLabel ? ` ${intensityLabel.toLowerCase()}` : ' unrated'}`,
+    )
+    .join(', ');
+
+  const untrained = cells.filter(
+    (cell) => !cell.trained && !cell.isFuture,
+  ).length;
+
+  return untrained > 0
+    ? `${sessions}. ${untrained} ${untrained === 1 ? 'day' : 'days'} not trained.`
+    : `${sessions}.`;
+};

--- a/src/pages/HistoryPage/components/index.ts
+++ b/src/pages/HistoryPage/components/index.ts
@@ -1,0 +1,2 @@
+export * from './SessionRow';
+export * from './WeekStrip';

--- a/src/pages/HistoryPage/utils/dayLabels.test.ts
+++ b/src/pages/HistoryPage/utils/dayLabels.test.ts
@@ -1,0 +1,21 @@
+import { DateTime } from 'luxon';
+
+import { getRowDateLabel } from './dayLabels';
+
+describe('getRowDateLabel', () => {
+  test('names today and yesterday the way a person would', () => {
+    expect(getRowDateLabel(new Date())).toBe('Today');
+    expect(
+      getRowDateLabel(DateTime.now().minus({ days: 1 }).toJSDate()),
+    ).toBe('Yesterday');
+  });
+
+  test('falls back to weekday and date once further back', () => {
+    expect(getRowDateLabel(new Date('2023-11-09T12:00:00'))).toBe('Thu 9');
+  });
+
+  test('ignores time of day when deciding how recent a date is', () => {
+    const lateToday = DateTime.now().startOf('day').plus({ hours: 23 });
+    expect(getRowDateLabel(lateToday.toJSDate())).toBe('Today');
+  });
+});

--- a/src/pages/HistoryPage/utils/dayLabels.ts
+++ b/src/pages/HistoryPage/utils/dayLabels.ts
@@ -1,0 +1,16 @@
+import { DateTime } from 'luxon';
+
+/**
+ * Gutter label for a session row. Recent days get named relative to today the
+ * way a person would say them; everything older falls back to weekday + date.
+ */
+export const getRowDateLabel = (date: Date): string => {
+  const day = DateTime.fromJSDate(date).startOf('day');
+  const today = DateTime.now().startOf('day');
+
+  const daysAgo = today.diff(day, 'days').days;
+  if (daysAgo === 0) return 'Today';
+  if (daysAgo === 1) return 'Yesterday';
+
+  return day.toFormat('ccc d');
+};

--- a/src/pages/HistoryPage/utils/grouping.ts
+++ b/src/pages/HistoryPage/utils/grouping.ts
@@ -1,0 +1,91 @@
+import { DateTime } from 'luxon';
+
+import { WorkoutLog } from '~/types';
+
+export interface WorkoutDay {
+  date: Date;
+  workoutLogs: WorkoutLog[];
+}
+
+export interface WorkoutWeek {
+  weekKey: string;
+  weekYear: number;
+  weekNumber: number;
+  workoutDays: WorkoutDay[];
+}
+
+export const groupByDate = (workoutLogs: WorkoutLog[] = []): WorkoutDay[] => {
+  const groupedByDate: { [dateKey: string]: WorkoutLog[] } = {};
+
+  workoutLogs.forEach((log) => {
+    const dateKey = log.startedAt.toDateString();
+    if (!groupedByDate[dateKey]) {
+      groupedByDate[dateKey] = [];
+    }
+    groupedByDate[dateKey].push(log);
+    groupedByDate[dateKey].sort(
+      (a, b) => a.startedAt.getTime() - b.startedAt.getTime(),
+    );
+  });
+
+  return Object.entries(groupedByDate)
+    .sort(([a], [b]) => new Date(b).getTime() - new Date(a).getTime())
+    .map(([dateKey, workoutLogs]) => ({
+      date: new Date(dateKey),
+      workoutLogs,
+    }));
+};
+
+export const groupByWeek = (workoutDays: WorkoutDay[]): WorkoutWeek[] => {
+  const groupedByWeek: { [weekKey: string]: WorkoutDay[] } = {};
+
+  workoutDays.forEach((workoutDay) => {
+    const year = DateTime.fromJSDate(workoutDay.date).weekYear;
+    const weekNumber = DateTime.fromJSDate(workoutDay.date).weekNumber;
+    const weekKey = `${year}-W${weekNumber}`;
+    if (!groupedByWeek[weekKey]) {
+      groupedByWeek[weekKey] = [];
+    }
+    groupedByWeek[weekKey].push(workoutDay);
+    groupedByWeek[weekKey].sort((a, b) => b.date.getTime() - a.date.getTime());
+  });
+
+  return Object.entries(groupedByWeek)
+    .map(([weekKey, workoutDays]) => ({
+      weekKey,
+      weekYear: Number(weekKey.split('-W')[0]),
+      weekNumber: Number(weekKey.split('-W')[1]),
+      workoutDays,
+    }))
+    .sort(
+      (a, b) =>
+        b.workoutDays[0].date.getTime() - a.workoutDays[0].date.getTime(),
+    );
+};
+
+// "Week 27" means nothing to a human — label weeks relative to today, then by
+// date range once they're further back.
+export const getWeekLabel = (weekYear: number, weekNumber: number): string => {
+  const now = DateTime.now();
+  if (weekYear === now.weekYear && weekNumber === now.weekNumber) {
+    return 'This week';
+  }
+
+  const lastWeek = now.minus({ weeks: 1 });
+  if (weekYear === lastWeek.weekYear && weekNumber === lastWeek.weekNumber) {
+    return 'Last week';
+  }
+
+  const start = startOfWeek(weekYear, weekNumber);
+  const end = start.plus({ days: 6 });
+  const range =
+    start.month === end.month
+      ? `${start.toFormat('MMM d')} – ${end.toFormat('d')}`
+      : `${start.toFormat('MMM d')} – ${end.toFormat('MMM d')}`;
+
+  return start.year === now.year ? range : `${range}, ${start.year}`;
+};
+
+/** Monday of an ISO week — the anchor both the label and the strip build from. */
+export const startOfWeek = (weekYear: number, weekNumber: number): DateTime =>
+  DateTime.fromObject({ weekYear, weekNumber, weekday: 1 });

--- a/src/pages/HistoryPage/utils/index.ts
+++ b/src/pages/HistoryPage/utils/index.ts
@@ -1,0 +1,3 @@
+export * from './dayLabels';
+export * from './grouping';
+export * from './intensity';

--- a/src/pages/HistoryPage/utils/intensity.test.ts
+++ b/src/pages/HistoryPage/utils/intensity.test.ts
@@ -1,0 +1,32 @@
+import { WorkoutLog } from '~/types';
+
+import { hardestRpe } from './intensity';
+
+const session = (rpe: WorkoutLog['rpe']) => ({ rpe }) as WorkoutLog;
+
+describe('hardestRpe', () => {
+  test('returns null when no session was rated', () => {
+    expect(hardestRpe([session(null), session(null)])).toBeNull();
+  });
+
+  test('returns null for a day with no sessions', () => {
+    expect(hardestRpe([])).toBeNull();
+  });
+
+  test('takes the harder of two ratings regardless of order', () => {
+    expect(hardestRpe([session('easy'), session('maxEffort')])).toBe(
+      'maxEffort',
+    );
+    expect(hardestRpe([session('maxEffort'), session('easy')])).toBe(
+      'maxEffort',
+    );
+  });
+
+  test('ignores unrated sessions alongside rated ones', () => {
+    expect(hardestRpe([session(null), session('hard')])).toBe('hard');
+  });
+
+  test('treats noEffort as a rating, not an absence', () => {
+    expect(hardestRpe([session('noEffort')])).toBe('noEffort');
+  });
+});

--- a/src/pages/HistoryPage/utils/intensity.ts
+++ b/src/pages/HistoryPage/utils/intensity.ts
@@ -1,0 +1,35 @@
+import { RpeOptions, WorkoutLog } from '~/types';
+
+export type IntensityLevel = 0 | 1 | 2 | 3 | 4;
+
+export const RPE_INTENSITY: Record<RpeOptions, IntensityLevel> = {
+  noEffort: 0,
+  easy: 1,
+  ideal: 2,
+  hard: 3,
+  maxEffort: 4,
+};
+
+export const INTENSITY_BG: Record<IntensityLevel, string> = {
+  0: 'bg-intensity-0',
+  1: 'bg-intensity-1',
+  2: 'bg-intensity-2',
+  3: 'bg-intensity-3',
+  4: 'bg-intensity-4',
+};
+
+export const INTENSITY_LABEL: Record<IntensityLevel, string> = {
+  0: 'No effort',
+  1: 'Easy',
+  2: 'Ideal',
+  3: 'Hard',
+  4: 'Max effort',
+};
+
+/** A day is summarized by its hardest session; null when none were rated. */
+export const hardestRpe = (workoutLogs: WorkoutLog[]): RpeOptions | null =>
+  workoutLogs.reduce<RpeOptions | null>((hardest, { rpe }) => {
+    if (!rpe) return hardest;
+    if (!hardest) return rpe;
+    return RPE_INTENSITY[rpe] > RPE_INTENSITY[hardest] ? rpe : hardest;
+  }, null);

--- a/src/tailwind.css
+++ b/src/tailwind.css
@@ -41,6 +41,15 @@
     /* custom add-ons */
     --status-warning: 27 96% 61%;
     --status-positive: 142 69.2% 58%;
+
+    /* Exertion ramp, no-effort through max-effort. Desaturated from the
+       RPE selector's swatches so it can carry a whole page of history
+       without turning it into a stoplight. */
+    --intensity-0: 210 8% 62%;
+    --intensity-1: 160 32% 45%;
+    --intensity-2: 45 55% 47%;
+    --intensity-3: 24 62% 50%;
+    --intensity-4: 4 60% 50%;
   }
 
   .dark {
@@ -80,6 +89,12 @@
     /* custom add-ons */
     --status-warning: 31 97.2% 72.4%;
     --status-positive: 142 76.6% 73.1%;
+
+    --intensity-0: 210 8% 48%;
+    --intensity-1: 160 30% 52%;
+    --intensity-2: 45 52% 58%;
+    --intensity-3: 24 58% 58%;
+    --intensity-4: 4 58% 58%;
   }
 }
 

--- a/src/utils/formatVolume.ts
+++ b/src/utils/formatVolume.ts
@@ -1,0 +1,2 @@
+export const formatVolume = (kg: number): string =>
+  `${Math.round(kg).toLocaleString()} kg`;

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,5 +1,6 @@
 export * from './bellColors';
 export * from './formatRungDuration';
+export * from './formatVolume';
 export * from './movementSearch';
 export * from './movementWeightModeFilter';
 export * from './ordinalSuffixOf';

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -39,6 +39,13 @@ export default {
         foreground: 'hsl(var(--foreground))',
         ['status-warning']: 'hsl(var(--status-warning))',
         ['status-success']: 'hsl(var(--status-positive))',
+        intensity: {
+          0: 'hsl(var(--intensity-0))',
+          1: 'hsl(var(--intensity-1))',
+          2: 'hsl(var(--intensity-2))',
+          3: 'hsl(var(--intensity-3))',
+          4: 'hsl(var(--intensity-4))',
+        },
         primary: {
           DEFAULT: 'hsl(var(--primary))',
           foreground: 'hsl(var(--primary-foreground))',


### PR DESCRIPTION
## Description

The History page is where a lifter goes to answer "am I training consistently, and how hard?" The old layout could only answer "what did I do on Oct 11" — three levels of chrome (week header → day card → row) wrapped around what is usually a single workout per day, with an overloaded right rail (Complex badge + text RPE pill + volume + duration competing in ~45% of a 375px row) and several latent bugs.

This rebuilds it around the week:

- **Week strip (the signature).** One card per week opening with a 7-segment meter, one per ISO day, tinted by that day's hardest exertion rating. Three states so "skipped" and "hasn't happened yet" don't read alike: trained (intensity color), past untrained (`bg-muted`), future day of the current week (`bg-muted/40`). Non-interactive; announced as a single `role="img"` (e.g. *"Tuesday unrated, Thursday ideal. 2 days not trained."*).
- **Flat rows replace day cards.** Sessions collapse to a `divide-y` list, matching the pattern `ProgramsPage` already uses. The `Complex` badge and text RPE pill are cut — `Complex` becomes a word in the metadata line, RPE becomes a 6px intensity dot leading it. Net chrome per row goes *down*.
- **Fixes carried along.** Raw `date.toDateString()` labels ("Mon Jul 21 2026") become Today/Yesterday/weekday; volume gains thousands separators via a `formatVolume` promoted out of `WeeklyBalance`; the week summary leads with session count so bodyweight-only weeks no longer render a half-empty header (the old `weekVolume > 0 && …` rendered nothing).
- **Intensity tokens.** A desaturated 5-step ramp added as themed CSS variables, tuned separately for light and dark. The RPE selector's saturated swatches are left untouched.

One deviation from the approved plan: I dropped the fixed date gutter. Once "Yesterday" had to fit, an 80px column left the title too little room at 375px, and the strip already carries the temporal scan — so the row's date leads the metadata line instead and the title gets full width.

## How tested

- `npm test` — 489 passed / 75 files. Updated three assertions that described the old markup (`1000 kg` → `1,000 kg`, the date format, the Complex badge); added coverage for week summaries, the bodyweight-only week, the strip's aria-label, and `hardestRpe`.
- `npm run compile:ts` and `npm run lint` — clean.
- Storybook at 375×812, light and dark. No horizontal overflow (375/375) even with a 70-character title truncating on both lines; rows measure 52–53px (44px floor); `focus-visible` confirmed as a 2px inset ring in the `--ring` token; all three strip states render distinctly.
- **Not** run end-to-end against local Supabase — the page is exercised through MSW fixtures in tests and Storybook, but a live logging round-trip is unverified.

## Related issue

<!-- none -->

## Tradeoffs

Considered a **calendar-first** view (a month grid as the primary surface) — it gives the strongest possible consistency read and would scale to longer histories. Rejected for now because it's a much larger change and reorders the whole page's information hierarchy; the week strip delivers most of the consistency signal while keeping the session list primary. The strip encodes exertion with hue, which asks something of color-vision — mitigated by the per-day `role="img"` text, but a future pass could add a non-color cue (height or fill) if it matters.