### PR TITLE
feat(programs): pick a starting weight per movement on enrollment

### DIFF
--- a/docs/program-tracking.md
+++ b/docs/program-tracking.md
@@ -233,3 +233,25 @@ session — atomic), and the PROD-219 editing pair `reorder_program_sessions` /
   values/units verbatim, no offset math and no unit-match check; (3) otherwise
   the offset math. Omitting `p_weight_overrides` is byte-identical to the
   offset-only behavior, and an entry matching no session is a silent no-op.
+- **Per-movement starting weights (current):** the shared-weight + weight-group
+  model above applied one weight to every movement in a session, which is right
+  only when a session's movements share a config. Easy Strength mixes a
+  bodyweight pull-up, a single-bell swing and double-bell lifts, so the uniform
+  fold turned the pull-up and swing into doubles. Enrollment now picks a weight
+  **per movement**: `ProgramDetailsPage` renders one control per distinct
+  movement, sized to its config via `deriveMovementWeights`
+  (`ProgramDetailsPage/utils`) + `getWeightTabValue` — bodyweight movements show
+  a "Bodyweight" line (no picker), single-bell one input, double two — and sends
+  them as `p_movement_weights` (`MovementWeight[]` on `useEnrollProgram`), keyed
+  by `movementName`. `enroll_in_program`
+  (`*_enroll_in_program_per_movement_weights.sql`) rebuilds each session's
+  `movements[]`, applying the chosen weight in that movement's own config shape
+  (preserving null/0 slots) shifted by that movement's authored per-session
+  offset from its **per-movement** modal, so cross-session scaling still holds.
+  `complexSet` programs (one bell pair for the whole complex, ABC) keep the
+  single shared-weight picker and the uniform fold; a caller that passes only
+  `p_shared_weight_*` (the homogeneous programs' e2e path) also takes the fold,
+  so the shared-weight API stays backward-compatible. `deriveWeightGroups` +
+  `applyGroupOffset` + `p_weight_overrides` are retired from the enrollment flow
+  (per-movement offset replaces per-group override); `deriveStartingWeight` is
+  kept only to pre-fill the `complexSet` shared picker.

--- a/e2e/program-easy-strength.spec.ts
+++ b/e2e/program-easy-strength.spec.ts
@@ -96,8 +96,11 @@ async function rpcPost<T = unknown>(
 interface MovementOpt {
   movementName: string;
   repScheme: number[];
+  timedRungs?: boolean;
   weightOneValue: number | null;
+  weightOneUnit: string | null;
   weightTwoValue: number | null;
+  weightTwoUnit: string | null;
 }
 interface WorkoutOpts {
   complexSet: boolean;
@@ -115,7 +118,8 @@ interface SessionRow {
 }
 
 // The "Even Easier Strength" 10-workout / 2-week cycle: one shared rep scheme per
-// session applied across all five movement patterns.
+// session applied across the rep-counted movements. The Farmer's Carry runs on
+// the clock instead (a fixed 30-second rung), so it carries its own scheme.
 const EXPECTED_REP_SCHEMES: number[][] = [
   [5, 5], // W1D1 2x5
   [5, 5], // W1D2 2x5
@@ -189,9 +193,15 @@ test.describe('program schema — Easy Strength seed', () => {
         EXPECTED_MOVEMENTS,
       );
 
-      // Each movement carries this session's rep scheme.
+      // Each rep-counted movement carries this session's rep scheme; the timed
+      // carry runs on its own fixed 30-second rung.
       for (const m of s.workout_options.movements) {
-        expect(m.repScheme).toEqual(expectedReps);
+        if (m.movementName === "Kettlebell Farmer's Carry") {
+          expect(m.timedRungs).toBe(true);
+          expect(m.repScheme).toEqual([30]);
+        } else {
+          expect(m.repScheme).toEqual(expectedReps);
+        }
       }
 
       // Straight sets: both sets of a movement before the next movement, per the
@@ -218,6 +228,8 @@ test.describe('program schema — Easy Strength seed', () => {
         24,
       );
       expect(byName["Kettlebell Farmer's Carry"].weightTwoValue).toBe(24);
+      // The carry is a timed double-bell movement, not rep-counted.
+      expect(byName["Kettlebell Farmer's Carry"].timedRungs).toBe(true);
     });
   });
 
@@ -276,5 +288,87 @@ test.describe('program schema — Easy Strength seed', () => {
     expect(cloned.every((s) => s.workout_options.straightSets === true)).toBe(
       true,
     );
+  });
+
+  // The regression this feature exists for: enrolling with a starting weight
+  // used to fold ONE weight onto every movement, turning the bodyweight pull-up
+  // and single-bell swing into doubles. Per-movement weights must land in each
+  // movement's own config shape.
+  test('enrolling with per-movement weights preserves each movement’s config', async () => {
+    const user = await signUpThrowawayUser();
+    const [es] = await restJson<Array<{ id: string }>>(
+      `programs?slug=eq.${ES_SLUG}&select=id`,
+      user.token,
+    );
+
+    const userProgramId = await rpcPost<string>(
+      'enroll_in_program',
+      {
+        p_program_id: es.id,
+        p_movement_weights: [
+          {
+            movementName: 'Double Kettlebell Military Press',
+            weightOneValue: 20,
+            weightOneUnit: 'kilograms',
+            weightTwoValue: 20,
+            weightTwoUnit: 'kilograms',
+          },
+          {
+            movementName: 'Kettlebell Swing',
+            weightOneValue: 32,
+            weightOneUnit: 'kilograms',
+            weightTwoValue: null,
+            weightTwoUnit: null,
+          },
+          {
+            movementName: 'Double Kettlebell Front Squat',
+            weightOneValue: 28,
+            weightOneUnit: 'kilograms',
+            weightTwoValue: 28,
+            weightTwoUnit: 'kilograms',
+          },
+          {
+            movementName: "Kettlebell Farmer's Carry",
+            weightOneValue: 40,
+            weightOneUnit: 'kilograms',
+            weightTwoValue: 40,
+            weightTwoUnit: 'kilograms',
+          },
+        ],
+      },
+      user.token,
+    );
+
+    const [enrollment] = await restJson<Array<{ program_id: string }>>(
+      `user_programs?id=eq.${userProgramId}&select=program_id`,
+      user.token,
+    );
+
+    const [first] = await restJson<Array<{ workout_options: WorkoutOpts }>>(
+      `program_sessions?program_id=eq.${enrollment.program_id}&sequence_index=eq.0&select=workout_options`,
+      user.token,
+    );
+    const byName = Object.fromEntries(
+      first.workout_options.movements.map((m) => [m.movementName, m]),
+    );
+
+    // Chosen weights land per movement, each in its own config shape.
+    expect(byName['Double Kettlebell Military Press'].weightOneValue).toBe(20);
+    expect(byName['Double Kettlebell Military Press'].weightTwoValue).toBe(20);
+    expect(byName['Double Kettlebell Front Squat'].weightOneValue).toBe(28);
+    expect(byName['Double Kettlebell Front Squat'].weightTwoValue).toBe(28);
+
+    // Bodyweight stays bodyweight — never folded into a double.
+    expect(byName['Pull-Up'].weightOneValue).toBeNull();
+    expect(byName['Pull-Up'].weightTwoValue).toBeNull();
+
+    // Single-bell swing keeps its empty second slot.
+    expect(byName['Kettlebell Swing'].weightOneValue).toBe(32);
+    expect(byName['Kettlebell Swing'].weightTwoValue).toBeNull();
+
+    // The carry takes its chosen double load and stays timed.
+    expect(byName["Kettlebell Farmer's Carry"].weightOneValue).toBe(40);
+    expect(byName["Kettlebell Farmer's Carry"].weightTwoValue).toBe(40);
+    expect(byName["Kettlebell Farmer's Carry"].timedRungs).toBe(true);
   });
 });

--- a/e2e/program-schema.spec.ts
+++ b/e2e/program-schema.spec.ts
@@ -1044,7 +1044,7 @@ test.describe('program schema — enroll_in_program (starting weight, PROD-TBD)'
     }
   });
 
