### PR TITLE
feat(programs): auto-repeat toggle + Simple & Sinister and Onnit beginner workouts

### DIFF
--- a/e2e/program-onnit-beginner-full-body.spec.ts
+++ b/e2e/program-onnit-beginner-full-body.spec.ts
@@ -1,0 +1,141 @@
+import { expect, test } from '@playwright/test';
+
+// Backend coverage for the seeded shared "Onnit Beginner Full-Body" program,
+// mirroring program-kettlebell-mile.spec.ts: hit the LOCAL Supabase REST API
+// directly. A repeating workout (default_auto_repeat true) modeled as a single
+// 3-round circuit. The assertions pin the "map to closest, drop hip-pass" catalog
+// mapping and the per-movement loading modes so a rename can't silently break it.
+
+const SUPABASE_URL = process.env.VITE_SUPABASE_URL!;
+const SUPABASE_ANON_KEY = process.env.VITE_SUPABASE_ANON_KEY!;
+const ONNIT_SLUG = 'onnit-beginner-full-body';
+
+interface AuthSession {
+  access_token: string;
+  user: { id: string; email: string; [key: string]: unknown };
+}
+interface TestUser {
+  token: string;
+  uid: string;
+  email: string;
+}
+
+async function signUpThrowawayUser(): Promise<TestUser> {
+  const email = `onnit-${Date.now()}-${Math.floor(Math.random() * 1e9)}@example.com`;
+  const password = 'testpassword123';
+
+  const res = await fetch(`${SUPABASE_URL}/auth/v1/signup`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', apikey: SUPABASE_ANON_KEY },
+    body: JSON.stringify({ email, password }),
+  });
+  if (!res.ok) throw new Error(`signup failed (${res.status}): ${await res.text()}`);
+
+  const body = (await res.json()) as Partial<AuthSession>;
+  if (body.access_token && body.user) {
+    return { token: body.access_token, uid: body.user.id, email };
+  }
+
+  const signInRes = await fetch(
+    `${SUPABASE_URL}/auth/v1/token?grant_type=password`,
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', apikey: SUPABASE_ANON_KEY },
+      body: JSON.stringify({ email, password }),
+    },
+  );
+  if (!signInRes.ok)
+    throw new Error(`sign-in failed (${signInRes.status}): ${await signInRes.text()}`);
+  const s = (await signInRes.json()) as AuthSession;
+  return { token: s.access_token, uid: s.user.id, email };
+}
+
+async function restJson<T = unknown>(path: string, token: string): Promise<T> {
+  const res = await fetch(`${SUPABASE_URL}/rest/v1/${path}`, {
+    headers: { apikey: SUPABASE_ANON_KEY, Authorization: `Bearer ${token}` },
+  });
+  if (!res.ok) throw new Error(`${path} failed (${res.status}): ${await res.text()}`);
+  return res.json() as Promise<T>;
+}
+
+interface MovementOpt {
+  movementName: string;
+  repScheme: number[];
+  weightOneValue: number | null;
+  weightTwoValue: number | null;
+}
+interface WorkoutOpts {
+  complexSet: boolean;
+  straightSets?: boolean;
+  intervalTimer: number;
+  workoutGoal: number;
+  workoutGoalUnits: string;
+  movements: MovementOpt[];
+}
+interface SessionRow {
+  sequence_index: number;
+  workout_options: WorkoutOpts;
+}
+
+// [name, reps, weightTwoValue] -- weightTwoValue 0 marks the one-handed (mirrored)
+// movements; null marks the two-handed single-bell ones.
+const EXPECTED_MOVEMENTS: Array<[string, number[], number | null]> = [
+  ['Goblet Squat', [10], null],
+  ['One-Arm Kettlebell Row', [8], 0],
+  ['One-Arm Kettlebell Military Press', [5], 0],
+  ['Kettlebell Swing', [15], null],
+  ['Kettlebell Halo', [8], null],
+  ['Kettlebell Figure 8', [5], null],
+];
+
+test.describe('program schema — Onnit Beginner Full-Body seed', () => {
+  test('is present, public, system-owned, repeating, with the right metadata', async () => {
+    const user = await signUpThrowawayUser();
+    const programs = await restJson<
+      Array<{
+        is_public: boolean;
+        owner_id: string | null;
+        default_auto_repeat: boolean;
+        author_name: string;
+        title: string;
+      }>
+    >(`programs?slug=eq.${ONNIT_SLUG}&select=*`, user.token);
+
+    expect(programs).toHaveLength(1);
+    const onnit = programs[0];
+    expect(onnit.is_public).toBe(true);
+    expect(onnit.owner_id).toBeNull();
+    expect(onnit.default_auto_repeat).toBe(true);
+    expect(onnit.author_name).toBe('Onnit');
+    expect(onnit.title).toBe('Onnit Beginner Full-Body');
+  });
+
+  test('is one 3-round circuit with the mapped movements and loading modes', async () => {
+    const user = await signUpThrowawayUser();
+    const [onnit] = await restJson<Array<{ id: string }>>(
+      `programs?slug=eq.${ONNIT_SLUG}&select=id`,
+      user.token,
+    );
+    const sessions = await restJson<SessionRow[]>(
+      `program_sessions?program_id=eq.${onnit.id}&select=sequence_index,workout_options&order=sequence_index.asc`,
+      user.token,
+    );
+
+    expect(sessions).toHaveLength(1);
+    const opts = sessions[0].workout_options;
+    // A circuit: rotate through the movements each round, 3 rounds.
+    expect(opts.complexSet).toBe(false);
+    expect(opts.straightSets).toBe(false);
+    expect(opts.workoutGoal).toBe(3);
+    expect(opts.workoutGoalUnits).toBe('rounds');
+
+    expect(opts.movements).toHaveLength(EXPECTED_MOVEMENTS.length);
+    opts.movements.forEach((mv, i) => {
+      const [name, reps, weightTwo] = EXPECTED_MOVEMENTS[i];
+      expect(mv.movementName).toBe(name);
+      expect(mv.repScheme).toEqual(reps);
+      expect(mv.weightOneValue).toBe(16);
+      expect(mv.weightTwoValue).toBe(weightTwo);
+    });
+  });
+});

