### PR TITLE
feat(nav): add desktop sidebar, unify nav as one system

### DIFF
--- a/src/app/Root.tsx
+++ b/src/app/Root.tsx
@@ -3,26 +3,31 @@ import { Outlet } from 'react-router-dom';
 import { QueryParamProvider } from 'use-query-params';
 import { ReactRouter6Adapter } from 'use-query-params/adapters/react-router-6';
 
-import { BottomNav, Header, useBottomNavVisible } from '~/components';
+import { BottomNav, Header, Sidebar, useBottomNavVisible } from '~/components';
 import { useFeatures } from '~/hooks';
 
 // Rendered only when the `bottomNav` flag is on so the keyboard subscription in
 // `useBottomNavVisible` never mounts for flag-off sessions, and its focus/blur
-// re-renders stay scoped to the bar and this wrapper instead of all of `Root`.
-const BottomNavLayout = ({ children }: { children: ReactNode }) => {
+// re-renders stay scoped to the nav chrome and this wrapper instead of all of
+// `Root`. Lays out the two coordinated nav surfaces: the desktop `Sidebar` rail
+// (`lg` and up) and the mobile `BottomNav` thumb bar (below `lg`).
+const NavLayout = ({ children }: { children: ReactNode }) => {
   const bottomNavVisible = useBottomNavVisible();
 
   return (
-    <>
-      {/* Offset content so nothing is trapped behind the fixed bar on mobile;
-          the bar is desktop-hidden, so remove the padding at `sm`. Only pad
-          while the bar is actually on screen so immersive routes and the
-          open-keyboard state have no dead space. */}
-      <div className={bottomNavVisible ? 'pb-bottomnav sm:pb-0' : undefined}>
-        {children}
+    <div className="lg:flex">
+      <Sidebar />
+      <div className="min-w-0 flex-1">
+        {/* Offset content so nothing is trapped behind the fixed bar on mobile;
+            the bar is hidden at `lg`, so drop the padding there. Only pad while
+            the bar is actually on screen so immersive routes and the
+            open-keyboard state have no dead space. */}
+        <div className={bottomNavVisible ? 'pb-bottomnav lg:pb-0' : undefined}>
+          {children}
+        </div>
       </div>
       <BottomNav />
-    </>
+    </div>
   );
 };
 
@@ -31,13 +36,16 @@ export const Root = () => {
 
   return (
     <QueryParamProvider adapter={ReactRouter6Adapter}>
-      <Header />
       {features.bottomNav ? (
-        <BottomNavLayout>
+        // The Sidebar (desktop) + BottomNav (mobile) own navigation; no top Header.
+        <NavLayout>
           <Outlet />
-        </BottomNavLayout>
+        </NavLayout>
       ) : (
-        <Outlet />
+        <>
+          <Header />
+          <Outlet />
+        </>
       )}
     </QueryParamProvider>
   );

--- a/src/components/BottomNav/BottomNav.tsx
+++ b/src/components/BottomNav/BottomNav.tsx
@@ -23,11 +23,21 @@ import { buildTabs } from './buildTabs';
 import { useBottomNavVisible } from './useBottomNavVisible';
 
 const cellClasses =
-  'flex flex-1 flex-col items-center justify-center gap-0.5 text-muted-foreground transition-colors active:bg-accent/50 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring';
+  'm-0.5 flex flex-1 flex-col items-center justify-center gap-0.5 rounded-md text-muted-foreground transition-colors active:bg-accent/50 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring';
+
+// Shared active affordance — the soft primary-tinted pill, matched to the
+// desktop sidebar so both nav surfaces read as one system.
+const activeCellClasses = 'bg-primary/10 text-primary';
+
+// Rows inside the "More" sheet; horizontal like the sidebar's rows, so they use
+// the same active pill.
+const sheetRowClasses =
+  'flex items-center gap-1 rounded-md px-2 py-1.5 text-sm text-muted-foreground transition-colors hover:bg-accent/50 hover:text-foreground';
+const sheetActiveClasses = 'bg-primary/10 text-primary';
 
 /**
  * Fixed bottom "thumb" navigation for mobile viewports. Hidden on desktop
- * (`sm:hidden`) where the top Header remains the nav. Gated behind the
+ * (`lg:hidden`) where the `Sidebar` rail takes over. Gated behind the
  * `bottomNav` feature flag, and suppressed on immersive routes and while a text
  * input is focused (mobile keyboard). See the thumb-nav design plan.
  */
@@ -43,23 +53,31 @@ export const BottomNav = () => {
   return (
     <nav
       aria-label="Primary"
-      className="fixed inset-x-0 bottom-0 z-40 border-t border-border bg-background/95 backdrop-blur sm:hidden"
+      className="fixed inset-x-0 bottom-0 z-40 border-t border-border bg-background/95 backdrop-blur lg:hidden"
       style={{ paddingBottom: 'env(safe-area-inset-bottom, 0)' }}
     >
       <ul className="flex h-6">
         {tabs.map((tab) => {
-          const Icon = tab.icon;
+          const { icon: Icon, activeIcon: ActiveIcon } = tab;
           return (
             <li key={tab.key} className="flex flex-1">
               <NavLink
                 to={tab.to}
                 end={tab.to === '/'}
                 className={({ isActive }) =>
-                  cn(cellClasses, isActive && 'text-primary')
+                  cn(cellClasses, isActive && activeCellClasses)
                 }
               >
-                <Icon className="h-3 w-3" aria-hidden="true" />
-                <span className="text-xs">{tab.label}</span>
+                {({ isActive }) => (
+                  <>
+                    {isActive ? (
+                      <ActiveIcon className="h-3 w-3" aria-hidden="true" />
+                    ) : (
+                      <Icon className="h-3 w-3" aria-hidden="true" />
+                    )}
+                    <span className="text-xs">{tab.label}</span>
+                  </>
+                )}
               </NavLink>
             </li>
           );
@@ -86,10 +104,7 @@ export const BottomNav = () => {
                   <NavLink
                     to="/account"
                     className={({ isActive }) =>
-                      cn(
-                        'flex items-center gap-1 rounded-md px-2 py-1.5 text-sm transition-colors hover:bg-accent hover:text-accent-foreground',
-                        isActive && 'bg-accent text-accent-foreground',
-                      )
+                      cn(sheetRowClasses, isActive && sheetActiveClasses)
                     }
                   >
                     <UserCircleIcon className="h-3 w-3" aria-hidden="true" />
@@ -104,10 +119,7 @@ export const BottomNav = () => {
                       <NavLink
                         to={feature.to}
                         className={({ isActive }) =>
-                          cn(
-                            'flex items-center gap-1 rounded-md px-2 py-1.5 text-sm transition-colors hover:bg-accent hover:text-accent-foreground',
-                            isActive && 'bg-accent text-accent-foreground',
-                          )
+                          cn(sheetRowClasses, isActive && sheetActiveClasses)
                         }
                       >
                         <Icon className="h-3 w-3" aria-hidden="true" />
@@ -120,7 +132,7 @@ export const BottomNav = () => {
                 <button
                   type="button"
                   onClick={handleClickLightDarkMode}
-                  className="flex items-center gap-1 rounded-md px-2 py-1.5 text-left text-sm transition-colors hover:bg-accent hover:text-accent-foreground"
+                  className={cn(sheetRowClasses, 'text-left')}
                 >
                   <MoonIcon className="h-3 w-3" aria-hidden="true" />
                   Light / Dark
@@ -129,7 +141,7 @@ export const BottomNav = () => {
                 <button
                   type="button"
                   onClick={handleSignOut}
-                  className="flex items-center gap-1 rounded-md px-2 py-1.5 text-left text-sm transition-colors hover:bg-accent hover:text-accent-foreground"
+                  className={cn(sheetRowClasses, 'text-left')}
                 >
                   <ArrowRightOnRectangleIcon
                     className="h-3 w-3"

--- a/src/components/BottomNav/buildTabs.ts
+++ b/src/components/BottomNav/buildTabs.ts
@@ -1,80 +1,22 @@
-import {
-  ClockIcon,
-  HomeIcon,
-  MagnifyingGlassIcon,
-  RectangleStackIcon,
-  ScaleIcon,
-  SparklesIcon,
-} from '@heroicons/react/24/outline';
-import { ComponentType, SVGProps } from 'react';
-
 import { Features } from '~/config/features';
+import { NavItem, navItemByKey } from '~/lib/navItems';
 
-export type NavIcon = ComponentType<SVGProps<SVGSVGElement>>;
-
-export interface NavTab {
-  /** Stable identity for React keys and tests. */
-  key: string;
-  /** Visible label rendered beneath the icon. */
-  label: string;
-  /** Router destination. */
-  to: string;
-  icon: NavIcon;
-}
-
-/**
- * Feature-gated destinations, in slot-4 promotion priority order. The first
- * enabled feature is promoted into the bar; the rest degrade into "More".
- */
-const PRIORITY_FEATURES: {
-  key: string;
-  flag: keyof Features;
-  label: string;
-  to: string;
-  icon: NavIcon;
-}[] = [
-  {
-    key: 'ai',
-    flag: 'premium',
-    label: 'AI',
-    to: '/recommendations',
-    icon: SparklesIcon,
-  },
-  {
-    key: 'balance',
-    flag: 'weeklyBalance',
-    label: 'Balance',
-    to: '/balance',
-    icon: ScaleIcon,
-  },
-  {
-    key: 'explore',
-    flag: 'explore',
-    label: 'Explore',
-    to: '/movements',
-    icon: MagnifyingGlassIcon,
-  },
-];
+// Promoted-slot priority (slot 4): the first enabled feature wins the bar; the
+// rest degrade into "More". See §3 of the thumb-nav design plan.
+const PRIORITY_KEYS = ['ai', 'balance', 'explore'] as const;
 
 export interface BuiltTabs {
   /** Link tabs rendered directly in the bar, left of the always-present "More". */
-  tabs: NavTab[];
+  tabs: NavItem[];
   /** Enabled features that did not win the promoted slot; shown inside "More". */
-  moreFeatures: NavTab[];
+  moreFeatures: NavItem[];
 }
 
-const stripFlag = (f: (typeof PRIORITY_FEATURES)[number]): NavTab => ({
-  key: f.key,
-  label: f.label,
-  to: f.to,
-  icon: f.icon,
-});
-
 /**
- * Deterministic 5-slot priority fill for the bottom tab bar (see the thumb-nav
- * design plan §3). Slots, in order:
+ * Deterministic 5-slot priority fill for the bottom tab bar, built from the
+ * shared `NAV_ITEMS` registry (see `~/lib/navItems`). Slots, in order:
  *   1. Home        (always)
- *   2. Programs    (reserved — see TODO below)
+ *   2. Programs    (reserved; `programs` flag)
  *   3. History     (always)
  *   4. one promoted feature, AI → Balance → Explore (first enabled wins)
  *   5. More        (always; rendered by the component, not part of `tabs`)
@@ -82,27 +24,18 @@ const stripFlag = (f: (typeof PRIORITY_FEATURES)[number]): NavTab => ({
  * Pure and side-effect free so every flag combination is cheap to unit-test.
  */
 export const buildTabs = (features: Features): BuiltTabs => {
-  const tabs: NavTab[] = [
-    { key: 'home', label: 'Home', to: '/', icon: HomeIcon },
-    // Slot 2 is reserved for Programs (design plan §3), gated by the `programs`
-    // flag until the feature is flipped on.
-    ...(features.programs
-      ? [
-          {
-            key: 'programs',
-            label: 'Programs',
-            to: '/programs',
-            icon: RectangleStackIcon,
-          },
-        ]
-      : []),
-    { key: 'history', label: 'History', to: '/history', icon: ClockIcon },
+  const tabs: NavItem[] = [
+    navItemByKey('home'),
+    ...(features.programs ? [navItemByKey('programs')] : []),
+    navItemByKey('history'),
   ];
 
-  const enabled = PRIORITY_FEATURES.filter((f) => features[f.flag]);
+  const enabled = PRIORITY_KEYS.map(navItemByKey).filter(
+    (item) => item.flag && features[item.flag],
+  );
   const [promoted, ...overflow] = enabled;
 
-  if (promoted) tabs.push(stripFlag(promoted));
+  if (promoted) tabs.push(promoted);
 
-  return { tabs, moreFeatures: overflow.map(stripFlag) };
+  return { tabs, moreFeatures: overflow };
 };

--- a/src/components/Sidebar/Sidebar.stories.tsx
+++ b/src/components/Sidebar/Sidebar.stories.tsx
@@ -1,0 +1,48 @@
+import { Session } from '@supabase/supabase-js';
+import type React from 'react';
+import { MemoryRouter } from 'react-router-dom';
+
+import { setPreviewOverrideEnabled } from '~/config/features';
+import { SessionProvider } from '~/contexts';
+
+import { Sidebar } from './Sidebar';
+
+// The rail reads flags from the session-aware `useFeatures()` hook and is
+// desktop-only (`hidden lg:flex`). Use an owner session + the preview override
+// so every destination resolves on, and view it on a wide (>=1024px) canvas.
+const ownerSession = {
+  user: { email: 'daniel_bowers@icloud.com' },
+} as unknown as Session;
+
+setPreviewOverrideEnabled(true);
+
+export default {
+  component: Sidebar,
+  decorators: [
+    (Story: () => React.JSX.Element) => (
+      <SessionProvider value={ownerSession}>
+        <Story />
+      </SessionProvider>
+    ),
+  ],
+};
+
+export const Default = {
+  decorators: [
+    (Story: () => React.JSX.Element) => (
+      <MemoryRouter initialEntries={['/']}>
+        <Story />
+      </MemoryRouter>
+    ),
+  ],
+};
+
+export const OnHistory = {
+  decorators: [
+    (Story: () => React.JSX.Element) => (
+      <MemoryRouter initialEntries={['/history']}>
+        <Story />
+      </MemoryRouter>
+    ),
+  ],
+};

--- a/src/components/Sidebar/Sidebar.test.tsx
+++ b/src/components/Sidebar/Sidebar.test.tsx
@@ -1,0 +1,87 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { Mock, beforeEach, vi } from 'vitest';
+
+import { Features } from '~/config/features';
+import { useFeatures } from '~/hooks';
+
+import { Sidebar } from './Sidebar';
+
+vi.mock('~/hooks', () => ({
+  useFeatures: vi.fn(),
+}));
+
+const mockedUseFeatures = useFeatures as unknown as Mock;
+
+const featuresWith = (overrides: Partial<Features> = {}): Features => ({
+  bottomNav: true,
+  complexMode: false,
+  explore: false,
+  premium: false,
+  programs: false,
+  weeklyBalance: false,
+  ...overrides,
+});
+
+const renderSidebar = (initialPath = '/') =>
+  render(
+    <MemoryRouter initialEntries={[initialPath]}>
+      <Sidebar />
+    </MemoryRouter>,
+  );
+
+beforeEach(() => {
+  mockedUseFeatures.mockReset();
+});
+
+describe('Sidebar', () => {
+  test('renders the brand and the always-on destinations', () => {
+    mockedUseFeatures.mockReturnValue(featuresWith());
+    renderSidebar();
+    expect(
+      screen.getByRole('navigation', { name: 'Primary' }),
+    ).toBeInTheDocument();
+    expect(screen.getByText('BellSkill')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Home' })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'History' })).toBeInTheDocument();
+  });
+
+  test('reveals flag-gated destinations only when enabled', () => {
+    mockedUseFeatures.mockReturnValue(featuresWith());
+    renderSidebar();
+    expect(screen.queryByRole('link', { name: 'Programs' })).toBeNull();
+    expect(screen.queryByRole('link', { name: 'AI' })).toBeNull();
+
+    mockedUseFeatures.mockReturnValue(
+      featuresWith({ programs: true, premium: true }),
+    );
+    renderSidebar();
+    expect(screen.getByRole('link', { name: 'Programs' })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'AI' })).toBeInTheDocument();
+  });
+
+  test('exposes the Account link, theme toggle and Sign Out', () => {
+    mockedUseFeatures.mockReturnValue(featuresWith());
+    renderSidebar();
+    expect(screen.getByRole('link', { name: /Account/ })).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /Light \/ Dark/ }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /Sign Out/ }),
+    ).toBeInTheDocument();
+  });
+
+  test('marks the active destination with aria-current', () => {
+    mockedUseFeatures.mockReturnValue(featuresWith());
+    renderSidebar('/history');
+    expect(screen.getByRole('link', { name: 'History' })).toHaveAttribute(
+      'aria-current',
+      'page',
+    );
+    // `end` on Home keeps it inactive on other routes.
+    expect(screen.getByRole('link', { name: 'Home' })).not.toHaveAttribute(
+      'aria-current',
+    );
+  });
+});

--- a/src/components/Sidebar/Sidebar.tsx
+++ b/src/components/Sidebar/Sidebar.tsx
@@ -1,0 +1,112 @@
+import {
+  ArrowRightOnRectangleIcon,
+  MoonIcon,
+  UserCircleIcon,
+} from '@heroicons/react/24/outline';
+import { UserCircleIcon as UserCircleSolidIcon } from '@heroicons/react/24/solid';
+import { NavLink } from 'react-router-dom';
+
+import { useFeatures } from '~/hooks';
+import { handleClickLightDarkMode, handleSignOut } from '~/lib/nav-actions';
+import { NavIcon, getNavItems } from '~/lib/navItems';
+import { cn } from '~/lib/utils';
+
+const rowClasses =
+  'flex items-center gap-1 rounded-md px-2 py-1.5 text-sm font-medium text-muted-foreground transition-colors hover:bg-accent/50 hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring';
+
+// The shared active affordance: a soft primary-tinted pill. Kept identical to
+// the bottom bar's active cell so the two nav surfaces read as one system.
+const activeClasses = 'bg-primary/10 text-primary';
+
+/**
+ * Desktop-only left navigation rail. Hidden below `lg` (`hidden lg:flex`), where
+ * the `BottomNav` thumb bar takes over. Rendered by `Root` only when the
+ * `bottomNav` feature flag is on; the flag-off path keeps the top `Header`.
+ */
+export const Sidebar = () => {
+  const features = useFeatures();
+  const items = getNavItems(features);
+
+  return (
+    <aside className="sticky top-0 hidden h-screen w-[240px] shrink-0 flex-col border-r border-sidebar-border bg-sidebar text-sidebar-foreground lg:flex">
+      <div className="px-1.5 py-2">
+        <div className="flex items-center gap-1 px-2">
+          <img
+            src="/favicon.svg"
+            alt=""
+            className="h-2.5 w-2.5"
+            aria-hidden="true"
+          />
+          <span className="text-lg font-medium">BellSkill</span>
+        </div>
+      </div>
+
+      <nav aria-label="Primary" className="flex flex-col gap-0.5 px-1.5">
+        {items.map((item) => (
+          <NavRow
+            key={item.key}
+            to={item.to}
+            label={item.label}
+            icon={item.icon}
+            activeIcon={item.activeIcon}
+            end={item.to === '/'}
+          />
+        ))}
+      </nav>
+
+      <div className="mt-auto flex flex-col gap-0.5 px-1.5 pb-2">
+        <NavRow
+          to="/account"
+          label="Account"
+          icon={UserCircleIcon}
+          activeIcon={UserCircleSolidIcon}
+        />
+
+        <button
+          type="button"
+          onClick={handleClickLightDarkMode}
+          className={cn(rowClasses, 'text-left')}
+        >
+          <MoonIcon className="h-3 w-3" aria-hidden="true" />
+          Light / Dark
+        </button>
+
+        <button
+          type="button"
+          onClick={handleSignOut}
+          className={cn(rowClasses, 'text-left')}
+        >
+          <ArrowRightOnRectangleIcon className="h-3 w-3" aria-hidden="true" />
+          Sign Out
+        </button>
+      </div>
+    </aside>
+  );
+};
+
+interface NavRowProps {
+  to: string;
+  label: string;
+  icon: NavIcon;
+  activeIcon: NavIcon;
+  end?: boolean;
+}
+
+const NavRow = ({ to, label, icon: Icon, activeIcon: ActiveIcon, end }: NavRowProps) => (
+  <NavLink
+    to={to}
+    end={end}
+    className={({ isActive }) => cn(rowClasses, isActive && activeClasses)}
+  >
+    {({ isActive }) => (
+      <>
+        {isActive ? (
+          <ActiveIcon className="h-3 w-3" aria-hidden="true" />
+        ) : (
+          <Icon className="h-3 w-3" aria-hidden="true" />
+        )}
+        {label}
+      </>
+    )}
+  </NavLink>
+);

--- a/src/components/Sidebar/index.ts
+++ b/src/components/Sidebar/index.ts
@@ -1,0 +1,1 @@
+export * from './Sidebar';

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -7,6 +7,7 @@ export * from './PWAInstallPrompt';
 export * from './Page';
 export * from './PremiumGate';
 export * from './SafeAreaWrapper';
+export * from './Sidebar';
 export * from './TrialStatusPill';
 export * from './ValueCarousel';
 export * from './WeeklyBalance';

--- a/src/lib/navItems.test.ts
+++ b/src/lib/navItems.test.ts
@@ -1,0 +1,81 @@
+import { Features } from '~/config/features';
+
+import { getNavItems, navItemByKey } from './navItems';
+
+const allOff: Features = {
+  bottomNav: true,
+  complexMode: false,
+  explore: false,
+  premium: false,
+  programs: false,
+  weeklyBalance: false,
+};
+
+const keys = (features: Features) => getNavItems(features).map((i) => i.key);
+
+describe('getNavItems', () => {
+  test('always includes the Home and History anchors, in order', () => {
+    expect(keys(allOff)).toEqual(['home', 'history']);
+  });
+
+  test('reveals each destination only when its flag is on', () => {
+    expect(keys({ ...allOff, programs: true })).toEqual([
+      'home',
+      'programs',
+      'history',
+    ]);
+    expect(keys({ ...allOff, explore: true })).toEqual([
+      'home',
+      'explore',
+      'history',
+    ]);
+    expect(keys({ ...allOff, premium: true })).toEqual([
+      'home',
+      'ai',
+      'history',
+    ]);
+    expect(keys({ ...allOff, weeklyBalance: true })).toEqual([
+      'home',
+      'balance',
+      'history',
+    ]);
+  });
+
+  test('keeps sidebar display order with every flag on', () => {
+    const allOn: Features = {
+      ...allOff,
+      programs: true,
+      explore: true,
+      premium: true,
+      weeklyBalance: true,
+    };
+    expect(keys(allOn)).toEqual([
+      'home',
+      'programs',
+      'explore',
+      'ai',
+      'balance',
+      'history',
+    ]);
+  });
+
+  test('carries both an outline and a solid icon for each destination', () => {
+    for (const item of getNavItems(allOff)) {
+      expect(item.icon).toBeTruthy();
+      expect(item.activeIcon).toBeTruthy();
+    }
+  });
+});
+
+describe('navItemByKey', () => {
+  test('resolves a known destination', () => {
+    expect(navItemByKey('ai')).toMatchObject({
+      label: 'AI',
+      to: '/recommendations',
+    });
+  });
+
+  test('throws on an unknown key', () => {
+    expect(() => navItemByKey('nope')).toThrow(/Unknown nav item/);
+  });
+});

--- a/src/lib/navItems.ts
+++ b/src/lib/navItems.ts
@@ -1,0 +1,102 @@
+import {
+  ClockIcon,
+  HomeIcon,
+  MagnifyingGlassIcon,
+  RectangleStackIcon,
+  ScaleIcon,
+  SparklesIcon,
+} from '@heroicons/react/24/outline';
+import {
+  ClockIcon as ClockSolidIcon,
+  HomeIcon as HomeSolidIcon,
+  MagnifyingGlassIcon as MagnifyingGlassSolidIcon,
+  RectangleStackIcon as RectangleStackSolidIcon,
+  ScaleIcon as ScaleSolidIcon,
+  SparklesIcon as SparklesSolidIcon,
+} from '@heroicons/react/24/solid';
+import { ComponentType, SVGProps } from 'react';
+
+import { Features } from '~/config/features';
+
+export type NavIcon = ComponentType<SVGProps<SVGSVGElement>>;
+
+export interface NavItem {
+  /** Stable identity for React keys and tests. */
+  key: string;
+  /** Visible label. */
+  label: string;
+  /** Router destination. */
+  to: string;
+  /** Outline icon, shown when the destination is inactive. */
+  icon: NavIcon;
+  /** Solid icon, shown when the destination is active. */
+  activeIcon: NavIcon;
+  /** Feature flag gating this destination; omit for always-on anchors. */
+  flag?: keyof Features;
+}
+
+/**
+ * The full set of primary destinations, in sidebar display order — the single
+ * source of truth shared by the desktop `Sidebar` and the mobile `BottomNav`
+ * (via `buildTabs`). The bottom bar reorders and overflows this list into its
+ * 5-slot layout; the sidebar renders it as-is.
+ */
+export const NAV_ITEMS: NavItem[] = [
+  {
+    key: 'home',
+    label: 'Home',
+    to: '/',
+    icon: HomeIcon,
+    activeIcon: HomeSolidIcon,
+  },
+  {
+    key: 'programs',
+    label: 'Programs',
+    to: '/programs',
+    icon: RectangleStackIcon,
+    activeIcon: RectangleStackSolidIcon,
+    flag: 'programs',
+  },
+  {
+    key: 'explore',
+    label: 'Explore',
+    to: '/movements',
+    icon: MagnifyingGlassIcon,
+    activeIcon: MagnifyingGlassSolidIcon,
+    flag: 'explore',
+  },
+  {
+    key: 'ai',
+    label: 'AI',
+    to: '/recommendations',
+    icon: SparklesIcon,
+    activeIcon: SparklesSolidIcon,
+    flag: 'premium',
+  },
+  {
+    key: 'balance',
+    label: 'Balance',
+    to: '/balance',
+    icon: ScaleIcon,
+    activeIcon: ScaleSolidIcon,
+    flag: 'weeklyBalance',
+  },
+  {
+    key: 'history',
+    label: 'History',
+    to: '/history',
+    icon: ClockIcon,
+    activeIcon: ClockSolidIcon,
+  },
+];
+
+/** Destinations visible for the given flags, in sidebar order. */
+export const getNavItems = (features: Features): NavItem[] =>
+  NAV_ITEMS.filter((item) => !item.flag || features[item.flag]);
+
+/** Look up a destination by key (throws on unknown key — a programming error). */
+export const navItemByKey = (key: string): NavItem => {
+  const item = NAV_ITEMS.find((i) => i.key === key);
+  if (!item) throw new Error(`Unknown nav item: ${key}`);
+  return item;
+};

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -67,6 +67,16 @@ export default {
           DEFAULT: 'hsl(var(--card))',
           foreground: 'hsl(var(--card-foreground))',
         },
+        sidebar: {
+          DEFAULT: 'hsl(var(--sidebar))',
+          foreground: 'hsl(var(--sidebar-foreground))',
+          primary: 'hsl(var(--sidebar-primary))',
+          'primary-foreground': 'hsl(var(--sidebar-primary-foreground))',
+          accent: 'hsl(var(--sidebar-accent))',
+          'accent-foreground': 'hsl(var(--sidebar-accent-foreground))',
+          border: 'hsl(var(--sidebar-border))',
+          ring: 'hsl(var(--sidebar-ring))',
+        },
       },
       borderRadius: {
         lg: 'var(--radius)',


### PR DESCRIPTION
## Why

There was no dedicated desktop navigation. With the `bottomNav` flag on, the mobile bottom bar owned small screens and the old top `Header` was simply re-shown at `sm` — a repurposed bar, not a designed desktop surface. Nav destinations were also declared twice (in `buildTabs` and inline in `Header`), so they could drift.

## What

Adds a dedicated left-sidebar rail for desktop and refreshes the mobile bottom bar so both surfaces share one active-state language: a filled Heroicon + primary label in a soft primary-tinted pill. Destinations now come from a single `getNavItems` source consumed by both surfaces, and the desktop/mobile split moves from `sm` to `lg` so tablets keep the thumb bar. The sidebar wires up the `--sidebar-*` theme tokens that already shipped unused.

## How to test

- `npm test` (522 pass — new `navItems` and `Sidebar` suites), `npm run compile:ts`, `npm run lint` — all green.
- Storybook: `Sidebar` (Default / On History) and `BottomNav` stories — verified the active pill + solid-icon swap, footer pinned to the bottom, light + dark, and the `lg` breakpoint (rail hidden below 1024px, bottom bar hidden at/above).
- In-app: set `VITE_FEATURE_BOTTOMNAV=true` (e.g. a gitignored `.env.local`) and sign in — desktop shows the rail beside content; tablet and mobile keep the bottom bar.

## Gallery

**Desktop sidebar (new UI)** — light / dark

<!-- drop sidebar-light.png and sidebar-dark.png here -->

**Bottom bar (changed UI)** — active state is now a filled icon + primary-tinted pill (was bare colored text)

Before:

<!-- drop bottomnav-before.png here -->

After:

<!-- drop bottomnav-after.png here -->

## Deploy notes

No migrations or env changes. The redesign rides the existing `bottomNav` flag — its name is now slightly stale since it also gates the desktop sidebar, left as-is to avoid config/test churn. The flag-off path keeps the old top `Header` untouched.

## Tradeoffs

Considered redesigning the top bar instead of adding a sidebar; a left rail is the standard dedicated-desktop pattern and the theme already carried unused `--sidebar-*` tokens pointing that way. Kept the `bottomNav` flag name rather than renaming it to limit blast radius across config and tests.
