### PR TITLE
feat(activation): enable curated first workout + variant lift read

### DIFF
--- a/docs/launchpad-shell.md
+++ b/docs/launchpad-shell.md
@@ -1,22 +1,26 @@
 # Launchpad Shell (PROD-171)
 
-The launchpad "start screen" is gated behind **one master runtime flag**,
-`launchpad_shell` (seed migration `*_seed_launchpad_shell_flag.sql`), not a pile
-of per-content flags. It lives entirely in `StartWorkoutPage.tsx`:
+The launchpad "start screen" (now the hub) lives entirely in
+`StartWorkoutPage.tsx`. The hub **graduated from experiment to baseline** — it
+is the default home surface for everyone, no longer gated behind the
+`launchpad_shell` flag (that flag is retained only so exposure logging keeps
+recording assignment; seed migration `*_seed_launchpad_shell_flag.sql`).
 
-- **Master gate:** `experimentFeatures.launchpadShell` OFF → the pure custom
-  builder (the true control baseline); ON → the browse shell. An active program
-  still forces browse independently (separate `programs` release feature).
 - **Population routing** (derived from `useWorkoutLogs()` count, tri-state
   `isFirstWorkout`): new user (0 logs) → curated first-workout content; returning
-  (≥1) → repeat-previous + build-custom, plus the Phase-2 `recommender` nested
-  flag. Content is routed by population, **not** by the old `curated_first_workout`
-  / `repeat_previous` flags — those are retained in the registry for optionality
-  but no longer gate the shell.
+  (≥1) → repeat-previous + the Phase-2 `recommender` surface.
+- **Content gates:** hub suggestions sit behind their own runtime flags, routed
+  by population — `curated_first_workout` (new users; the PROD-172 activation
+  treatment, enabled at 100% rollout by
+  `*_enable_curated_first_workout.sql`), `repeat_previous` and `recommender`
+  (returning users). An active program forces the program hero independently
+  (separate `programs` release feature).
 - **Exposure logging:** the `launchpad_exposed` analytics event
   (`AnalyticsEvent.LaunchpadExposed`, fired once per mount from a `useEffect`)
   records `{ shell_variant, population, content }`, keyed by `user_id` so it joins
   to the PROD-170 funnel events in `analytics_events`. The sticky assignment
-  itself is the server-side `feature_flag_assignments` row. Behavior is covered by
+  itself is the server-side `feature_flag_assignments` row, and
+  `activation_funnel_by_variant(flag_key, from, to)` reads the funnel per
+  variant for the PROD-172 lift measurement. Behavior is covered by
   `StartWorkoutPage.launchpad.test.jsx` (gate + logging) and
   `StartWorkoutPage.recommendations.test.jsx` (population content).

