### PR TITLE
fix(programs): A+A Plan A seed fidelity + single-arm complex EMOM

### DIFF
--- a/e2e/program-aa-protocol.spec.ts
+++ b/e2e/program-aa-protocol.spec.ts
@@ -10,12 +10,14 @@ import { expect, test } from '@playwright/test';
 // authenticated user).
 //
 // The layout asserted here is the refit one from
-// *_refit_aa_protocol_plan_a_autoregulated.sql (PROD-245), which reconciles the
-// seed with the source article: duration is autoregulated (every session a
-// 30-minute ceiling, not a ramp), and progression is milestone-based — the
-// C+J -> C+J+C -> C+J+C+J stages ARE the session blocks, each a single-arm
-// complex (one bell, weightTwoValue 0) so it alternates hands under EMOM and
-// sums volume per lift. Every fourth week deloads one bell size lighter.
+// *_refit_aa_protocol_plan_a_autoregulated.sql (PROD-245): a single 4-week
+// clean & jerk block. Duration is autoregulated (every session a 30-minute
+// ceiling, not a ramp) and every session is the same single-arm C+J complex
+// (One-Arm Clean + One-Arm Jerk, one bell / weightTwoValue 0) so it alternates
+// hands under EMOM and sums volume per lift. The 4th week is a deload one bell
+// size lighter. The later complexes (C+J+C, C+J+C+J) live in the program
+// description as the next step, not as encoded sessions — the app has no
+// queue/repeat primitive to sequence stages, so a user repeats this block.
 
 const SUPABASE_URL = process.env.VITE_SUPABASE_URL!;
 const SUPABASE_ANON_KEY = process.env.VITE_SUPABASE_ANON_KEY!;
@@ -24,24 +26,16 @@ const CLEAN = 'One-Arm Kettlebell Clean';
 const JERK = 'One-Arm Kettlebell Jerk';
 const EMOM_INTERVAL_SECONDS = 30;
 const GOAL_CEILING = 30;
-const NUM_WEEKS = 12;
+const NUM_WEEKS = 4;
 const DAYS_PER_WEEK = 2;
 const WORKING_WEIGHT = 24;
 // "-8kg for gentlemen" from the 24 kg placeholder.
 const DELOAD_WEIGHT = 16;
-const DELOAD_WEEKS = [4, 8, 12];
+const DELOAD_WEEKS = [4];
 
-// The decomposed complex per milestone stage (no compound "Clean and Jerk").
-const STAGE_MOVEMENTS: Record<number, string[]> = {
-  1: [CLEAN, JERK], // C+J
-  2: [CLEAN, JERK, CLEAN], // C+J+C
-  3: [CLEAN, JERK, CLEAN, JERK], // C+J+C+J
-};
-const STAGE_BY_WEEK: Record<number, number> = {
-  1: 1, 2: 1, 3: 1, 4: 1,
-  5: 2, 6: 2, 7: 2, 8: 2,
-  9: 3, 10: 3, 11: 3, 12: 3,
-};
+// The single-arm clean & jerk complex, decomposed (no compound "Clean and
+// Jerk"). Every session in the block is this same C+J pair.
+const CJ_MOVEMENTS = [CLEAN, JERK];
 
 interface ExpectedSession {
   seq: number;
@@ -52,12 +46,11 @@ interface ExpectedSession {
   movements: string[];
 }
 
-// 12 weeks x 2 days = 24 sessions, in sequence order.
+// 4 weeks x 2 days = 8 sessions, in sequence order.
 const EXPECTED_SESSIONS: ExpectedSession[] = [];
 {
   let seq = 0;
   for (let week = 1; week <= NUM_WEEKS; week++) {
-    const stage = STAGE_BY_WEEK[week];
     const isDeload = DELOAD_WEEKS.includes(week);
     for (let day = 1; day <= DAYS_PER_WEEK; day++) {
       EXPECTED_SESSIONS.push({
@@ -66,7 +59,7 @@ const EXPECTED_SESSIONS: ExpectedSession[] = [];
         day,
         weight: isDeload ? DELOAD_WEIGHT : WORKING_WEIGHT,
         isDeload,
-        movements: STAGE_MOVEMENTS[stage],
+        movements: CJ_MOVEMENTS,
       });
     }
   }
@@ -214,12 +207,21 @@ test.describe('program schema — A+A Protocol "Plan A" seed', () => {
       });
     });
 
-    // Every session belongs to exactly one of twelve weeks, two days apiece.
+    // Every session belongs to exactly one of four weeks, two days apiece.
     expect(new Set(sessions.map((s) => s.week_number)).size).toBe(NUM_WEEKS);
     for (let week = 1; week <= NUM_WEEKS; week++) {
       const inWeek = sessions.filter((s) => s.week_number === week);
       expect(inWeek).toHaveLength(DAYS_PER_WEEK);
       expect(inWeek.map((s) => s.day_number)).toEqual([1, 2]);
+    }
+
+    // Single stage: every session is the same 2-lift C+J complex — no encoded
+    // C+J+C / C+J+C+J progression (that lives in the description as the next step).
+    for (const s of sessions) {
+      expect(s.workout_options.movements.map((m) => m.movementName)).toEqual([
+        CLEAN,
+        JERK,
+      ]);
     }
 
     // Duration is autoregulated, not a ramp: every session shares the 30-minute

--- a/e2e/program-aa-protocol.spec.ts
+++ b/e2e/program-aa-protocol.spec.ts
@@ -1,49 +1,76 @@
 import { expect, test } from '@playwright/test';
 
 // Focused backend test for the seeded StrongFirst "A+A Protocol, Plan A" program
-// (PROD-229). This is the FIRST shipped program to use intervalTimer, so it
-// asserts every session carries the non-zero EMOM interval plus the single-KB
-// one-arm clean & jerk / minutes-goal shape the seed migration encodes. Like
-// e2e/program-schema.spec.ts it hits the LOCAL Supabase REST API directly rather
-// than driving the browser; programs REVOKE anon, so it authenticates as a
-// throwaway user (public rows are readable by any authenticated user).
+// (PROD-229). This is the FIRST shipped program to use intervalTimer AND the
+// first single-arm complex, so it asserts every session carries the non-zero
+// EMOM interval plus the single-KB, one-hand, decomposed clean+jerk complex the
+// seed migration encodes. Like e2e/program-schema.spec.ts it hits the LOCAL
+// Supabase REST API directly rather than driving the browser; programs REVOKE
+// anon, so it authenticates as a throwaway user (public rows are readable by any
+// authenticated user).
 //
-// The layout asserted here is the reshaped one from
-// *_reshape_aa_protocol_plan_a.sql, which reconciles the seed with the source
-// article: twice a week for eight weeks, a duration ramp toward 30 minutes, and
-// every fourth week deloaded one bell size lighter at the SAME duration.
+// The layout asserted here is the refit one from
+// *_refit_aa_protocol_plan_a_autoregulated.sql (PROD-245), which reconciles the
+// seed with the source article: duration is autoregulated (every session a
+// 30-minute ceiling, not a ramp), and progression is milestone-based — the
+// C+J -> C+J+C -> C+J+C+J stages ARE the session blocks, each a single-arm
+// complex (one bell, weightTwoValue 0) so it alternates hands under EMOM and
+// sums volume per lift. Every fourth week deloads one bell size lighter.
 
 const SUPABASE_URL = process.env.VITE_SUPABASE_URL!;
 const SUPABASE_ANON_KEY = process.env.VITE_SUPABASE_ANON_KEY!;
 const AA_SLUG = 'aa-protocol-plan-a';
-const MOVEMENT = 'One-Arm Kettlebell Clean and Jerk';
+const CLEAN = 'One-Arm Kettlebell Clean';
+const JERK = 'One-Arm Kettlebell Jerk';
 const EMOM_INTERVAL_SECONDS = 30;
-const NUM_WEEKS = 8;
+const GOAL_CEILING = 30;
+const NUM_WEEKS = 12;
 const DAYS_PER_WEEK = 2;
 const WORKING_WEIGHT = 24;
 // "-8kg for gentlemen" from the 24 kg placeholder.
 const DELOAD_WEIGHT = 16;
-const DELOAD_WEEKS = [4, 8];
+const DELOAD_WEEKS = [4, 8, 12];
 