-  test('an explicit weight override beats the derived offset for its group', async () => {
+  test('per-movement weights carry each movement’s cross-session offset', async () => {
     const user = await signUpThrowawayUser();
 
     const [aa] = await restJson<Array<{ id: string }>>(
@@ -1053,19 +1053,15 @@ test.describe('program schema — enroll_in_program (starting weight, PROD-TBD)'
       user.token,
     );
 
-    // The offset would put the deload at 20 - 8 = 12 kg. The enrollee owns a
-    // 14, so the picker sends that group's weight explicitly, keyed by the
-    // group's AUTHORED 16 kg.
+    // Single-bell clean & jerk at 16 kg. The deload weeks are authored 8 kg below
+    // the 24 kg modal, so they must scale to 8 relative to the chosen weight
+    // rather than freezing at their absolute seed load.
     await rpc<string>('enroll_in_program', user.token, {
       p_program_id: aa.id,
-      p_shared_weight_one_value: 20,
-      p_shared_weight_one_unit: 'kilograms',
-      p_shared_weight_two_value: 0,
-      p_weight_overrides: [
+      p_movement_weights: [
         {
-          sourceWeightOneValue: 16,
-          sourceWeightTwoValue: 0,
-          weightOneValue: 14,
+          movementName: 'One-Arm Kettlebell Clean and Jerk',
+          weightOneValue: 16,
           weightOneUnit: 'kilograms',
           weightTwoValue: 0,
           weightTwoUnit: null,
@@ -1078,13 +1074,13 @@ test.describe('program schema — enroll_in_program (starting weight, PROD-TBD)'
       `programs?source_program_id=eq.${aa.id}&owner_id=eq.${user.uid}&select=id`,
       user.token,
     );
+    expect(clones).toHaveLength(1);
 
     const sessions = await restJson<
       Array<{
         week_number: number;
         weight_label: string | null;
         workout_options: {
-          sharedWeightOneValue: number | null;
           movements: Array<{ weightOneValue: number; weightTwoValue: number }>;
         };
       }>
@@ -1098,19 +1094,16 @@ test.describe('program schema — enroll_in_program (starting weight, PROD-TBD)'
     for (const session of sessions) {
       const isDeloadWeek = AA_DELOAD_WEEKS.includes(session.week_number);
       expect(session.workout_options.movements[0].weightOneValue).toBe(
-        isDeloadWeek ? 14 : 20,
+        isDeloadWeek ? 8 : 16,
       );
-      // Single-bell loading survives the override: weight two stays 0, never
-      // clamped up to 1.
+      // Single-bell loading survives: weight two stays 0, never clamped up to 1.
       expect(session.workout_options.movements[0].weightTwoValue).toBe(0);
       // The group's authored label rides along onto the clone.
-      expect(session.weight_label).toBe(
-        isDeloadWeek ? 'Deload weeks' : null,
-      );
+      expect(session.weight_label).toBe(isDeloadWeek ? 'Deload weeks' : null);
     }
   });
 
-  test('an override in a different unit lands verbatim, where the offset path declines', async () => {
+  test('a per-movement weight in a different unit lands flat, declining the offset', async () => {
     const user = await signUpThrowawayUser();
 
     const [aa] = await restJson<Array<{ id: string }>>(
@@ -1119,19 +1112,14 @@ test.describe('program schema — enroll_in_program (starting weight, PROD-TBD)'
       user.token,
     );
 
-    // Pounds against a kg-authored seed: the offset path refuses to convert and
-    // falls back to a flat override, which silently loses the deload. An
-    // explicit entry is exactly how the picker restores it.
+    // Pounds against a kg-authored seed: no cross-unit arithmetic, so every
+    // session — deload weeks included — lands flat at the chosen 44 lb.
     await rpc<string>('enroll_in_program', user.token, {
       p_program_id: aa.id,
-      p_shared_weight_one_value: 44,
-      p_shared_weight_one_unit: 'pounds',
-      p_shared_weight_two_value: 0,
-      p_weight_overrides: [
+      p_movement_weights: [
         {
-          sourceWeightOneValue: 16,
-          sourceWeightTwoValue: 0,
-          weightOneValue: 26,
+          movementName: 'One-Arm Kettlebell Clean and Jerk',
+          weightOneValue: 44,
           weightOneUnit: 'pounds',
           weightTwoValue: 0,
           weightTwoUnit: null,
@@ -1147,55 +1135,21 @@ test.describe('program schema — enroll_in_program (starting weight, PROD-TBD)'
 
     const sessions = await restJson<
       Array<{
-        week_number: number;
         workout_options: {
           movements: Array<{ weightOneValue: number; weightOneUnit: string }>;
         };
       }>
     >(
       'GET',
-      `program_sessions?program_id=eq.${clones[0].id}&select=week_number,workout_options&order=sequence_index.asc`,
+      `program_sessions?program_id=eq.${clones[0].id}&select=workout_options&order=sequence_index.asc`,
       user.token,
     );
 
     for (const session of sessions) {
-      const isDeloadWeek = AA_DELOAD_WEEKS.includes(session.week_number);
       const movement = session.workout_options.movements[0];
-      expect(movement.weightOneValue).toBe(isDeloadWeek ? 26 : 44);
+      expect(movement.weightOneValue).toBe(44);
       expect(movement.weightOneUnit).toBe('pounds');
     }
-  });
-
-  test('an override matching no session is a no-op, leaving the offset math alone', async () => {
-    const user = await signUpThrowawayUser();
-    const dfwId = await getDfwProgramId(user.token);
-
-    await rpc<string>('enroll_in_program', user.token, {
-      p_program_id: dfwId,
-      p_shared_weight_one_value: 28,
-      p_shared_weight_one_unit: 'kilograms',
-      // No DFW session is authored at 99 kg.
-      p_weight_overrides: [
-        {
-          sourceWeightOneValue: 99,
-          sourceWeightTwoValue: 99,
-          weightOneValue: 8,
-          weightOneUnit: 'kilograms',
-          weightTwoValue: null,
-          weightTwoUnit: null,
-        },
-      ],
-    });
-
-    const { sessions } = await getCloneSessions(user, dfwId);
-
-    // Identical to the no-overrides case: working sessions at the chosen 28,
-    // the test day still carrying its authored +4.
-    for (const session of sessions.filter((s) => s.sequence_index < 13)) {
-      expect(session.workout_options.movements[0].weightOneValue).toBe(28);
-    }
-    const testDay = sessions.find((s) => s.sequence_index === 13);
-    expect(testDay?.workout_options.movements[0].weightOneValue).toBe(32);
   });
 
   test('a starting weight is ignored when enrolling in your own program (no clone, no session mutation)', async () => {

--- a/src/api/useEnrollProgram.test.ts
+++ b/src/api/useEnrollProgram.test.ts
@@ -132,6 +132,61 @@ describe('useEnrollProgram', () => {
     });
   });
 
+  it('passes per-movement weights through as p_movement_weights', async () => {
+    let receivedBody: unknown;
+    server.use(
+      http.post(RPC_URL, async ({ request }) => {
+        receivedBody = await request.json();
+        return HttpResponse.json('new-user-program-id');
+      }),
+    );
+
+    const { result } = renderHook(() => useEnrollProgram(), {
+      wrapper: makeWrapper(),
+    });
+
+    const movementWeights = [
+      {
+        movementName: 'Kettlebell Swing',
+        weightOneValue: 32,
+        weightOneUnit: 'kilograms' as const,
+        weightTwoValue: null,
+        weightTwoUnit: null,
+      },
+    ];
+
+    await result.current.mutateAsync({
+      programId: 'program-abc',
+      movementWeights,
+    });
+
+    expect(receivedBody).toEqual({
+      p_program_id: 'program-abc',
+      p_movement_weights: movementWeights,
+    });
+  });
+
+  it('omits p_movement_weights when the array is empty', async () => {
+    let receivedBody: unknown;
+    server.use(
+      http.post(RPC_URL, async ({ request }) => {
+        receivedBody = await request.json();
+        return HttpResponse.json('new-user-program-id');
+      }),
+    );
+
+    const { result } = renderHook(() => useEnrollProgram(), {
+      wrapper: makeWrapper(),
+    });
+
+    await result.current.mutateAsync({
+      programId: 'program-abc',
+      movementWeights: [],
+    });
+
+    expect(receivedBody).toEqual({ p_program_id: 'program-abc' });
+  });
+
   it('surfaces RPC errors', async () => {
     server.use(
       http.post(RPC_URL, () =>

--- a/src/api/useEnrollProgram.ts
+++ b/src/api/useEnrollProgram.ts
@@ -9,14 +9,15 @@ import { supabase } from '../supabaseClient';
 import { useProgramMutationErrorHandler } from './useProgramMutationErrorHandler';
 
 /**
- * An explicit weight for one of the program's weight groups, keyed by the
- * group's **authored** weight pair. Overrides `enroll_in_program`'s default,
- * which shifts each group by its authored offset from the working weight — so
- * the enrollee can name the bell they actually own for a deload or test day.
+ * The enrollee's chosen starting weight for one movement, keyed by
+ * `movementName`, in that movement's own config shape (a single-bell movement
+ * carries `weightTwoValue` null, a bodyweight one is omitted entirely). The
+ * value is the movement's working weight; `enroll_in_program` shifts each
+ * session by that movement's authored offset from its modal, so a program's
+ * heavier test days and lighter deloads still scale along with it.
  */
-export interface ProgramWeightOverride {
-  sourceWeightOneValue: number | null;
-  sourceWeightTwoValue: number | null;
+export interface MovementWeight {
+  movementName: string;
   weightOneValue: number | null;
   weightOneUnit: WeightUnit | null;
   weightTwoValue: number | null;
@@ -41,8 +42,12 @@ export interface EnrollProgramArgs {
    * the lowest free slot and raises `PROGRAM_SLOTS_FULL`.
    */
   replaceUserProgramId?: string | null;
-  /** Per-group explicit weights; omit to let the RPC derive them by offset. */
-  weightOverrides?: ProgramWeightOverride[];
+  /**
+   * Per-movement starting weights, one entry per distinct non-bodyweight
+   * movement. Omit for complexSet programs (which use the shared weight above)
+   * or to clone verbatim.
+   */
+  movementWeights?: MovementWeight[];
 }
 
 /**
@@ -67,7 +72,7 @@ export const useEnrollProgram = () => {
       sharedWeightTwoValue,
       sharedWeightTwoUnit,
       replaceUserProgramId,
-      weightOverrides,
+      movementWeights,
     }: EnrollProgramArgs): Promise<string> => {
       const { data, error } = await supabase.rpc('enroll_in_program', {
         p_program_id: programId,
@@ -78,9 +83,9 @@ export const useEnrollProgram = () => {
         p_replace_user_program_id: replaceUserProgramId ?? undefined,
         // Cast: the generated RPC arg is `Json`, which a typed interface can't
         // satisfy structurally (no index signature). The shape is asserted by
-        // ProgramWeightOverride and by the enroll e2e cases.
-        p_weight_overrides: weightOverrides?.length
-          ? (weightOverrides as unknown as Json)
+        // MovementWeight and by the enroll e2e cases.
+        p_movement_weights: movementWeights?.length
+          ? (movementWeights as unknown as Json)
           : undefined,
       });
 

--- a/src/pages/ProgramDetailsPage/ProgramDetailsPage.test.tsx
+++ b/src/pages/ProgramDetailsPage/ProgramDetailsPage.test.tsx
@@ -32,27 +32,41 @@ vi.mock('~/contexts', async () => {
   };
 });
 
-// A shared-program session whose first-movement weights drive the derived
-// starting weight. `weightTwo` null → two-hand, 0 → single, >0 → double.
-const sharedSession = (
+// One movement in a session's `movements[]`. The weight config is read from the
+// null-pattern: weightOne null → bodyweight, weightTwo null → two-hand single,
+// weightTwo 0 → single, weightTwo > 0 → double.
+const movement = (
+  movementName: string,
+  weightOne: number | null,
+  weightTwo: number | null,
+) => ({
+  movementName,
+  repScheme: [5],
+  weightOneValue: weightOne,
+  weightOneUnit: weightOne === null ? null : ('kilograms' as const),
+  weightTwoValue: weightTwo,
+  weightTwoUnit:
+    weightTwo === null || weightTwo === 0 ? null : ('kilograms' as const),
+});
+
+const session = (
   seq: number,
   week: number,
   day: number,
   title: string,
-  weightOne: number,
-  weightTwo: number | null,
-  weightLabel: string | null = null,
+  movements: ReturnType<typeof movement>[],
+  { complexSet = false }: { complexSet?: boolean } = {},
 ) => ({
   id: `s-${seq}`,
-  programId: 'dfw-1',
+  programId: 'p-1',
   sequenceIndex: seq,
   weekNumber: week,
   dayNumber: day,
   title,
   notes: null,
-  weightLabel,
+  weightLabel: null,
   workoutOptions: {
-    complexSet: false,
+    complexSet,
     intervalTimer: 0,
     restTimer: 0,
     title: null,
@@ -63,24 +77,7 @@ const sharedSession = (
     sharedWeightOneUnit: null,
     sharedWeightTwoValue: null,
     sharedWeightTwoUnit: null,
-    movements: [
-      {
-        movementName: 'Double Kettlebell Press',
-        repScheme: [5],
-        weightOneValue: weightOne,
-        weightOneUnit: 'kilograms',
-        weightTwoValue: weightTwo,
-        weightTwoUnit: weightTwo ? 'kilograms' : null,
-      },
-      {
-        movementName: 'Kettlebell Swing',
-        repScheme: [10],
-        weightOneValue: weightOne,
-        weightOneUnit: 'kilograms',
-        weightTwoValue: weightTwo,
-        weightTwoUnit: weightTwo ? 'kilograms' : null,
-      },
-    ],
+    movements,
   },
 });
 
@@ -99,9 +96,16 @@ const dfw = {
   archivedAt: null,
 };
 
+// Two double-bell movements at a flat 24 kg.
 const dfwSessions = [
-  sharedSession(0, 1, 1, 'Press Ladders', 24, 24),
-  sharedSession(1, 2, 1, 'Clean & Press', 24, 24),
+  session(0, 1, 1, 'Press Ladders', [
+    movement('Double Kettlebell Press', 24, 24),
+    movement('Kettlebell Swing', 24, 24),
+  ]),
+  session(1, 2, 1, 'Clean & Press', [
+    movement('Double Kettlebell Press', 24, 24),
+    movement('Kettlebell Swing', 24, 24),
+  ]),
 ];
 
 const renderPage = (id = 'dfw-1') =>
@@ -152,68 +156,200 @@ describe('ProgramDetailsPage', () => {
     expect(screen.getAllByText('20 min')).toHaveLength(2);
   });
 
-  it('pre-fills the starting weight from the program and enrolls on Start', () => {
+  it('renders one control per movement, pre-filled, and enrolls per movement', () => {
     enrollMutate.mockImplementation((_input, { onSuccess }) => onSuccess());
 
     renderPage();
 
-    // DFW is double-24: two weight inputs pre-filled at 24.
-    const inputs = screen.getAllByRole('spinbutton');
-    expect(inputs).toHaveLength(2);
-    expect(inputs[0]).toHaveValue(24);
-    expect(inputs[1]).toHaveValue(24);
-
-    // The loading mode is fixed by the program's sessions — no mode tabs to
-    // switch a two-hand program into double bells (mirrors #150).
+    // A heading per distinct movement (separate from the session summary spans).
     expect(
-      screen.queryByRole('tab', { name: 'Two-Hand' }),
-    ).not.toBeInTheDocument();
+      screen.getByRole('heading', { name: 'Double Kettlebell Press' }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', { name: 'Kettlebell Swing' }),
+    ).toBeInTheDocument();
+
+    // Two double movements → two bell inputs each, all pre-filled at 24.
+    const inputs = screen.getAllByRole('spinbutton');
+    expect(inputs).toHaveLength(4);
+    inputs.forEach((input) => expect(input).toHaveValue(24));
 
     fireEvent.click(screen.getByRole('button', { name: 'Start program' }));
 
     expect(enrollMutate).toHaveBeenCalledWith(
       {
         programId: 'dfw-1',
-        sharedWeightOneValue: 24,
-        sharedWeightOneUnit: 'kilograms',
-        sharedWeightTwoValue: 24,
-        sharedWeightTwoUnit: 'kilograms',
+        movementWeights: [
+          {
+            movementName: 'Double Kettlebell Press',
+            weightOneValue: 24,
+            weightOneUnit: 'kilograms',
+            weightTwoValue: 24,
+            weightTwoUnit: 'kilograms',
+          },
+          {
+            movementName: 'Kettlebell Swing',
+            weightOneValue: 24,
+            weightOneUnit: 'kilograms',
+            weightTwoValue: 24,
+            weightTwoUnit: 'kilograms',
+          },
+        ],
       },
       expect.anything(),
     );
-    // Enroll success lands on home.
     expect(screen.getByText('home')).toBeInTheDocument();
   });
 
-  it('pre-fills single loading at the modal weight for a single-bell program', () => {
+  it('sends each movement in its own config shape, omitting bodyweight', () => {
     mockUseProgram.mockReturnValue({
       data: {
-        program: { ...dfw, id: 'snatch-1', title: 'Snatch Test Plan' },
+        program: { ...dfw, id: 'es-1', title: 'Easy Strength' },
         sessions: [
-          sharedSession(0, 1, 1, 'Snatches', 24, 0),
-          sharedSession(1, 1, 2, 'Snatches', 24, 0),
+          session(0, 1, 1, '2x5', [
+            movement('Double Kettlebell Front Squat', 24, 24),
+            movement('Pull-Up', null, null),
+            movement('Kettlebell Swing', 24, null),
+          ]),
         ],
       },
       isLoading: false,
       isError: false,
     });
 
-    renderPage('snatch-1');
+    renderPage('es-1');
 
-    // Single-bell collapses to one weight input at the modal 24kg.
-    const inputs = screen.getAllByRole('spinbutton');
-    expect(inputs).toHaveLength(1);
-    expect(inputs[0]).toHaveValue(24);
+    // Bodyweight movement shows a label, no picker; the single swing collapses to
+    // one input; the double squat keeps two — three inputs total.
+    expect(
+      screen.getByRole('heading', { name: 'Pull-Up' }),
+    ).toBeInTheDocument();
+    expect(screen.getByText('Bodyweight')).toBeInTheDocument();
+    expect(screen.getAllByRole('spinbutton')).toHaveLength(3);
 
     fireEvent.click(screen.getByRole('button', { name: 'Start program' }));
 
     expect(enrollMutate).toHaveBeenCalledWith(
       {
-        programId: 'snatch-1',
+        programId: 'es-1',
+        movementWeights: [
+          {
+            movementName: 'Double Kettlebell Front Squat',
+            weightOneValue: 24,
+            weightOneUnit: 'kilograms',
+            weightTwoValue: 24,
+            weightTwoUnit: 'kilograms',
+          },
+          {
+            movementName: 'Kettlebell Swing',
+            weightOneValue: 24,
+            weightOneUnit: 'kilograms',
+            weightTwoValue: null,
+            weightTwoUnit: null,
+          },
+        ],
+      },
+      expect.anything(),
+    );
+  });
+
+  it('edits one movement independently of the others', () => {
+    renderPage();
+
+    // Drop only the swing; the press stays put.
+    fireEvent.change(screen.getByLabelText('Kettlebell Swing bell 1'), {
+      target: { value: '20' },
+    });
+    expect(screen.getByLabelText('Double Kettlebell Press bell 1')).toHaveValue(
+      24,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Start program' }));
+
+    expect(enrollMutate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        movementWeights: [
+          expect.objectContaining({
+            movementName: 'Double Kettlebell Press',
+            weightOneValue: 24,
+          }),
+          expect.objectContaining({
+            movementName: 'Kettlebell Swing',
+            weightOneValue: 20,
+          }),
+        ],
+      }),
+      expect.anything(),
+    );
+  });
+
+  it('pre-fills each movement at its own modal weight across sessions', () => {
+    // A heavier test day: the press runs at 24 on two working days and 28 once,
+    // so its modal (and pre-fill) is 24 — the RPC applies the per-session offset.
+    mockUseProgram.mockReturnValue({
+      data: {
+        program: { ...dfw, id: 'dfw-1' },
+        sessions: [
+          ...dfwSessions,
+          session(2, 5, 1, 'Test - new press max', [
+            movement('Double Kettlebell Press', 28, 28),
+            movement('Kettlebell Swing', 28, 28),
+          ]),
+        ],
+      },
+      isLoading: false,
+      isError: false,
+    });
+
+    renderPage();
+
+    // No separate "test day" control — one control per movement, at the modal 24.
+    expect(screen.getByLabelText('Double Kettlebell Press bell 1')).toHaveValue(
+      24,
+    );
+    expect(screen.getAllByRole('spinbutton')).toHaveLength(4);
+  });
+
+  it('uses a single shared weight for a complex-set program', () => {
+    mockUseProgram.mockReturnValue({
+      data: {
+        program: { ...dfw, id: 'abc-1', title: 'Armor Building Complex' },
+        sessions: [
+          session(
+            0,
+            1,
+            1,
+            '5 rounds',
+            [
+              movement('Double Kettlebell Clean', 24, 24),
+              movement('Double Kettlebell Military Press', 24, 24),
+              movement('Double Kettlebell Front Squat', 24, 24),
+            ],
+            { complexSet: true },
+          ),
+        ],
+      },
+      isLoading: false,
+      isError: false,
+    });
+
+    renderPage('abc-1');
+
+    // One shared picker (two bells) for the whole complex — not one per movement.
+    expect(
+      screen.queryByRole('heading', { name: 'Double Kettlebell Clean' }),
+    ).not.toBeInTheDocument();
+    expect(screen.getAllByRole('spinbutton')).toHaveLength(2);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Start program' }));
+
+    expect(enrollMutate).toHaveBeenCalledWith(
+      {
+        programId: 'abc-1',
         sharedWeightOneValue: 24,
         sharedWeightOneUnit: 'kilograms',
-        sharedWeightTwoValue: 0,
-        sharedWeightTwoUnit: null,
+        sharedWeightTwoValue: 24,
+        sharedWeightTwoUnit: 'kilograms',
       },
       expect.anything(),
     );
@@ -236,14 +372,11 @@ describe('ProgramDetailsPage', () => {
 
     expect(screen.queryByText('Replace a program?')).not.toBeInTheDocument();
     expect(enrollMutate).toHaveBeenCalledWith(
-      {
+      expect.objectContaining({
         programId: 'dfw-1',
-        sharedWeightOneValue: 24,
-        sharedWeightOneUnit: 'kilograms',
-        sharedWeightTwoValue: 24,
-        sharedWeightTwoUnit: 'kilograms',
         replaceUserProgramId: undefined,
-      },
+        movementWeights: expect.any(Array),
+      }),
       expect.anything(),
     );
   });
@@ -270,113 +403,11 @@ describe('ProgramDetailsPage', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Replace program' }));
 
     expect(enrollMutate).toHaveBeenCalledWith(
-      {
+      expect.objectContaining({
         programId: 'dfw-1',
-        sharedWeightOneValue: 24,
-        sharedWeightOneUnit: 'kilograms',
-        sharedWeightTwoValue: 24,
-        sharedWeightTwoUnit: 'kilograms',
         replaceUserProgramId: 'up-1',
-      },
-      expect.anything(),
-    );
-  });
-
-  // A program whose sessions run at two different weights: 24kg working plus a
-  // deliberately heavier 28kg test day, the shape enroll_in_program offsets.
-  const withTestDay = (weightLabel: string | null = 'Test day') => ({
-    data: {
-      program: { ...dfw, id: 'dfw-1' },
-      sessions: [
-        ...dfwSessions,
-        sharedSession(2, 5, 1, 'Test - new press max', 28, 28, weightLabel),
-      ],
-    },
-    isLoading: false,
-    isError: false,
-  });
-
-  it('renders no extra control for a program that runs at one weight', () => {
-    renderPage();
-
-    expect(screen.getByText('Starting weight')).toBeInTheDocument();
-    expect(screen.getAllByRole('spinbutton')).toHaveLength(2);
-  });
-
-  it('adds a control per extra weight group, labelled from the seed', () => {
-    mockUseProgram.mockReturnValue(withTestDay());
-
-    renderPage();
-
-    expect(screen.getByText('Test day')).toBeInTheDocument();
-    expect(screen.getByText('4 kg heavier · week 5')).toBeInTheDocument();
-    // Working double-24 (2 inputs) + the test day's double-28 (2 more).
-    expect(screen.getByLabelText('Test day bell 1')).toHaveValue(28);
-    expect(screen.getByLabelText('Test day bell 2')).toHaveValue(28);
-  });
-
-  it('describes an unlabelled group by its offset instead', () => {
-    mockUseProgram.mockReturnValue(withTestDay(null));
-
-    renderPage();
-
-    expect(screen.getAllByText('4 kg heavier · week 5').length).toBeGreaterThan(
-      0,
-    );
-    expect(screen.queryByText('Test day')).not.toBeInTheDocument();
-  });
-
-  it('an untouched group follows the working weight, and pins once edited', () => {
-    mockUseProgram.mockReturnValue(withTestDay());
-
-    renderPage();
-
-    // Drop the working bell 24 → 20; the test day rides along, staying +4.
-    fireEvent.click(
-      screen.getByRole('button', { name: '- kg — Starting weight bell 1' }),
-    );
-    expect(screen.getByLabelText('Starting weight bell 1')).toHaveValue(23);
-    expect(screen.getByLabelText('Test day bell 1')).toHaveValue(27);
-
-    // Editing the test day pins it: further working-weight changes leave it.
-    fireEvent.change(screen.getByLabelText('Test day bell 1'), {
-      target: { value: '32' },
-    });
-    fireEvent.click(
-      screen.getByRole('button', { name: '- kg — Starting weight bell 1' }),
-    );
-    expect(screen.getByLabelText('Starting weight bell 1')).toHaveValue(22);
-    expect(screen.getByLabelText('Test day bell 1')).toHaveValue(32);
-  });
-
-  it('sends the chosen group weights as enroll overrides, keyed by source weight', () => {
-    mockUseProgram.mockReturnValue(withTestDay());
-
-    renderPage();
-
-    fireEvent.change(screen.getByLabelText('Test day bell 1'), {
-      target: { value: '32' },
-    });
-    fireEvent.click(screen.getByRole('button', { name: 'Start program' }));
-
-    expect(enrollMutate).toHaveBeenCalledWith(
-      {
-        programId: 'dfw-1',
-        sharedWeightOneValue: 24,
-        sharedWeightOneUnit: 'kilograms',
-        sharedWeightTwoValue: 24,
-        sharedWeightTwoUnit: 'kilograms',
-        weightOverrides: [
-          {
-            sourceWeightOneValue: 28,
-            sourceWeightTwoValue: 28,
-            weightOneValue: 32,
-            weightOneUnit: 'kilograms',
-            weightTwoValue: 28,
-            weightTwoUnit: 'kilograms',
-          },
-        ],
-      },
+        movementWeights: expect.any(Array),
+      }),
       expect.anything(),
     );
   });

--- a/src/pages/ProgramDetailsPage/ProgramDetailsPage.tsx
+++ b/src/pages/ProgramDetailsPage/ProgramDetailsPage.tsx
@@ -7,7 +7,7 @@ import {
   useEnrollProgram,
   useProgram,
 } from '~/api';
-import type { ProgramWeightOverride } from '~/api';
+import type { MovementWeight } from '~/api';
 import { ModifyCountButtons, Page, WeightUnitTabs } from '~/components';
 import { Button } from '~/components/ui/button';
 import { Card, CardContent } from '~/components/ui/card';
@@ -27,15 +27,17 @@ import {
   WeightUnit,
   WorkoutGoalUnits,
 } from '~/types';
-import { getWeightRange, getWeightUnitLabel } from '~/utils';
+import {
+  getWeightRange,
+  getWeightUnitLabel,
+  WEIGHT_MODE_LABELS,
+} from '~/utils';
 
 import {
-  applyGroupOffset,
-  deriveStartingWeight,
-  deriveWeightGroups,
-  StartingWeight,
-  WeightGroup,
-} from './utils/deriveWeightGroups';
+  deriveMovementWeights,
+  isComplexProgram,
+} from './utils/deriveMovementWeights';
+import { deriveStartingWeight, StartingWeight } from './utils/deriveWeightGroups';
 
 // Fallback weight/unit for the picker's initial state before the per-program
 // pre-fill from deriveWeightGroups lands. The loading mode is fixed by the
@@ -147,6 +149,7 @@ export const ProgramDetailsPage = () => {
 
   const [seeded, setSeeded] = useState(false);
   const [pendingSwitch, setPendingSwitch] = useState(false);
+  // Complex-set path: one shared bell pair for the whole complex.
   const [sharedWeightOneValue, setSharedWeightOneValue] = useState<
     number | null
   >(DEFAULT_STARTING_WEIGHT_VALUE);
@@ -157,14 +160,10 @@ export const ProgramDetailsPage = () => {
   >(DEFAULT_STARTING_WEIGHT_VALUE);
   const [sharedWeightTwoUnit, setSharedWeightTwoUnit] =
     useState<WeightUnit | null>(DEFAULT_WEIGHT_UNIT);
-  // Chosen weight per non-modal group, and the groups the user has touched.
-  // An untouched group tracks the working weight by its authored offset; once
-  // pinned it stops following, so picking a 14kg deload survives a later change
-  // to the working weight.
-  const [groupWeights, setGroupWeights] = useState<
+  // Non-complex path: chosen starting weight per movement, keyed by name.
+  const [movementWeights, setMovementWeights] = useState<
     Record<string, StartingWeight>
   >({});
-  const [pinnedGroups, setPinnedGroups] = useState<string[]>([]);
 
   const program = data?.program;
   const sessions = data?.sessions;
@@ -174,12 +173,17 @@ export const ProgramDetailsPage = () => {
   // for a program you already configured in the builder.
   const isOwnProgram = !!program && program.ownerId === userId;
 
-  const groups = useMemo(
-    () => (sessions ? deriveWeightGroups(sessions) : []),
+  // A complex program (ABC) uses one bell pair for the whole complex, so it
+  // keeps a single shared-weight picker; every other program gets a control per
+  // movement, each sized to that movement's own config.
+  const complex = useMemo(
+    () => (sessions ? isComplexProgram(sessions) : false),
     [sessions],
   );
-  const modalGroup = groups.find((group) => group.isModal);
-  const offsetGroups = groups.filter((group) => !group.isModal);
+  const movementControls = useMemo(
+    () => (sessions ? deriveMovementWeights(sessions) : []),
+    [sessions],
+  );
 
   const workingWeight: StartingWeight = {
     sharedWeightOneValue,
@@ -190,40 +194,24 @@ export const ProgramDetailsPage = () => {
 
   useEffect(() => {
     if (!sessions || seeded) return;
-    const derived = deriveStartingWeight(sessions);
-    setSharedWeightOneValue(derived.sharedWeightOneValue);
-    setSharedWeightOneUnit(derived.sharedWeightOneUnit);
-    setSharedWeightTwoValue(derived.sharedWeightTwoValue);
-    setSharedWeightTwoUnit(derived.sharedWeightTwoUnit);
+    if (complex) {
+      const derived = deriveStartingWeight(sessions);
+      setSharedWeightOneValue(derived.sharedWeightOneValue);
+      setSharedWeightOneUnit(derived.sharedWeightOneUnit);
+      setSharedWeightTwoValue(derived.sharedWeightTwoValue);
+      setSharedWeightTwoUnit(derived.sharedWeightTwoUnit);
+    } else {
+      setMovementWeights(
+        Object.fromEntries(
+          movementControls.map((control) => [
+            control.movementName,
+            control.modalWeight,
+          ]),
+        ),
+      );
+    }
     setSeeded(true);
-  }, [sessions, seeded]);
-
-  // Re-derive every un-pinned group whenever the working weight moves, so
-  // dropping the working bell 24 → 20 carries the deload 16 → 12 along with it.
-  useEffect(() => {
-    if (!seeded || !modalGroup) return;
-    setGroupWeights((current) => {
-      const next = { ...current };
-      for (const group of offsetGroups) {
-        if (pinnedGroups.includes(group.key)) continue;
-        next[group.key] = applyGroupOffset(
-          group.sourceWeight,
-          modalGroup.sourceWeight,
-          workingWeight,
-        );
-      }
-      return next;
-    });
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [
-    seeded,
-    groups,
-    pinnedGroups,
-    sharedWeightOneValue,
-    sharedWeightOneUnit,
-    sharedWeightTwoValue,
-    sharedWeightTwoUnit,
-  ]);
+  }, [sessions, seeded, complex, movementControls]);
 
   useEffect(() => {
     if (isOwnProgram && id) navigate(`/programs/${id}`, { replace: true });
@@ -236,26 +224,21 @@ export const ProgramDetailsPage = () => {
     setSharedWeightTwoUnit(weight.sharedWeightTwoUnit);
   };
 
-  const handleChangeGroupWeight = (
-    group: WeightGroup,
+  const handleChangeMovementWeight = (
+    movementName: string,
     weight: StartingWeight,
   ) => {
-    setGroupWeights((current) => ({ ...current, [group.key]: weight }));
-    setPinnedGroups((current) =>
-      current.includes(group.key) ? current : [...current, group.key],
-    );
+    setMovementWeights((current) => ({ ...current, [movementName]: weight }));
   };
 
-  // Sent for every offset group, edited or not, so the weight shown on this
-  // screen is exactly the weight that clones — the RPC's own offset math stays
-  // the fallback for callers that send nothing.
-  const weightOverrides: ProgramWeightOverride[] = offsetGroups
-    .filter((group) => groupWeights[group.key])
-    .map((group) => {
-      const chosen = groupWeights[group.key];
+  // One entry per movement carrying a loaded bell — bodyweight movements
+  // ('none') are omitted, so the RPC keeps them bodyweight.
+  const movementWeightPayload: MovementWeight[] = movementControls
+    .filter((control) => control.mode !== 'none')
+    .map((control) => {
+      const chosen = movementWeights[control.movementName] ?? control.modalWeight;
       return {
-        sourceWeightOneValue: group.sourceWeight.sharedWeightOneValue,
-        sourceWeightTwoValue: group.sourceWeight.sharedWeightTwoValue,
+        movementName: control.movementName,
         weightOneValue: chosen.sharedWeightOneValue,
         weightOneUnit: chosen.sharedWeightOneUnit,
         weightTwoValue: chosen.sharedWeightTwoValue,
@@ -279,12 +262,15 @@ export const ProgramDetailsPage = () => {
     enroll.mutate(
       {
         programId: id,
-        sharedWeightOneValue,
-        sharedWeightOneUnit,
-        sharedWeightTwoValue,
-        sharedWeightTwoUnit,
         replaceUserProgramId: displaced?.enrollment.id,
-        ...(weightOverrides.length ? { weightOverrides } : {}),
+        ...(complex
+          ? {
+              sharedWeightOneValue,
+              sharedWeightOneUnit,
+              sharedWeightTwoValue,
+              sharedWeightTwoUnit,
+            }
+          : { movementWeights: movementWeightPayload }),
       },
       { onSuccess: () => navigate('/') },
     );
@@ -397,10 +383,9 @@ export const ProgramDetailsPage = () => {
           it session by session once you&apos;re in the program.
         </p>
         {!seeded && <p className="text-sm text-muted-foreground">Loading…</p>}
-        {seeded && modalGroup?.label && (
-          <p className="text-xs text-muted-foreground">{modalGroup.label}</p>
-        )}
-        {seeded && (
+        {/* Complex sets share one bell pair for the whole complex, so a single
+            picker; every other program gets one control per movement. */}
+        {seeded && complex && (
           <WeightSlots
             weight={workingWeight}
             onChange={handleChangeWorkingWeight}
@@ -409,28 +394,28 @@ export const ProgramDetailsPage = () => {
         )}
       </div>
 
-      {/* One control per weight this program runs at beyond the working one —
-          A+A's deload weeks, DFW's test day, the Snatch Test's light/heavy
-          rungs. Each follows the working weight until it's edited. */}
       {seeded &&
-        offsetGroups.map((group) => {
-          const weight = groupWeights[group.key];
-          if (!weight) return null;
-          const heading = group.label ?? group.description;
-          return (
-            <div key={group.key} className="flex flex-col gap-1">
-              <h2 className="text-sm font-semibold">{heading}</h2>
-              <p className="text-xs text-muted-foreground">
-                {group.label ? group.description : `${group.sessionCount} sessions`}
+        !complex &&
+        movementControls.map((control) => (
+          <div key={control.movementName} className="flex flex-col gap-1">
+            <h2 className="text-sm font-semibold">{control.movementName}</h2>
+            {control.mode === 'none' ? (
+              <p className="text-sm text-muted-foreground">
+                {WEIGHT_MODE_LABELS.none}
               </p>
+            ) : (
               <WeightSlots
-                weight={weight}
-                onChange={(next) => handleChangeGroupWeight(group, next)}
-                namePrefix={heading}
+                weight={
+                  movementWeights[control.movementName] ?? control.modalWeight
+                }
+                onChange={(next) =>
+                  handleChangeMovementWeight(control.movementName, next)
+                }
+                namePrefix={control.movementName}
               />
-            </div>
-          );
-        })}
+            )}
+          </div>
+        ))}
 
       <Button onClick={handleStart} disabled={enroll.isPending || !seeded}>
         Start program

--- a/src/pages/ProgramDetailsPage/utils/deriveMovementWeights.test.ts
+++ b/src/pages/ProgramDetailsPage/utils/deriveMovementWeights.test.ts
@@ -1,0 +1,150 @@
+import { MovementOptions, ProgramSession, WeightUnit } from '~/types';
+
+import {
+  deriveMovementWeights,
+  isComplexProgram,
+} from './deriveMovementWeights';
+
+const kg = (value: number | null): WeightUnit | null =>
+  value == null ? null : 'kilograms';
+
+// A movement whose weight config is read from the null-pattern: weightOne null →
+// bodyweight, weightTwo null → two-hand single, weightTwo 0 → single, else double.
+const movement = (
+  movementName: string,
+  weightOne: number | null,
+  weightTwo: number | null,
+): MovementOptions => ({
+  movementName,
+  repScheme: [5],
+  weightOneValue: weightOne,
+  weightOneUnit: kg(weightOne),
+  weightTwoValue: weightTwo,
+  weightTwoUnit: weightTwo == null || weightTwo === 0 ? null : 'kilograms',
+});
+
+const session = (
+  seq: number,
+  movements: MovementOptions[],
+  { complexSet = false }: { complexSet?: boolean } = {},
+): ProgramSession => ({
+  id: `s-${seq}`,
+  programId: 'p',
+  sequenceIndex: seq,
+  weekNumber: 1,
+  dayNumber: 1,
+  title: 't',
+  notes: null,
+  weightLabel: null,
+  workoutOptions: {
+    complexSet,
+    intervalTimer: 0,
+    restTimer: 0,
+    title: null,
+    preWorkoutNotes: null,
+    workoutGoal: 0,
+    workoutGoalUnits: 'minutes',
+    sharedWeightOneValue: null,
+    sharedWeightOneUnit: null,
+    sharedWeightTwoValue: null,
+    sharedWeightTwoUnit: null,
+    movements,
+  },
+});
+
+describe('deriveMovementWeights', () => {
+  it('returns one control per distinct movement, in first-appearance order', () => {
+    const controls = deriveMovementWeights([
+      session(0, [
+        movement('Press', 24, 24),
+        movement('Pull-Up', null, null),
+        movement('Swing', 24, null),
+      ]),
+    ]);
+
+    expect(controls.map((c) => c.movementName)).toEqual([
+      'Press',
+      'Pull-Up',
+      'Swing',
+    ]);
+  });
+
+  it('derives the config mode from each movement’s null-pattern', () => {
+    const controls = deriveMovementWeights([
+      session(0, [
+        movement('Double', 24, 24),
+        movement('Body', null, null),
+        movement('TwoHand', 24, null),
+        movement('Single', 24, 0),
+      ]),
+    ]);
+
+    expect(controls.map((c) => c.mode)).toEqual([
+      'double',
+      'none',
+      '2h',
+      '1h',
+    ]);
+  });
+
+  it('pre-fills a bodyweight movement with all-null weights', () => {
+    const [control] = deriveMovementWeights([
+      session(0, [movement('Pull-Up', null, null)]),
+    ]);
+
+    expect(control.mode).toBe('none');
+    expect(control.modalWeight).toEqual({
+      sharedWeightOneValue: null,
+      sharedWeightOneUnit: null,
+      sharedWeightTwoValue: null,
+      sharedWeightTwoUnit: null,
+    });
+  });
+
+  it('picks the most common authored weight as the movement’s modal', () => {
+    // Two working days at 24, one test day at 28 → modal 24.
+    const [press] = deriveMovementWeights([
+      session(0, [movement('Press', 24, 24)]),
+      session(1, [movement('Press', 24, 24)]),
+      session(2, [movement('Press', 28, 28)]),
+    ]);
+
+    expect(press.modalWeight.sharedWeightOneValue).toBe(24);
+    expect(press.modalWeight.sharedWeightTwoValue).toBe(24);
+  });
+
+  it('breaks a modal tie toward the lighter weight', () => {
+    // Equal counts of 20 and 28 → the lighter 20 wins, mirroring the RPC.
+    const [swing] = deriveMovementWeights([
+      session(0, [movement('Swing', 28, 0)]),
+      session(1, [movement('Swing', 20, 0)]),
+    ]);
+
+    expect(swing.modalWeight.sharedWeightOneValue).toBe(20);
+  });
+
+  it('keeps a single-bell movement’s weight two shape in its modal', () => {
+    const [swing] = deriveMovementWeights([
+      session(0, [movement('Swing', 24, null)]),
+    ]);
+
+    expect(swing.mode).toBe('2h');
+    expect(swing.modalWeight.sharedWeightTwoValue).toBeNull();
+  });
+});
+
+describe('isComplexProgram', () => {
+  it('is true when any session is a complex set', () => {
+    expect(
+      isComplexProgram([
+        session(0, [movement('Clean', 24, 24)], { complexSet: true }),
+      ]),
+    ).toBe(true);
+  });
+
+  it('is false when no session is a complex set', () => {
+    expect(
+      isComplexProgram([session(0, [movement('Press', 24, 24)])]),
+    ).toBe(false);
+  });
+});

--- a/src/pages/ProgramDetailsPage/utils/deriveMovementWeights.ts
+++ b/src/pages/ProgramDetailsPage/utils/deriveMovementWeights.ts
@@ -1,0 +1,93 @@
+import { ProgramSession, WeightTabValue } from '~/types';
+import { getWeightTabValue } from '~/utils';
+
+import { StartingWeight, weightKey } from './deriveWeightGroups';
+
+/**
+ * One editable starting weight on the enrollment screen: a distinct movement
+ * across the program's sessions, its config mode (bodyweight / single / double),
+ * and the authored weight the picker pre-fills. `enroll_in_program` applies the
+ * chosen weight to every occurrence of this movement, shifted by that session's
+ * offset from `modalWeight`, so a program's heavier/lighter days scale along.
+ */
+export interface MovementWeightControl {
+  movementName: string;
+  /** Derived from `modalWeight`'s null-pattern: 'none' | '2h' | '1h' | 'double'. */
+  mode: WeightTabValue;
+  /** The movement's modal authored weight — the picker's pre-fill. */
+  modalWeight: StartingWeight;
+}
+
+/** A movement's authored weight, mapped onto the shared-weight field names so it
+ *  feeds `WeightSlots` (which reads `sharedWeight*`) directly. */
+const movementWeight = (movement: {
+  weightOneValue: number | null;
+  weightOneUnit: StartingWeight['sharedWeightOneUnit'];
+  weightTwoValue: number | null;
+  weightTwoUnit: StartingWeight['sharedWeightTwoUnit'];
+}): StartingWeight => ({
+  sharedWeightOneValue: movement.weightOneValue,
+  sharedWeightOneUnit: movement.weightOneUnit,
+  sharedWeightTwoValue: movement.weightTwoValue,
+  sharedWeightTwoUnit: movement.weightTwoUnit,
+});
+
+/** True when any session is a complex set — those movements share one bell pair
+ *  for the whole complex, so enrollment offers a single shared weight rather
+ *  than a control per movement. */
+export const isComplexProgram = (sessions: ProgramSession[]): boolean =>
+  sessions.some((session) => session.workoutOptions.complexSet);
+
+/**
+ * One weight control per distinct movement (by name), in first-appearance order.
+ * Each movement's modal authored weight is the most common pair it carries
+ * across sessions, tie-broken toward the lighter first weight — the same rule as
+ * `deriveWeightGroups` and the `enroll_in_program` RPC, so the picker's pre-fill
+ * equals the weight that clones.
+ *
+ * Bodyweight movements (all-null weights, mode 'none') are included so the
+ * screen can label them, but they carry no editable weight.
+ */
+export const deriveMovementWeights = (
+  sessions: ProgramSession[],
+): MovementWeightControl[] => {
+  const order: string[] = [];
+  const pairs = new Map<string, Map<string, { weight: StartingWeight; count: number }>>();
+
+  for (const session of sessions) {
+    for (const movement of session.workoutOptions.movements) {
+      const name = movement.movementName;
+      if (!name) continue;
+      if (!pairs.has(name)) {
+        pairs.set(name, new Map());
+        order.push(name);
+      }
+      const weight = movementWeight(movement);
+      const byPair = pairs.get(name)!;
+      const key = weightKey(weight);
+      const existing = byPair.get(key);
+      if (existing) existing.count += 1;
+      else byPair.set(key, { weight, count: 1 });
+    }
+  }
+
+  return order.map((movementName) => {
+    const byPair = [...pairs.get(movementName)!.values()];
+    const modal = byPair.sort((a, b) => {
+      if (b.count !== a.count) return b.count - a.count;
+      const oneA = a.weight.sharedWeightOneValue ?? 0;
+      const oneB = b.weight.sharedWeightOneValue ?? 0;
+      if (oneA !== oneB) return oneA - oneB;
+      return (a.weight.sharedWeightTwoValue ?? 0) - (b.weight.sharedWeightTwoValue ?? 0);
+    })[0].weight;
+
+    return {
+      movementName,
+      mode: getWeightTabValue({
+        weightOneValue: modal.sharedWeightOneValue,
+        weightTwoValue: modal.sharedWeightTwoValue,
+      }),
+      modalWeight: modal,
+    };
+  });
+};

--- a/supabase/migrations/20260724000003_easy_strength_farmers_carry_timed.sql
+++ b/supabase/migrations/20260724000003_easy_strength_farmers_carry_timed.sql
@@ -1,0 +1,65 @@
+-- Make the seeded "Easy Strength" Farmer's Carry a timed movement.
+--
+-- 20260714000002_seed_easy_strength.sql seeds all five movements through one
+-- helper that shares the session's rep ladder, so the Kettlebell Farmer's Carry
+-- came out rep-counted like the presses and squats. A loaded carry runs on the
+-- clock, not on reps: `timedRungs: true` reinterprets each repScheme entry as
+-- seconds per rung (see MovementOptions, and Kettlebell Mile's single-rung
+-- [60]/timed shape in 20260723130000_seed_kettlebell_mile.sql).
+--
+-- Set the carry to a single 30-second rung (`repScheme [30]`, `timedRungs true`)
+-- and leave its 24 kg double loading untouched. A single fixed rung keeps the
+-- carry consistent across every session rather than ballooning to the session's
+-- rung count (e.g. the 6x1 day would otherwise be six 30s carries).
+--
+-- Forward DATA FIX over deployed rows (the original seed is applied in
+-- production and is ON CONFLICT DO NOTHING). Scoped to the SYSTEM-OWNED template
+-- (slug = 'easy-strength' AND owner_id IS NULL); copy-on-enroll clones carry
+-- slug NULL + a real owner_id, so existing enrollees keep what they started.
+-- Matched by movementName (not array index) and idempotent: a session whose
+-- carry is already timed no-ops on re-run. Modeled on
+-- 20260724000002_easy_strength_straight_sets.sql; guarded, RAISE NOTICE count.
+
+DO $$
+DECLARE
+  v_program_id     UUID;
+  v_sessions_fixed INT := 0;
+BEGIN
+  SELECT id INTO v_program_id
+  FROM public.programs
+  WHERE slug = 'easy-strength' AND owner_id IS NULL;
+
+  IF v_program_id IS NULL THEN
+    RAISE NOTICE 'Easy Strength template not found; nothing to update.';
+    RETURN;
+  END IF;
+
+  UPDATE public.program_sessions ps
+  SET workout_options = jsonb_set(
+    ps.workout_options,
+    '{movements}',
+    (
+      SELECT jsonb_agg(
+        CASE elem->>'movementName'
+          WHEN 'Kettlebell Farmer''s Carry'
+            THEN jsonb_set(
+                   jsonb_set(elem, '{timedRungs}', 'true'::jsonb),
+                   '{repScheme}', '[30]'::jsonb)
+          ELSE elem
+        END
+        ORDER BY ord
+      )
+      FROM jsonb_array_elements(ps.workout_options->'movements')
+        WITH ORDINALITY AS m(elem, ord)
+    )
+  )
+  WHERE ps.program_id = v_program_id
+    AND ps.workout_options->'movements' @> '[{"movementName": "Kettlebell Farmer''s Carry"}]'::jsonb
+    AND NOT (
+      ps.workout_options->'movements'
+        @> '[{"movementName": "Kettlebell Farmer''s Carry", "timedRungs": true}]'::jsonb
+    );
+  GET DIAGNOSTICS v_sessions_fixed = ROW_COUNT;
+
+  RAISE NOTICE 'Easy Strength timed carry: program_sessions updated=%', v_sessions_fixed;
+END $$;

--- a/supabase/migrations/20260724000004_enroll_in_program_per_movement_weights.sql
+++ b/supabase/migrations/20260724000004_enroll_in_program_per_movement_weights.sql
@@ -1,0 +1,335 @@
+-- Program Tracking: let the enrollee set a starting weight PER MOVEMENT.
+--
+-- 20260723160001_enroll_in_program_weight_overrides.sql resolved ONE weight per
+-- cloned session and folded it onto every movement identically. That is correct
+-- only when a session's movements share a config (DFW's two doubles, the Snatch
+-- Test's two singles, ABC's three doubles) -- but Easy Strength mixes a
+-- bodyweight pull-up, a single-bell swing and double-bell lifts in one session,
+-- so the uniform fold turned the pull-up and swing into doubles. This migration
+-- resolves a weight PER movement name instead, preserving each movement's
+-- authored config shape (bodyweight stays bodyweight, single stays single) and
+-- keeping cross-session scaling (test days heavier, deloads lighter) by offset
+-- from that movement's OWN modal authored weight.
+--
+-- p_movement_weights replaces p_weight_overrides: one entry per distinct
+-- non-bodyweight movement, the enrollee's chosen working weight in that
+-- movement's config shape, keyed by movementName:
+--
+--   [{"movementName": "Kettlebell Swing",
+--     "weightOneValue": 24, "weightOneUnit": "kilograms",
+--     "weightTwoValue": null, "weightTwoUnit": null}]
+--
+-- Resolution per cloned session:
+--   1. No starting weight passed at all -> clone verbatim (unchanged).
+--   2. Non-complex session WITH p_movement_weights -> rebuild {movements},
+--      applying each movement's chosen weight in its own config shape, shifted by
+--      that movement's authored per-session offset from its modal. Movements with
+--      no matching entry (bodyweight, or any the client omitted) are kept as-is.
+--      sharedWeight* is left as authored -- non-complex seeds carry null there and
+--      the runtime reads each movement's own weight.
+--   3. Otherwise (complexSet, or a caller that passed only p_shared_weight_*) ->
+--      the shared-weight uniform fold, unchanged from the prior migration: one
+--      bell pair folded onto sharedWeight* and every movement, using
+--      p_shared_weight_* and the program-level modal/offset from movements->0.
+--      complexSet programs hold one bell pair for the whole complex (ABC), and
+--      this also keeps the shared-weight enroll API working for homogeneous
+--      programs (DFW / A+A / Snatch / 10K / Mile), whose movements share a config.
+--
+-- The per-movement modal (movement_modal CTE) mirrors the client's
+-- deriveMovementWeights tie-break (COUNT DESC, weightOne, weightTwo -> lighter
+-- wins) so the picker's pre-fill equals the cloned value. Unit mismatches
+-- (a pounds choice against a kg-authored seed) pass through with a zero delta
+-- rather than doing cross-unit arithmetic, as the prior override path did.
+--
+-- The enrollment-lifecycle preamble (duplicate-program check, replace path, the
+-- 1..3 slot picker, own-program branch, weight_label carry-through) is carried
+-- over VERBATIM from 20260723160001_enroll_in_program_weight_overrides.sql; only
+-- the clone body changes.
+--
+-- DROP + CREATE, one signature only: a PostgREST overload would make the shorter
+-- call ambiguous ("function is not unique"), cf. 20260720160000_resume_program.sql.
+DROP FUNCTION IF EXISTS public.enroll_in_program(UUID);
+DROP FUNCTION IF EXISTS public.enroll_in_program(UUID, NUMERIC, TEXT, NUMERIC, TEXT);
+DROP FUNCTION IF EXISTS public.enroll_in_program(UUID, NUMERIC, TEXT, NUMERIC, TEXT, UUID);
+DROP FUNCTION IF EXISTS public.enroll_in_program(UUID, NUMERIC, TEXT, NUMERIC, TEXT, UUID, JSONB);
+
+CREATE FUNCTION public.enroll_in_program(
+  p_program_id UUID,
+  p_shared_weight_one_value NUMERIC DEFAULT NULL,
+  p_shared_weight_one_unit  TEXT    DEFAULT NULL,
+  p_shared_weight_two_value NUMERIC DEFAULT NULL,
+  p_shared_weight_two_unit  TEXT    DEFAULT NULL,
+  p_replace_user_program_id UUID    DEFAULT NULL,
+  p_movement_weights        JSONB   DEFAULT NULL
+)
+RETURNS UUID
+LANGUAGE plpgsql
+SECURITY INVOKER
+SET search_path = public
+AS $$
+DECLARE
+  v_user_id         UUID    := auth.uid();
+  v_owner_id        UUID;
+  v_target_program  UUID;
+  v_user_program_id UUID;
+  v_modal_one       NUMERIC;
+  v_modal_two       NUMERIC;
+  v_slot            SMALLINT;
+  v_override        BOOLEAN := p_shared_weight_one_value IS NOT NULL
+                              OR p_movement_weights IS NOT NULL;
+BEGIN
+  IF v_user_id IS NULL THEN
+    RAISE EXCEPTION 'Not authenticated';
+  END IF;
+
+  -- RLS on this SELECT already restricts to public-or-own; a NOT FOUND result
+  -- means the program does not exist or is not visible to the caller.
+  SELECT owner_id INTO v_owner_id
+  FROM programs WHERE id = p_program_id;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Program % not found or not accessible', p_program_id;
+  END IF;
+
+  -- One live cursor per program. `p.source_program_id = p_program_id` catches
+  -- re-enrolling in a shared program whose earlier clone is still running.
+  IF EXISTS (
+    SELECT 1
+    FROM user_programs up
+    JOIN programs p ON p.id = up.program_id
+    WHERE up.user_id = v_user_id
+      AND up.status = 'active'
+      AND up.id IS DISTINCT FROM p_replace_user_program_id
+      AND (p.id = p_program_id OR p.source_program_id = p_program_id)
+  ) THEN
+    RAISE EXCEPTION 'PROGRAM_ALREADY_ACTIVE';
+  END IF;
+
+  -- Free the replaced slot first so the picker below can reuse it.
+  IF p_replace_user_program_id IS NOT NULL THEN
+    UPDATE user_programs
+      SET status = 'abandoned'
+      WHERE id = p_replace_user_program_id
+        AND user_id = v_user_id
+        AND status = 'active';
+    IF NOT FOUND THEN
+      RAISE EXCEPTION 'No active enrollment % to replace', p_replace_user_program_id;
+    END IF;
+  END IF;
+
+  SELECT s.slot INTO v_slot
+  FROM generate_series(1, 3) AS s(slot)
+  WHERE NOT EXISTS (
+    SELECT 1 FROM user_programs up
+    WHERE up.user_id = v_user_id
+      AND up.status = 'active'
+      AND up.active_slot = s.slot
+  )
+  ORDER BY s.slot
+  LIMIT 1;
+
+  IF v_slot IS NULL THEN
+    RAISE EXCEPTION 'PROGRAM_SLOTS_FULL';
+  END IF;
+
+  IF v_owner_id = v_user_id THEN
+    v_target_program := p_program_id;                     -- own program: no clone
+  ELSE
+    INSERT INTO programs
+      (owner_id, source_program_id, slug, title, description, author_name,
+       num_weeks, days_per_week, is_public)
+    SELECT v_user_id, id, NULL, title, description, author_name,
+           num_weeks, days_per_week, false
+    FROM programs WHERE id = p_program_id
+    RETURNING id INTO v_target_program;
+
+    IF v_override THEN
+      -- The modal (weightOne, weightTwo) pair across the program's sessions:
+      -- the shared placeholder load every deliberately-different session is
+      -- offset from, used only by the complexSet uniform-fold path. Ties break
+      -- toward the lighter pair, mirroring deriveStartingWeight.
+      SELECT one_val, two_val INTO v_modal_one, v_modal_two
+      FROM (
+        SELECT (workout_options->'movements'->0->>'weightOneValue')::NUMERIC AS one_val,
+               (workout_options->'movements'->0->>'weightTwoValue')::NUMERIC AS two_val,
+               COUNT(*) AS cnt
+        FROM program_sessions
+        WHERE program_id = p_program_id
+        GROUP BY one_val, two_val
+        ORDER BY cnt DESC, one_val, two_val
+        LIMIT 1
+      ) modal;
+    END IF;
+
+    INSERT INTO program_sessions
+      (program_id, sequence_index, week_number, day_number, title,
+       workout_options, notes, weight_label)
+    -- Per-movement modal authored weight, one row per movement name. Rows with a
+    -- null weight one (bodyweight) never form a modal, so a bodyweight movement
+    -- has no row and its element is kept untouched below. Tie-break mirrors the
+    -- client's deriveMovementWeights so pre-fill equals the cloned value.
+    WITH movement_modal AS (
+      SELECT DISTINCT ON (name)
+        name, one_val, two_val
+      FROM (
+        SELECT
+          mv->>'movementName' AS name,
+          (mv->>'weightOneValue')::NUMERIC AS one_val,
+          (mv->>'weightTwoValue')::NUMERIC AS two_val,
+          COUNT(*) AS cnt
+        FROM program_sessions ps2,
+             jsonb_array_elements(ps2.workout_options->'movements') AS mv
+        WHERE ps2.program_id = p_program_id
+          AND (mv->>'weightOneValue') IS NOT NULL
+        GROUP BY name, one_val, two_val
+      ) per_pair
+      ORDER BY name, cnt DESC, one_val, two_val
+    )
+    SELECT
+      v_target_program, ps.sequence_index, ps.week_number, ps.day_number, ps.title,
+      CASE
+        WHEN NOT v_override THEN ps.workout_options
+        -- non-complex with per-movement weights: rebuild each element in its own
+        -- config shape, offset from that movement's modal.
+        WHEN p_movement_weights IS NOT NULL
+             AND ps.workout_options->>'complexSet' IS DISTINCT FROM 'true'
+          THEN jsonb_set(
+                 ps.workout_options,
+                 '{movements}',
+                 (
+                   SELECT jsonb_agg(
+                            CASE
+                              WHEN mw.value IS NULL THEN elem
+                              ELSE elem || jsonb_build_object(
+                                'weightOneValue',
+                                  COALESCE(to_jsonb(
+                                    CASE
+                                      WHEN (mw.value->>'weightOneValue')::NUMERIC IS NULL
+                                        OR r.one_delta = 0
+                                        THEN (mw.value->>'weightOneValue')::NUMERIC
+                                      ELSE GREATEST((mw.value->>'weightOneValue')::NUMERIC + r.one_delta, 1)
+                                    END), 'null'::jsonb),
+                                'weightOneUnit',
+                                  COALESCE(to_jsonb(mw.value->>'weightOneUnit'), 'null'::jsonb),
+                                'weightTwoValue',
+                                  COALESCE(to_jsonb(
+                                    CASE
+                                      WHEN (mw.value->>'weightTwoValue')::NUMERIC IS NULL
+                                        OR r.two_delta = 0
+                                        THEN (mw.value->>'weightTwoValue')::NUMERIC
+                                      ELSE GREATEST((mw.value->>'weightTwoValue')::NUMERIC + r.two_delta, 1)
+                                    END), 'null'::jsonb),
+                                'weightTwoUnit',
+                                  COALESCE(to_jsonb(mw.value->>'weightTwoUnit'), 'null'::jsonb)
+                              )
+                            END
+                            ORDER BY ord
+                          )
+                   FROM jsonb_array_elements(ps.workout_options->'movements')
+                          WITH ORDINALITY AS e(elem, ord)
+                   LEFT JOIN LATERAL (
+                     SELECT o.value
+                     FROM jsonb_array_elements(p_movement_weights) AS o(value)
+                     WHERE o.value->>'movementName' = elem->>'movementName'
+                     LIMIT 1
+                   ) mw ON TRUE
+                   LEFT JOIN movement_modal mm ON mm.name = elem->>'movementName'
+                   CROSS JOIN LATERAL (
+                     SELECT
+                       -- Offset only when the movement's authored unit matches the
+                       -- chosen unit; a cross-unit choice passes through (delta 0).
+                       CASE WHEN elem->>'weightOneUnit'
+                                 IS NOT DISTINCT FROM mw.value->>'weightOneUnit'
+                            THEN COALESCE((elem->>'weightOneValue')::NUMERIC, 0)
+                                 - COALESCE(mm.one_val, 0)
+                            ELSE 0 END AS one_delta,
+                       CASE WHEN elem->>'weightTwoUnit'
+                                 IS NOT DISTINCT FROM mw.value->>'weightTwoUnit'
+                            THEN COALESCE((elem->>'weightTwoValue')::NUMERIC, 0)
+                                 - COALESCE(mm.two_val, 0)
+                            ELSE 0 END AS two_delta
+                   ) r
+                 ))
+        -- complexSet (one bell pair for the whole complex, ABC), or a caller that
+        -- passed only p_shared_weight_* (the homogeneous shared-weight programs):
+        -- the prior uniform fold. COALESCE(..., 'null'::jsonb): jsonb_set is
+        -- strict and to_jsonb(NULL) is SQL NULL, so an unset slot must be coerced
+        -- to a JSON null. `m || jsonb_build_object(...)` overrides only the four
+        -- weight keys, preserving movementName / repScheme / etc.
+        ELSE jsonb_set(
+               jsonb_set(
+                 jsonb_set(
+                   jsonb_set(
+                     jsonb_set(
+                       ps.workout_options,
+                       '{sharedWeightOneValue}',
+                       COALESCE(to_jsonb(w.one_value), 'null'::jsonb)),
+                     '{sharedWeightOneUnit}',
+                     COALESCE(to_jsonb(w.one_unit), 'null'::jsonb)),
+                   '{sharedWeightTwoValue}',
+                   COALESCE(to_jsonb(w.two_value), 'null'::jsonb)),
+                 '{sharedWeightTwoUnit}',
+                 COALESCE(to_jsonb(w.two_unit), 'null'::jsonb)),
+               '{movements}',
+               (
+                 SELECT jsonb_agg(
+                          m || jsonb_build_object(
+                            'weightOneValue', COALESCE(to_jsonb(w.one_value), 'null'::jsonb),
+                            'weightOneUnit',  COALESCE(to_jsonb(w.one_unit),  'null'::jsonb),
+                            'weightTwoValue', COALESCE(to_jsonb(w.two_value), 'null'::jsonb),
+                            'weightTwoUnit',  COALESCE(to_jsonb(w.two_unit),  'null'::jsonb)
+                          )
+                        )
+                 FROM jsonb_array_elements(ps.workout_options->'movements') AS m
+               ))
+      END,
+      ps.notes,
+      ps.weight_label
+    FROM program_sessions ps
+    -- Per-session shared weight for the complexSet path: the enrollee's choice
+    -- shifted by this session's authored offset from the modal. A zero delta
+    -- passes the chosen value through untouched -- notably it must NOT hit the
+    -- >= 1 clamp, since a single-bell enrollment carries weight two = 0.
+    CROSS JOIN LATERAL (
+      SELECT
+        CASE
+          WHEN p_shared_weight_one_value IS NULL OR d.one_delta = 0
+            THEN p_shared_weight_one_value
+          ELSE GREATEST(p_shared_weight_one_value + d.one_delta, 1)
+        END AS one_value,
+        CASE
+          WHEN p_shared_weight_two_value IS NULL OR d.two_delta = 0
+            THEN p_shared_weight_two_value
+          ELSE GREATEST(p_shared_weight_two_value + d.two_delta, 1)
+        END AS two_value,
+        p_shared_weight_one_unit AS one_unit,
+        p_shared_weight_two_unit AS two_unit
+      FROM (
+        SELECT
+          COALESCE(
+            CASE WHEN ps.workout_options->'movements'->0->>'weightOneUnit'
+                      IS NOT DISTINCT FROM p_shared_weight_one_unit
+                 THEN (ps.workout_options->'movements'->0->>'weightOneValue')::NUMERIC
+                      - v_modal_one
+            END, 0) AS one_delta,
+          COALESCE(
+            CASE WHEN ps.workout_options->'movements'->0->>'weightTwoUnit'
+                      IS NOT DISTINCT FROM p_shared_weight_two_unit
+                 THEN (ps.workout_options->'movements'->0->>'weightTwoValue')::NUMERIC
+                      - v_modal_two
+            END, 0) AS two_delta
+      ) d
+    ) w
+    WHERE ps.program_id = p_program_id
+    ORDER BY ps.sequence_index;
+  END IF;
+
+  INSERT INTO user_programs (user_id, program_id, status, active_slot)
+  VALUES (v_user_id, v_target_program, 'active', v_slot)
+  RETURNING id INTO v_user_program_id;
+
+  RETURN v_user_program_id;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.enroll_in_program(UUID, NUMERIC, TEXT, NUMERIC, TEXT, UUID, JSONB) FROM public;
+GRANT EXECUTE ON FUNCTION public.enroll_in_program(UUID, NUMERIC, TEXT, NUMERIC, TEXT, UUID, JSONB) TO authenticated;

--- a/types/supabase.ts
+++ b/types/supabase.ts
@@ -776,13 +776,13 @@ export type Database = {
       }
       enroll_in_program: {
         Args: {
+          p_movement_weights?: Json
           p_program_id: string
           p_replace_user_program_id?: string
           p_shared_weight_one_unit?: string
           p_shared_weight_one_value?: number
           p_shared_weight_two_unit?: string
           p_shared_weight_two_value?: number
-          p_weight_overrides?: Json
         }
         Returns: string
       }


### PR DESCRIPTION
## Why

Enrolling in a program resolved **one** weight per session and folded it onto every movement. That's correct only when a session's movements share a config — but Easy Strength mixes a bodyweight pull-up, a single-bell swing, and double-bell lifts in one session, so the fold turned the pull-up and swing into doubles, and the enrollment step offered a single "double" weight applied to all five movements. There was no way to weight movements separately.

The audit also surfaced one real seed defect: the Easy Strength Farmer's Carry was seeded rep-counted, though it's a timed loaded carry.

## What

Three parts:

1. **Per-movement starting weights.** `ProgramDetailsPage` renders one control per distinct movement, sized to its config via `deriveMovementWeights` + `getWeightTabValue` — bodyweight shows a "Bodyweight" line (no picker), single one bell, double two — and sends them as `p_movement_weights` (`MovementWeight[]`).
2. **RPC rebuild.** `enroll_in_program` (new migration) rebuilds each session's `movements[]`, applying the chosen weight in that movement's own config shape (preserving null / 0 slots) shifted by that movement's authored per-session offset from its own modal, so cross-session scaling (test days, deloads) still holds. `complexSet` programs (ABC) and callers that pass only `p_shared_weight_*` keep the uniform fold, so the shared-weight API stays backward-compatible.
3. **Seed fix.** The Easy Strength Farmer's Carry becomes a timed carry (`timedRungs`, a fixed 30-second rung), double loading unchanged.

## How to test

- `npm run compile:ts`, `npm run lint` — clean.
- `npx vitest run` — 550 unit/component tests pass, including a new `deriveMovementWeights` suite and a rewritten `ProgramDetailsPage` suite (per-movement controls, bodyweight omitted from payload, complex-set shared picker).
- `npx playwright test program-` — 56 program e2e tests pass, including a new Easy Strength regression asserting the cloned pull-up stays `null/null`, the swing keeps `weightTwo null`, press/squat/carry land at their chosen doubles, and the carry stays `timedRungs`. DFW / A+A / Snatch shared-weight offset tests still pass unchanged.
- By hand against local Supabase (`enroll_in_program` via `db query`): Easy Strength per-movement (each config preserved), DFW (test day keeps +4), A+A (deloads scale), ABC (uniform fold via the shared path).

## Gallery

<!-- before.png / after.png sent via chat — drag-drop here. GitHub CDN uploads are permanent. -->

**Before** — one shared "Starting weight" picker (two identical double bells) applied to every movement.

_drag before.png here_

**After** — one control per movement: Pull-Up shows "Bodyweight", Swing one bell, Press / Front Squat / Farmer's Carry two bells each.

_drag after.png here_

## Deploy notes

- Two migrations: `20260724000003_easy_strength_farmers_carry_timed.sql` (data fix, scoped to the system template, idempotent) and `20260724000004_enroll_in_program_per_movement_weights.sql` (`enroll_in_program` DROP+CREATE, single signature).
- `npm run gen:types` was run for the new `p_movement_weights` arg; `types/supabase.ts` is committed.
- No env vars or feature flags.

## Tradeoffs

- **Kept the shared-weight uniform fold as a backward-compatible fallback** rather than removing it. Full removal is cleaner and states the new contract more sharply, but every homogeneous program (DFW, A+A, Snatch, 10K, Mile) already enrolls correctly through the shared-weight API and has e2e coverage on it; retiring it would churn those tests for no user-facing gain. The fold now fires only for `complexSet` sessions or callers that pass `p_shared_weight_*` without per-movement weights — never the new UI path.
- **Per-movement modal anchoring on the Snatch Test.** Because its test days contain only the snatch, the swing and snatch anchor at their own modals. Accepting the pre-fills reproduces the authored program exactly; setting both movements to the same non-modal number can make them diverge on heavy days. That's inherent to modeling weights per movement (and only surfaces if you override the pre-fill), not a regression to the default enrollment.