--- a/src/config/experiments.ts
+++ b/src/config/experiments.ts
@@ -13,15 +13,14 @@
  */
 
 export const EXPERIMENT_FLAG_KEYS = [
-  // Master gate for the launchpad "start screen" shell (PROD-171). Treatment =
-  // land on the launchpad; control = drop straight into the pure custom builder
-  // (the true baseline). Repeat-previous and curated are *content* of the shell,
-  // not their own gates — this one flag decides shell vs. builder for both the
-  // new-user activation test (PROD-172) and the returning-user retention test.
+  // Former master gate for the launchpad shell (PROD-171). The hub graduated to
+  // the baseline surface for everyone, so this no longer gates any UI — it's
+  // retained only so exposure logging can keep recording which arm a user was
+  // assigned to.
   'launchpad_shell',
-  // Retained for optionality (PROD-171 builds all the flags now), but no longer
-  // the gate: shell content is routed by population, not these. `recommender` is
-  // still read as the Phase-2 nested content flag inside the returning-user shell.
+  // Content gates inside the hub, routed by population: curated first workout
+  // for new users (the PROD-172 activation treatment), repeat-previous and the
+  // Phase-2 recommender for returning users.
   'curated_first_workout',
   'repeat_previous',
   'recommender',

--- a/supabase/migrations/20260729000000_enable_curated_first_workout.sql
+++ b/supabase/migrations/20260729000000_enable_curated_first_workout.sql
@@ -1,0 +1,18 @@
+-- Enable the curated first-workout treatment (PROD-172).
+--
+-- The clean pure-builder baseline has fully matured: PROD-174 turned the
+-- curated / repeat-previous surfaces OFF at 2026-06-29 17:51 UTC, and the
+-- 14-day north-star window for that flags-OFF cohort closed on 2026-07-13.
+-- This flips the intervention on for the before/after read.
+--
+-- rollout_percentage = 100: every user who evaluates the flag from here on is
+-- bucketed into treatment and gets a sticky feature_flag_assignments row
+-- (variant + assigned_at), which is what makes the lift attributable — see
+-- activation_funnel_by_variant. The surface itself still only renders for the
+-- new-user population (0 workout logs), so returning users are unaffected.
+-- No assignment rows exist from the disabled period (disabled flags resolve to
+-- default_variant without writing one), so nobody is stuck in a stale bucket.
+UPDATE public.feature_flags
+SET enabled = true,
+    rollout_percentage = 100
+WHERE key = 'curated_first_workout';

--- a/supabase/migrations/20260729000001_add_activation_funnel_by_variant.sql
+++ b/supabase/migrations/20260729000001_add_activation_funnel_by_variant.sql
@@ -1,0 +1,83 @@
+-- Variant-attributed activation funnel read (PROD-172).
+--
+-- activation_funnel_window slices by signup date, which is enough for a pure
+-- before/after read but can't attribute a user to the flag arm they actually
+-- saw. This function joins user_activation to the sticky
+-- feature_flag_assignments rows for a given flag, so each row is one variant's
+-- funnel — the attributable lift read PROD-172 asks for. Users who signed up
+-- in-window but were never bucketed (signed up before the flag was enabled, or
+-- never evaluated it) report under the 'unassigned' variant; with the
+-- curated_first_workout flip that population IS the clean baseline cohort.
+--
+-- Lift read for the curated first-workout experiment (all-mature cohorts):
+--   SELECT * FROM activation_funnel_by_variant(
+--     'curated_first_workout', '2026-06-29 17:51:53+00', now() - interval '14 days');
+--
+-- Same cohort-maturity rules as activation_funnel_window: the north-star
+-- metrics (3+ workouts / 14 days) are computed only over the matured subset
+-- (signup_at <= now() - 14 days), with mature_signups as that denominator; cap
+-- p_signup_to at now() - interval '14 days' for a fully-mature comparison.
+
+CREATE OR REPLACE FUNCTION public.activation_funnel_by_variant(
+  p_flag_key    text,
+  p_signup_from timestamptz DEFAULT NULL,
+  p_signup_to   timestamptz DEFAULT NULL
+)
+RETURNS TABLE (
+  variant text,
+  total_signups bigint,
+  mature_signups bigint,
+  users_with_first_workout bigint,
+  signup_to_first_workout_rate numeric,
+  activated_24h_count bigint,
+  activated_24h_rate numeric,
+  activated_north_star_count bigint,
+  activated_north_star_rate numeric,
+  avg_seconds_to_first_workout bigint,
+  median_seconds_to_first_workout bigint
+)
+LANGUAGE sql
+STABLE
+SECURITY INVOKER
+SET search_path = ''
+AS $$
+  SELECT
+    COALESCE(ffa.variant, 'unassigned'),
+    COUNT(*),
+    COUNT(*) FILTER (WHERE ua.signup_at <= now() - INTERVAL '14 days'),
+    COUNT(ua.first_workout_at),
+    ROUND(
+      COUNT(ua.first_workout_at)::numeric / NULLIF(COUNT(*), 0), 4
+    ),
+    COUNT(*) FILTER (WHERE ua.activated_24h),
+    ROUND(
+      COUNT(*) FILTER (WHERE ua.activated_24h)::numeric / NULLIF(COUNT(*), 0), 4
+    ),
+    COUNT(*) FILTER (
+      WHERE ua.activated_north_star
+        AND ua.signup_at <= now() - INTERVAL '14 days'
+    ),
+    ROUND(
+      COUNT(*) FILTER (
+        WHERE ua.activated_north_star
+          AND ua.signup_at <= now() - INTERVAL '14 days'
+      )::numeric
+      / NULLIF(COUNT(*) FILTER (WHERE ua.signup_at <= now() - INTERVAL '14 days'), 0),
+      4
+    ),
+    ROUND(AVG(ua.seconds_to_first_workout))::bigint,
+    PERCENTILE_CONT(0.5) WITHIN GROUP (
+      ORDER BY ua.seconds_to_first_workout
+    )::bigint
+  FROM public.user_activation ua
+  LEFT JOIN public.feature_flag_assignments ffa
+    ON ffa.user_id = ua.user_id AND ffa.flag_key = p_flag_key
+  WHERE (p_signup_from IS NULL OR ua.signup_at >= p_signup_from)
+    AND (p_signup_to   IS NULL OR ua.signup_at <  p_signup_to)
+  GROUP BY COALESCE(ffa.variant, 'unassigned');
+$$;
+
+-- Analyst-only, exactly like activation_funnel_window: aggregates across all
+-- users, so service-role querying only — never exposed to anon/authenticated.
+REVOKE ALL ON FUNCTION public.activation_funnel_by_variant(text, timestamptz, timestamptz) FROM public;
+GRANT EXECUTE ON FUNCTION public.activation_funnel_by_variant(text, timestamptz, timestamptz) TO service_role;

--- a/types/supabase.ts
+++ b/types/supabase.ts
@@ -756,6 +756,26 @@ export type Database = {
       }
     }
     Functions: {
+      activation_funnel_by_variant: {
+        Args: {
+          p_flag_key: string
+          p_signup_from?: string
+          p_signup_to?: string
+        }
+        Returns: {
+          activated_24h_count: number
+          activated_24h_rate: number
+          activated_north_star_count: number
+          activated_north_star_rate: number
+          avg_seconds_to_first_workout: number
+          mature_signups: number
+          median_seconds_to_first_workout: number
+          signup_to_first_workout_rate: number
+          total_signups: number
+          users_with_first_workout: number
+          variant: string
+        }[]
+      }
       activation_funnel_window: {
         Args: { p_signup_from?: string; p_signup_to?: string }
         Returns: {


### PR DESCRIPTION
## Why

PROD-172: the curated first-workout intervention against the 79% first-workout cliff has been flag-gated and dormant since the PROD-174 baseline reset (2026-06-29 17:51 UTC). The flags-OFF cohort's 14-day north-star window fully matured on 2026-07-13, so the treatment can now turn on — and we need a read that attributes activation metrics to the flag arm a user was actually assigned to, not just a signup-date window.

https://linear.app/djbowers/issue/PROD-172

## What

Flips `curated_first_workout` to enabled at 100% rollout (migration), and adds `activation_funnel_by_variant(flag_key, from, to)` — the PROD-170 funnel metrics joined to sticky `feature_flag_assignments` rows, grouped per variant, with un-bucketed users reported as `unassigned` (the clean baseline cohort). Also refreshes the launchpad-shell doc and `experiments.ts` comments that still described pre-hub-graduation gating.

## How to test

- `supabase db reset` — both migrations apply cleanly on local.
- Verified locally: `feature_flags` shows `curated_first_workout` enabled / rollout 100; `activation_funnel_by_variant('curated_first_workout')` returns the seed user as `unassigned`, and flips to `treatment` after inserting an assignment row.
- `npm run gen:types` (committed), `npm run compile:ts` clean, `npm test` — 82 files / 564 tests pass.
- No UI change: the curated surface and its flag gating already exist (covered by `StartWorkoutPage.recommendations.test.jsx`); this only turns the flag on server-side.

## Deploy notes

- Two migrations: the flag flip and the new analyst function (service-role only, like `activation_funnel_window`).
- Treatment goes live for new users the moment the flip migration reaches prod — the before/after clock starts there.
- Lift read once the treatment cohort matures (~14 days after deploy):
  `SELECT * FROM activation_funnel_by_variant('curated_first_workout', '2026-06-29 17:51:53+00', now() - interval '14 days');`

## Tradeoffs

Toggling the flag via Studio would avoid a migration and was the path PROD-171's seed comment anticipated — it's instant and reversible. A migration was chosen anyway so the flip is reviewed, timestamped in history, and hits staging before prod; reverting is still a one-line `UPDATE` either way.