--- a/e2e/program-simple-and-sinister.spec.ts
+++ b/e2e/program-simple-and-sinister.spec.ts
@@ -1,0 +1,226 @@
+import { expect, test } from '@playwright/test';
+
+// Backend coverage for the seeded shared "Simple & Sinister" program (Pavel
+// Tsatsouline, StrongFirst), mirroring program-kettlebell-mile.spec.ts: hit the
+// LOCAL Supabase REST API directly rather than driving the browser, since this is
+// seed-data + RPC-behavior verification.
+//
+// S&S is the catalog's first REPEATING WORKOUT (default_auto_repeat true). The
+// assertions cover the two things that would silently break it: the single-session
+// swing+get-up shape with one-handed mirror loading (weightTwoValue 0), and -- the
+// real point -- that finishing an auto-repeat enrollment LOOPS rather than flipping
+// to 'completed'.
+
+const SUPABASE_URL = process.env.VITE_SUPABASE_URL!;
+const SUPABASE_ANON_KEY = process.env.VITE_SUPABASE_ANON_KEY!;
+const SS_SLUG = 'simple-and-sinister';
+
+interface AuthSession {
+  access_token: string;
+  user: { id: string; email: string; [key: string]: unknown };
+}
+interface TestUser {
+  token: string;
+  uid: string;
+  email: string;
+}
+
+async function signUpThrowawayUser(): Promise<TestUser> {
+  const email = `ss-${Date.now()}-${Math.floor(Math.random() * 1e9)}@example.com`;
+  const password = 'testpassword123';
+
+  const res = await fetch(`${SUPABASE_URL}/auth/v1/signup`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', apikey: SUPABASE_ANON_KEY },
+    body: JSON.stringify({ email, password }),
+  });
+  if (!res.ok) throw new Error(`signup failed (${res.status}): ${await res.text()}`);
+
+  const body = (await res.json()) as Partial<AuthSession>;
+  if (body.access_token && body.user) {
+    return { token: body.access_token, uid: body.user.id, email };
+  }
+
+  const signInRes = await fetch(
+    `${SUPABASE_URL}/auth/v1/token?grant_type=password`,
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', apikey: SUPABASE_ANON_KEY },
+      body: JSON.stringify({ email, password }),
+    },
+  );
+  if (!signInRes.ok)
+    throw new Error(`sign-in failed (${signInRes.status}): ${await signInRes.text()}`);
+  const s = (await signInRes.json()) as AuthSession;
+  return { token: s.access_token, uid: s.user.id, email };
+}
+
+async function restJson<T = unknown>(
+  path: string,
+  token: string,
+  init?: RequestInit,
+): Promise<T> {
+  const res = await fetch(`${SUPABASE_URL}/rest/v1/${path}`, {
+    ...init,
+    headers: {
+      apikey: SUPABASE_ANON_KEY,
+      Authorization: `Bearer ${token}`,
+      ...(init?.body ? { 'Content-Type': 'application/json' } : {}),
+      ...(init?.headers ?? {}),
+    },
+  });
+  if (!res.ok) throw new Error(`${path} failed (${res.status}): ${await res.text()}`);
+  return res.json() as Promise<T>;
+}
+
+async function rpc<T = unknown>(
+  fn: string,
+  token: string,
+  args: Record<string, unknown>,
+): Promise<T> {
+  const res = await fetch(`${SUPABASE_URL}/rest/v1/rpc/${fn}`, {
+    method: 'POST',
+    headers: {
+      apikey: SUPABASE_ANON_KEY,
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(args),
+  });
+  if (!res.ok) throw new Error(`rpc ${fn} failed (${res.status}): ${await res.text()}`);
+  return res.json() as Promise<T>;
+}
+
+interface MovementOpt {
+  movementName: string;
+  repScheme: number[];
+  weightOneValue: number | null;
+  weightTwoValue: number | null;
+}
+interface WorkoutOpts {
+  complexSet: boolean;
+  straightSets?: boolean;
+  intervalTimer: number;
+  workoutGoal: number;
+  workoutGoalUnits: string;
+  movements: MovementOpt[];
+}
+interface SessionRow {
+  sequence_index: number;
+  workout_options: WorkoutOpts;
+}
+
+test.describe('program schema — Simple & Sinister seed', () => {
+  test('is present, public, system-owned, repeating, with the right metadata', async () => {
+    const user = await signUpThrowawayUser();
+    const programs = await restJson<
+      Array<{
+        is_public: boolean;
+        owner_id: string | null;
+        num_weeks: number | null;
+        days_per_week: number | null;
+        default_auto_repeat: boolean;
+        author_name: string;
+        title: string;
+      }>
+    >(`programs?slug=eq.${SS_SLUG}&select=*`, user.token);
+
+    expect(programs).toHaveLength(1);
+    const ss = programs[0];
+    expect(ss.is_public).toBe(true);
+    expect(ss.owner_id).toBeNull();
+    expect(ss.default_auto_repeat).toBe(true);
+    // A repeating workout has no fixed length.
+    expect(ss.num_weeks).toBeNull();
+    expect(ss.days_per_week).toBeNull();
+    expect(ss.author_name).toBe('Pavel Tsatsouline (StrongFirst)');
+    expect(ss.title).toBe('Simple & Sinister');
+  });
+
+  test('is one session: 100 one-arm swings then 10 get-ups, mirrored', async () => {
+    const user = await signUpThrowawayUser();
+    const [ss] = await restJson<Array<{ id: string }>>(
+      `programs?slug=eq.${SS_SLUG}&select=id`,
+      user.token,
+    );
+    const sessions = await restJson<SessionRow[]>(
+      `program_sessions?program_id=eq.${ss.id}&select=sequence_index,workout_options&order=sequence_index.asc`,
+      user.token,
+    );
+
+    expect(sessions).toHaveLength(1);
+    const opts = sessions[0].workout_options;
+    expect(opts.complexSet).toBe(false);
+    // All swings, then all get-ups.
+    expect(opts.straightSets).toBe(true);
+    expect(opts.intervalTimer).toBe(0);
+    expect(opts.workoutGoal).toBe(1);
+    expect(opts.workoutGoalUnits).toBe('rounds');
+
+    const [swing, getup] = opts.movements;
+    expect(opts.movements).toHaveLength(2);
+
+    expect(swing.movementName).toBe('One-Arm Kettlebell Swing');
+    expect(swing.repScheme).toEqual([10, 10, 10, 10, 10]); // 5 rungs, mirrored -> 100
+    expect(swing.weightOneValue).toBe(24);
+    expect(swing.weightTwoValue).toBe(0); // single-bell '1h' mode: mirror per hand
+
+    expect(getup.movementName).toBe('Kettlebell Turkish Get-Up');
+    expect(getup.repScheme).toEqual([1, 1, 1, 1, 1]); // 5 rungs, mirrored -> 10
+    expect(getup.weightOneValue).toBe(24);
+    expect(getup.weightTwoValue).toBe(0);
+  });
+
+  test('finishing an auto-repeat enrollment loops instead of completing', async () => {
+    const user = await signUpThrowawayUser();
+    const [ss] = await restJson<Array<{ id: string }>>(
+      `programs?slug=eq.${SS_SLUG}&select=id`,
+      user.token,
+    );
+
+    // Enroll: default_auto_repeat true flows into user_programs.auto_repeat.
+    const userProgramId = await rpc<string>('enroll_in_program', user.token, {
+      p_program_id: ss.id,
+    });
+
+    const [enrollment] = await restJson<
+      Array<{ status: string; auto_repeat: boolean; cycles_completed: number; program_id: string }>
+    >(
+      `user_programs?id=eq.${userProgramId}&select=status,auto_repeat,cycles_completed,program_id`,
+      user.token,
+    );
+    expect(enrollment.auto_repeat).toBe(true);
+    expect(enrollment.cycles_completed).toBe(0);
+
+    // The single cloned session.
+    const [cloneSession] = await restJson<Array<{ id: string }>>(
+      `program_sessions?program_id=eq.${enrollment.program_id}&select=id&order=sequence_index.asc`,
+      user.token,
+    );
+
+    // Complete it. The program has one session, so this satisfies "all" -- but
+    // auto_repeat must loop rather than finish.
+    const doneAll = await rpc<boolean>('complete_program_session', user.token, {
+      p_user_program_id: userProgramId,
+      p_program_session_id: cloneSession.id,
+    });
+    expect(doneAll).toBe(false); // never reports "complete" for a repeating workout
+
+    const [after] = await restJson<
+      Array<{ status: string; cycles_completed: number }>
+    >(
+      `user_programs?id=eq.${userProgramId}&select=status,cycles_completed`,
+      user.token,
+    );
+    // Still active, one cycle banked...
+    expect(after.status).toBe('active');
+    expect(after.cycles_completed).toBe(1);
+
+    // ...and progress reset, so the same session is served again next.
+    const completions = await restJson<Array<{ program_session_id: string }>>(
+      `program_session_completions?user_program_id=eq.${userProgramId}&select=program_session_id`,
+      user.token,
+    );
+    expect(completions).toHaveLength(0);
+  });
+});

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -26,6 +26,7 @@ export * from './useProgramProgress';
 export * from './usePrograms';
 export * from './useSaveProgramSession';
 export * from './useSetProgramArchived';
+export * from './useSetProgramAutoRepeat';
 export * from './useUpdateProgramSession';
 export * from './useRecentRepeatableWorkouts';
 export * from './useRecommendSession';

--- a/src/api/program.ts
+++ b/src/api/program.ts
@@ -31,6 +31,7 @@ export const mapProgramRow = (row: ProgramRow): Program => ({
   isPublic: row.is_public,
   createdAt: row.created_at,
   archivedAt: row.archived_at,
+  defaultAutoRepeat: row.default_auto_repeat,
 });
 
 /**
@@ -78,4 +79,6 @@ export const mapUserProgramRow = (row: UserProgramRow): UserProgram => ({
   startedAt: row.started_at,
   completedAt: row.completed_at,
   activeSlot: row.active_slot,
+  autoRepeat: row.auto_repeat,
+  cyclesCompleted: row.cycles_completed,
 });

--- a/src/api/useEnrollProgram.ts
+++ b/src/api/useEnrollProgram.ts
@@ -48,6 +48,12 @@ export interface EnrollProgramArgs {
    * or to clone verbatim.
    */
   movementWeights?: MovementWeight[];
+  /**
+   * Whether the new enrollment should loop back to its first session on
+   * completion instead of finishing. Omit to inherit the program's
+   * `defaultAutoRepeat`; pass a boolean to override the pre-enroll toggle choice.
+   */
+  autoRepeat?: boolean;
 }
 
 /**
@@ -73,6 +79,7 @@ export const useEnrollProgram = () => {
       sharedWeightTwoUnit,
       replaceUserProgramId,
       movementWeights,
+      autoRepeat,
     }: EnrollProgramArgs): Promise<string> => {
       const { data, error } = await supabase.rpc('enroll_in_program', {
         p_program_id: programId,
@@ -87,6 +94,7 @@ export const useEnrollProgram = () => {
         p_movement_weights: movementWeights?.length
           ? (movementWeights as unknown as Json)
           : undefined,
+        p_auto_repeat: autoRepeat ?? undefined,
       });
 
       if (error) throw error;

--- a/src/api/useSetProgramAutoRepeat.ts
+++ b/src/api/useSetProgramAutoRepeat.ts
@@ -1,0 +1,40 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { QUERIES } from '~/constants';
+
+import { supabase } from '../supabaseClient';
+import { useProgramMutationErrorHandler } from './useProgramMutationErrorHandler';
+
+export interface SetProgramAutoRepeatInput {
+  /** The enrollment (`user_programs.id`) to update. */
+  userProgramId: string;
+  /** `true` to loop the program on completion, `false` to let it finish. */
+  autoRepeat: boolean;
+}
+
+/**
+ * Flips an enrollment's auto-repeat toggle. When on, finishing the program's
+ * last session loops back to the first (see complete_program_session) instead of
+ * flipping to `completed`. A one-column update on the user's own enrollment; RLS
+ * keeps it scoped to them.
+ */
+export const useSetProgramAutoRepeat = () => {
+  const queryClient = useQueryClient();
+  const onError = useProgramMutationErrorHandler();
+
+  return useMutation({
+    mutationFn: async (input: SetProgramAutoRepeatInput): Promise<void> => {
+      const { error } = await supabase
+        .from('user_programs')
+        .update({ auto_repeat: input.autoRepeat })
+        .eq('id', input.userProgramId);
+      if (error) throw error;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: [QUERIES.ACTIVE_PROGRAM] });
+      queryClient.invalidateQueries({ queryKey: [QUERIES.PROGRAM_PROGRESS] });
+      queryClient.invalidateQueries({ queryKey: [QUERIES.PROGRAMS] });
+    },
+    onError,
+  });
+};