-// Per-session expectations, in sequence order.
-const EXPECTED_SESSIONS = [
-  { seq: 0, week: 1, day: 1, goal: 10, weight: WORKING_WEIGHT },
-  { seq: 1, week: 1, day: 2, goal: 12, weight: WORKING_WEIGHT },
-  { seq: 2, week: 2, day: 1, goal: 14, weight: WORKING_WEIGHT },
-  { seq: 3, week: 2, day: 2, goal: 16, weight: WORKING_WEIGHT },
-  { seq: 4, week: 3, day: 1, goal: 18, weight: WORKING_WEIGHT },
-  { seq: 5, week: 3, day: 2, goal: 20, weight: WORKING_WEIGHT },
-  { seq: 6, week: 4, day: 1, goal: 20, weight: DELOAD_WEIGHT },
-  { seq: 7, week: 4, day: 2, goal: 20, weight: DELOAD_WEIGHT },
-  { seq: 8, week: 5, day: 1, goal: 22, weight: WORKING_WEIGHT },
-  { seq: 9, week: 5, day: 2, goal: 24, weight: WORKING_WEIGHT },
-  { seq: 10, week: 6, day: 1, goal: 26, weight: WORKING_WEIGHT },
-  { seq: 11, week: 6, day: 2, goal: 28, weight: WORKING_WEIGHT },
-  { seq: 12, week: 7, day: 1, goal: 30, weight: WORKING_WEIGHT },
-  { seq: 13, week: 7, day: 2, goal: 30, weight: WORKING_WEIGHT },
-  { seq: 14, week: 8, day: 1, goal: 30, weight: DELOAD_WEIGHT },
-  { seq: 15, week: 8, day: 2, goal: 30, weight: DELOAD_WEIGHT },
-];
+// The decomposed complex per milestone stage (no compound "Clean and Jerk").
+const STAGE_MOVEMENTS: Record<number, string[]> = {
+  1: [CLEAN, JERK], // C+J
+  2: [CLEAN, JERK, CLEAN], // C+J+C
+  3: [CLEAN, JERK, CLEAN, JERK], // C+J+C+J
+};
+const STAGE_BY_WEEK: Record<number, number> = {
+  1: 1, 2: 1, 3: 1, 4: 1,
+  5: 2, 6: 2, 7: 2, 8: 2,
+  9: 3, 10: 3, 11: 3, 12: 3,
+};
+
+interface ExpectedSession {
+  seq: number;
+  week: number;
+  day: number;
+  weight: number;
+  isDeload: boolean;
+  movements: string[];
+}
+
+// 12 weeks x 2 days = 24 sessions, in sequence order.
+const EXPECTED_SESSIONS: ExpectedSession[] = [];
+{
+  let seq = 0;
+  for (let week = 1; week <= NUM_WEEKS; week++) {
+    const stage = STAGE_BY_WEEK[week];
+    const isDeload = DELOAD_WEEKS.includes(week);
+    for (let day = 1; day <= DAYS_PER_WEEK; day++) {
+      EXPECTED_SESSIONS.push({
+        seq: seq++,
+        week,
+        day,
+        weight: isDeload ? DELOAD_WEIGHT : WORKING_WEIGHT,
+        isDeload,
+        movements: STAGE_MOVEMENTS[stage],
+      });
+    }
+  }
+}
 
 interface MovementOption {
   movementName: string;
@@ -58,6 +85,8 @@ interface WorkoutOptions {
   restTimer: number;
   workoutGoal: number;
   workoutGoalUnits: string;
+  sharedWeightOneValue: number;
+  sharedWeightTwoValue: number;
   movements: MovementOption[];
 }
 
@@ -106,7 +135,7 @@ async function restJson<T = unknown>(path: string, token: string): Promise<T> {
 }
 
 test.describe('program schema — A+A Protocol "Plan A" seed', () => {
-  test('is present, public, system-owned, with intervalTimer-paced sessions', async () => {
+  test('is present, public, system-owned, with single-arm complex EMOM sessions', async () => {
     const token = await signUpThrowawayUser();
 
     const programs = await restJson<
@@ -153,32 +182,39 @@ test.describe('program schema — A+A Protocol "Plan A" seed', () => {
       const expected = EXPECTED_SESSIONS[i];
       const wo = s.workout_options;
 
-      // Twice a week for eight weeks — the cadence the program advertises.
+      // Twice a week for twelve weeks — the cadence the program advertises.
       expect(s.week_number).toBe(expected.week);
       expect(s.day_number).toBe(expected.day);
 
       // The defining feature: every session is EMOM-paced by a non-zero interval,
       // with no separate between-set rest.
       expect(wo.intervalTimer).toBe(EMOM_INTERVAL_SECONDS);
-      expect(wo.intervalTimer).toBeGreaterThan(0);
       expect(wo.restTimer).toBe(0);
 
-      // Single-movement, minutes-goal shape (not a complex).
-      expect(wo.complexSet).toBe(false);
+      // Autoregulated duration: a 30-minute ceiling on every session (the note,
+      // not the goal, tells the athlete to stop early on a failed talk test).
       expect(wo.workoutGoalUnits).toBe('minutes');
-      expect(wo.workoutGoal).toBe(expected.goal);
-      expect(wo.movements).toHaveLength(1);
+      expect(wo.workoutGoal).toBe(GOAL_CEILING);
 
-      const movement = wo.movements[0];
-      expect(movement.movementName).toBe(MOVEMENT);
-      expect(movement.repScheme).toEqual([1]);
-      // One-handed: primary weight set, secondary 0 -> drives left/right EMOM
-      // alternation at runtime.
-      expect(movement.weightOneValue).toBe(expected.weight);
-      expect(movement.weightTwoValue).toBe(0);
+      // Single-arm complex: one shared bell (weightTwo 0), decomposed lifts.
+      expect(wo.complexSet).toBe(true);
+      expect(wo.sharedWeightOneValue).toBe(expected.weight);
+      expect(wo.sharedWeightTwoValue).toBe(0);
+
+      // Stage decomposition: C+J -> C+J+C -> C+J+C+J, in order, no compound lift.
+      expect(wo.movements.map((m) => m.movementName)).toEqual(
+        expected.movements,
+      );
+      wo.movements.forEach((movement) => {
+        expect(movement.repScheme).toEqual([1]);
+        // One-handed single bell: primary weight set, secondary 0 -> drives the
+        // left/right EMOM alternation at runtime.
+        expect(movement.weightOneValue).toBe(expected.weight);
+        expect(movement.weightTwoValue).toBe(0);
+      });
     });
 
-    // Every session belongs to exactly one of eight weeks, two days apiece.
+    // Every session belongs to exactly one of twelve weeks, two days apiece.
     expect(new Set(sessions.map((s) => s.week_number)).size).toBe(NUM_WEEKS);
     for (let week = 1; week <= NUM_WEEKS; week++) {
       const inWeek = sessions.filter((s) => s.week_number === week);
@@ -186,14 +222,11 @@ test.describe('program schema — A+A Protocol "Plan A" seed', () => {
       expect(inWeek.map((s) => s.day_number)).toEqual([1, 2]);
     }
 
-    // Duration never regresses: the ramp builds toward the 30-minute target and
-    // each deload week HOLDS the preceding week's duration rather than cutting
-    // it — the source deloads by dropping a bell size, nothing else.
-    const goals = sessions.map((s) => s.workout_options.workoutGoal);
-    for (let i = 1; i < goals.length; i++) {
-      expect(goals[i]).toBeGreaterThanOrEqual(goals[i - 1]);
-    }
-    expect(goals[goals.length - 1]).toBe(30);
+    // Duration is autoregulated, not a ramp: every session shares the 30-minute
+    // ceiling, deloads included.
+    expect(
+      sessions.every((s) => s.workout_options.workoutGoal === GOAL_CEILING),
+    ).toBe(true);
 
     // The deload group carries an authored name so the enrollment picker can
     // label its weight control something better than "8 kg lighter".
@@ -203,17 +236,15 @@ test.describe('program schema — A+A Protocol "Plan A" seed', () => {
       );
     }
 
+    // Deload weeks are the same stage complex, one bell size lighter (24 -> 16).
     for (const week of DELOAD_WEEKS) {
       const deload = sessions.filter((s) => s.week_number === week);
-      const priorWeek = sessions.filter((s) => s.week_number === week - 1);
-      const priorDuration = priorWeek[priorWeek.length - 1].workout_options
-        .workoutGoal;
       for (const s of deload) {
-        expect(s.workout_options.workoutGoal).toBe(priorDuration);
-        // "-8kg for gentlemen" — one kettlebell size below the working load.
-        expect(s.workout_options.movements[0].weightOneValue).toBe(
-          WORKING_WEIGHT - 8,
-        );
+        expect(s.workout_options.sharedWeightOneValue).toBe(DELOAD_WEIGHT);
+        for (const movement of s.workout_options.movements) {
+          // "-8kg for gentlemen" — one kettlebell size below the working load.
+          expect(movement.weightOneValue).toBe(WORKING_WEIGHT - 8);
+        }
       }
     }
   });

--- a/e2e/program-schema.spec.ts
+++ b/e2e/program-schema.spec.ts
@@ -18,8 +18,8 @@ const SWING10K_SESSION_COUNT = 20;
 const SNATCH_SLUG = 'strongfirst-snatch-test-plan';
 const SNATCH_SESSION_COUNT = 30; // 10 weeks x 3 days
 const AA_SLUG = 'aa-protocol-plan-a';
-const AA_SESSION_COUNT = 16; // 8 weeks x 2 days
-const AA_DELOAD_WEEKS = [4, 8]; // authored one bell size below the placeholder
+const AA_SESSION_COUNT = 24; // 12 weeks x 2 days (PROD-245 refit)
+const AA_DELOAD_WEEKS = [4, 8, 12]; // authored one bell size below the placeholder
 
 // ── Types ────────────────────────────────────────────────────────────────────
 
@@ -1044,7 +1044,7 @@ test.describe('program schema — enroll_in_program (starting weight, PROD-TBD)'
     }
   });
 
-  test('per-movement weights carry each movement’s cross-session offset', async () => {
+  test('the chosen single bell folds onto every movement of the complex, offset and labelled', async () => {
     const user = await signUpThrowawayUser();
 
     const [aa] = await restJson<Array<{ id: string }>>(
@@ -1053,20 +1053,15 @@ test.describe('program schema — enroll_in_program (starting weight, PROD-TBD)'
       user.token,
     );
 
-    // Single-bell clean & jerk at 16 kg. The deload weeks are authored 8 kg below
-    // the 24 kg modal, so they must scale to 8 relative to the chosen weight
-    // rather than freezing at their absolute seed load.
+    // A+A is now a single-arm complexSet program — one bell for the whole
+    // Clean+Jerk chain — so the picker sends a shared weight (like the ABC), not
+    // per-movement weights. The deload weeks are authored 8 kg below the 24 kg
+    // modal, so they scale to 8 relative to the chosen 16 kg.
     await rpc<string>('enroll_in_program', user.token, {
       p_program_id: aa.id,
-      p_movement_weights: [
-        {
-          movementName: 'One-Arm Kettlebell Clean and Jerk',
-          weightOneValue: 16,
-          weightOneUnit: 'kilograms',
-          weightTwoValue: 0,
-          weightTwoUnit: null,
-        },
-      ],
+      p_shared_weight_one_value: 16,
+      p_shared_weight_one_unit: 'kilograms',
+      p_shared_weight_two_value: 0,
     });
 
     const clones = await restJson<Array<{ id: string }>>(
@@ -1081,6 +1076,7 @@ test.describe('program schema — enroll_in_program (starting weight, PROD-TBD)'
         week_number: number;
         weight_label: string | null;
         workout_options: {
+          sharedWeightOneValue: number;
           movements: Array<{ weightOneValue: number; weightTwoValue: number }>;
         };
       }>
@@ -1093,17 +1089,20 @@ test.describe('program schema — enroll_in_program (starting weight, PROD-TBD)'
 
     for (const session of sessions) {
       const isDeloadWeek = AA_DELOAD_WEEKS.includes(session.week_number);
-      expect(session.workout_options.movements[0].weightOneValue).toBe(
-        isDeloadWeek ? 8 : 16,
-      );
-      // Single-bell loading survives: weight two stays 0, never clamped up to 1.
-      expect(session.workout_options.movements[0].weightTwoValue).toBe(0);
+      const expectedWeight = isDeloadWeek ? 8 : 16;
+      // The offset lands on the shared bell and on EVERY decomposed lift.
+      expect(session.workout_options.sharedWeightOneValue).toBe(expectedWeight);
+      for (const movement of session.workout_options.movements) {
+        expect(movement.weightOneValue).toBe(expectedWeight);
+        // Single-bell loading survives: weight two stays 0, never clamped up to 1.
+        expect(movement.weightTwoValue).toBe(0);
+      }
       // The group's authored label rides along onto the clone.
       expect(session.weight_label).toBe(isDeloadWeek ? 'Deload weeks' : null);
     }
   });
 
-  test('a per-movement weight in a different unit lands flat, declining the offset', async () => {
+  test('a chosen bell in a different unit lands flat, declining the offset', async () => {
     const user = await signUpThrowawayUser();
 
     const [aa] = await restJson<Array<{ id: string }>>(
@@ -1116,15 +1115,9 @@ test.describe('program schema — enroll_in_program (starting weight, PROD-TBD)'
     // session — deload weeks included — lands flat at the chosen 44 lb.
     await rpc<string>('enroll_in_program', user.token, {
       p_program_id: aa.id,
-      p_movement_weights: [
-        {
-          movementName: 'One-Arm Kettlebell Clean and Jerk',
-          weightOneValue: 44,
-          weightOneUnit: 'pounds',
-          weightTwoValue: 0,
-          weightTwoUnit: null,
-        },
-      ],
+      p_shared_weight_one_value: 44,
+      p_shared_weight_one_unit: 'pounds',
+      p_shared_weight_two_value: 0,
     });
 
     const clones = await restJson<Array<{ id: string }>>(
@@ -1136,6 +1129,8 @@ test.describe('program schema — enroll_in_program (starting weight, PROD-TBD)'
     const sessions = await restJson<
       Array<{
         workout_options: {
+          sharedWeightOneValue: number;
+          sharedWeightOneUnit: string;
           movements: Array<{ weightOneValue: number; weightOneUnit: string }>;
         };
       }>
@@ -1146,9 +1141,12 @@ test.describe('program schema — enroll_in_program (starting weight, PROD-TBD)'
     );
 
     for (const session of sessions) {
-      const movement = session.workout_options.movements[0];
-      expect(movement.weightOneValue).toBe(44);
-      expect(movement.weightOneUnit).toBe('pounds');
+      expect(session.workout_options.sharedWeightOneValue).toBe(44);
+      expect(session.workout_options.sharedWeightOneUnit).toBe('pounds');
+      for (const movement of session.workout_options.movements) {
+        expect(movement.weightOneValue).toBe(44);
+        expect(movement.weightOneUnit).toBe('pounds');
+      }
     }
   });
 

--- a/e2e/program-schema.spec.ts
+++ b/e2e/program-schema.spec.ts
@@ -18,8 +18,8 @@ const SWING10K_SESSION_COUNT = 20;
 const SNATCH_SLUG = 'strongfirst-snatch-test-plan';
 const SNATCH_SESSION_COUNT = 30; // 10 weeks x 3 days
 const AA_SLUG = 'aa-protocol-plan-a';
-const AA_SESSION_COUNT = 24; // 12 weeks x 2 days (PROD-245 refit)
-const AA_DELOAD_WEEKS = [4, 8, 12]; // authored one bell size below the placeholder
+const AA_SESSION_COUNT = 8; // 4 weeks x 2 days (PROD-245 refit)
+const AA_DELOAD_WEEKS = [4]; // authored one bell size below the placeholder
 
 // ── Types ────────────────────────────────────────────────────────────────────
 

--- a/src/pages/ActiveWorkoutPage/ActiveWorkoutPage.stories.tsx
+++ b/src/pages/ActiveWorkoutPage/ActiveWorkoutPage.stories.tsx
@@ -271,6 +271,48 @@ export const AAProtocolPlanASession: Story = {
   },
 };
 
+// A+A Protocol "Plan A" stage 2+ (PROD-245): a SINGLE-arm complex under EMOM.
+// The whole Clean + Jerk chain is done on one hand, then the next interval fires
+// it on the other — left on the minute, right 30s later — while volume sums
+// across every movement. Single bell (weightTwoValue 0 / sharedWeightTwoValue 0)
+// is what distinguishes this from the two-hand and double-bell complexes, which
+// do not alternate sides.
+export const SingleArmComplexEMOM: Story = {
+  parameters: {
+    workoutOptions: {
+      complexSet: true,
+      intervalTimer: 30,
+      restTimer: 0,
+      workoutGoal: 30,
+      workoutGoalUnits: 'minutes',
+      sharedWeightOneValue: 24,
+      sharedWeightOneUnit: 'kilograms',
+      sharedWeightTwoValue: 0,
+      sharedWeightTwoUnit: 'kilograms',
+      movements: [
+        {
+          ...DEFAULT_MOVEMENT_OPTIONS,
+          movementName: 'One-Arm Kettlebell Clean',
+          repScheme: [1],
+          weightOneValue: 24,
+          weightOneUnit: 'kilograms',
+          weightTwoValue: 0,
+          weightTwoUnit: 'kilograms',
+        },
+        {
+          ...DEFAULT_MOVEMENT_OPTIONS,
+          movementName: 'One-Arm Kettlebell Jerk',
+          repScheme: [1],
+          weightOneValue: 24,
+          weightOneUnit: 'kilograms',
+          weightTwoValue: 0,
+          weightTwoUnit: 'kilograms',
+        },
+      ] satisfies MovementOptions[],
+    },
+  },
+};
+
 // Timed movements (PROD-200) — the Kettlebell Mile seed's shape: a single
 // one-handed suitcase carry on ONE 60-second rung, with rounds as the
 // progression lever (week 1 is 3 rounds = 6 min under load). One-handed loading

--- a/src/pages/ActiveWorkoutPage/ActiveWorkoutPage.test.jsx
+++ b/src/pages/ActiveWorkoutPage/ActiveWorkoutPage.test.jsx
@@ -20,6 +20,7 @@ const {
   MultipleMovementsAndMixedWeights,
   OneHanded,
   AAProtocolPlanASession,
+  SingleArmComplexEMOM,
   KettlebellMileSession,
   TimedRungsVaryingDurations,
   TimedRungsVolumeGoal,
@@ -1167,6 +1168,13 @@ describe('active workout page (complex mode)', () => {
     expect(round).toHaveTextContent('1');
   });
 
+  // Regression guard for PROD-245: a two-hand complex (weightTwoValue null) is
+  // NOT a single-arm complex, so it must not alternate sides or show the side
+  // indicator that single-bell one-arm complexes now render.
+  test('does not show a side indicator (two-hand complex, no side-switching)', () => {
+    expect(screen.queryByTestId('current-side')).toBeNull();
+  });
+
   test('shows shared weight in card header', () => {
     const weight = screen.getByTestId('complex-shared-weight');
     expect(weight).toHaveTextContent('24');
@@ -1354,6 +1362,64 @@ describe('active workout page (A+A Protocol interval EMOM cadence)', () => {
     expect(leftWeight).toHaveAttribute('data-active', 'true');
     expect(rightWeight).toHaveAttribute('data-active', 'false');
     expect(round).toHaveTextContent('2');
+  });
+});
+
+// Single-arm complex under EMOM (PROD-245). The A+A seed's stage 2+ shape: a
+// Clean + Jerk chain done on ONE hand, then the other on the next interval fire.
+// complexSet no longer forfeits the arm-alternation a one-handed intervalTimer
+// movement gets — the whole chain mirrors, left on the minute, right 30s later.
+describe('active workout page (single-arm complex EMOM cadence)', () => {
+  vi.mock('~/api', () => ({
+    useLogWorkout: vi.fn(),
+  }));
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    useLogWorkout.mockReturnValue({
+      mutate: vi.fn(),
+      data: null,
+      isLoading: false,
+    });
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    vi.useRealTimers();
+  });
+
+  test('auto-alternates hands every 30s, one L+R pair per round', () => {
+    render(<SingleArmComplexEMOM />);
+
+    const side = screen.getByTestId('current-side');
+    const round = screen.getByTestId('current-round');
+
+    // Left hand does the whole complex "on the minute".
+    expect(side).toHaveTextContent('Left hand · side 1 of 2');
+    expect(round).toHaveTextContent('1');
+
+    // 30s later the interval fires a continue on its own -> right hand.
+    act(() => vi.advanceTimersByTime(30_000));
+    expect(side).toHaveTextContent('Right hand · side 2 of 2');
+    expect(round).toHaveTextContent('1');
+
+    // Another 30s completes the L+R pair -> back to left, round 2.
+    act(() => vi.advanceTimersByTime(30_000));
+    expect(side).toHaveTextContent('Left hand · side 1 of 2');
+    expect(round).toHaveTextContent('2');
+  });
+
+  test('sums volume across both movements per hand (24kg Clean + 24kg Jerk = 48kg/hand, 96kg per L+R round)', () => {
+    render(<SingleArmComplexEMOM />);
+
+    const summary = screen.getByTestId('completed-section');
+    expect(summary).toHaveTextContent('0 kg');
+
+    // Each interval fire is one hand's full complex (Clean 24 + Jerk 24 = 48kg).
+    act(() => vi.advanceTimersByTime(30_000)); // left  -> 48kg
+    act(() => vi.advanceTimersByTime(30_000)); // right -> 96kg, one L+R round
+
+    expect(summary).toHaveTextContent('96 kg');
   });
 });
 

--- a/src/pages/ActiveWorkoutPage/ActiveWorkoutPage.tsx
+++ b/src/pages/ActiveWorkoutPage/ActiveWorkoutPage.tsx
@@ -245,6 +245,20 @@ export const ActiveWorkoutPage = ({
     ? Math.max(...movements.map((m) => m.repScheme.length))
     : currentMovementRungs;
 
+  // Single-arm complex (PROD-245): every movement is a one-hand single bell
+  // (weightTwoValue === 0), so each interval fire alternates hands the way a
+  // non-complex one-handed movement does. weightTwoValue null (two-hand) or > 0
+  // (double) are excluded, keeping the two-hand and double-bell complexes on
+  // their existing no-side-switch path.
+  const isSingleArmComplex =
+    complexSet &&
+    movements.every(
+      (m) =>
+        m.weightOneValue !== null &&
+        m.weightOneValue > 0 &&
+        m.weightTwoValue === 0,
+    );
+
   const incrementReps = () =>
     setCompletedReps((prev) =>
       isTimedRung
@@ -311,6 +325,18 @@ export const ActiveWorkoutPage = ({
       setCurrentMovementRungIndex(0);
     } else {
       setCurrentMovementRungIndex((prev) => prev + 1);
+    }
+  };
+
+  // Single-arm complex: mirror the non-complex goToNextSide cadence — the first
+  // fire flips to the other hand at the same rung, the second returns and
+  // advances the rung/round. One round = one L+R pair.
+  const goToNextSideComplex = () => {
+    if (isMirrorSet) {
+      setIsMirrorSet(false);
+      goToNextSetComplex();
+    } else {
+      setIsMirrorSet(true);
     }
   };
 
@@ -399,7 +425,11 @@ export const ActiveWorkoutPage = ({
     if (complexSet) {
       incrementRepsComplex();
       incrementVolumeComplex();
-      goToNextSetComplex();
+      if (isSingleArmComplex) {
+        goToNextSideComplex();
+      } else {
+        goToNextSetComplex();
+      }
     } else {
       incrementReps();
       incrementVolume();
@@ -566,12 +596,14 @@ export const ActiveWorkoutPage = ({
       {complexSet ? (
         <ComplexMovementDisplay
           currentRound={currentRound}
+          currentSide={currentSide}
           movements={movements}
           rungIndex={currentMovementRungIndex}
           sharedWeightTwoUnit={sharedWeightTwoUnit}
           sharedWeightTwoValue={sharedWeightTwoValue}
           sharedWeightUnit={sharedWeightOneUnit}
           sharedWeightValue={sharedWeightOneValue}
+          totalSides={isSingleArmComplex ? totalSides : 1}
         />
       ) : (
         <CurrentMovement

--- a/src/pages/ActiveWorkoutPage/components/ComplexMovementDisplay.tsx
+++ b/src/pages/ActiveWorkoutPage/components/ComplexMovementDisplay.tsx
@@ -1,29 +1,43 @@
-import { Card, CardContent, CardHeader, CardTitle } from '~/components/ui/card';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '~/components/ui/card';
 import { MovementOptions, WeightUnit } from '~/types';
 import { formatRungDuration, getWeightUnitLabel } from '~/utils';
 
 interface ComplexMovementDisplayProps {
   currentRound: number;
+  currentSide?: number;
   movements: MovementOptions[];
   rungIndex: number;
   sharedWeightTwoUnit: WeightUnit | null;
   sharedWeightTwoValue: number | null;
   sharedWeightUnit: WeightUnit | null;
   sharedWeightValue: number | null;
+  totalSides?: number;
 }
 
 export const ComplexMovementDisplay = ({
   currentRound,
+  currentSide = 1,
   movements,
   rungIndex,
   sharedWeightTwoUnit,
   sharedWeightTwoValue,
   sharedWeightUnit,
   sharedWeightValue,
+  totalSides = 1,
 }: ComplexMovementDisplayProps) => {
   const hasWeightOne = sharedWeightValue !== null && sharedWeightValue > 0;
   const hasWeightTwo =
     sharedWeightTwoValue !== null && sharedWeightTwoValue > 0;
+
+  // Single-arm complex: the whole chain is done on one hand, then the other on
+  // the next set. currentSide 1 = left, 2 = right.
+  const activeHand = currentSide === 1 ? 'Left' : 'Right';
 
   return (
     <Card>
@@ -74,6 +88,15 @@ export const ComplexMovementDisplay = ({
       </CardHeader>
 
       <CardContent>
+        {totalSides > 1 && (
+          <CardDescription
+            className="pb-1 text-center"
+            data-testid="current-side"
+          >
+            {activeHand} hand · side {currentSide} of {totalSides}
+          </CardDescription>
+        )}
+
         <div className="divide-y">
           {movements.map((movement, index) => {
             const repIndex = Math.min(rungIndex, movement.repScheme.length - 1);

--- a/supabase/migrations/20260724000005_refit_aa_protocol_plan_a_autoregulated.sql
+++ b/supabase/migrations/20260724000005_refit_aa_protocol_plan_a_autoregulated.sql
@@ -1,5 +1,5 @@
 -- Refit the StrongFirst "A+A Protocol, Plan A" template to its source's
--- autoregulated, milestone-based structure (PROD-245).
+-- autoregulated structure, as a single 4-week clean & jerk block (PROD-245).
 -- Source: https://www.strongfirst.com/the-best-all-around-training-method-ever/
 --
 -- 20260723000001_reshape_aa_protocol_plan_a.sql fixed the cadence but modeled
@@ -18,17 +18,23 @@
 --                  early stop.)
 --   2. Note        The reshape's note stated only the "stop early" half. Now it
 --                  states both halves ("carry on until ... stop then").
---   3. Progression Milestone stages, not a calendar ramp. The C+J -> C+J+C ->
---                  C+J+C+J milestones ARE the session progression (see mapping
---                  below), each a single-arm complex so per-lift volume is exact.
---   4. Lifts       Fully decomposed into One-Arm Clean + One-Arm Jerk (no
---                  compound "Clean and Jerk"), so each lift is counted once and
---                  cleans bucket to hinge / jerks to push. Volume grows 2 -> 3
---                  -> 4x the bell across the stages.
+--   3. Structure   A single 4-week block: three build weeks + a deload week.
+--                  The source progression (C+J -> C+J+C -> C+J+C+J) is milestone-
+--                  gated ("repeat until you own 30 min, then escalate"), and the
+--                  app has no queue/repeat/program-family primitive to sequence
+--                  separate stages, so we ship the first stage (C+J) as a short
+--                  block a user repeats. Repeating a 4-week block reproduces the
+--                  source's every-4th-week deload for free. The later complexes
+--                  live in the description as the next step, not as encoded
+--                  sessions (escalating them is a future program-series feature).
+--   4. Lifts       C+J is a single-arm complex of decomposed lifts (One-Arm
+--                  Clean + One-Arm Jerk, no compound "Clean and Jerk"), so each
+--                  lift is counted once for volume and cleans bucket to hinge /
+--                  jerks to push.
 --   5. Deloads     KEPT (source-accurate: "Every fourth week deload by going
 --                  down a kettlebell size -4 kg per kettlebell for ladies, -8 kg
---                  for gentlemen"), but refit to the same 30-min ceiling instead
---                  of the reshape's fixed 20/30-min holds.
+--                  for gentlemen"), the 4th week of the block, at the same 30-min
+--                  ceiling one bell size lighter.
 --
 -- NB: pg_temp functions persist for the whole connection, and CI applies every
 -- migration in one session, so these helpers are prefixed aa_refit_ to avoid
@@ -36,25 +42,14 @@
 -- the reshape migration defines earlier in the same session (a same-signature,
 -- different-parameter-name CREATE fails with SQLSTATE 42P13).
 --
--- These sessions are the app's first SINGLE-ARM complexes: complexSet true with
--- one-hand movements (weightTwoValue 0) and intervalTimer 30, so each interval
--- fire runs the whole complex on one hand, then the other 30s later. The runtime
--- support for that (side-switch on a single-bell complex) ships alongside this
--- migration in src/pages/ActiveWorkoutPage.
+-- This is the app's first SINGLE-ARM complex: complexSet true with one-hand
+-- movements (weightTwoValue 0) and intervalTimer 30, so each interval fire runs
+-- the whole complex on one hand, then the other 30s later. The runtime support
+-- for that (side-switch on a single-bell complex) ships alongside this migration
+-- in src/pages/ActiveWorkoutPage.
 --
--- Milestone -> program_sessions mapping (12 weeks x 2 days = 24 sessions;
--- deload every 4th week per the source). Because the schema has no per-enrollment
--- "advance when ready" state, the 12-week calendar is a REPRESENTATIVE scaffold:
--- the notes tell the athlete progression is milestone-gated (repeat a stage until
--- 30 min is repeatable with a clean talk test), not calendar-gated. Modeling that
--- mutable per-enrollment stage state is deferred to PROD-243 ("don't solve it
--- twice").
---   Weeks 1-3   Stage 1  C+J        (Clean, Jerk)
---   Week  4     Deload   Stage 1, one bell size lighter
---   Weeks 5-7   Stage 2  C+J+C      (Clean, Jerk, Clean)
---   Week  8     Deload   Stage 2, one bell size lighter
---   Weeks 9-11  Stage 3  C+J+C+J    (Clean, Jerk, Clean, Jerk)
---   Week  12    Deload   Stage 3, one bell size lighter
+--   Weeks 1-3   C+J  (Clean, Jerk)          work, 24 kg placeholder
+--   Week  4     Deload C+J, one bell size lighter (24 -> 16 kg)
 --
 -- Forward DATA FIX over deployed rows (the original seed and the reshape are
 -- applied in prod and ON CONFLICT DO NOTHING, so re-running them changes
@@ -73,23 +68,12 @@ RETURNS JSONB LANGUAGE sql IMMUTABLE AS $$
     'weightTwoUnit', 'kilograms', 'weightTwoValue', 0);
 $$;
 
--- The ordered complex for a stage: C+J, C+J+C, or C+J+C+J.
-CREATE OR REPLACE FUNCTION pg_temp.aa_refit_stage_movements(p_stage INT, p_weight INT)
+-- The clean & jerk complex: one clean, one jerk, on a single bell.
+CREATE OR REPLACE FUNCTION pg_temp.aa_refit_cj(p_weight INT)
 RETURNS JSONB LANGUAGE sql IMMUTABLE AS $$
-  SELECT CASE p_stage
-    WHEN 1 THEN jsonb_build_array(
-      pg_temp.aa_refit_mv('One-Arm Kettlebell Clean', p_weight),
-      pg_temp.aa_refit_mv('One-Arm Kettlebell Jerk', p_weight))
-    WHEN 2 THEN jsonb_build_array(
-      pg_temp.aa_refit_mv('One-Arm Kettlebell Clean', p_weight),
-      pg_temp.aa_refit_mv('One-Arm Kettlebell Jerk', p_weight),
-      pg_temp.aa_refit_mv('One-Arm Kettlebell Clean', p_weight))
-    ELSE jsonb_build_array(
-      pg_temp.aa_refit_mv('One-Arm Kettlebell Clean', p_weight),
-      pg_temp.aa_refit_mv('One-Arm Kettlebell Jerk', p_weight),
-      pg_temp.aa_refit_mv('One-Arm Kettlebell Clean', p_weight),
-      pg_temp.aa_refit_mv('One-Arm Kettlebell Jerk', p_weight))
-  END;
+  SELECT jsonb_build_array(
+    pg_temp.aa_refit_mv('One-Arm Kettlebell Clean', p_weight),
+    pg_temp.aa_refit_mv('One-Arm Kettlebell Jerk', p_weight));
 $$;
 
 -- Full workout_options for one session. Shape MUST match
@@ -114,41 +98,28 @@ RETURNS JSONB LANGUAGE sql IMMUTABLE AS $$
     'movements', p_movements);
 $$;
 
--- A working session at the placeholder 24 kg for the given stage.
-CREATE OR REPLACE FUNCTION pg_temp.aa_refit_work(p_stage INT)
+-- A working session at the placeholder 24 kg.
+CREATE OR REPLACE FUNCTION pg_temp.aa_refit_work()
 RETURNS JSONB LANGUAGE sql IMMUTABLE AS $$
-  SELECT pg_temp.aa_refit_options(24, CASE p_stage
-    WHEN 1 THEN
-      'Stage 1 - clean & jerk (C+J). One set every 30s, alternating hands: '
-      'left on the minute, right 30s later. Carry on until you cannot pass the '
-      'talk test right before the next set; stop then, or at 30 min, whichever '
-      'comes first. Repeat this stage until 30 min is repeatable with a clean '
-      'talk test, then advance to Stage 2 by adding a second clean (C+J+C).'
-    WHEN 2 THEN
-      'Stage 2 - clean, jerk, clean (C+J+C). One set every 30s, alternating '
-      'hands: left on the minute, right 30s later. Carry on until you cannot '
-      'pass the talk test right before the next set; stop then, or at 30 min, '
-      'whichever comes first. Repeat this stage until 30 min is repeatable with '
-      'a clean talk test, then advance to Stage 3 by adding a second jerk '
-      '(C+J+C+J).'
-    ELSE
-      'Stage 3 - clean, jerk, clean, jerk (C+J+C+J). One set every 30s, '
-      'alternating hands: left on the minute, right 30s later. Carry on until '
-      'you cannot pass the talk test right before the next set; stop then, or at '
-      '30 min, whichever comes first. Keep building toward three clean & jerks '
-      'every 30s.'
-  END, pg_temp.aa_refit_stage_movements(p_stage, 24));
+  SELECT pg_temp.aa_refit_options(24,
+    'Clean & jerk (C+J) - one bell, one set every 30s, alternating hands: left '
+    'on the minute, right 30s later. Carry on until you cannot pass the talk '
+    'test right before the next set; stop then, or at 30 min, whichever comes '
+    'first. Once 30 min is repeatable with a clean talk test, progress by adding '
+    'a second clean to each set (C+J+C).',
+    pg_temp.aa_refit_cj(24));
 $$;
 
--- A deload session: the same stage complex one bell size lighter (24 -> 16 kg),
+-- The deload session: same clean & jerk one bell size lighter (24 -> 16 kg),
 -- same 30s cadence and open-ended 30-min ceiling.
-CREATE OR REPLACE FUNCTION pg_temp.aa_refit_deload(p_stage INT)
+CREATE OR REPLACE FUNCTION pg_temp.aa_refit_deload()
 RETURNS JSONB LANGUAGE sql IMMUTABLE AS $$
   SELECT pg_temp.aa_refit_options(16,
     'Deload week - one kettlebell size lighter (-8 kg gentlemen, -4 kg ladies), '
-    'same complex and same 30s left/right cadence. Duration stays autoregulated: '
-    'carry on until the talk test fails, up to 30 min. Explode, and keep it easy.',
-    pg_temp.aa_refit_stage_movements(p_stage, 16));
+    'same clean & jerk and same 30s left/right cadence. Duration stays '
+    'autoregulated: carry on until the talk test fails, up to 30 min. Explode, '
+    'and keep it easy.',
+    pg_temp.aa_refit_cj(16));
 $$;
 
 DO $$
@@ -167,7 +138,7 @@ BEGIN
   END IF;
 
   UPDATE programs
-  SET num_weeks     = 12,
+  SET num_weeks     = 4,
       days_per_week = 2,
       description =
         'A single-kettlebell alactic+aerobic conditioning protocol built on the '
@@ -177,12 +148,12 @@ BEGIN
         'weight settles near 40% of bodyweight for men. Train twice a week (the '
         'source prescribes Monday and Thursday). Duration is autoregulated, not '
         'scheduled: carry on until you cannot pass the talk test right before the '
-        'next set - stop then, or at 30 minutes, whichever comes first. Progress '
-        'by milestone, not calendar: once 30 minutes is repeatable with a clean '
-        'talk test, add a second clean to each set (C+J+C), then a second jerk '
-        '(C+J+C+J), up to three clean & jerks every 30 seconds. Every fourth week, '
-        'deload one kettlebell size lighter (-8 kg gentlemen, -4 kg ladies) at the '
-        'same cadence.'
+        'next set - stop then, or at 30 minutes, whichever comes first. This is a '
+        'four-week block: three build weeks and a deload week one kettlebell size '
+        'lighter (-8 kg gentlemen, -4 kg ladies). Repeat the block until 30 '
+        'minutes of clean & jerk is repeatable with a clean talk test, then '
+        'progress by adding a second clean to each set (C+J+C), then a second '
+        'jerk (C+J+C+J), up to three clean & jerks every 30 seconds.'
   WHERE id = v_program_id;
 
   DELETE FROM program_sessions WHERE program_id = v_program_id;
@@ -191,36 +162,16 @@ BEGIN
   INSERT INTO program_sessions
     (program_id, sequence_index, week_number, day_number, title, workout_options)
   VALUES
-    -- Weeks 1-3: Stage 1, C+J
-    (v_program_id,  0,  1, 1, 'C+J',            pg_temp.aa_refit_work(1)),
-    (v_program_id,  1,  1, 2, 'C+J',            pg_temp.aa_refit_work(1)),
-    (v_program_id,  2,  2, 1, 'C+J',            pg_temp.aa_refit_work(1)),
-    (v_program_id,  3,  2, 2, 'C+J',            pg_temp.aa_refit_work(1)),
-    (v_program_id,  4,  3, 1, 'C+J',            pg_temp.aa_refit_work(1)),
-    (v_program_id,  5,  3, 2, 'C+J',            pg_temp.aa_refit_work(1)),
-    -- Week 4: deload, Stage 1
-    (v_program_id,  6,  4, 1, 'Deload · C+J',   pg_temp.aa_refit_deload(1)),
-    (v_program_id,  7,  4, 2, 'Deload · C+J',   pg_temp.aa_refit_deload(1)),
-    -- Weeks 5-7: Stage 2, C+J+C
-    (v_program_id,  8,  5, 1, 'C+J+C',          pg_temp.aa_refit_work(2)),
-    (v_program_id,  9,  5, 2, 'C+J+C',          pg_temp.aa_refit_work(2)),
-    (v_program_id, 10,  6, 1, 'C+J+C',          pg_temp.aa_refit_work(2)),
-    (v_program_id, 11,  6, 2, 'C+J+C',          pg_temp.aa_refit_work(2)),
-    (v_program_id, 12,  7, 1, 'C+J+C',          pg_temp.aa_refit_work(2)),
-    (v_program_id, 13,  7, 2, 'C+J+C',          pg_temp.aa_refit_work(2)),
-    -- Week 8: deload, Stage 2
-    (v_program_id, 14,  8, 1, 'Deload · C+J+C', pg_temp.aa_refit_deload(2)),
-    (v_program_id, 15,  8, 2, 'Deload · C+J+C', pg_temp.aa_refit_deload(2)),
-    -- Weeks 9-11: Stage 3, C+J+C+J
-    (v_program_id, 16,  9, 1, 'C+J+C+J',          pg_temp.aa_refit_work(3)),
-    (v_program_id, 17,  9, 2, 'C+J+C+J',          pg_temp.aa_refit_work(3)),
-    (v_program_id, 18, 10, 1, 'C+J+C+J',          pg_temp.aa_refit_work(3)),
-    (v_program_id, 19, 10, 2, 'C+J+C+J',          pg_temp.aa_refit_work(3)),
-    (v_program_id, 20, 11, 1, 'C+J+C+J',          pg_temp.aa_refit_work(3)),
-    (v_program_id, 21, 11, 2, 'C+J+C+J',          pg_temp.aa_refit_work(3)),
-    -- Week 12: deload, Stage 3
-    (v_program_id, 22, 12, 1, 'Deload · C+J+C+J', pg_temp.aa_refit_deload(3)),
-    (v_program_id, 23, 12, 2, 'Deload · C+J+C+J', pg_temp.aa_refit_deload(3));
+    -- Weeks 1-3: work, C+J
+    (v_program_id, 0, 1, 1, 'C+J',          pg_temp.aa_refit_work()),
+    (v_program_id, 1, 1, 2, 'C+J',          pg_temp.aa_refit_work()),
+    (v_program_id, 2, 2, 1, 'C+J',          pg_temp.aa_refit_work()),
+    (v_program_id, 3, 2, 2, 'C+J',          pg_temp.aa_refit_work()),
+    (v_program_id, 4, 3, 1, 'C+J',          pg_temp.aa_refit_work()),
+    (v_program_id, 5, 3, 2, 'C+J',          pg_temp.aa_refit_work()),
+    -- Week 4: deload
+    (v_program_id, 6, 4, 1, 'Deload · C+J', pg_temp.aa_refit_deload()),
+    (v_program_id, 7, 4, 2, 'Deload · C+J', pg_temp.aa_refit_deload());
   GET DIAGNOSTICS v_sessions_seeded = ROW_COUNT;
 
   -- Label the deload weight group so the enrollment picker shows "Deload weeks"

--- a/supabase/migrations/20260724000005_refit_aa_protocol_plan_a_autoregulated.sql
+++ b/supabase/migrations/20260724000005_refit_aa_protocol_plan_a_autoregulated.sql
@@ -1,0 +1,237 @@
+-- Refit the StrongFirst "A+A Protocol, Plan A" template to its source's
+-- autoregulated, milestone-based structure (PROD-245).
+-- Source: https://www.strongfirst.com/the-best-all-around-training-method-ever/
+--
+-- 20260723000001_reshape_aa_protocol_plan_a.sql fixed the cadence but modeled
+-- duration as a fixed +2 min ramp (10 -> 30 over 8 weeks) and left the C+J ->
+-- C+J+C -> C+J+C+J progression as prose. Found in live use (workout 1256,
+-- W1D1): the athlete stopped at the 10-min goal feeling easy, when the source
+-- says to carry on until the talk test fails. Corrected here:
+--
+--   1. Duration    Fixed ramp -> autoregulated. Every work session carries a
+--                  30-min ceiling (workoutGoal 30) with a note stating the FULL
+--                  rule: carry on until you cannot pass the talk test right
+--                  before the next set; stop then, or at 30 min, whichever comes
+--                  first. (The app needs workoutGoal > 0 to start and has no
+--                  "no target" unit, so 30 min models the ceiling: the countdown
+--                  auto-finishes = "whichever comes first"; the note governs the
+--                  early stop.)
+--   2. Note        The reshape's note stated only the "stop early" half. Now it
+--                  states both halves ("carry on until ... stop then").
+--   3. Progression Milestone stages, not a calendar ramp. The C+J -> C+J+C ->
+--                  C+J+C+J milestones ARE the session progression (see mapping
+--                  below), each a single-arm complex so per-lift volume is exact.
+--   4. Lifts       Fully decomposed into One-Arm Clean + One-Arm Jerk (no
+--                  compound "Clean and Jerk"), so each lift is counted once and
+--                  cleans bucket to hinge / jerks to push. Volume grows 2 -> 3
+--                  -> 4x the bell across the stages.
+--   5. Deloads     KEPT (source-accurate: "Every fourth week deload by going
+--                  down a kettlebell size -4 kg per kettlebell for ladies, -8 kg
+--                  for gentlemen"), but refit to the same 30-min ceiling instead
+--                  of the reshape's fixed 20/30-min holds.
+--
+-- NB: pg_temp functions persist for the whole connection, and CI applies every
+-- migration in one session, so these helpers are prefixed aa_refit_ to avoid
+-- colliding with the identically-named-but-differently-signed pg_temp helpers
+-- the reshape migration defines earlier in the same session (a same-signature,
+-- different-parameter-name CREATE fails with SQLSTATE 42P13).
+--
+-- These sessions are the app's first SINGLE-ARM complexes: complexSet true with
+-- one-hand movements (weightTwoValue 0) and intervalTimer 30, so each interval
+-- fire runs the whole complex on one hand, then the other 30s later. The runtime
+-- support for that (side-switch on a single-bell complex) ships alongside this
+-- migration in src/pages/ActiveWorkoutPage.
+--
+-- Milestone -> program_sessions mapping (12 weeks x 2 days = 24 sessions;
+-- deload every 4th week per the source). Because the schema has no per-enrollment
+-- "advance when ready" state, the 12-week calendar is a REPRESENTATIVE scaffold:
+-- the notes tell the athlete progression is milestone-gated (repeat a stage until
+-- 30 min is repeatable with a clean talk test), not calendar-gated. Modeling that
+-- mutable per-enrollment stage state is deferred to PROD-243 ("don't solve it
+-- twice").
+--   Weeks 1-3   Stage 1  C+J        (Clean, Jerk)
+--   Week  4     Deload   Stage 1, one bell size lighter
+--   Weeks 5-7   Stage 2  C+J+C      (Clean, Jerk, Clean)
+--   Week  8     Deload   Stage 2, one bell size lighter
+--   Weeks 9-11  Stage 3  C+J+C+J    (Clean, Jerk, Clean, Jerk)
+--   Week  12    Deload   Stage 3, one bell size lighter
+--
+-- Forward DATA FIX over deployed rows (the original seed and the reshape are
+-- applied in prod and ON CONFLICT DO NOTHING, so re-running them changes
+-- nothing). Every statement is scoped to the SYSTEM-OWNED template
+-- (slug = 'aa-protocol-plan-a' AND owner_id IS NULL). Copy-on-enroll clones carry
+-- slug NULL and a real owner_id, so existing enrollees keep the program they
+-- started, and deleting the template's sessions cascades no completions.
+
+-- One decomposed lift in the complex: a single bell (weightTwoValue 0), one rep.
+CREATE OR REPLACE FUNCTION pg_temp.aa_refit_mv(p_name TEXT, p_weight INT)
+RETURNS JSONB LANGUAGE sql IMMUTABLE AS $$
+  SELECT jsonb_build_object(
+    'movementName', p_name,
+    'repScheme', to_jsonb(ARRAY[1]::INT[]),
+    'weightOneUnit', 'kilograms', 'weightOneValue', p_weight,
+    'weightTwoUnit', 'kilograms', 'weightTwoValue', 0);
+$$;
+
+-- The ordered complex for a stage: C+J, C+J+C, or C+J+C+J.
+CREATE OR REPLACE FUNCTION pg_temp.aa_refit_stage_movements(p_stage INT, p_weight INT)
+RETURNS JSONB LANGUAGE sql IMMUTABLE AS $$
+  SELECT CASE p_stage
+    WHEN 1 THEN jsonb_build_array(
+      pg_temp.aa_refit_mv('One-Arm Kettlebell Clean', p_weight),
+      pg_temp.aa_refit_mv('One-Arm Kettlebell Jerk', p_weight))
+    WHEN 2 THEN jsonb_build_array(
+      pg_temp.aa_refit_mv('One-Arm Kettlebell Clean', p_weight),
+      pg_temp.aa_refit_mv('One-Arm Kettlebell Jerk', p_weight),
+      pg_temp.aa_refit_mv('One-Arm Kettlebell Clean', p_weight))
+    ELSE jsonb_build_array(
+      pg_temp.aa_refit_mv('One-Arm Kettlebell Clean', p_weight),
+      pg_temp.aa_refit_mv('One-Arm Kettlebell Jerk', p_weight),
+      pg_temp.aa_refit_mv('One-Arm Kettlebell Clean', p_weight),
+      pg_temp.aa_refit_mv('One-Arm Kettlebell Jerk', p_weight))
+  END;
+$$;
+
+-- Full workout_options for one session. Shape MUST match
+-- Omit<WorkoutOptions,'startedAt'> exactly (camelCase keys): single-bell complex
+-- under EMOM, 30-min ceiling, notes under preWorkoutNotes.
+CREATE OR REPLACE FUNCTION pg_temp.aa_refit_options(
+  p_weight INT, p_details TEXT, p_movements JSONB
+)
+RETURNS JSONB LANGUAGE sql IMMUTABLE AS $$
+  SELECT jsonb_build_object(
+    'complexSet', true,
+    'intervalTimer', 30,
+    'restTimer', 0,
+    'workoutGoal', 30,
+    'workoutGoalUnits', 'minutes',
+    'preWorkoutNotes', p_details,
+    'title', NULL,
+    'sharedWeightOneUnit', 'kilograms',
+    'sharedWeightOneValue', p_weight,
+    'sharedWeightTwoUnit', 'kilograms',
+    'sharedWeightTwoValue', 0,
+    'movements', p_movements);
+$$;
+
+-- A working session at the placeholder 24 kg for the given stage.
+CREATE OR REPLACE FUNCTION pg_temp.aa_refit_work(p_stage INT)
+RETURNS JSONB LANGUAGE sql IMMUTABLE AS $$
+  SELECT pg_temp.aa_refit_options(24, CASE p_stage
+    WHEN 1 THEN
+      'Stage 1 - clean & jerk (C+J). One set every 30s, alternating hands: '
+      'left on the minute, right 30s later. Carry on until you cannot pass the '
+      'talk test right before the next set; stop then, or at 30 min, whichever '
+      'comes first. Repeat this stage until 30 min is repeatable with a clean '
+      'talk test, then advance to Stage 2 by adding a second clean (C+J+C).'
+    WHEN 2 THEN
+      'Stage 2 - clean, jerk, clean (C+J+C). One set every 30s, alternating '
+      'hands: left on the minute, right 30s later. Carry on until you cannot '
+      'pass the talk test right before the next set; stop then, or at 30 min, '
+      'whichever comes first. Repeat this stage until 30 min is repeatable with '
+      'a clean talk test, then advance to Stage 3 by adding a second jerk '
+      '(C+J+C+J).'
+    ELSE
+      'Stage 3 - clean, jerk, clean, jerk (C+J+C+J). One set every 30s, '
+      'alternating hands: left on the minute, right 30s later. Carry on until '
+      'you cannot pass the talk test right before the next set; stop then, or at '
+      '30 min, whichever comes first. Keep building toward three clean & jerks '
+      'every 30s.'
+  END, pg_temp.aa_refit_stage_movements(p_stage, 24));
+$$;
+
+-- A deload session: the same stage complex one bell size lighter (24 -> 16 kg),
+-- same 30s cadence and open-ended 30-min ceiling.
+CREATE OR REPLACE FUNCTION pg_temp.aa_refit_deload(p_stage INT)
+RETURNS JSONB LANGUAGE sql IMMUTABLE AS $$
+  SELECT pg_temp.aa_refit_options(16,
+    'Deload week - one kettlebell size lighter (-8 kg gentlemen, -4 kg ladies), '
+    'same complex and same 30s left/right cadence. Duration stays autoregulated: '
+    'carry on until the talk test fails, up to 30 min. Explode, and keep it easy.',
+    pg_temp.aa_refit_stage_movements(p_stage, 16));
+$$;
+
+DO $$
+DECLARE
+  v_program_id       UUID;
+  v_sessions_deleted INT;
+  v_sessions_seeded  INT;
+BEGIN
+  SELECT id INTO v_program_id
+  FROM programs
+  WHERE slug = 'aa-protocol-plan-a' AND owner_id IS NULL;
+
+  IF v_program_id IS NULL THEN
+    RAISE NOTICE 'A+A Protocol template not found; nothing to refit.';
+    RETURN;
+  END IF;
+
+  UPDATE programs
+  SET num_weeks     = 12,
+      days_per_week = 2,
+      description =
+        'A single-kettlebell alactic+aerobic conditioning protocol built on the '
+        'one-arm clean & jerk. Every set is one bell on a 30-second interval - '
+        'left hand on the minute, right hand 30 seconds later. Pick the bell you '
+        'can clean & jerk 6-12 times with your WEAKER arm; long term the working '
+        'weight settles near 40% of bodyweight for men. Train twice a week (the '
+        'source prescribes Monday and Thursday). Duration is autoregulated, not '
+        'scheduled: carry on until you cannot pass the talk test right before the '
+        'next set - stop then, or at 30 minutes, whichever comes first. Progress '
+        'by milestone, not calendar: once 30 minutes is repeatable with a clean '
+        'talk test, add a second clean to each set (C+J+C), then a second jerk '
+        '(C+J+C+J), up to three clean & jerks every 30 seconds. Every fourth week, '
+        'deload one kettlebell size lighter (-8 kg gentlemen, -4 kg ladies) at the '
+        'same cadence.'
+  WHERE id = v_program_id;
+
+  DELETE FROM program_sessions WHERE program_id = v_program_id;
+  GET DIAGNOSTICS v_sessions_deleted = ROW_COUNT;
+
+  INSERT INTO program_sessions
+    (program_id, sequence_index, week_number, day_number, title, workout_options)
+  VALUES
+    -- Weeks 1-3: Stage 1, C+J
+    (v_program_id,  0,  1, 1, 'C+J',            pg_temp.aa_refit_work(1)),
+    (v_program_id,  1,  1, 2, 'C+J',            pg_temp.aa_refit_work(1)),
+    (v_program_id,  2,  2, 1, 'C+J',            pg_temp.aa_refit_work(1)),
+    (v_program_id,  3,  2, 2, 'C+J',            pg_temp.aa_refit_work(1)),
+    (v_program_id,  4,  3, 1, 'C+J',            pg_temp.aa_refit_work(1)),
+    (v_program_id,  5,  3, 2, 'C+J',            pg_temp.aa_refit_work(1)),
+    -- Week 4: deload, Stage 1
+    (v_program_id,  6,  4, 1, 'Deload · C+J',   pg_temp.aa_refit_deload(1)),
+    (v_program_id,  7,  4, 2, 'Deload · C+J',   pg_temp.aa_refit_deload(1)),
+    -- Weeks 5-7: Stage 2, C+J+C
+    (v_program_id,  8,  5, 1, 'C+J+C',          pg_temp.aa_refit_work(2)),
+    (v_program_id,  9,  5, 2, 'C+J+C',          pg_temp.aa_refit_work(2)),
+    (v_program_id, 10,  6, 1, 'C+J+C',          pg_temp.aa_refit_work(2)),
+    (v_program_id, 11,  6, 2, 'C+J+C',          pg_temp.aa_refit_work(2)),
+    (v_program_id, 12,  7, 1, 'C+J+C',          pg_temp.aa_refit_work(2)),
+    (v_program_id, 13,  7, 2, 'C+J+C',          pg_temp.aa_refit_work(2)),
+    -- Week 8: deload, Stage 2
+    (v_program_id, 14,  8, 1, 'Deload · C+J+C', pg_temp.aa_refit_deload(2)),
+    (v_program_id, 15,  8, 2, 'Deload · C+J+C', pg_temp.aa_refit_deload(2)),
+    -- Weeks 9-11: Stage 3, C+J+C+J
+    (v_program_id, 16,  9, 1, 'C+J+C+J',          pg_temp.aa_refit_work(3)),
+    (v_program_id, 17,  9, 2, 'C+J+C+J',          pg_temp.aa_refit_work(3)),
+    (v_program_id, 18, 10, 1, 'C+J+C+J',          pg_temp.aa_refit_work(3)),
+    (v_program_id, 19, 10, 2, 'C+J+C+J',          pg_temp.aa_refit_work(3)),
+    (v_program_id, 20, 11, 1, 'C+J+C+J',          pg_temp.aa_refit_work(3)),
+    (v_program_id, 21, 11, 2, 'C+J+C+J',          pg_temp.aa_refit_work(3)),
+    -- Week 12: deload, Stage 3
+    (v_program_id, 22, 12, 1, 'Deload · C+J+C+J', pg_temp.aa_refit_deload(3)),
+    (v_program_id, 23, 12, 2, 'Deload · C+J+C+J', pg_temp.aa_refit_deload(3));
+  GET DIAGNOSTICS v_sessions_seeded = ROW_COUNT;
+
+  -- Label the deload weight group so the enrollment picker shows "Deload weeks"
+  -- rather than a derived "8 kg lighter" description. Keyed on the authored
+  -- 16 kg deload load, mirroring 20260723160000_program_sessions_weight_label.sql
+  -- (the DELETE above dropped that backfill's labels along with the old rows).
+  UPDATE program_sessions ps
+  SET weight_label = 'Deload weeks'
+  WHERE ps.program_id = v_program_id
+    AND (ps.workout_options->'movements'->0->>'weightOneValue')::NUMERIC = 16;
+
+  RAISE NOTICE 'A+A Protocol refit: % sessions deleted, % seeded.',
+    v_sessions_deleted, v_sessions_seeded;
+END $$;


### PR DESCRIPTION
## Why

Linear: [PROD-245](https://linear.app/djbowers/issue/PROD-245)

The shipped A+A "Plan A" seed deviated from its StrongFirst source in ways that change the training method. Found in live use (workout 1256, W1D1): the athlete stopped at the prescribed 10-min goal feeling easy, when the source says to carry on until the talk test fails. Duration was a fixed +2 min ramp (invented, borrowed from a different article), the pre-workout note stated only the "stop early" half of the rule, and the C+J → C+J+C → C+J+C+J progression existed only as prose.

Re-checking the source corrected two of the ticket's own assumptions: the every-4th-week deloads **are** source-accurate ("go down a kettlebell size, −8 kg gentlemen / −4 kg ladies" — one pood-based size, 24→16 kg), and 2×/week Mon/Thu was already right.

## What

Two parts:

1. **Runtime** — single-arm complexes (one bell, `weightTwoValue 0`) now alternate hands across EMOM interval fires: left on the minute, right 30 s later, one round per L+R pair. Complex volume already summed per movement; this restores the arm-alternation that `complexSet` previously forfeited (it advanced via `goToNextSetComplex`, which never toggled the mirror side). Gated behind `isSingleArmComplex` — two-hand (`weightTwoValue null`) and double-bell (`> 0`) complexes are excluded and unchanged.
2. **Seed** (forward data-fix, system template only) — A+A Plan A becomes a single **4-week C+J block** (8 sessions): three build weeks at a 30-min **autoregulated ceiling** with the full talk-test note, then a **deload week** one bell size lighter (24 → 16 kg). C+J is the decomposed single-arm **Clean + Jerk** complex, so volume is counted per lift. Repeating the block reproduces the source's every-4th-week deload for free; the later complexes (C+J+C → C+J+C+J) live in the **description** as the next step — the app has no queue/repeat/program-family primitive to sequence separate stages yet. Description also carries the verified 2×/week (Mon/Thu) cadence and the weaker-arm 6–12RM / ~40 % BW weight rule.

Scope per the ticket's captain's decision: template only. Existing copy-on-enroll enrollees keep their current program; re-enroll to pick up the correction.

## How to test

- `npx vitest run` — **553 pass**, incl. the new single-arm-complex cadence (hands flip every 30 s, one round per L+R), per-hand volume (24 kg Clean + 24 kg Jerk = 96 kg/round), and a two-hand-complex regression guard (no side indicator, no side-switch).
- `npm run compile:ts`, `npm run lint` — clean.
- `supabase db reset` → `16 sessions deleted, 8 seeded`; verified the 8 rows (4 weeks × 2 days, every session the 2-movement C+J complex, `complexSet`/interval 30/goal 30, deload week 4 at 16 kg with `weight_label = 'Deload weeks'`).
- Full Playwright **e2e suite** green, with `program-aa-protocol.spec.ts` and the A+A enroll cases in `program-schema.spec.ts` updated to the 8-session / deload-week-4 shape.
- Storybook `SingleArmComplexEMOM`: confirmed the active session shows one bell, the "Left/Right hand · side N of 2" indicator, the 30-min ceiling, and interval-driven hand alternation (Gallery).

## Gallery

New UI — single-arm Clean + Jerk complex under EMOM. Left hand on the minute, right hand 30 s later:

_Screenshots attached below (left hand / right-hand flip)._

## Deploy notes

- New migration `20260724000005_refit_aa_protocol_plan_a_autoregulated.sql` — upgrade-only, scoped to the system template (`slug = 'aa-protocol-plan-a' AND owner_id IS NULL`). No schema change → no `gen:types`.

## Tradeoffs

- **Shipped one stage (C+J) as a short repeatable 4-week block** rather than a 12-week 3-stage arc. The milestone progression is really "repeat until you own 30 min, then escalate the complex," which a fixed calendar can't express — and the app has no queue/repeat/program-family primitive to sequence separate stage-programs (same-program re-enroll is refused while active, completion is a dead-end screen, no next-stage concept). A 4-week block repeated reproduces the every-4th-week deload for free. The description names the escalation (C+J+C → C+J+C+J) so the athlete knows the path; encoding it is deferred to a future program-series / repeat feature.
- Chose single-arm complexes (exact per-lift volume **and** arm-alternation) over prose-only stages or double-bell complexes — the latter would have dropped the signature EMOM hand-switch. Left the compound `One-Arm Kettlebell Clean and Jerk` in the catalog (removing it would orphan existing logs) — just unused in this program.
