### PR TITLE
feat(programs): seed Strong Endurance Plan 025 (swing/snatch A+A)

### DIFF
--- a/e2e/program-strong-endurance-025.spec.ts
+++ b/e2e/program-strong-endurance-025.spec.ts
@@ -1,0 +1,226 @@
+import { expect, test } from '@playwright/test';
+
+// Backend coverage for the seeded shared "Strong Endurance Plan 025" program
+// (swing/snatch A+A, PROD-243), mirroring program-kettlebell-mile.spec.ts: hit
+// the LOCAL Supabase REST API directly rather than driving the browser, since
+// this is pure seed-data verification.
+//
+// 025 is the catalog's first program with AUTOREGULATED volume, so the
+// assertions pin the modeling decisions that would silently break it: the
+// minutes CEILINGS (50/40/30) standing in for "no target", the OTM cadence
+// (intervalTimer 60 + one-handed loading so arms alternate by the minute), the
+// repeating one-week block (default_auto_repeat), and the notes that carry the
+// real governor -- the talk test / StrongFirst Stop Signs and the 80%/60%
+// derivation from the last high day.
+
+const SUPABASE_URL = process.env.VITE_SUPABASE_URL!;
+const SUPABASE_ANON_KEY = process.env.VITE_SUPABASE_ANON_KEY!;
+const SE_SLUG = 'strong-endurance-plan-025';
+const SE_SESSION_COUNT = 3;
+
+interface AuthSession {
+  access_token: string;
+  user: { id: string; email: string; [key: string]: unknown };
+}
+
+interface TestUser {
+  token: string;
+  uid: string;
+  email: string;
+}
+
+async function signUpThrowawayUser(): Promise<TestUser> {
+  const email = `se-${Date.now()}-${Math.floor(Math.random() * 1e9)}@example.com`;
+  const password = 'testpassword123';
+
+  const res = await fetch(`${SUPABASE_URL}/auth/v1/signup`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', apikey: SUPABASE_ANON_KEY },
+    body: JSON.stringify({ email, password }),
+  });
+  if (!res.ok) {
+    throw new Error(`signup failed (${res.status}): ${await res.text()}`);
+  }
+
+  const body = (await res.json()) as Partial<AuthSession>;
+  if (body.access_token && body.user) {
+    return { token: body.access_token, uid: body.user.id, email };
+  }
+
+  const signInRes = await fetch(
+    `${SUPABASE_URL}/auth/v1/token?grant_type=password`,
+    {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        apikey: SUPABASE_ANON_KEY,
+      },
+      body: JSON.stringify({ email, password }),
+    },
+  );
+  if (!signInRes.ok) {
+    throw new Error(
+      `sign-in failed (${signInRes.status}): ${await signInRes.text()}`,
+    );
+  }
+  const session = (await signInRes.json()) as AuthSession;
+  return { token: session.access_token, uid: session.user.id, email };
+}
+
+async function restJson<T = unknown>(path: string, token: string): Promise<T> {
+  const res = await fetch(`${SUPABASE_URL}/rest/v1/${path}`, {
+    headers: { apikey: SUPABASE_ANON_KEY, Authorization: `Bearer ${token}` },
+  });
+  if (!res.ok) {
+    throw new Error(`GET ${path} failed (${res.status}): ${await res.text()}`);
+  }
+  return res.json() as Promise<T>;
+}
+
+interface MovementOpt {
+  movementName: string;
+  repScheme: number[];
+  weightOneValue: number | null;
+  weightTwoValue: number | null;
+}
+interface WorkoutOpts {
+  complexSet: boolean;
+  intervalTimer: number;
+  restTimer: number;
+  workoutGoal: number;
+  workoutGoalUnits: string;
+  preWorkoutNotes: string;
+  movements: MovementOpt[];
+}
+interface SessionRow {
+  sequence_index: number;
+  week_number: number;
+  day_number: number;
+  title: string;
+  workout_options: WorkoutOpts;
+}
+
+// Each ceiling is that day's share of the terminal 50-set high day: high 50,
+// medium 40 (80%), low 30 (60%). Ceilings, not targets -- the notes govern.
+const EXPECTED_CEILING_MINUTES = [50, 40, 30];
+const EXPECTED_TITLES = ['High volume', 'Medium volume', 'Low volume'];
+
+test.describe('program schema — Strong Endurance Plan 025 seed', () => {
+  test('is present, public, system-owned, and a repeating one-week block', async () => {
+    const user = await signUpThrowawayUser();
+
+    const programs = await restJson<
+      Array<{
+        is_public: boolean;
+        owner_id: string | null;
+        num_weeks: number | null;
+        days_per_week: number | null;
+        default_auto_repeat: boolean;
+        author_name: string;
+        title: string;
+        description: string;
+      }>
+    >(`programs?slug=eq.${SE_SLUG}&select=*`, user.token);
+
+    expect(programs).toHaveLength(1);
+    const se = programs[0];
+    expect(se.is_public).toBe(true);
+    expect(se.owner_id).toBeNull();
+    // Open-ended plan: a 1-week, 3-day block that auto-repeats until the
+    // athlete graduates at sets of 10.
+    expect(se.num_weeks).toBe(1);
+    expect(se.days_per_week).toBe(3);
+    expect(se.default_auto_repeat).toBe(true);
+    expect(se.author_name).toBe('Pavel Tsatsouline (StrongFirst)');
+    expect(se.title).toBe('Strong Endurance Plan 025');
+
+    // Goal metadata: the source labels 025 fat loss + aerobic base, NOT
+    // strength -- the description must say so, so it is never mis-recommended
+    // against a strength goal.
+    const description = se.description.toLowerCase();
+    expect(description).toContain('fat loss');
+    expect(description).toContain('aerobic');
+    expect(description).toContain('not strength');
+    // The swing-vs-snatch branch is real in the source; the seed defaults to
+    // the one-arm swing and the description offers the swap.
+    expect(description).toContain('snatch');
+  });
+
+  test('has 3 OTM sessions in Friday-start order with autoregulated ceilings', async () => {
+    const user = await signUpThrowawayUser();
+    const [se] = await restJson<Array<{ id: string }>>(
+      `programs?slug=eq.${SE_SLUG}&select=id`,
+      user.token,
+    );
+
+    const sessions = await restJson<SessionRow[]>(
+      `program_sessions?program_id=eq.${se.id}&select=sequence_index,week_number,day_number,title,workout_options&order=sequence_index.asc`,
+      user.token,
+    );
+
+    expect(sessions).toHaveLength(SE_SESSION_COUNT);
+    expect(sessions.map((s) => s.sequence_index)).toEqual([0, 1, 2]);
+    expect(sessions.map((s) => s.week_number)).toEqual([1, 1, 1]);
+    expect(sessions.map((s) => s.day_number)).toEqual([1, 2, 3]);
+    // The source starts on Friday: High, then Monday medium, Wednesday low.
+    expect(sessions.map((s) => s.title)).toEqual(EXPECTED_TITLES);
+
+    sessions.forEach((s, i) => {
+      const opts = s.workout_options;
+      const movements = opts.movements;
+
+      // One movement, sets of 5 -- the whole session is one rung repeated OTM.
+      expect(movements).toHaveLength(1);
+      expect(movements[0].movementName).toBe('One-Arm Kettlebell Swing');
+      expect(movements[0].repScheme).toEqual([5]);
+
+      // OTM cadence: intervalTimer 60 fires one set per minute, and one-handed
+      // loading (weightTwoValue 0 => '1h' mode) mirrors sides, so arms
+      // alternate minute by minute exactly as the source prescribes.
+      expect(opts.intervalTimer).toBe(60);
+      expect(opts.restTimer).toBe(0);
+      expect(movements[0].weightOneValue).toBe(24);
+      expect(movements[0].weightTwoValue).toBe(0);
+
+      // Autoregulation seam: the app has no "no target" unit, so each day
+      // carries a minutes CEILING sized to its share of the terminal 50-set
+      // high day. The countdown is the backstop; the notes are the governor.
+      expect(opts.workoutGoalUnits).toBe('minutes');
+      expect(opts.workoutGoal).toBe(EXPECTED_CEILING_MINUTES[i]);
+
+      expect(opts.complexSet).toBe(false);
+    });
+  });
+
+  test('the notes carry the real governor: talk test, stop signs, and 80/60 derivation', async () => {
+    const user = await signUpThrowawayUser();
+    const [se] = await restJson<Array<{ id: string }>>(
+      `programs?slug=eq.${SE_SLUG}&select=id`,
+      user.token,
+    );
+
+    const sessions = await restJson<SessionRow[]>(
+      `program_sessions?program_id=eq.${se.id}&select=sequence_index,workout_options&order=sequence_index.asc`,
+      user.token,
+    );
+
+    // High day: the talk test and Stop Signs are the stop rule, the ceiling is
+    // not a target, and the +1-rep-at-50-sets progression is user-triggered.
+    const high = sessions[0].workout_options.preWorkoutNotes.toLowerCase();
+    expect(high).toContain('talk test');
+    expect(high).toContain('stop');
+    expect(high).toMatch(/ceiling|not a target/);
+    expect(high).toContain('50 sets');
+    expect(high).toContain('add one rep');
+
+    // Medium/low days: volume derives from the LAST HIGH DAY's set count --
+    // the per-enrollment state the schema lacks lives in these notes.
+    const medium = sessions[1].workout_options.preWorkoutNotes.toLowerCase();
+    expect(medium).toContain('80%');
+    expect(medium).toContain('high day');
+
+    const low = sessions[2].workout_options.preWorkoutNotes.toLowerCase();
+    expect(low).toContain('60%');
+    expect(low).toContain('high day');
+  });
+});