--- a/src/examples/active-program.examples.ts
+++ b/src/examples/active-program.examples.ts
@@ -63,6 +63,8 @@ export const exampleActiveProgram = ({
       startedAt: '2026-07-01T00:00:00Z',
       completedAt: isComplete ? '2026-07-22T00:00:00Z' : null,
       activeSlot,
+      autoRepeat: false,
+      cyclesCompleted: 0,
     },
     program: {
       id: `${id}-program`,
@@ -77,6 +79,7 @@ export const exampleActiveProgram = ({
       isPublic: false,
       archivedAt: null,
       createdAt: '2026-07-01T00:00:00Z',
+      defaultAutoRepeat: false,
     },
     nextSession: isComplete
       ? null

--- a/src/pages/ProgramDetailsPage/ProgramDetailsPage.test.tsx
+++ b/src/pages/ProgramDetailsPage/ProgramDetailsPage.test.tsx
@@ -441,4 +441,50 @@ describe('ProgramDetailsPage', () => {
 
     expect(screen.getByText('Program not found.')).toBeInTheDocument();
   });
+
+  it('defaults the repeat toggle from the program and passes it to enroll', () => {
+    // No navigating onSuccess here: keep the page mounted so the toggle can be
+    // flipped and Start clicked a second time.
+    mockUseProgram.mockReturnValue({
+      data: {
+        program: {
+          ...dfw,
+          id: 'ss-1',
+          title: 'Simple & Sinister',
+          defaultAutoRepeat: true,
+        },
+        sessions: [
+          session(0, 1, 1, '100 swings + 10 get-ups', [
+            movement('One-Arm Kettlebell Swing', 24, 0),
+          ]),
+        ],
+      },
+      isLoading: false,
+      isError: false,
+    });
+
+    renderPage('ss-1');
+
+    // A repeating program pre-checks the toggle...
+    const toggle = screen.getByRole('checkbox', {
+      name: /repeat automatically/i,
+    });
+    expect(toggle).toBeChecked();
+
+    // ...and enrolling carries autoRepeat true.
+    fireEvent.click(screen.getByRole('button', { name: 'Start program' }));
+    expect(enrollMutate).toHaveBeenCalledWith(
+      expect.objectContaining({ programId: 'ss-1', autoRepeat: true }),
+      expect.anything(),
+    );
+
+    // Unchecking it and re-enrolling flips the flag off.
+    enrollMutate.mockClear();
+    fireEvent.click(toggle);
+    fireEvent.click(screen.getByRole('button', { name: 'Start program' }));
+    expect(enrollMutate).toHaveBeenCalledWith(
+      expect.objectContaining({ autoRepeat: false }),
+      expect.anything(),
+    );
+  });
 });

--- a/src/pages/ProgramDetailsPage/ProgramDetailsPage.tsx
+++ b/src/pages/ProgramDetailsPage/ProgramDetailsPage.tsx
@@ -22,7 +22,6 @@ import {
 import { useSession } from '~/contexts';
 import {
   MovementOptions,
-  Program,
   ProgramSession,
   WeightUnit,
   WorkoutGoalUnits,
@@ -30,6 +29,7 @@ import {
 import {
   getWeightRange,
   getWeightUnitLabel,
+  programCadenceLabel,
   WEIGHT_MODE_LABELS,
 } from '~/utils';
 
@@ -44,11 +44,6 @@ import { deriveStartingWeight, StartingWeight } from './utils/deriveWeightGroups
 // program's own sessions — only the weights are editable here.
 const DEFAULT_STARTING_WEIGHT_VALUE = 24;
 const DEFAULT_WEIGHT_UNIT: WeightUnit = 'kilograms';
-
-const cadenceLabel = (program: Program): string | null =>
-  program.numWeeks && program.daysPerWeek
-    ? `${program.numWeeks} weeks · ${program.daysPerWeek}/week`
-    : null;
 
 const goalLabel = (goal: number, units: WorkoutGoalUnits): string | null => {
   if (units === 'minutes') return `${goal} min`;
@@ -164,6 +159,9 @@ export const ProgramDetailsPage = () => {
   const [movementWeights, setMovementWeights] = useState<
     Record<string, StartingWeight>
   >({});
+  // Whether the enrollment should loop on completion. Seeded from the program's
+  // template default once it loads; the user can flip it before starting.
+  const [autoRepeat, setAutoRepeat] = useState(false);
 
   const program = data?.program;
   const sessions = data?.sessions;
@@ -217,6 +215,14 @@ export const ProgramDetailsPage = () => {
     if (isOwnProgram && id) navigate(`/programs/${id}`, { replace: true });
   }, [isOwnProgram, id, navigate]);
 
+  // Seed the toggle from the program's default once, when the program loads.
+  useEffect(() => {
+    if (program) setAutoRepeat(program.defaultAutoRepeat);
+    // Keyed on program identity so a later re-render never clobbers the user's
+    // choice; only a different program re-seeds the default.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [program?.id]);
+
   const handleChangeWorkingWeight = (weight: StartingWeight) => {
     setSharedWeightOneValue(weight.sharedWeightOneValue);
     setSharedWeightOneUnit(weight.sharedWeightOneUnit);
@@ -263,6 +269,7 @@ export const ProgramDetailsPage = () => {
       {
         programId: id,
         replaceUserProgramId: displaced?.enrollment.id,
+        autoRepeat,
         ...(complex
           ? {
               sharedWeightOneValue,
@@ -322,7 +329,7 @@ export const ProgramDetailsPage = () => {
         <CardContent className="flex flex-col gap-1 pt-2">
           <p className="text-xs text-muted-foreground">
             {data.program.authorName ? `${data.program.authorName} · ` : ''}
-            {cadenceLabel(data.program) ?? 'No sessions yet'}
+            {programCadenceLabel(data.program) ?? 'No sessions yet'}
           </p>
           {data.program.description && (
             <p className="text-sm text-muted-foreground">
@@ -416,6 +423,22 @@ export const ProgramDetailsPage = () => {
             )}
           </div>
         ))}
+
+      <label className="flex items-start gap-2">
+        <input
+          type="checkbox"
+          className="mt-0.5 h-3 w-3 shrink-0"
+          checked={autoRepeat}
+          onChange={(event) => setAutoRepeat(event.target.checked)}
+        />
+        <span className="flex flex-col gap-0.5">
+          <span className="text-sm font-medium">Repeat automatically</span>
+          <span className="text-xs text-muted-foreground">
+            When on, finishing the last session starts the program over instead
+            of ending it. Progress by adding weight over time.
+          </span>
+        </span>
+      </label>
 
       <Button onClick={handleStart} disabled={enroll.isPending || !seeded}>
         Start program

--- a/src/pages/ProgramProgressPage/ProgramProgressPage.test.tsx
+++ b/src/pages/ProgramProgressPage/ProgramProgressPage.test.tsx
@@ -11,6 +11,7 @@ const { mockUseProgramProgress } = vi.hoisted(() => ({
 
 vi.mock('~/api', () => ({
   useProgramProgress: mockUseProgramProgress,
+  useSetProgramAutoRepeat: () => ({ mutate: vi.fn(), isPending: false }),
 }));
 
 const session = (seq: number, week: number, day: number, title: string) => ({

--- a/src/pages/ProgramProgressPage/ProgramProgressPage.tsx
+++ b/src/pages/ProgramProgressPage/ProgramProgressPage.tsx
@@ -5,6 +5,7 @@ import {
   SessionState,
   WeekProgress,
   useProgramProgress,
+  useSetProgramAutoRepeat,
 } from '~/api';
 import { Page } from '~/components';
 import { Button } from '~/components/ui/button';
@@ -33,6 +34,7 @@ export const ProgramProgressPage = () => {
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
   const { data, isLoading, isError } = useProgramProgress(id);
+  const setAutoRepeat = useSetProgramAutoRepeat();
 
   if (isLoading) {
     return (
@@ -66,6 +68,13 @@ export const ProgramProgressPage = () => {
 
   const percent =
     totalCount > 0 ? Math.round((completedCount / totalCount) * 100) : 0;
+
+  // A repeating enrollment never "completes" — it loops. Show its cycle count
+  // and, for a single-session repeat, drop the within-cycle progress bar (it
+  // would sit empty). Multi-session repeats keep the bar to show cycle progress.
+  const isRepeating = enrollment?.autoRepeat ?? false;
+  const showProgressBar = !isRepeating || totalCount > 1;
+  const cyclesCompleted = enrollment?.cyclesCompleted ?? 0;
 
   // An upcoming session is startable only while the enrollment is active — any
   // session, not just the next one. Starting a later session leaves the earlier
@@ -101,26 +110,51 @@ export const ProgramProgressPage = () => {
         <CardContent className="flex flex-col gap-1 pt-2">
           <div className="flex items-baseline justify-between text-sm font-medium">
             <span>
-              {isComplete
-                ? '🎉 Program complete'
-                : `Week ${currentWeek} of ${totalWeeks}`}
+              {isRepeating
+                ? 'Repeating workout'
+                : isComplete
+                  ? '🎉 Program complete'
+                  : `Week ${currentWeek} of ${totalWeeks}`}
             </span>
             <span className="text-muted-foreground">
-              {completedCount} of {totalCount} sessions
+              {isRepeating
+                ? `${cyclesCompleted} ${cyclesCompleted === 1 ? 'cycle' : 'cycles'} done`
+                : `${completedCount} of ${totalCount} sessions`}
             </span>
           </div>
-          <div
-            className="h-0.5 w-full overflow-hidden rounded-full bg-secondary"
-            role="progressbar"
-            aria-valuenow={completedCount}
-            aria-valuemin={0}
-            aria-valuemax={totalCount}
-          >
+          {showProgressBar && (
             <div
-              className="h-full rounded-full bg-primary transition-all"
-              style={{ width: `${percent}%` }}
-            />
-          </div>
+              className="h-0.5 w-full overflow-hidden rounded-full bg-secondary"
+              role="progressbar"
+              aria-valuenow={completedCount}
+              aria-valuemin={0}
+              aria-valuemax={totalCount}
+            >
+              <div
+                className="h-full rounded-full bg-primary transition-all"
+                style={{ width: `${percent}%` }}
+              />
+            </div>
+          )}
+          {enrollment && (
+            <label className="mt-1 flex items-center gap-2">
+              <input
+                type="checkbox"
+                className="h-3 w-3 shrink-0"
+                checked={isRepeating}
+                disabled={setAutoRepeat.isPending}
+                onChange={(event) =>
+                  setAutoRepeat.mutate({
+                    userProgramId: enrollment.id,
+                    autoRepeat: event.target.checked,
+                  })
+                }
+              />
+              <span className="text-xs text-muted-foreground">
+                Repeat automatically when finished
+              </span>
+            </label>
+          )}
         </CardContent>
       </Card>
 

--- a/src/pages/ProgramsPage/ProgramsPage.test.tsx
+++ b/src/pages/ProgramsPage/ProgramsPage.test.tsx
@@ -195,6 +195,31 @@ describe('ProgramsPage', () => {
     expect(screen.queryByText('Starting weight')).not.toBeInTheDocument();
   });
 
+  it('labels a repeating workout and badges it, instead of a week cadence', () => {
+    const simpleSinister = {
+      ...dfw,
+      id: 'ss-1',
+      slug: 'simple-and-sinister',
+      title: 'Simple & Sinister',
+      authorName: 'Pavel Tsatsouline (StrongFirst)',
+      numWeeks: null,
+      daysPerWeek: null,
+      defaultAutoRepeat: true,
+    };
+    mockUsePrograms.mockReturnValue({
+      data: [simpleSinister],
+      isLoading: false,
+    });
+
+    renderPage();
+
+    // Cadence reads "Repeating workout", not a weeks/day span, and a badge shows.
+    expect(
+      screen.getByText('Pavel Tsatsouline (StrongFirst) · Repeating workout'),
+    ).toBeInTheDocument();
+    expect(screen.getByText('Repeats')).toBeInTheDocument();
+  });
+
   it('enrolls in your own program directly, with no starting-weight prompt', () => {
     renderPage();
 

--- a/src/pages/ProgramsPage/ProgramsPage.tsx
+++ b/src/pages/ProgramsPage/ProgramsPage.tsx
@@ -31,13 +31,7 @@ import { Input } from '~/components/ui/input';
 import { Label } from '~/components/ui/label';
 import { useSession } from '~/contexts';
 import { Program } from '~/types';
-
-// "5 weeks · 3/week" from the program's derived cadence, or null before any
-// session gives it one (see Program.numWeeks — derived from the sessions).
-const cadenceLabel = (program: Program): string | null =>
-  program.numWeeks && program.daysPerWeek
-    ? `${program.numWeeks} weeks · ${program.daysPerWeek}/week`
-    : null;
+import { programCadenceLabel } from '~/utils';
 
 export const ProgramsPage = () => {
   const navigate = useNavigate();
@@ -256,12 +250,17 @@ export const ProgramsPage = () => {
                 className="flex items-center justify-between gap-2 p-2 hover:bg-secondary"
               >
                 <div className="min-w-0">
-                  <p className="truncate text-sm font-medium">
+                  <p className="flex items-center gap-1 truncate text-sm font-medium">
                     {program.title}
+                    {program.defaultAutoRepeat && (
+                      <span className="rounded bg-secondary px-0.5 text-xs font-normal text-muted-foreground">
+                        Repeats
+                      </span>
+                    )}
                   </p>
                   <p className="truncate text-xs text-muted-foreground">
                     {program.authorName ? `${program.authorName} · ` : ''}
-                    {cadenceLabel(program) ?? 'No sessions yet'}
+                    {programCadenceLabel(program) ?? 'No sessions yet'}
                   </p>
                 </div>
                 <ChevronRightIcon
@@ -336,7 +335,7 @@ export const ProgramsPage = () => {
               )}
             </CardTitle>
             <p className="text-xs text-muted-foreground">
-              {cadenceLabel(program) ?? 'No sessions yet'}
+              {programCadenceLabel(program) ?? 'No sessions yet'}
             </p>
           </CardHeader>
           <CardContent className="flex flex-col gap-2">

--- a/src/types/program.interface.ts
+++ b/src/types/program.interface.ts
@@ -30,4 +30,11 @@ export interface Program {
   createdAt: string;
   /** Soft-archive marker: NULL when live, a timestamp once archived (hidden from the default list, restorable). */
   archivedAt: string | null;
+  /**
+   * Template default for the per-enrollment auto-repeat toggle. `true` for
+   * "repeating workouts" (Simple & Sinister, the Onnit circuit) that loop rather
+   * than finish; `false` for ordinary finite programs. Copied into
+   * {@link UserProgram.autoRepeat} at enroll time, where the user can override it.
+   */
+  defaultAutoRepeat: boolean;
 }

--- a/src/types/user-program.interface.ts
+++ b/src/types/user-program.interface.ts
@@ -22,4 +22,12 @@ export interface UserProgram {
    * stale value, which the partial unique index ignores.
    */
   activeSlot: number | null;
+  /**
+   * When `true`, finishing the program's last session loops back to the first
+   * session (a fresh cycle) instead of flipping `status` to `'completed'`.
+   * Initialized from {@link Program.defaultAutoRepeat} at enroll; user-toggleable.
+   */
+  autoRepeat: boolean;
+  /** Number of times this enrollment has looped (bumped on each auto-repeat cycle). */
+  cyclesCompleted: number;
 }

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -4,6 +4,7 @@ export * from './formatVolume';
 export * from './movementSearch';
 export * from './movementWeightModeFilter';
 export * from './ordinalSuffixOf';
+export * from './programCadenceLabel';
 export * from './patternDebt';
 export * from './rankMovements';
 export * from './resolveAuthSession';

--- a/src/utils/programCadenceLabel.ts
+++ b/src/utils/programCadenceLabel.ts
@@ -1,0 +1,15 @@
+import { Program } from '~/types';
+
+/**
+ * The one-line cadence descriptor shown under a program's title in the browse
+ * list and details header. A repeating workout (Simple & Sinister, the Onnit
+ * circuit) has no finish line, so it reads as "Repeating workout" rather than a
+ * "N weeks · X/week" span. Ordinary programs show their derived cadence, or
+ * `null` before any session gives them one (see {@link Program.numWeeks}).
+ */
+export const programCadenceLabel = (program: Program): string | null => {
+  if (program.defaultAutoRepeat) return 'Repeating workout';
+  return program.numWeeks && program.daysPerWeek
+    ? `${program.numWeeks} weeks · ${program.daysPerWeek}/week`
+    : null;
+};

--- a/supabase/migrations/20260727000000_add_program_auto_repeat.sql
+++ b/supabase/migrations/20260727000000_add_program_auto_repeat.sql
@@ -1,0 +1,28 @@
+-- Auto-repeat: let a program loop back to its first session instead of ending.
+--
+-- Programs are otherwise linear and finite -- once every session is satisfied the
+-- enrollment flips to 'completed' (see complete_program_session). That is wrong
+-- for "repeating workouts" (Simple & Sinister, the Onnit beginner circuit): the
+-- same session done over and over, where progress is added load, not advancing
+-- through sessions. This adds a per-enrollment toggle -- available on ANY program,
+-- not a special program kind -- plus a template default the seeds set.
+--
+--   programs.default_auto_repeat   the template's default; the two repeating-workout
+--                                  seeds set it true, every existing program stays false.
+--   user_programs.auto_repeat      the toggle the user actually controls; initialized
+--                                  from the template default at enroll (enroll_in_program),
+--                                  flippable anytime via useSetProgramAutoRepeat.
+--   user_programs.cycles_completed bumped each time the program loops, so the UI can show
+--                                  "Cycle N" and a count survives the completions reset
+--                                  that a loop performs.
+--
+-- Behavior lives in the two RPC migrations that follow; this is columns only.
+
+ALTER TABLE programs
+  ADD COLUMN default_auto_repeat BOOLEAN NOT NULL DEFAULT false;
+
+ALTER TABLE user_programs
+  ADD COLUMN auto_repeat BOOLEAN NOT NULL DEFAULT false;
+
+ALTER TABLE user_programs
+  ADD COLUMN cycles_completed INTEGER NOT NULL DEFAULT 0;

--- a/supabase/migrations/20260727000001_enroll_in_program_auto_repeat.sql
+++ b/supabase/migrations/20260727000001_enroll_in_program_auto_repeat.sql
@@ -1,0 +1,301 @@
+-- Enroll: carry the auto-repeat toggle through to the new enrollment.
+--
+-- Adds p_auto_repeat and sets user_programs.auto_repeat to
+-- COALESCE(p_auto_repeat, <program>.default_auto_repeat) -- so a caller that says
+-- nothing inherits the template's default (true for the repeating-workout seeds),
+-- and an explicit choice from the pre-enroll toggle wins. The clone also copies
+-- default_auto_repeat so a re-enroll of the user's own copy keeps the default.
+--
+-- The body is carried over VERBATIM from
+-- 20260724000004_enroll_in_program_per_movement_weights.sql; the only changes are
+-- the new parameter, the default_auto_repeat lookup/clone-copy, and the auto_repeat
+-- column on the final user_programs insert. DROP + CREATE, one signature only: a
+-- PostgREST overload would make the shorter call ambiguous.
+DROP FUNCTION IF EXISTS public.enroll_in_program(UUID);
+DROP FUNCTION IF EXISTS public.enroll_in_program(UUID, NUMERIC, TEXT, NUMERIC, TEXT);
+DROP FUNCTION IF EXISTS public.enroll_in_program(UUID, NUMERIC, TEXT, NUMERIC, TEXT, UUID);
+DROP FUNCTION IF EXISTS public.enroll_in_program(UUID, NUMERIC, TEXT, NUMERIC, TEXT, UUID, JSONB);
+
+CREATE FUNCTION public.enroll_in_program(
+  p_program_id UUID,
+  p_shared_weight_one_value NUMERIC DEFAULT NULL,
+  p_shared_weight_one_unit  TEXT    DEFAULT NULL,
+  p_shared_weight_two_value NUMERIC DEFAULT NULL,
+  p_shared_weight_two_unit  TEXT    DEFAULT NULL,
+  p_replace_user_program_id UUID    DEFAULT NULL,
+  p_movement_weights        JSONB   DEFAULT NULL,
+  p_auto_repeat             BOOLEAN  DEFAULT NULL
+)
+RETURNS UUID
+LANGUAGE plpgsql
+SECURITY INVOKER
+SET search_path = public
+AS $$
+DECLARE
+  v_user_id            UUID    := auth.uid();
+  v_owner_id           UUID;
+  v_default_auto_repeat BOOLEAN;
+  v_target_program     UUID;
+  v_user_program_id    UUID;
+  v_modal_one          NUMERIC;
+  v_modal_two          NUMERIC;
+  v_slot               SMALLINT;
+  v_override           BOOLEAN := p_shared_weight_one_value IS NOT NULL
+                                 OR p_movement_weights IS NOT NULL;
+BEGIN
+  IF v_user_id IS NULL THEN
+    RAISE EXCEPTION 'Not authenticated';
+  END IF;
+
+  -- RLS on this SELECT already restricts to public-or-own; a NOT FOUND result
+  -- means the program does not exist or is not visible to the caller.
+  SELECT owner_id, default_auto_repeat INTO v_owner_id, v_default_auto_repeat
+  FROM programs WHERE id = p_program_id;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Program % not found or not accessible', p_program_id;
+  END IF;
+
+  -- One live cursor per program. `p.source_program_id = p_program_id` catches
+  -- re-enrolling in a shared program whose earlier clone is still running.
+  IF EXISTS (
+    SELECT 1
+    FROM user_programs up
+    JOIN programs p ON p.id = up.program_id
+    WHERE up.user_id = v_user_id
+      AND up.status = 'active'
+      AND up.id IS DISTINCT FROM p_replace_user_program_id
+      AND (p.id = p_program_id OR p.source_program_id = p_program_id)
+  ) THEN
+    RAISE EXCEPTION 'PROGRAM_ALREADY_ACTIVE';
+  END IF;
+
+  -- Free the replaced slot first so the picker below can reuse it.
+  IF p_replace_user_program_id IS NOT NULL THEN
+    UPDATE user_programs
+      SET status = 'abandoned'
+      WHERE id = p_replace_user_program_id
+        AND user_id = v_user_id
+        AND status = 'active';
+    IF NOT FOUND THEN
+      RAISE EXCEPTION 'No active enrollment % to replace', p_replace_user_program_id;
+    END IF;
+  END IF;
+
+  SELECT s.slot INTO v_slot
+  FROM generate_series(1, 3) AS s(slot)
+  WHERE NOT EXISTS (
+    SELECT 1 FROM user_programs up
+    WHERE up.user_id = v_user_id
+      AND up.status = 'active'
+      AND up.active_slot = s.slot
+  )
+  ORDER BY s.slot
+  LIMIT 1;
+
+  IF v_slot IS NULL THEN
+    RAISE EXCEPTION 'PROGRAM_SLOTS_FULL';
+  END IF;
+
+  IF v_owner_id = v_user_id THEN
+    v_target_program := p_program_id;                     -- own program: no clone
+  ELSE
+    INSERT INTO programs
+      (owner_id, source_program_id, slug, title, description, author_name,
+       num_weeks, days_per_week, is_public, default_auto_repeat)
+    SELECT v_user_id, id, NULL, title, description, author_name,
+           num_weeks, days_per_week, false, default_auto_repeat
+    FROM programs WHERE id = p_program_id
+    RETURNING id INTO v_target_program;
+
+    IF v_override THEN
+      -- The modal (weightOne, weightTwo) pair across the program's sessions:
+      -- the shared placeholder load every deliberately-different session is
+      -- offset from, used only by the complexSet uniform-fold path. Ties break
+      -- toward the lighter pair, mirroring deriveStartingWeight.
+      SELECT one_val, two_val INTO v_modal_one, v_modal_two
+      FROM (
+        SELECT (workout_options->'movements'->0->>'weightOneValue')::NUMERIC AS one_val,
+               (workout_options->'movements'->0->>'weightTwoValue')::NUMERIC AS two_val,
+               COUNT(*) AS cnt
+        FROM program_sessions
+        WHERE program_id = p_program_id
+        GROUP BY one_val, two_val
+        ORDER BY cnt DESC, one_val, two_val
+        LIMIT 1
+      ) modal;
+    END IF;
+
+    INSERT INTO program_sessions
+      (program_id, sequence_index, week_number, day_number, title,
+       workout_options, notes, weight_label)
+    -- Per-movement modal authored weight, one row per movement name. Rows with a
+    -- null weight one (bodyweight) never form a modal, so a bodyweight movement
+    -- has no row and its element is kept untouched below. Tie-break mirrors the
+    -- client's deriveMovementWeights so pre-fill equals the cloned value.
+    WITH movement_modal AS (
+      SELECT DISTINCT ON (name)
+        name, one_val, two_val
+      FROM (
+        SELECT
+          mv->>'movementName' AS name,
+          (mv->>'weightOneValue')::NUMERIC AS one_val,
+          (mv->>'weightTwoValue')::NUMERIC AS two_val,
+          COUNT(*) AS cnt
+        FROM program_sessions ps2,
+             jsonb_array_elements(ps2.workout_options->'movements') AS mv
+        WHERE ps2.program_id = p_program_id
+          AND (mv->>'weightOneValue') IS NOT NULL
+        GROUP BY name, one_val, two_val
+      ) per_pair
+      ORDER BY name, cnt DESC, one_val, two_val
+    )
+    SELECT
+      v_target_program, ps.sequence_index, ps.week_number, ps.day_number, ps.title,
+      CASE
+        WHEN NOT v_override THEN ps.workout_options
+        -- non-complex with per-movement weights: rebuild each element in its own
+        -- config shape, offset from that movement's modal.
+        WHEN p_movement_weights IS NOT NULL
+             AND ps.workout_options->>'complexSet' IS DISTINCT FROM 'true'
+          THEN jsonb_set(
+                 ps.workout_options,
+                 '{movements}',
+                 (
+                   SELECT jsonb_agg(
+                            CASE
+                              WHEN mw.value IS NULL THEN elem
+                              ELSE elem || jsonb_build_object(
+                                'weightOneValue',
+                                  COALESCE(to_jsonb(
+                                    CASE
+                                      WHEN (mw.value->>'weightOneValue')::NUMERIC IS NULL
+                                        OR r.one_delta = 0
+                                        THEN (mw.value->>'weightOneValue')::NUMERIC
+                                      ELSE GREATEST((mw.value->>'weightOneValue')::NUMERIC + r.one_delta, 1)
+                                    END), 'null'::jsonb),
+                                'weightOneUnit',
+                                  COALESCE(to_jsonb(mw.value->>'weightOneUnit'), 'null'::jsonb),
+                                'weightTwoValue',
+                                  COALESCE(to_jsonb(
+                                    CASE
+                                      WHEN (mw.value->>'weightTwoValue')::NUMERIC IS NULL
+                                        OR r.two_delta = 0
+                                        THEN (mw.value->>'weightTwoValue')::NUMERIC
+                                      ELSE GREATEST((mw.value->>'weightTwoValue')::NUMERIC + r.two_delta, 1)
+                                    END), 'null'::jsonb),
+                                'weightTwoUnit',
+                                  COALESCE(to_jsonb(mw.value->>'weightTwoUnit'), 'null'::jsonb)
+                              )
+                            END
+                            ORDER BY ord
+                          )
+                   FROM jsonb_array_elements(ps.workout_options->'movements')
+                          WITH ORDINALITY AS e(elem, ord)
+                   LEFT JOIN LATERAL (
+                     SELECT o.value
+                     FROM jsonb_array_elements(p_movement_weights) AS o(value)
+                     WHERE o.value->>'movementName' = elem->>'movementName'
+                     LIMIT 1
+                   ) mw ON TRUE
+                   LEFT JOIN movement_modal mm ON mm.name = elem->>'movementName'
+                   CROSS JOIN LATERAL (
+                     SELECT
+                       -- Offset only when the movement's authored unit matches the
+                       -- chosen unit; a cross-unit choice passes through (delta 0).
+                       CASE WHEN elem->>'weightOneUnit'
+                                 IS NOT DISTINCT FROM mw.value->>'weightOneUnit'
+                            THEN COALESCE((elem->>'weightOneValue')::NUMERIC, 0)
+                                 - COALESCE(mm.one_val, 0)
+                            ELSE 0 END AS one_delta,
+                       CASE WHEN elem->>'weightTwoUnit'
+                                 IS NOT DISTINCT FROM mw.value->>'weightTwoUnit'
+                            THEN COALESCE((elem->>'weightTwoValue')::NUMERIC, 0)
+                                 - COALESCE(mm.two_val, 0)
+                            ELSE 0 END AS two_delta
+                   ) r
+                 ))
+        -- complexSet (one bell pair for the whole complex, ABC), or a caller that
+        -- passed only p_shared_weight_* (the homogeneous shared-weight programs):
+        -- the prior uniform fold. COALESCE(..., 'null'::jsonb): jsonb_set is
+        -- strict and to_jsonb(NULL) is SQL NULL, so an unset slot must be coerced
+        -- to a JSON null. `m || jsonb_build_object(...)` overrides only the four
+        -- weight keys, preserving movementName / repScheme / etc.
+        ELSE jsonb_set(
+               jsonb_set(
+                 jsonb_set(
+                   jsonb_set(
+                     jsonb_set(
+                       ps.workout_options,
+                       '{sharedWeightOneValue}',
+                       COALESCE(to_jsonb(w.one_value), 'null'::jsonb)),
+                     '{sharedWeightOneUnit}',
+                     COALESCE(to_jsonb(w.one_unit), 'null'::jsonb)),
+                   '{sharedWeightTwoValue}',
+                   COALESCE(to_jsonb(w.two_value), 'null'::jsonb)),
+                 '{sharedWeightTwoUnit}',
+                 COALESCE(to_jsonb(w.two_unit), 'null'::jsonb)),
+               '{movements}',
+               (
+                 SELECT jsonb_agg(
+                          m || jsonb_build_object(
+                            'weightOneValue', COALESCE(to_jsonb(w.one_value), 'null'::jsonb),
+                            'weightOneUnit',  COALESCE(to_jsonb(w.one_unit),  'null'::jsonb),
+                            'weightTwoValue', COALESCE(to_jsonb(w.two_value), 'null'::jsonb),
+                            'weightTwoUnit',  COALESCE(to_jsonb(w.two_unit),  'null'::jsonb)
+                          )
+                        )
+                 FROM jsonb_array_elements(ps.workout_options->'movements') AS m
+               ))
+      END,
+      ps.notes,
+      ps.weight_label
+    FROM program_sessions ps
+    -- Per-session shared weight for the complexSet path: the enrollee's choice
+    -- shifted by this session's authored offset from the modal. A zero delta
+    -- passes the chosen value through untouched -- notably it must NOT hit the
+    -- >= 1 clamp, since a single-bell enrollment carries weight two = 0.
+    CROSS JOIN LATERAL (
+      SELECT
+        CASE
+          WHEN p_shared_weight_one_value IS NULL OR d.one_delta = 0
+            THEN p_shared_weight_one_value
+          ELSE GREATEST(p_shared_weight_one_value + d.one_delta, 1)
+        END AS one_value,
+        CASE
+          WHEN p_shared_weight_two_value IS NULL OR d.two_delta = 0
+            THEN p_shared_weight_two_value
+          ELSE GREATEST(p_shared_weight_two_value + d.two_delta, 1)
+        END AS two_value,
+        p_shared_weight_one_unit AS one_unit,
+        p_shared_weight_two_unit AS two_unit
+      FROM (
+        SELECT
+          COALESCE(
+            CASE WHEN ps.workout_options->'movements'->0->>'weightOneUnit'
+                      IS NOT DISTINCT FROM p_shared_weight_one_unit
+                 THEN (ps.workout_options->'movements'->0->>'weightOneValue')::NUMERIC
+                      - v_modal_one
+            END, 0) AS one_delta,
+          COALESCE(
+            CASE WHEN ps.workout_options->'movements'->0->>'weightTwoUnit'
+                      IS NOT DISTINCT FROM p_shared_weight_two_unit
+                 THEN (ps.workout_options->'movements'->0->>'weightTwoValue')::NUMERIC
+                      - v_modal_two
+            END, 0) AS two_delta
+      ) d
+    ) w
+    WHERE ps.program_id = p_program_id
+    ORDER BY ps.sequence_index;
+  END IF;
+
+  INSERT INTO user_programs (user_id, program_id, status, active_slot, auto_repeat)
+  VALUES (v_user_id, v_target_program, 'active', v_slot,
+          COALESCE(p_auto_repeat, v_default_auto_repeat, false))
+  RETURNING id INTO v_user_program_id;
+
+  RETURN v_user_program_id;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.enroll_in_program(UUID, NUMERIC, TEXT, NUMERIC, TEXT, UUID, JSONB, BOOLEAN) FROM public;
+GRANT EXECUTE ON FUNCTION public.enroll_in_program(UUID, NUMERIC, TEXT, NUMERIC, TEXT, UUID, JSONB, BOOLEAN) TO authenticated;

--- a/supabase/migrations/20260727000002_complete_program_session_auto_repeat.sql
+++ b/supabase/migrations/20260727000002_complete_program_session_auto_repeat.sql
@@ -1,0 +1,94 @@
+-- complete_program_session: loop instead of finish when auto_repeat is on.
+--
+-- Original behavior (20260707000000): recording the final unsatisfied session's
+-- completion flips the enrollment to 'completed'. For a repeating workout that is
+-- wrong -- the program should start over. When the enrollment has auto_repeat set,
+-- satisfying the last session instead RESETS the enrollment's completions (a fresh
+-- cycle) and bumps cycles_completed, leaving status 'active'. The completions
+-- UNIQUE (user_program_id, program_session_id) guard means we cannot stack a
+-- second completion per session, so a reset -- not a duplicate insert -- is how a
+-- loop is expressed. Workout history is untouched: each finished session is its own
+-- workout_logs row whose "{Program} · W#D# {title}" name is composed at start time,
+-- not derived from the completion we delete here.
+--
+-- Everything else is carried over verbatim from
+-- 20260707000000_create_complete_program_session_function.sql.
+CREATE OR REPLACE FUNCTION public.complete_program_session(
+  p_user_program_id uuid,
+  p_program_session_id uuid,
+  p_workout_log_id bigint DEFAULT NULL,
+  p_status text DEFAULT 'completed'
+)
+RETURNS boolean
+LANGUAGE plpgsql
+SECURITY INVOKER
+SET search_path = public
+AS $$
+DECLARE
+  v_user_id     uuid := auth.uid();
+  v_program_id  uuid;
+  v_auto_repeat boolean;
+  v_total       int;
+  v_satisfied   int;
+  v_all_done    boolean;
+BEGIN
+  IF v_user_id IS NULL THEN
+    RAISE EXCEPTION 'Not authenticated';
+  END IF;
+
+  IF p_status NOT IN ('completed', 'skipped') THEN
+    RAISE EXCEPTION 'Invalid completion status: %', p_status;
+  END IF;
+
+  -- Confirm the enrollment is the caller's own and capture its program (the
+  -- user-owned clone) and its auto-repeat toggle. RLS also guards this, but the
+  -- explicit check yields a clear error and the values in one round trip.
+  SELECT program_id, auto_repeat INTO v_program_id, v_auto_repeat
+  FROM user_programs
+  WHERE id = p_user_program_id AND user_id = v_user_id;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Enrollment % not found or not owned by caller', p_user_program_id;
+  END IF;
+
+  -- A session is satisfied at most once per enrollment (UNIQUE guard). Make a
+  -- duplicate fire (e.g. a double onSuccess, or a retry) a harmless no-op rather
+  -- than a unique violation.
+  INSERT INTO program_session_completions
+    (user_program_id, program_session_id, user_id, workout_log_id, status)
+  VALUES
+    (p_user_program_id, p_program_session_id, v_user_id, p_workout_log_id, p_status)
+  ON CONFLICT (user_program_id, program_session_id) DO NOTHING;
+
+  -- Is every session in the program now satisfied?
+  SELECT count(*) INTO v_total
+  FROM program_sessions
+  WHERE program_id = v_program_id;
+
+  SELECT count(*) INTO v_satisfied
+  FROM program_session_completions
+  WHERE user_program_id = p_user_program_id;
+
+  v_all_done := v_total > 0 AND v_satisfied >= v_total;
+
+  IF v_all_done AND v_auto_repeat THEN
+    -- Loop: clear this cycle's completions so the next session resolves back to
+    -- sequence_index 0, keep the enrollment active, and record the cycle. Returns
+    -- FALSE so the client shows no "program complete" message.
+    DELETE FROM program_session_completions
+      WHERE user_program_id = p_user_program_id;
+    UPDATE user_programs
+      SET cycles_completed = cycles_completed + 1
+      WHERE id = p_user_program_id;
+    RETURN false;
+  ELSIF v_all_done THEN
+    UPDATE user_programs
+      SET status = 'completed', completed_at = NOW()
+      WHERE id = p_user_program_id AND status = 'active';
+  END IF;
+
+  RETURN v_all_done;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.complete_program_session(uuid, uuid, bigint, text) FROM public;
+GRANT EXECUTE ON FUNCTION public.complete_program_session(uuid, uuid, bigint, text) TO authenticated;

--- a/supabase/migrations/20260727000003_seed_simple_and_sinister.sql
+++ b/supabase/migrations/20260727000003_seed_simple_and_sinister.sql
@@ -1,0 +1,99 @@
+-- Seed the shared "Simple & Sinister" program (Pavel Tsatsouline, StrongFirst).
+-- Public + system-owned (owner_id NULL, is_public true) so every user sees it and
+-- can one-tap "Start"; enrolling clones it into an editable copy (enroll_in_program).
+-- Idempotent on slug: a re-run (or fresh env) skips re-seeding. This is a MIGRATION
+-- (not seed.sql) so it also reaches staging/production, where seed.sql never runs.
+--
+-- Source: https://www.strongfirst.com/achieve/sinister/ -- the S&S protocol is free
+-- and ubiquitous. It is the single most-followed beginner kettlebell program, and
+-- the first REPEATING WORKOUT in the catalog: default_auto_repeat = true, so finishing
+-- it loops back to the same session rather than flipping to "complete". Progress is
+-- added load over weeks (Timeless Simple -> Simple 32 kg -> Sinister 48 kg), not
+-- advancing through sessions -- exactly what the auto-repeat toggle models.
+--
+-- THE WORKOUT (one session, done most days):
+--   * 100 one-arm swings: 5 rungs of 10, single-bell one-handed (weightTwoValue 0
+--     => '1h' mode), so the runtime MIRRORS each rung per hand -> 10 L + 10 R x 5 =
+--     100 swings, 50 per side.
+--   * 10 Turkish get-ups: 5 rungs of 1, likewise mirrored -> 1 L + 1 R x 5 = 10
+--     get-ups, 5 per side.
+--   * straightSets = true: every swing rung is completed before the get-ups begin
+--     (all swings, then all get-ups), matching how S&S is performed.
+--
+-- MODELING DECISIONS:
+--   * ROUNDS goal of 1: one round = the whole ladder once (all swings + all get-ups).
+--     Mirrors Easy Strength -- the repScheme already encodes every set, so a single
+--     round is a complete session.
+--   * NO EMOM. The "Timeless Simple" on-ramp is done for quality with rest as needed,
+--     not on the minute (intervalTimer 0). The 5-minute swing / 10-minute get-up
+--     pace of the "Simple"/"Sinister" standards is a benchmark the lifter grows into,
+--     noted in preWorkoutNotes rather than enforced by a timer.
+--   * 24 kg is a PLACEHOLDER, as in every seed; the enrollment weight picker pre-fills
+--     single-bell and the user sets their own load (Pavel's beginner start is 16 kg
+--     women / 24 kg men, working toward the 32 kg "Simple" standard).
+--   * NO FIXED CADENCE. num_weeks / days_per_week are NULL: a repeating workout has no
+--     finish line, so cadence is left blank and the UI shows it as a repeating workout.
+
+-- One single-bell, one-handed movement object (weightTwoValue 0 => mirror per hand).
+CREATE OR REPLACE FUNCTION pg_temp.ss_movement(p_name TEXT, p_reps INT[])
+RETURNS JSONB LANGUAGE sql IMMUTABLE AS $$
+  SELECT jsonb_build_object(
+    'movementName', p_name,
+    'repScheme', to_jsonb(p_reps),
+    'weightOneUnit', 'kilograms', 'weightOneValue', 24,
+    'weightTwoUnit', NULL, 'weightTwoValue', 0);
+$$;
+
+DO $$
+DECLARE
+  v_program_id UUID;
+BEGIN
+  INSERT INTO programs (owner_id, slug, title, description, author_name,
+                        num_weeks, days_per_week, is_public, default_auto_repeat)
+  VALUES (NULL, 'simple-and-sinister',
+          'Simple & Sinister',
+          'Two movements, done most days, forever: 100 one-arm swings and 10 '
+          'Turkish get-ups. The most-followed beginner kettlebell program -- built '
+          'to give the greatest return from the fewest exercises. You do not '
+          'progress by changing the workout; you progress by adding weight. Repeats '
+          'automatically.',
+          'Pavel Tsatsouline (StrongFirst)', NULL, NULL, true, true)
+  ON CONFLICT (slug) DO NOTHING
+  RETURNING id INTO v_program_id;
+
+  -- If the row already existed, skip re-seeding sessions.
+  IF v_program_id IS NULL THEN
+    RAISE NOTICE 'Simple & Sinister program already seeded; skipping sessions.';
+    RETURN;
+  END IF;
+
+  -- One session, two movements, run straight-sets (all swings, then all get-ups).
+  -- Both movements are single-bell one-handed (weightTwoValue 0), so the runtime
+  -- mirrors each rung per hand: 5x10 swings -> 100 total, 5x1 get-ups -> 10 total.
+  INSERT INTO program_sessions
+    (program_id, sequence_index, week_number, day_number, title, workout_options)
+  VALUES
+    (v_program_id, 0, 1, 1, '100 swings + 10 get-ups',
+     jsonb_build_object(
+       'complexSet', false,
+       'straightSets', true,
+       'intervalTimer', 0,
+       'restTimer', 0,
+       'workoutGoal', 1,
+       'workoutGoalUnits', 'rounds',
+       'title', NULL,
+       'preWorkoutNotes',
+         '100 one-arm swings (10 per hand x 5), then 10 Turkish get-ups (5 per hand). '
+         'Swings in sets of 10 for power, get-ups as singles for perfect technique. '
+         'Rest as needed and keep every rep crisp -- this is built for quality, not a '
+         'race. Progress by adding weight, not reps: work toward doing it with a 32 kg '
+         'bell (the "Simple" standard). Start around 16 kg (women) / 24 kg (men).',
+       'sharedWeightOneUnit', NULL,
+       'sharedWeightOneValue', NULL,
+       'sharedWeightTwoUnit', NULL,
+       'sharedWeightTwoValue', NULL,
+       'movements', jsonb_build_array(
+         pg_temp.ss_movement('One-Arm Kettlebell Swing', ARRAY[10,10,10,10,10]::INT[]),
+         pg_temp.ss_movement('Kettlebell Turkish Get-Up', ARRAY[1,1,1,1,1]::INT[])
+       )));
+END $$;

--- a/supabase/migrations/20260727000004_seed_onnit_beginner_full_body.sql
+++ b/supabase/migrations/20260727000004_seed_onnit_beginner_full_body.sql
@@ -1,0 +1,94 @@
+-- Seed the shared "Onnit Beginner Full-Body" program. Public + system-owned
+-- (owner_id NULL, is_public true); enrolling clones it (enroll_in_program).
+-- Idempotent on slug. MIGRATION (not seed.sql) so it reaches staging/production.
+--
+-- Source: https://www.onnit.com/blogs/the-edge/full-body-kettlebell-workout-for-beginners
+-- A 3-round full-body circuit run up to 3x/week -- one of the most widely shared free
+-- beginner routines. Like Simple & Sinister it is a REPEATING WORKOUT
+-- (default_auto_repeat = true): the routine is published with no week-to-week
+-- progression, so finishing loops back to the same circuit rather than "completing".
+--
+-- THE WORKOUT (one session, a circuit): rotate through the movements once per round
+-- (straightSets false, complexSet false), 3 rounds (workoutGoal 3). 16 kg placeholder
+-- (Onnit recommends 8 kg women / 16 kg men).
+--
+-- CATALOG MAPPING -- "map to closest, drop hip-pass". Onnit's exact movement names
+-- are not all in the catalog, so a few are mapped to the nearest existing movement
+-- (movementName must match scripts/data/movements.csv exactly). These substitutions
+-- change the movement label, not the training intent:
+--   Onnit "Goblet Squat"          -> Goblet Squat (exact)
+--   Onnit "Split-Stance Row"      -> One-Arm Kettlebell Row (catalog's only 1-arm row)
+--   Onnit "Strict Press"          -> One-Arm Kettlebell Military Press
+--   Onnit "Chest-Loaded Swing"    -> Kettlebell Swing (the two swing blocks in the
+--                                    published circuit are folded into this one entry)
+--   Onnit "Shoulder Halo"         -> Kettlebell Halo (exact intent)
+--   Onnit "Figure-8"              -> Kettlebell Figure 8
+--   Onnit "Hip Pass"              -> DROPPED (no catalog equivalent)
+--
+-- WEIGHT MODES: goblet squat / swing / halo / figure-8 are two-handed on one bell
+-- (weightTwoValue NULL => '2h'); the row and press are one-handed (weightTwoValue 0
+-- => '1h'), so the runtime mirrors each per hand -- matching Onnit's "each side".
+
+-- One movement object at the 16 kg placeholder. p_weight_two = 0 marks a one-handed
+-- (mirrored) movement; NULL marks a two-handed single-bell movement.
+CREATE OR REPLACE FUNCTION pg_temp.onnit_movement(p_name TEXT, p_reps INT[], p_weight_two INT)
+RETURNS JSONB LANGUAGE sql IMMUTABLE AS $$
+  SELECT jsonb_build_object(
+    'movementName', p_name,
+    'repScheme', to_jsonb(p_reps),
+    'weightOneUnit', 'kilograms', 'weightOneValue', 16,
+    'weightTwoUnit', NULL, 'weightTwoValue', p_weight_two);
+$$;
+
+DO $$
+DECLARE
+  v_program_id UUID;
+BEGIN
+  INSERT INTO programs (owner_id, slug, title, description, author_name,
+                        num_weeks, days_per_week, is_public, default_auto_repeat)
+  VALUES (NULL, 'onnit-beginner-full-body',
+          'Onnit Beginner Full-Body',
+          'A full-body kettlebell circuit for your first month: goblet squat, row, '
+          'press, swing, halo, and figure-8, done as a 3-round circuit up to three '
+          'times a week. One light bell, every major movement pattern. Repeats '
+          'automatically.',
+          'Onnit', NULL, NULL, true, true)
+  ON CONFLICT (slug) DO NOTHING
+  RETURNING id INTO v_program_id;
+
+  -- If the row already existed, skip re-seeding sessions.
+  IF v_program_id IS NULL THEN
+    RAISE NOTICE 'Onnit Beginner Full-Body program already seeded; skipping sessions.';
+    RETURN;
+  END IF;
+
+  INSERT INTO program_sessions
+    (program_id, sequence_index, week_number, day_number, title, workout_options)
+  VALUES
+    (v_program_id, 0, 1, 1, '3-round circuit',
+     jsonb_build_object(
+       'complexSet', false,
+       'straightSets', false,
+       'intervalTimer', 0,
+       'restTimer', 0,
+       'workoutGoal', 3,
+       'workoutGoalUnits', 'rounds',
+       'title', NULL,
+       'preWorkoutNotes',
+         'Do one set of each movement in order, without resting in between, then '
+         'rest 1-2 minutes and repeat -- 3 rounds total. Row and press are per hand. '
+         'Keep it light and smooth; this is a first-month full-body circuit, not a '
+         'grind. Onnit recommends an 8 kg (women) / 16 kg (men) bell to start.',
+       'sharedWeightOneUnit', NULL,
+       'sharedWeightOneValue', NULL,
+       'sharedWeightTwoUnit', NULL,
+       'sharedWeightTwoValue', NULL,
+       'movements', jsonb_build_array(
+         pg_temp.onnit_movement('Goblet Squat', ARRAY[10]::INT[], NULL),
+         pg_temp.onnit_movement('One-Arm Kettlebell Row', ARRAY[8]::INT[], 0),
+         pg_temp.onnit_movement('One-Arm Kettlebell Military Press', ARRAY[5]::INT[], 0),
+         pg_temp.onnit_movement('Kettlebell Swing', ARRAY[15]::INT[], NULL),
+         pg_temp.onnit_movement('Kettlebell Halo', ARRAY[8]::INT[], NULL),
+         pg_temp.onnit_movement('Kettlebell Figure 8', ARRAY[5]::INT[], NULL)
+       )));
+END $$;

--- a/types/supabase.ts
+++ b/types/supabase.ts
@@ -372,6 +372,7 @@ export type Database = {
           author_name: string | null
           created_at: string
           days_per_week: number | null
+          default_auto_repeat: boolean
           description: string | null
           id: string
           is_public: boolean
@@ -386,6 +387,7 @@ export type Database = {
           author_name?: string | null
           created_at?: string
           days_per_week?: number | null
+          default_auto_repeat?: boolean
           description?: string | null
           id?: string
           is_public?: boolean
@@ -400,6 +402,7 @@ export type Database = {
           author_name?: string | null
           created_at?: string
           days_per_week?: number | null
+          default_auto_repeat?: boolean
           description?: string | null
           id?: string
           is_public?: boolean
@@ -532,8 +535,10 @@ export type Database = {
       user_programs: {
         Row: {
           active_slot: number | null
+          auto_repeat: boolean
           completed_at: string | null
           config: Json
+          cycles_completed: number
           id: string
           program_id: string
           started_at: string
@@ -542,8 +547,10 @@ export type Database = {
         }
         Insert: {
           active_slot?: number | null
+          auto_repeat?: boolean
           completed_at?: string | null
           config?: Json
+          cycles_completed?: number
           id?: string
           program_id: string
           started_at?: string
@@ -552,8 +559,10 @@ export type Database = {
         }
         Update: {
           active_slot?: number | null
+          auto_repeat?: boolean
           completed_at?: string | null
           config?: Json
+          cycles_completed?: number
           id?: string
           program_id?: string
           started_at?: string
@@ -776,6 +785,7 @@ export type Database = {
       }
       enroll_in_program: {
         Args: {
+          p_auto_repeat?: boolean
           p_movement_weights?: Json
           p_program_id: string
           p_replace_user_program_id?: string


### PR DESCRIPTION
## Why

Every shared program is modeled as a **linear, finite** progression: walk the sessions in order, and satisfying the last one flips the enrollment to `completed` — a one-way trip. That's wrong for a whole class of popular beginner training: **repeating workouts**, where the same workout is done over and over and progress comes from adding weight, not advancing through sessions. The two most-followed free beginner programs — **Simple & Sinister** and the **Onnit beginner circuit** — are exactly this shape, and the catalog had no minimalist beginner staple.

## What

Adds a **universal auto-repeat toggle** to any program: when on, finishing the last session loops back to the first (a fresh cycle) instead of ending. Then seeds the two beginner workouts with that toggle defaulted on.

- **Schema:** `programs.default_auto_repeat` (template default), `user_programs.auto_repeat` (per-enrollment toggle), `user_programs.cycles_completed`.
- **RPCs:** `enroll_in_program` threads `p_auto_repeat` (`COALESCE(param, template default)`); `complete_program_session` resets the enrollment's completions and bumps `cycles_completed` — staying `active` — when `auto_repeat` is on, rather than flipping to `completed`.
- **UI:** a "Repeat automatically" toggle on the program details (pre-enroll) and progress pages; a shared "Repeating workout" cadence label + "Repeats" badge in the browse list; the progress card reads "Repeating workout · Cycle N" and never shows the completion state.
- **Seeds:** Simple & Sinister (100 one-arm swings 5×10 mirrored + 10 Turkish get-ups 5×1 mirrored, straight sets) and Onnit Beginner Full-Body (a 3-round circuit). Onnit moves absent from the catalog are mapped to the closest entry (split-stance row → One-Arm Row, strict press → One-Arm Military Press, figure-8 → Figure 8); hip-pass is dropped, documented in the migration header.

History attribution is unaffected by the loop: each finished session is its own `workout_logs` row whose composed `{program} · W#D# {title}` name is stamped at start, not derived from the completion the reset clears.

## How to test

- `npm run start:server` → `supabase db reset` applies all five migrations cleanly; `npm run diff-db` reports no schema changes; `npm run gen:types` shows the three new columns.
- `npm test` — 555 unit tests pass (incl. new details-page toggle→enroll wiring and the browse "Repeating workout" label/badge). `npm run compile:ts` and `npm run lint` clean.
- e2e (`npx playwright test program-`): 61 pass, including the two new seed-shape specs and a loop test proving an `auto_repeat` enrollment does **not** complete on finishing its last session — it stays `active` and `cycles_completed` increments, with completions reset.
- Manual, in the running app: enrolled in S&S → the enrollment carried `auto_repeat = true` and cloned at the correct 24 kg; the active workout **mirrors per hand** ("Left hand · side 1 of 2", 24 kg, Set 1 of 5) under straight sets with the composed "Simple & Sinister · W1D1…" title; the progress page reads "Repeating workout · 0 cycles done".

## Gallery

Captured during verification (I can drag-drop the PNGs — the browser automation screenshots didn't land as committable files):

1. **Browse programs** — "Onnit Beginner Full-Body" and "Simple & Sinister" each with a `Repeats` badge and a "· Repeating workout" subtitle, alongside the normal "N weeks · X/week" programs.
2. **Program details (S&S)** — "Pavel Tsatsouline (StrongFirst) · Repeating workout" header and a checked "Repeat automatically" toggle above Start.
3. **Progress page (S&S)** — "Repeating workout · 0 cycles done", the live toggle, no completion state.
4. **Active workout (S&S)** — "One-Arm Kettlebell Swing", "Set 1 of 5", "Left hand · side 1 of 2", Left 24 kg / Right 24 kg — mirror-per-hand under straight sets.

## Deploy notes

- Five new migrations (three capability, two seeds). No `supabase/seed.sql` changes; the shared programs ship as idempotent migrations so they reach staging **and** production.
- `types/supabase.ts` regenerated (committed).
- No feature-flag change — new public programs surface automatically; the `programs` build flag already gates the surface.

## Tradeoffs

Looping **resets** the enrollment's completions each cycle (keeping a `cycles_completed` counter) rather than tracking per-cycle completion rows. That's a direct consequence of the existing `UNIQUE (user_program_id, program_session_id)` guard, and it keeps the change small; workout history is fully preserved either way. Per-cycle program↔log linkage (only the first cycle links) was considered and rejected as out of scope — it would mean relaxing that constraint or adding a cycle dimension to completions.
