### PR TITLE
refactor(theme): route remaining hardcoded colors through design tokens

### DIFF
--- a/src/components/PWAInstallPrompt/PWAInstallPrompt.tsx
+++ b/src/components/PWAInstallPrompt/PWAInstallPrompt.tsx
@@ -121,10 +121,10 @@ export function PWAInstallPrompt() {
           : 'bottom-4',
       )}
     >
-      <div className="relative rounded-lg border border-gray-200 bg-white p-3 shadow-lg">
+      <div className="relative rounded-lg border border-border bg-card p-3 shadow-lg">
         <button
           onClick={handleDismiss}
-          className="absolute right-1 top-1 p-1 text-gray-400 transition-colors hover:text-gray-600"
+          className="absolute right-1 top-1 p-1 text-muted-foreground transition-colors hover:text-foreground"
           aria-label="Dismiss"
         >
           <XMarkIcon className="h-2.5 w-2.5" />
@@ -132,14 +132,14 @@ export function PWAInstallPrompt() {
 
         <div className="flex items-center space-x-3 pr-2.5">
           <div className="flex-shrink-0">
-            <DevicePhoneMobileIcon className="h-2.5 w-2.5 text-blue-600" />
+            <DevicePhoneMobileIcon className="h-2.5 w-2.5 text-primary" />
           </div>
 
           <div className="min-w-0 flex-1">
-            <p className="text-sm font-medium text-gray-900">
+            <p className="text-sm font-medium text-card-foreground">
               Install BellSkill
             </p>
-            <p className="inline text-xs text-gray-500">
+            <p className="inline text-xs text-muted-foreground">
               Tap the <ArrowUpTrayIcon className="inline h-2 w-2" /> share
               button below, then select &quot;Add to Home Screen&quot;
             </p>

--- a/src/components/WeeklyBalance/patternDisplay.ts
+++ b/src/components/WeeklyBalance/patternDisplay.ts
@@ -27,15 +27,15 @@ export const PATTERN_LABELS: Record<Pattern, string> = {
 };
 
 export const BAND_BAR_CLASS: Record<DebtBand, string> = {
-  green: 'bg-green-500',
-  yellow: 'bg-yellow-500',
-  red: 'bg-red-500',
+  green: 'bg-status-success',
+  yellow: 'bg-status-warning',
+  red: 'bg-destructive',
 };
 
 export const BAND_TEXT_CLASS: Record<DebtBand, string> = {
-  green: 'text-green-600',
-  yellow: 'text-yellow-600',
-  red: 'text-red-600',
+  green: 'text-status-success',
+  yellow: 'text-status-warning',
+  red: 'text-destructive',
 };
 
 export const BAND_LABEL: Record<DebtBand, string> = {

--- a/src/pages/CompletedWorkoutPage/CompletedWorkoutPage.tsx
+++ b/src/pages/CompletedWorkoutPage/CompletedWorkoutPage.tsx
@@ -118,7 +118,7 @@ export const CompletedWorkoutPage = () => {
               <DialogTrigger asChild>
                 <Button
                   variant="ghost"
-                  className="flex items-center gap-0.5 text-red-500"
+                  className="flex items-center gap-0.5 text-destructive"
                 >
                   Delete <TrashIcon className="h-2.5 w-2.5" />
                 </Button>

--- a/src/pages/StartWorkoutPage/StartWorkoutPage.tsx
+++ b/src/pages/StartWorkoutPage/StartWorkoutPage.tsx
@@ -1204,7 +1204,7 @@ export const StartWorkoutPage = ({
           </Button>
 
           {isDifferentRepSchemes && (
-            <div className="text-sm text-red-500">
+            <div className="text-sm text-destructive">
               Rep schemes must contain the same number of rungs for each
               movement.
             </div>


### PR DESCRIPTION
## Why

The theme is already a complete shadcn CSS-variable token system, but a handful of spots still reached for raw Tailwind palette utilities (`bg-white`, `text-gray-500`, `bg-green-500`, `text-red-500`) and so escaped it. One of those, the PWA install prompt, was an actual dark-mode bug — its card stayed white against a dark page. This routes the stragglers back through tokens that already exist.

## What

Swaps hardcoded palette classes for existing semantic tokens in four spots. No new tokens introduced.

- **PWAInstallPrompt** — `bg-white` / `border-gray-200` / `text-gray-{400,500,600,900}` / `text-blue-600` → `bg-card` / `border-border` / `text-muted-foreground` / `text-card-foreground` / `text-primary`. Fixes the white-card-in-dark-mode bug.
- **WeeklyBalance debt bands** (`patternDisplay.ts`) — green/yellow/red → `status-success` / `status-warning` / `destructive`, so the bands adapt in dark mode instead of staying fixed.
- **Two error strings** — `text-red-500` → `text-destructive` (StartWorkoutPage, CompletedWorkoutPage).

`src/utils/bellColors.ts` hex codes are deliberately left alone — those are real competition-kettlebell color constants, not theme.

## How to test

- `npm run compile:ts` — clean.
- `npm run lint` on the four touched files — clean.
- Grep confirms no remaining `bg-white` / `text-gray-` / `bg-green-500` / `text-red-500` in the touched files.
- Rendered `WeeklyBalance` (HingeHeavy story, which exercises all three bands) in Storybook in both light and dark: bars and labels render green/orange/red in light and shift to the correct brighter dark-variant hues in dark. See Gallery.

## Gallery

The token swaps are visually **identical in light mode** — the point is that they now adapt in dark mode where the raw palette classes could not. `WeeklyBalance` shown below in both themes (all three debt bands visible); `PWAInstallPrompt` goes from a hardcoded white card to `bg-card`, so it now inverts in dark mode.

> Screenshots captured locally (light + dark). I couldn't embed them via the CDN-upload flow in this session — @djbowers, happy to drag-drop the light/dark comparison in, or say the word and I'll wire up the upload.

## Deploy notes

None. No migrations, flags, env, or type regen.