--- a/supabase/migrations/20260727000006_seed_strong_endurance_plan_025.sql
+++ b/supabase/migrations/20260727000006_seed_strong_endurance_plan_025.sql
@@ -1,0 +1,153 @@
+-- Seed the shared "Strong Endurance Plan 025" program (Pavel Tsatsouline,
+-- StrongFirst): swing or snatch A+A, sets on the minute, autoregulated volume.
+-- Public + system-owned (owner_id NULL, is_public true); enrolling clones it
+-- into an editable copy (enroll_in_program). Idempotent on slug. MIGRATION
+-- (not seed.sql) so it reaches staging/production.
+--
+-- Source (free official PDF):
+-- https://www.strongfirst.com/wordpress/wp-content/uploads/2024/02/Strong-Endurance-plan-025.pdf
+-- Swing or snatch, sets of 5 on the minute alternating arms, 3x/week with
+-- varying volume: Friday high (start day), Monday medium (80% of the last high
+-- day's sets), Wednesday low (60%). Volume is AUTOREGULATED, not prescribed:
+-- carry on until the talk test fails (~50s into the rest minute you cannot
+-- speak several short sentences) or any StrongFirst Stop Sign appears (power
+-- drop, technique change, lengthening pauses between reps) -- then stop and
+-- note the set count. Progression: once a high day reaches 50 sets, add one
+-- rep to all sets the next Friday. Terminal target: sets of 10 OTM (500 reps
+-- in 50 min), then graduate to another Strong Endurance protocol. Goals per
+-- the source: fat loss + aerobic base, NOT strength (reflected in the
+-- description so it is not mis-recommended against a strength goal).
+--
+-- MODELING DECISIONS (PROD-243; follows the A+A Plan A precedent in
+-- 20260724000005_refit_aa_protocol_plan_a_autoregulated.sql):
+--
+--   * AUTOREGULATED VOLUME AS A MINUTES CEILING. The app needs workoutGoal > 0
+--     to start and has no "no target" unit, so each session carries a minutes
+--     ceiling sized to its day's share of the TERMINAL 50-set high day:
+--     high 50 min, medium 40 (80%), low 30 (60%). The countdown auto-finishing
+--     is the "whichever comes first" backstop; the preWorkoutNotes state the
+--     real governor (talk test / Stop Signs on the high day, last-Friday
+--     percentages on medium/low days). This is option (a)+(c)-in-notes from
+--     the issue: the high-day set count lives in the athlete's log, and the
+--     notes tell them how to derive Monday/Wednesday from it -- no
+--     per-enrollment mutable state required.
+--
+--   * OTM VIA intervalTimer 60 + ONE-HANDED LOADING. One movement, repScheme
+--     [5], weightTwoValue 0 ('1h' mode): each interval fire runs the set on
+--     one arm and the runtime mirrors sides, so arms alternate minute by
+--     minute -- exactly the source's cadence. restTimer 0; the interval IS the
+--     rest.
+--
+--   * ONE-ARM SWING IS THE SEEDED DEFAULT. The source offers swing OR snatch,
+--     one-arm or two-arm -- a real branch, not ours. There is no enrollment
+--     movement picker (that is PROD-232 territory), but enrolling clones an
+--     editable copy, so the description and notes tell the athlete to swap the
+--     movement to One-Arm Kettlebell Snatch or Kettlebell Swing (two-arm)
+--     after enrolling. One-arm swing is the default because it is the lowest
+--     barrier of the three (snatch is catalog-Expert).
+--
+--   * PROGRESSION IS USER-TRIGGERED, NOT CALENDAR-DRIVEN. "+1 rep once a high
+--     day hits 50 sets" is a milestone the athlete owns: they edit the rep
+--     scheme (5 -> 6 -> ... -> 10) on their cloned copy. Stated in the
+--     description and the high-day notes rather than encoded as sessions.
+--
+--   * A ONE-WEEK REPEATING BLOCK. Three sessions (High / Medium / Low, in the
+--     source's Friday-start order) with default_auto_repeat = true: the plan
+--     has no fixed length ("stay on the program until sets of 10"), so
+--     finishing the week loops rather than completing. num_weeks 1 /
+--     days_per_week 3 keep the real weekly cadence visible, unlike the
+--     cadence-less S&S.
+--
+--   * 24 kg is a PLACEHOLDER, as in every seed. The source's bell test (100
+--     perfect reps in 5 min, sets of 10 every 30s, ~50% effort) is in the
+--     description; single-bell, so the enrollment weight picker pre-fills one
+--     weight (PROD-232).
+
+-- Full workout_options for one session. Shape MUST match
+-- Omit<WorkoutOptions,'startedAt'> exactly (camelCase keys): one one-handed
+-- movement, sets of 5 OTM, minutes ceiling per day.
+CREATE OR REPLACE FUNCTION pg_temp.se025_options(p_minutes INT, p_details TEXT)
+RETURNS JSONB LANGUAGE sql IMMUTABLE AS $$
+  SELECT jsonb_build_object(
+    'complexSet', false,
+    'intervalTimer', 60,
+    'restTimer', 0,
+    'workoutGoal', p_minutes,
+    'workoutGoalUnits', 'minutes',
+    'title', NULL,
+    'preWorkoutNotes', p_details,
+    'sharedWeightOneUnit', NULL,
+    'sharedWeightOneValue', NULL,
+    'sharedWeightTwoUnit', NULL,
+    'sharedWeightTwoValue', NULL,
+    'movements', jsonb_build_array(
+      jsonb_build_object(
+        'movementName', 'One-Arm Kettlebell Swing',
+        'repScheme', to_jsonb(ARRAY[5]::INT[]),
+        'weightOneUnit', 'kilograms', 'weightOneValue', 24,
+        'weightTwoUnit', NULL, 'weightTwoValue', 0)
+    ));
+$$;
+
+DO $$
+DECLARE
+  v_program_id UUID;
+BEGIN
+  INSERT INTO programs (owner_id, slug, title, description, author_name,
+                        num_weeks, days_per_week, is_public, default_auto_repeat)
+  VALUES (NULL, 'strong-endurance-plan-025',
+          'Strong Endurance Plan 025',
+          'Swing or snatch A+A: sets of 5 on the minute, alternating arms, three '
+          'days a week at varying volume -- Friday high, Monday medium (80% of '
+          'Friday''s sets), Wednesday low (60%). Volume is autoregulated, not '
+          'prescribed: stop the moment you fail the talk test or hit any '
+          'StrongFirst Stop Sign (power drops, technique changes, pauses between '
+          'reps lengthen). Once a high day reaches 50 sets, add one rep to every '
+          'set; graduate at sets of 10 (500 reps in 50 min). Built for fat loss '
+          'and aerobic base, not strength. Seeded with the one-arm swing -- after '
+          'enrolling, swap the movement to the snatch or the two-arm swing if '
+          'that is your exercise of choice. Pick a bell you can swing or snatch '
+          'with perfect technique for 100 reps in 5 min (sets of 10 every 30s, '
+          'about 50% effort). Repeats weekly.',
+          'Pavel Tsatsouline (StrongFirst)', 1, 3, true, true)
+  ON CONFLICT (slug) DO NOTHING
+  RETURNING id INTO v_program_id;
+
+  -- If the row already existed, skip re-seeding sessions.
+  IF v_program_id IS NULL THEN
+    RAISE NOTICE 'Strong Endurance Plan 025 already seeded; skipping sessions.';
+    RETURN;
+  END IF;
+
+  -- Friday-start order per the source: High, then Medium (Mon), then Low (Wed).
+  -- Each ceiling is that day's share of the terminal 50-set high day; the notes
+  -- carry the real stop rule.
+  INSERT INTO program_sessions
+    (program_id, sequence_index, week_number, day_number, title, workout_options)
+  VALUES
+    (v_program_id, 0, 1, 1, 'High volume',
+     pg_temp.se025_options(50,
+       'High day (the source starts on Friday). Sets of 5 on the minute, '
+       'alternating arms each minute; walk and shake out between sets. Volume is '
+       'autoregulated: around 50s into each rest minute, do the talk test -- '
+       'speak several short sentences. The first time you cannot, or your power '
+       'drops, technique changes, or pauses between reps lengthen, STOP and note '
+       'your set count -- it sets Monday (80%) and Wednesday (60%). Do not push '
+       'past a stop sign even if you could. The 50-min ceiling is the terminal '
+       'day, not a target. Once you reach 50 sets at a rep count, add one rep to '
+       'all sets next Friday (edit the rep scheme); graduate at sets of 10.')),
+    (v_program_id, 1, 1, 2, 'Medium volume',
+     pg_temp.se025_options(40,
+       'Medium day (Monday): do 80% of your last high day''s set count, then '
+       'finish the workout -- e.g. 30 sets Friday means 24 today. Same sets of 5 '
+       'on the minute, alternating arms. The 40-min ceiling only matters at '
+       'terminal volume; your percentage is the real stop. Still respect the '
+       'StrongFirst Stop Signs if one appears sooner.')),
+    (v_program_id, 2, 1, 3, 'Low volume',
+     pg_temp.se025_options(30,
+       'Low day (Wednesday): do 60% of your last high day''s set count, then '
+       'finish the workout -- e.g. 30 sets Friday means 18 today. Same sets of 5 '
+       'on the minute, alternating arms. The 30-min ceiling only matters at '
+       'terminal volume; your percentage is the real stop. Still respect the '
+       'StrongFirst Stop Signs if one appears sooner.'));
+END $$;


### PR DESCRIPTION
## What

Seeds the StrongFirst **Strong Endurance Plan 025** (swing/snatch A+A) as a public, system-owned program, plus a backend e2e spec pinning the seeded shape. Last unshipped program in the PROD-225 epic.

## Why

Plan 025 is the hinge-dominant A+A counterpart to Plan A's clean & jerk and the catalog's first program with **autoregulated** volume — sets are governed by the talk test and StrongFirst Stop Signs, not a fixed count. Closes [PROD-243](https://linear.app/djbowers/issue/PROD-243).

Modeling (documented in the migration header, following the A+A Plan A refit precedent from #178):
- **Autoregulated volume as minutes ceilings** — the app needs `workoutGoal > 0`, so each day carries its share of the terminal 50-set high day (50/40/30 min); the notes carry the real governor (talk test / Stop Signs, and the 80%/60% derivation from the last high day's set count).
- **OTM via `intervalTimer: 60` + one-handed loading** (`weightTwoValue: 0`), so arms alternate minute by minute.
- **Repeating one-week High/Medium/Low block** (`default_auto_repeat`) — the plan has no fixed length; graduate at sets of 10.
- **One-arm swing seeded as the default**; the swing/snatch/two-arm branch is offered as a post-enroll movement swap in the description (no enrollment movement picker exists yet — PROD-232 territory).
- **Progression (+1 rep at 50 sets) is user-triggered**, stated in the notes rather than encoded as sessions.

## How tested

- Applied the seed SQL to local Supabase (via `docker exec psql`, per the apply_migration gotcha) and verified the rows.
- `npx playwright test e2e/program-strong-endurance-025.spec.ts` — 3 passed.
- `npm test` — 564 passed; `npm run compile:ts` clean.

## Tradeoffs

Considered per-enrollment mutable state for the high-day set count (option c in the issue) — truest to the source, but needs schema we don't have; the notes-based derivation ships now and can be upgraded later.