### PR TITLE
feat(programs): gate the shared catalog behind a released_at release flag

### DIFF
--- a/e2e/program-schema.spec.ts
+++ b/e2e/program-schema.spec.ts
@@ -425,6 +425,23 @@ test.describe('program schema — StrongFirst Snatch Test seed', () => {
   });
 });
 
+test.describe('program schema — release gate (PROD-246)', () => {
+  test('every shared program is released in the e2e environment (seed.sql contract)', async () => {
+    // Prod releases programs one by one after a manual test run; seed.sql
+    // releases everything locally so these specs can see the full catalog.
+    // A NULL released_at here means seed.sql and the shared seeds drifted.
+    const user = await signUpThrowawayUser();
+    const shared = await restJson<
+      Array<{ slug: string | null; released_at: string | null }>
+    >('GET', 'programs?is_public=eq.true&select=slug,released_at', user.token);
+
+    expect(shared.length).toBeGreaterThan(0);
+    for (const program of shared) {
+      expect(program.released_at, `${program.slug} unreleased`).not.toBeNull();
+    }
+  });
+});
+
 test.describe('program schema — RLS', () => {
   test("a user cannot read or write another user's private program", async () => {
     const alice = await signUpThrowawayUser();
@@ -942,6 +959,9 @@ test.describe('program schema — enroll_in_program (starting weight, PROD-TBD)'
           num_weeks: 1,
           days_per_week: 2,
           is_public: true,
+          // Public programs are enrollable by others only once released
+          // (PROD-246).
+          released_at: new Date().toISOString(),
         },
         prefer: 'return=representation',
       },

--- a/src/api/program.ts
+++ b/src/api/program.ts
@@ -32,6 +32,7 @@ export const mapProgramRow = (row: ProgramRow): Program => ({
   createdAt: row.created_at,
   archivedAt: row.archived_at,
   defaultAutoRepeat: row.default_auto_repeat,
+  releasedAt: row.released_at,
 });
 
 /**

--- a/src/api/usePrograms.test.ts
+++ b/src/api/usePrograms.test.ts
@@ -54,6 +54,7 @@ const programRow = (
   days_per_week: null,
   is_public: false,
   created_at: '',
+  released_at: null,
   program_sessions: sessions,
   ...overrides,
 });
@@ -113,6 +114,33 @@ describe('usePrograms', () => {
       id: 'seeded',
       numWeeks: 4,
       daysPerWeek: 3,
+    });
+  });
+
+  it('maps released_at through to releasedAt', async () => {
+    server.use(
+      http.get(PROGRAMS_URL, () =>
+        HttpResponse.json([
+          programRow(
+            {
+              id: 'released',
+              is_public: true,
+              released_at: '2026-07-28T12:00:00Z',
+            },
+            [],
+          ),
+        ]),
+      ),
+    );
+
+    const { result } = renderHook(() => usePrograms(), {
+      wrapper: makeWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data?.[0]).toMatchObject({
+      id: 'released',
+      releasedAt: '2026-07-28T12:00:00Z',
     });
   });
 

--- a/src/examples/active-program.examples.ts
+++ b/src/examples/active-program.examples.ts
@@ -81,6 +81,7 @@ export const exampleActiveProgram = ({
       archivedAt: null,
       createdAt: '2026-07-01T00:00:00Z',
       defaultAutoRepeat: false,
+      releasedAt: null,
     },
     nextSession: isComplete
       ? null

--- a/src/pages/ProgramsPage/ProgramsPage.test.tsx
+++ b/src/pages/ProgramsPage/ProgramsPage.test.tsx
@@ -68,12 +68,14 @@ vi.mock('~/api', () => ({
   MAX_ACTIVE_PROGRAMS: 3,
 }));
 
+let mockSessionEmail: string | undefined;
+
 vi.mock('~/contexts', async () => {
   const actual =
     await vi.importActual<typeof import('~/contexts')>('~/contexts');
   return {
     ...actual,
-    useSession: () => ({ user: { id: 'user-123' } }),
+    useSession: () => ({ user: { id: 'user-123', email: mockSessionEmail } }),
   };
 });
 
@@ -89,6 +91,7 @@ const dfw = {
   daysPerWeek: 3,
   isPublic: true,
   createdAt: '',
+  releasedAt: null,
 };
 
 const armor = {
@@ -103,6 +106,7 @@ const armor = {
   daysPerWeek: 3,
   isPublic: true,
   createdAt: '',
+  releasedAt: null,
 };
 
 const myProgram = {
@@ -117,6 +121,7 @@ const myProgram = {
   daysPerWeek: 3,
   isPublic: false,
   createdAt: '',
+  releasedAt: null,
 };
 
 const renderPage = () =>
@@ -135,6 +140,7 @@ const renderPage = () =>
 
 describe('ProgramsPage', () => {
   beforeEach(() => {
+    mockSessionEmail = undefined;
     enrollMutate.mockReset();
     resumeMutate.mockReset();
     createMutate.mockReset();
@@ -242,6 +248,39 @@ describe('ProgramsPage', () => {
       screen.getByText('Pavel Tsatsouline (StrongFirst) · Repeating workout'),
     ).toBeInTheDocument();
     expect(screen.getByText('Repeats')).toBeInTheDocument();
+  });
+
+  it('badges released shared programs for the owner account only', () => {
+    mockSessionEmail = 'daniel_bowers@icloud.com';
+    mockUsePrograms.mockReturnValue({
+      data: [
+        { ...dfw, releasedAt: '2026-07-28T12:00:00Z' },
+        { ...armor, releasedAt: null },
+      ],
+      isLoading: false,
+    });
+
+    renderPage();
+
+    // Chip on the released program only.
+    expect(screen.getAllByText('Released')).toHaveLength(1);
+    expect(
+      screen.getByLabelText('View Dry Fighting Weight'),
+    ).toHaveTextContent('Released');
+    expect(
+      screen.getByLabelText('View Armor Building Complex'),
+    ).not.toHaveTextContent('Released');
+  });
+
+  it('never shows the released badge to a non-owner', () => {
+    mockUsePrograms.mockReturnValue({
+      data: [{ ...dfw, releasedAt: '2026-07-28T12:00:00Z' }],
+      isLoading: false,
+    });
+
+    renderPage();
+
+    expect(screen.queryByText('Released')).not.toBeInTheDocument();
   });
 
   it('enrolls in your own program directly, with no starting-weight prompt', () => {

--- a/src/pages/ProgramsPage/ProgramsPage.tsx
+++ b/src/pages/ProgramsPage/ProgramsPage.tsx
@@ -32,6 +32,7 @@ import {
 } from '~/components/ui/dialog';
 import { Input } from '~/components/ui/input';
 import { Label } from '~/components/ui/label';
+import { isOwner } from '~/config/features';
 import { useSession } from '~/contexts';
 import { cn } from '~/lib/utils';
 import { Program } from '~/types';
@@ -281,6 +282,11 @@ export const ProgramsPage = () => {
                     {program.defaultAutoRepeat && (
                       <span className="rounded bg-secondary px-0.5 text-xs font-normal text-muted-foreground">
                         Repeats
+                      </span>
+                    )}
+                    {isOwner(session) && program.releasedAt && (
+                      <span className="rounded bg-secondary px-0.5 text-xs font-normal text-muted-foreground">
+                        Released
                       </span>
                     )}
                   </p>

--- a/src/types/program.interface.ts
+++ b/src/types/program.interface.ts
@@ -37,4 +37,11 @@ export interface Program {
    * {@link UserProgram.autoRepeat} at enroll time, where the user can override it.
    */
   defaultAutoRepeat: boolean;
+  /**
+   * Release gate for shared programs (PROD-246): NULL means seeded but not yet
+   * released — visible only to the owner account until a manual test run
+   * passes. RLS hides unreleased public programs from everyone else, so most
+   * clients only ever see timestamps here.
+   */
+  releasedAt: string | null;
 }

--- a/supabase/migrations/20260728120000_add_program_released_at.sql
+++ b/supabase/migrations/20260728120000_add_program_released_at.sql
@@ -1,0 +1,39 @@
+-- Program release gate (PROD-246): released_at column + RLS gating.
+--
+-- "Seeded" and "released" have been the same thing: is_public = true puts a
+-- shared program in every user's catalog the moment its migration lands,
+-- whether or not anyone has run it in the app. Plan A only got its fidelity
+-- fix (PROD-245) because live use caught the deviation; the other seeds have
+-- no recorded QA status.
+--
+-- released_at IS NULL means the program is seeded but not yet released: the
+-- SELECT policy below hides it from everyone except its owner and the app
+-- owner account, who runs the manual test pass and then releases it by
+-- setting released_at. Copy-on-enroll clones are owner-owned rows
+-- (owner_id = auth.uid()), so existing enrollments — including clones minted
+-- from unreleased programs during testing — remain visible to their owners
+-- regardless of release state.
+--
+-- The owner exemption matches on the JWT email mirroring OWNER_EMAILS in
+-- src/config/features.ts. Like that list, it reveals catalog content only —
+-- not a privilege boundary. Anonymous requests carry no email claim, so the
+-- predicate is simply false for them.
+--
+-- Backfill: only A+A Protocol "Plan A" is released at gate-creation time —
+-- it is the one shared program proven through live use. The rest are
+-- deliberately left unreleased and will be released one by one after a
+-- manual test run each (PROD-246). Local and staging environments release
+-- everything via supabase/seed.sql (which never reaches prod) so e2e specs
+-- and deploy previews keep seeing the full catalog.
+ALTER TABLE programs ADD COLUMN IF NOT EXISTS released_at TIMESTAMPTZ;
+
+UPDATE programs SET released_at = now()
+  WHERE slug = 'aa-protocol-plan-a' AND is_public;
+
+DROP POLICY "Users can view public or own programs" ON programs;
+CREATE POLICY "Users can view released public or own programs" ON programs
+  FOR SELECT USING (
+    (SELECT auth.uid()) = owner_id
+    OR (is_public AND released_at IS NOT NULL)
+    OR (is_public AND (SELECT auth.jwt() ->> 'email') = 'daniel_bowers@icloud.com')
+  );

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -373,3 +373,11 @@ BEGIN
 
 END $$;
 
+
+-- Release every shared program in local/staging environments (PROD-246).
+-- seed.sql never runs against prod, where programs are released one by one
+-- (released_at set after a manual test run). Releasing everything here keeps
+-- e2e specs (fresh non-owner users) and deploy previews seeing the full
+-- catalog.
+UPDATE public.programs SET released_at = now()
+  WHERE is_public AND released_at IS NULL;

--- a/types/supabase.ts
+++ b/types/supabase.ts
@@ -378,6 +378,7 @@ export type Database = {
           is_public: boolean
           num_weeks: number | null
           owner_id: string | null
+          released_at: string | null
           slug: string | null
           source_program_id: string | null
           title: string
@@ -393,6 +394,7 @@ export type Database = {
           is_public?: boolean
           num_weeks?: number | null
           owner_id?: string | null
+          released_at?: string | null
           slug?: string | null
           source_program_id?: string | null
           title: string
@@ -408,6 +410,7 @@ export type Database = {
           is_public?: boolean
           num_weeks?: number | null
           owner_id?: string | null
+          released_at?: string | null
           slug?: string | null
           source_program_id?: string | null
           title?: string


### PR DESCRIPTION
## Why

"Seeded" and "released" were the same thing: `is_public = true` puts a shared program in every user's catalog the moment its migration lands, whether or not anyone has run it in the app. Plan A only got its fidelity fix (PROD-245) because live use caught the deviation; the other seeds have no recorded QA status. Closes [PROD-246](https://linear.app/djbowers/issue/PROD-246/program-release-gate-add-released-at-to-programs-and-release-each).

## What

Adds `programs.released_at` (NULL = unreleased) and amends the SELECT policy so unreleased public programs are invisible everywhere — catalog, deep links, and `enroll_in_program`'s source read — except to the owner account (JWT email match mirroring `OWNER_EMAILS`). The owner sees a small "Released" chip on released programs. Only A+A Plan A is released at migration time; `seed.sql` releases everything for local/staging so e2e specs and deploy previews keep the full catalog.

## How to test

- `supabase db reset` — migration + seed apply cleanly.
- SQL smoke (in-transaction, rolled back): with all but Plan A unreleased, a non-owner JWT sees exactly `aa-protocol-plan-a`, the owner-email JWT sees all 9, anon still has no table access.
- `npm test` — 567 pass, including new cases: `releasedAt` mapping, owner-only chip on released cards, chip never renders for non-owners.
- `npx playwright test e2e/` — 63 pass, including a new spec asserting every shared program is released in the e2e environment (the seed.sql contract). One existing spec's public fixture program now sets `released_at` on insert — the gate correctly blocked its cross-user enroll until it did.
- Browser: signed in locally as the owner account, verified the chip renders on released programs and unreleased fixture programs stay visible to the owner (screenshot below).

## Gallery

Owner view of the Programs catalog — "Released" chip on released programs; the unreleased "Bodyweight builder" fixtures stay visible to the owner without a chip (new UI, after only):

![Programs catalog with owner-only Released chips](https://github.com/user-attachments/assets/06e6c0c4-e5b3-4263-9c85-315a6a4624f4)

## Deploy notes

- Migration `20260728120000_add_program_released_at.sql` (renumbered above a concurrent branch's `20260728000000`). `npm run gen:types` already committed.
- **Prod behavior change:** the public catalog shrinks to A+A Plan A for normal users until programs are released one by one (`UPDATE programs SET released_at = now() WHERE slug = '…'`). Existing enrollments are owner-owned clones and unaffected.
- Staging needs a reseed (`deploy:staging` label flow) to pick up the column and the release-all seed.
- Verify prod's Plan A slug is still `aa-protocol-plan-a` before deploy — if it ever changed, the backfill matches nothing and the public catalog goes empty.

## Tradeoffs

- Owner exemption matches the JWT email (`daniel_bowers@icloud.com`) in the policy. A uuid would be stabler against an email change but differs per environment; email mirrors the existing `OWNER_EMAILS` client convention and only reveals catalog content, not privileges.
- No admin UI for releasing — `released_at` flips via SQL, which is fine at current scale and keeps this PR to the gate itself.
