### PR TITLE
feat(ui): replace auto-repeat checkboxes with a Switch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@radix-ui/react-select": "^2.2.5",
         "@radix-ui/react-separator": "^1.0.3",
         "@radix-ui/react-slot": "^1.0.2",
+        "@radix-ui/react-switch": "^1.3.7",
         "@radix-ui/react-tabs": "^1.1.2",
         "@supabase/supabase-js": "^2.31.0",
         "@tanstack/react-query": "^5.90.2",
@@ -2047,6 +2048,182 @@
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-switch": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-switch/-/react-switch-1.3.7.tgz",
+      "integrity": "sha512-48tB/4dn2UVLBCYhTu9AuR63IHl73l/qLbLgxd86noTUor4/K4LFDAcYjK+isP5313qxaFpjPVogE7+Y0/V3Kw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.5",
+        "@radix-ui/react-context": "1.2.2",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-use-controllable-state": "1.2.6",
+        "@radix-ui/react-use-size": "1.1.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-switch/node_modules/@radix-ui/primitive": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.7.tgz",
+      "integrity": "sha512-rqWnm76nYT8HoNNqEjpgJ7Pw/DrBj5iBTrmEPo6HTX5+VJyBNOqTdv4g89G63HuR5g0AaENoAcH7Is5fF2kZ8Q==",
+      "license": "MIT"
+    },
+    "node_modules/@radix-ui/react-switch/node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.5.tgz",
+      "integrity": "sha512-+48PbAAbq3didjJxa+OaWY2ZwgAKsNiRGyeHKszblZMQ+kcpd9pAaT11cMkGEie0vsOi3QdeTE6d5Fe3Gn61kA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-switch/node_modules/@radix-ui/react-context": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.2.2.tgz",
+      "integrity": "sha512-RHCUGwKHDr0hDGg4X7ma4JG4/+12qxw8rkh5QKdDldlCvtja6nUx1Ef/8HVrJze81lEsgLQlqjzjGNHantgnQA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-switch/node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.10",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.10.tgz",
+      "integrity": "sha512-MucOnzh6hR5mid6VpkbglRAMYMjKLqRnGBbjXkzjK52fuQDd1qbkx78a5P40mkcnVXJdEVxm26E9OPAiUq7nBg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.3.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-switch/node_modules/@radix-ui/react-slot": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.3.3.tgz",
+      "integrity": "sha512-qx7oqnYbxnK9kYI9m317qmFmEgo6ywqWvbTogdj7cL9p3/yx4M48p7Rnw5z3H890cL/ow/EeWJsuTykeZVXP5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.5"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-switch/node_modules/@radix-ui/react-use-controllable-state": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.6.tgz",
+      "integrity": "sha512-uEQJGT97ZA/TgP/Hydw47lHu+/vQj6z/0jA+WeTbK1o9Rx45GImjpD0tc3W5ad3D6XTSR6e1yEO0FvGq6WQfVQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.7",
+        "@radix-ui/react-use-effect-event": "0.0.5",
+        "@radix-ui/react-use-layout-effect": "1.1.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-switch/node_modules/@radix-ui/react-use-effect-event": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-effect-event/-/react-use-effect-event-0.0.5.tgz",
+      "integrity": "sha512-7cshFL8HGS/7HEiHH+9kL9HBwp2sa9yX18Knwek6KYWmXwM7pegMgta2AXMQKI+rq3JnfSj9x8wYqFMTdG1Jgg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-switch/node_modules/@radix-ui/react-use-layout-effect": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.4.tgz",
+      "integrity": "sha512-K20DkRkUwDnxEYMBPcg3Y6voLkEy5p5QQmszZgLngKKiC7dzBR/aEuK3w1qlx2JWDUNH6FluahYdgR3BP+QbYw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-switch/node_modules/@radix-ui/react-use-size": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-size/-/react-use-size-1.1.4.tgz",
+      "integrity": "sha512-D3anSY15EJoxrihpsXI6SMrmmonnQtR2ni7arO+Lfdg3O95b9hNXxONk8jA5C8ANdF/h5HMAxejgs8PWJ6rlhw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.4"
       },
       "peerDependencies": {
         "@types/react": "*",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "@radix-ui/react-select": "^2.2.5",
     "@radix-ui/react-separator": "^1.0.3",
     "@radix-ui/react-slot": "^1.0.2",
+    "@radix-ui/react-switch": "^1.3.7",
     "@radix-ui/react-tabs": "^1.1.2",
     "@supabase/supabase-js": "^2.31.0",
     "@tanstack/react-query": "^5.90.2",

--- a/src/components/ui/switch.stories.tsx
+++ b/src/components/ui/switch.stories.tsx
@@ -1,0 +1,49 @@
+import { Label } from './label';
+import { Switch } from './switch';
+
+export default {
+  component: Switch,
+};
+
+export const Default = {
+  name: 'Switch',
+  args: {
+    defaultChecked: true,
+  },
+};
+
+const states = [
+  { label: 'On', props: { defaultChecked: true } },
+  { label: 'Off', props: { defaultChecked: false } },
+  { label: 'On, disabled', props: { defaultChecked: true, disabled: true } },
+  { label: 'Off, disabled', props: { defaultChecked: false, disabled: true } },
+];
+
+export const AllStates = () => (
+  <div className="flex flex-col gap-2">
+    {states.map(({ label, props }) => (
+      <div key={label} className="flex items-center gap-1">
+        <Switch {...props} />
+        <span className="text-sm text-muted-foreground">{label}</span>
+      </div>
+    ))}
+  </div>
+);
+
+export const SettingsRow = () => (
+  <div className="flex max-w-[24rem] items-start justify-between gap-2">
+    <div className="flex flex-col gap-0.5">
+      <Label htmlFor="story-auto-repeat">Repeat automatically</Label>
+      <span id="story-auto-repeat-help" className="text-xs text-muted-foreground">
+        When on, finishing the last session starts the program over instead of
+        ending it. Progress by adding weight over time.
+      </span>
+    </div>
+    <Switch
+      id="story-auto-repeat"
+      className="mt-0.5"
+      aria-describedby="story-auto-repeat-help"
+      defaultChecked
+    />
+  </div>
+);

--- a/src/components/ui/switch.tsx
+++ b/src/components/ui/switch.tsx
@@ -1,0 +1,27 @@
+import * as SwitchPrimitive from '@radix-ui/react-switch';
+import * as React from 'react';
+
+import { cn } from '~/lib/utils';
+
+// Sized against the project's custom spacing scale (1 = 8px), not Tailwind's
+// defaults: track 20x36px, thumb 16px, travel 16px.
+const Switch = ({
+  className,
+  ...props
+}: React.ComponentProps<typeof SwitchPrimitive.Root>) => (
+  <SwitchPrimitive.Root
+    className={cn(
+      'peer inline-flex h-2.5 w-[2.25rem] shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent shadow-sm transition-colors',
+      'focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background',
+      'disabled:cursor-not-allowed disabled:opacity-50',
+      'data-[state=checked]:bg-primary data-[state=unchecked]:bg-input',
+      className,
+    )}
+    {...props}
+  >
+    <SwitchPrimitive.Thumb className="pointer-events-none block h-2 w-2 rounded-full bg-primary-foreground shadow-lg ring-0 transition-transform data-[state=checked]:translate-x-2 data-[state=unchecked]:translate-x-0" />
+  </SwitchPrimitive.Root>
+);
+Switch.displayName = SwitchPrimitive.Root.displayName;
+
+export { Switch };

--- a/src/pages/ProgramDetailsPage/ProgramDetailsPage.test.tsx
+++ b/src/pages/ProgramDetailsPage/ProgramDetailsPage.test.tsx
@@ -466,7 +466,7 @@ describe('ProgramDetailsPage', () => {
     renderPage('ss-1');
 
     // A repeating program pre-checks the toggle...
-    const toggle = screen.getByRole('checkbox', {
+    const toggle = screen.getByRole('switch', {
       name: /repeat automatically/i,
     });
     expect(toggle).toBeChecked();

--- a/src/pages/ProgramDetailsPage/ProgramDetailsPage.tsx
+++ b/src/pages/ProgramDetailsPage/ProgramDetailsPage.tsx
@@ -19,6 +19,8 @@ import {
   DialogHeader,
   DialogTitle,
 } from '~/components/ui/dialog';
+import { Label } from '~/components/ui/label';
+import { Switch } from '~/components/ui/switch';
 import { useSession } from '~/contexts';
 import {
   MovementOptions,
@@ -424,21 +426,22 @@ export const ProgramDetailsPage = () => {
           </div>
         ))}
 
-      <label className="flex items-start gap-2">
-        <input
-          type="checkbox"
-          className="mt-0.5 h-3 w-3 shrink-0"
-          checked={autoRepeat}
-          onChange={(event) => setAutoRepeat(event.target.checked)}
-        />
-        <span className="flex flex-col gap-0.5">
-          <span className="text-sm font-medium">Repeat automatically</span>
-          <span className="text-xs text-muted-foreground">
+      <div className="flex items-start justify-between gap-2">
+        <div className="flex flex-col gap-0.5">
+          <Label htmlFor="auto-repeat">Repeat automatically</Label>
+          <span id="auto-repeat-help" className="text-xs text-muted-foreground">
             When on, finishing the last session starts the program over instead
             of ending it. Progress by adding weight over time.
           </span>
-        </span>
-      </label>
+        </div>
+        <Switch
+          id="auto-repeat"
+          className="mt-0.5"
+          aria-describedby="auto-repeat-help"
+          checked={autoRepeat}
+          onCheckedChange={setAutoRepeat}
+        />
+      </div>
 
       <Button onClick={handleStart} disabled={enroll.isPending || !seeded}>
         Start program

--- a/src/pages/ProgramProgressPage/ProgramProgressPage.tsx
+++ b/src/pages/ProgramProgressPage/ProgramProgressPage.tsx
@@ -10,6 +10,8 @@ import {
 import { Page } from '~/components';
 import { Button } from '~/components/ui/button';
 import { Card, CardContent } from '~/components/ui/card';
+import { Label } from '~/components/ui/label';
+import { Switch } from '~/components/ui/switch';
 import { cn } from '~/lib/utils';
 import { ProgramSession } from '~/types';
 
@@ -137,23 +139,26 @@ export const ProgramProgressPage = () => {
             </div>
           )}
           {enrollment && (
-            <label className="mt-1 flex items-center gap-2">
-              <input
-                type="checkbox"
-                className="h-3 w-3 shrink-0"
+            <div className="mt-1 flex items-center justify-between gap-2">
+              <Label
+                htmlFor="auto-repeat"
+                size="small"
+                className="text-muted-foreground"
+              >
+                Repeat automatically when finished
+              </Label>
+              <Switch
+                id="auto-repeat"
                 checked={isRepeating}
                 disabled={setAutoRepeat.isPending}
-                onChange={(event) =>
+                onCheckedChange={(autoRepeat) =>
                   setAutoRepeat.mutate({
                     userProgramId: enrollment.id,
-                    autoRepeat: event.target.checked,
+                    autoRepeat,
                   })
                 }
               />
-              <span className="text-xs text-muted-foreground">
-                Repeat automatically when finished
-              </span>
-            </label>
+            </div>
           )}
         </CardContent>
       </Card>


### PR DESCRIPTION
## Why

The "Repeat automatically" control on Program Details rendered as the browser-default checkbox — the one control on the screen not drawn from the app palette. It is also a boolean whose meaning is immediate ("when on, the program restarts"), which a switch communicates and a checkbox doesn't. The same control appears again on Program Progress in the same unstyled form.

## What

Adds `src/components/ui/switch.tsx` (shadcn Switch on `@radix-ui/react-switch`) and swaps both auto-repeat checkboxes for it, laid out as right-aligned settings rows.

Three details worth a reviewer's attention:

1. **Sizing.** `tailwind.config.js` *replaces* `theme.spacing` rather than extending it (`1 = 8px`), so shadcn's stock `h-5 w-9` would render a 48px track and silently drop `w-9`. Sized explicitly instead: 36×20px track, 16px thumb, 16px travel.
2. **Thumb color.** `bg-primary-foreground`, not shadcn's `bg-background` — in dark mode `--background` (`203 15% 10%`) is darker than the `--input` off-track (`202 38% 21%`), so the default thumb disappears when off.
3. **Label association.** Radix renders a `<button>`, which a wrapping `<label>` can't toggle, so both call sites use `Label htmlFor` + `aria-describedby`.

No `dark:` classes — everything routes through tokens, matching how the rest of the app handles theming.

## How to test

- `npm test` — 558 passed, 81 files. `ProgramDetailsPage.test.tsx:469` now queries `getByRole('switch')`; `toBeChecked()` and `fireEvent.click` still work because Radix renders a real button with `role="switch"` + `aria-checked`.
- `npm run compile:ts` and `npm run lint` — clean.
- Storybook `components-ui-switch`: on / off / disabled-on / disabled-off in both modes, plus keyboard focus ring.
- Deploy preview, Simple & Sinister details page at 390px: switch measures `36x20` via `getBoundingClientRect`, arrives pre-checked from `defaultAutoRepeat`, and toggles both ways in light and dark.

The `programs` flag is off locally in every env mode, so the live-page checks were done on this PR's Netlify preview, which forces flags on and auto-signs-in.

## Gallery

**Before** (local Storybook — the flag-gated routes don't render locally):

BEFORE_LIGHT
BEFORE_DARK

**After** (deploy preview, Simple & Sinister details page — on and off, light then dark):

AFTER_ROW_LIGHT_ON
AFTER_ROW_LIGHT_OFF
AFTER_ROW_DARK_ON
AFTER_ROW_DARK_OFF

**In page context:**

AFTER_FULL_LIGHT
AFTER_FULL_DARK

**All states** (Storybook):

STATES_LIGHT
STATES_DARK

## Deploy notes

New dependency: `@radix-ui/react-switch@^1.3.7`. No migrations, no flags, no `gen:types`.

## Tradeoffs

`@headlessui/react` is already a dependency and ships a `Switch` with `Field`/`Label`/`Description`, which would have avoided a new package and handled the label wiring for free — genuinely the lighter option here. Went with Radix because every other primitive in `src/components/ui/` is Radix + shadcn, and matching that keeps one pattern for future components instead of two.

The Program Progress row is covered by unit tests and the Storybook story but not a live screenshot: capturing it needs an active enrollment, and creating one would write to the shared staging DB behind the preview.
