### PR TITLE
test(nav): retarget More sheet row assertion off Balance

### DIFF
--- a/src/components/BottomNav/BottomNav.test.tsx
+++ b/src/components/BottomNav/BottomNav.test.tsx
@@ -91,9 +91,9 @@ describe('BottomNav', () => {
   });
 
   test('More sheet rows carry their resolved row classes', () => {
-    // AI wins the promoted slot, so Balance is the one that overflows.
+    // AI wins the promoted slot, so Explore is the one that overflows.
     mockedUseFeatures.mockReturnValue(
-      featuresWith({ premium: true, weeklyBalance: true }),
+      featuresWith({ premium: true, explore: true }),
     );
     renderNav();
     fireEvent.click(screen.getByRole('button', { name: 'More' }));
@@ -101,7 +101,7 @@ describe('BottomNav', () => {
     // Regression: routing these through `DialogClose asChild` forwarded
     // NavLink's function className to the anchor as a stringified arrow, so the
     // rows rendered with no styling at all.
-    for (const name of [/Account/, /Balance/]) {
+    for (const name of [/Account/, /Explore/]) {
       expect(screen.getByRole('link', { name })).toHaveClass(
         'flex',
         'items-center',


### PR DESCRIPTION
## Why

`main` is red. `BottomNav.test.tsx > More sheet rows carry their resolved row classes` fails on `c9f641d`:

```
TestingLibraryElementError: Unable to find an accessible element with the role "link" and name /Balance/
```

The test's premise died in #180, which "retire[d] the /balance route, page, and its nav/header entries" — it dropped the `balance` entry from `NAV_ITEMS` and removed `'balance'` from `PRIORITY_KEYS` in `buildTabs.ts`. Nothing can overflow into the More sheet as "Balance" any more, so `getByRole` throws before the assertion runs. The test itself was never updated.

Found while rebasing #183, which inherited the failure through its merge commit.

## What

Point the assertion at Explore, which is now the row that overflows when AI takes the promoted slot. The regression under test is untouched — it still checks that a `NavLink`'s function-form `className` resolves on a More-sheet row rather than landing on the anchor as a stringified arrow.

Two lines: `weeklyBalance: true` → `explore: true` in the feature overrides, and `/Balance/` → `/Explore/` in the loop.

## How to test

- `npm run test` on this branch: 82 files, 564 tests, all passing. On `c9f641d` it's 1 failed / 563 passed.
- `npm run compile:ts` and `npm run lint` clean.
- Confirmed the failure reproduces on a clean `origin/main` checkout with none of my other work applied, so this is main's, not a side effect of #183.

## Tradeoffs

Deleting the test would also go green, and there's a case for it — the row it covers is now whichever feature happens to overflow, which is a moving target as flags come and go. But the regression it guards is real and subtle (`DialogClose asChild` silently stringifying a function className), and it cost someone a debugging session once already. Retargeting keeps that coverage for two lines.

Kept separate from #183 rather than folded in, so a layout PR doesn't carry an unrelated nav test edit and `main` gets un-blocked on its own timeline.
