### PR TITLE
feat(programs): adjust active-program weights going forward

### DIFF
--- a/e2e/program-adjust-weights.spec.ts
+++ b/e2e/program-adjust-weights.spec.ts
@@ -1,0 +1,333 @@
+import { expect, test } from '@playwright/test';
+
+// PROD-237: adjust_program_weights backend behavior, hit directly against local
+// Supabase (auth + REST/RPC helpers mirror program-in-program-flow.spec.ts).
+// The RPC re-bases every NOT-yet-completed cloned session onto new working
+// weights, preserving authored per-session offsets, and never touches sessions
+// that already have a completion row. Expectations are derived from the clone
+// itself (modal + offset recomputed here) so the spec doesn't hard-code seed
+// weights.
+
+const SUPABASE_URL = process.env.VITE_SUPABASE_URL!;
+const SUPABASE_ANON_KEY = process.env.VITE_SUPABASE_ANON_KEY!;
+const ES_SLUG = 'easy-strength';
+const ABC_SLUG = 'armor-building-complex';
+const SWING = 'Kettlebell Swing';
+
+interface TestUser {
+  token: string;
+  uid: string;
+  email: string;
+}
+
+async function signUpThrowawayUser(): Promise<TestUser> {
+  const email = `progadjust-${Date.now()}-${Math.floor(Math.random() * 1e9)}@example.com`;
+  const password = 'testpassword123';
+
+  const res = await fetch(`${SUPABASE_URL}/auth/v1/signup`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', apikey: SUPABASE_ANON_KEY },
+    body: JSON.stringify({ email, password }),
+  });
+  if (!res.ok)
+    throw new Error(`signup failed (${res.status}): ${await res.text()}`);
+
+  const body = (await res.json()) as {
+    access_token?: string;
+    user?: { id: string };
+  };
+  if (body.access_token && body.user) {
+    return { token: body.access_token, uid: body.user.id, email };
+  }
+  throw new Error('signup did not return a session');
+}
+
+interface RestOptions {
+  body?: unknown;
+  prefer?: string;
+}
+
+async function restJson<T = unknown>(
+  method: string,
+  path: string,
+  token: string,
+  opts: RestOptions = {},
+): Promise<T> {
+  const headers: Record<string, string> = {
+    apikey: SUPABASE_ANON_KEY,
+    Authorization: `Bearer ${token}`,
+  };
+  if (opts.body !== undefined) headers['Content-Type'] = 'application/json';
+  if (opts.prefer) headers['Prefer'] = opts.prefer;
+  const res = await fetch(`${SUPABASE_URL}/rest/v1/${path}`, {
+    method,
+    headers,
+    body: opts.body !== undefined ? JSON.stringify(opts.body) : undefined,
+  });
+  if (!res.ok) {
+    throw new Error(
+      `${method} ${path} failed (${res.status}): ${await res.text()}`,
+    );
+  }
+  return res.json() as Promise<T>;
+}
+
+async function rpc<T = unknown>(
+  fn: string,
+  token: string,
+  args: Record<string, unknown>,
+): Promise<T> {
+  const res = await fetch(`${SUPABASE_URL}/rest/v1/rpc/${fn}`, {
+    method: 'POST',
+    headers: {
+      apikey: SUPABASE_ANON_KEY,
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(args),
+  });
+  if (!res.ok)
+    throw new Error(`rpc ${fn} failed (${res.status}): ${await res.text()}`);
+  return res.json() as Promise<T>;
+}
+
+interface MovementOpt {
+  movementName: string;
+  repScheme: number[];
+  weightOneValue: number | null;
+  weightOneUnit: string | null;
+  weightTwoValue: number | null;
+  weightTwoUnit: string | null;
+}
+
+interface SessionRow {
+  id: string;
+  sequence_index: number;
+  workout_options: {
+    complexSet: boolean;
+    sharedWeightOneValue: number | null;
+    sharedWeightTwoValue: number | null;
+    movements: MovementOpt[];
+    [key: string]: unknown;
+  };
+}
+
+async function orderedSessions(
+  token: string,
+  programId: string,
+): Promise<SessionRow[]> {
+  return restJson<SessionRow[]>(
+    'GET',
+    `program_sessions?program_id=eq.${programId}&select=id,sequence_index,workout_options&order=sequence_index.asc`,
+    token,
+  );
+}
+
+async function programIdBySlug(token: string, slug: string): Promise<string> {
+  const [row] = await restJson<Array<{ id: string }>>(
+    'GET',
+    `programs?slug=eq.${slug}&select=id`,
+    token,
+  );
+  return row.id;
+}
+
+async function cloneProgramId(
+  token: string,
+  userProgramId: string,
+): Promise<string> {
+  const [row] = await restJson<Array<{ program_id: string }>>(
+    'GET',
+    `user_programs?id=eq.${userProgramId}&select=program_id`,
+    token,
+  );
+  return row.program_id;
+}
+
+async function insertWorkoutLog(user: TestUser): Promise<number> {
+  const [row] = await restJson<Array<{ id: number }>>(
+    'POST',
+    'workout_logs',
+    user.token,
+    {
+      prefer: 'return=representation',
+      body: {
+        user_id: user.uid,
+        started_at: new Date().toISOString(),
+        movements: [SWING],
+        completed_reps: 10,
+        completed_rounds: 1,
+        completed_rungs: 1,
+        workout_goal: 30,
+      },
+    },
+  );
+  return row.id;
+}
+
+async function completeSession(
+  user: TestUser,
+  userProgramId: string,
+  sessionId: string,
+): Promise<void> {
+  const logId = await insertWorkoutLog(user);
+  await rpc('complete_program_session', user.token, {
+    p_user_program_id: userProgramId,
+    p_program_session_id: sessionId,
+    p_workout_log_id: logId,
+  });
+}
+
+/** The modal (most common) weight pair a movement carries across the clone,
+ *  tie-broken toward the lighter pair — the RPC's re-base baseline. */
+function movementModal(
+  sessions: SessionRow[],
+  movementName: string,
+): { one: number; two: number } {
+  const counts = new Map<string, { one: number; two: number; count: number }>();
+  for (const session of sessions) {
+    for (const m of session.workout_options.movements) {
+      if (m.movementName !== movementName || m.weightOneValue === null)
+        continue;
+      const key = `${m.weightOneValue}|${m.weightTwoValue}`;
+      const entry = counts.get(key);
+      if (entry) entry.count += 1;
+      else
+        counts.set(key, {
+          one: m.weightOneValue,
+          two: m.weightTwoValue ?? 0,
+          count: 1,
+        });
+    }
+  }
+  const modal = [...counts.values()].sort(
+    (a, b) => b.count - a.count || a.one - b.one || a.two - b.two,
+  )[0];
+  expect(modal).toBeDefined();
+  return modal;
+}
+
+test.describe('adjust_program_weights — mid-program weight change', () => {
+  test('per-movement adjust re-bases upcoming sessions, preserves offsets, skips completed and unlisted movements', async () => {
+    const user = await signUpThrowawayUser();
+    const esId = await programIdBySlug(user.token, ES_SLUG);
+    // Clone verbatim — the seed's authored weights are the baseline.
+    const userProgramId = await rpc<string>('enroll_in_program', user.token, {
+      p_program_id: esId,
+    });
+    const cloneId = await cloneProgramId(user.token, userProgramId);
+    const before = await orderedSessions(user.token, cloneId);
+
+    const modal = movementModal(before, SWING);
+    const newWeight = modal.one + 4;
+
+    // Lock in the first session before adjusting.
+    await completeSession(user, userProgramId, before[0].id);
+
+    const swingUnit = before
+      .flatMap((s) => s.workout_options.movements)
+      .find((m) => m.movementName === SWING)!.weightOneUnit;
+    const updated = await rpc<number>('adjust_program_weights', user.token, {
+      p_user_program_id: userProgramId,
+      p_movement_weights: [
+        {
+          movementName: SWING,
+          weightOneValue: newWeight,
+          weightOneUnit: swingUnit,
+          weightTwoValue: null,
+          weightTwoUnit: null,
+        },
+      ],
+    });
+    expect(updated).toBe(before.length - 1);
+
+    const after = await orderedSessions(user.token, cloneId);
+    for (let i = 0; i < after.length; i++) {
+      const beforeMovements = before[i].workout_options.movements;
+      const afterMovements = after[i].workout_options.movements;
+      expect(afterMovements).toHaveLength(beforeMovements.length);
+
+      for (let j = 0; j < afterMovements.length; j++) {
+        const was = beforeMovements[j];
+        const now = afterMovements[j];
+        if (i === 0) {
+          // Completed session: untouched, swing included.
+          expect(now).toEqual(was);
+        } else if (was.movementName === SWING) {
+          // Re-based: new working weight plus this session's authored offset
+          // from the swing's modal (a zero delta passes straight through).
+          const offset = (was.weightOneValue ?? 0) - modal.one;
+          expect(now.weightOneValue).toBe(
+            offset === 0 ? newWeight : Math.max(newWeight + offset, 1),
+          );
+          expect(now.weightOneUnit).toBe(swingUnit);
+          // A one-bell swing entry keeps its shape (weight two from payload).
+          expect(now.weightTwoValue).toBeNull();
+          expect(now.repScheme).toEqual(was.repScheme);
+        } else {
+          // Movements not in the payload (incl. bodyweight) are untouched.
+          expect(now).toEqual(was);
+        }
+      }
+    }
+  });
+
+  test('complexSet adjust folds the shared pair uniformly onto upcoming sessions only', async () => {
+    const user = await signUpThrowawayUser();
+    const abcId = await programIdBySlug(user.token, ABC_SLUG);
+    const userProgramId = await rpc<string>('enroll_in_program', user.token, {
+      p_program_id: abcId,
+      p_shared_weight_one_value: 24,
+      p_shared_weight_one_unit: 'kilograms',
+      p_shared_weight_two_value: 24,
+      p_shared_weight_two_unit: 'kilograms',
+    });
+    const cloneId = await cloneProgramId(user.token, userProgramId);
+    const before = await orderedSessions(user.token, cloneId);
+
+    await completeSession(user, userProgramId, before[0].id);
+
+    const updated = await rpc<number>('adjust_program_weights', user.token, {
+      p_user_program_id: userProgramId,
+      p_shared_weight_one_value: 28,
+      p_shared_weight_one_unit: 'kilograms',
+      p_shared_weight_two_value: 28,
+      p_shared_weight_two_unit: 'kilograms',
+    });
+    expect(updated).toBe(before.length - 1);
+
+    const after = await orderedSessions(user.token, cloneId);
+    // Completed session keeps the enrollment-time 24s.
+    expect(after[0].workout_options).toEqual(before[0].workout_options);
+    for (const session of after.slice(1)) {
+      const options = session.workout_options;
+      expect(options.sharedWeightOneValue).toBe(28);
+      expect(options.sharedWeightTwoValue).toBe(28);
+      for (const m of options.movements) {
+        expect(m.weightOneValue).toBe(28);
+        expect(m.weightTwoValue).toBe(28);
+      }
+    }
+  });
+
+  test('rejects an enrollment that is not the caller’s active one, and a weightless call', async () => {
+    const user = await signUpThrowawayUser();
+    await expect(
+      rpc('adjust_program_weights', user.token, {
+        p_user_program_id: '00000000-0000-0000-0000-000000000000',
+        p_shared_weight_one_value: 24,
+        p_shared_weight_one_unit: 'kilograms',
+      }),
+    ).rejects.toThrow(/No active enrollment/);
+
+    const esId = await programIdBySlug(user.token, ES_SLUG);
+    const userProgramId = await rpc<string>('enroll_in_program', user.token, {
+      p_program_id: esId,
+    });
+    await expect(
+      rpc('adjust_program_weights', user.token, {
+        p_user_program_id: userProgramId,
+      }),
+    ).rejects.toThrow(/No weights provided/);
+  });
+});

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -18,6 +18,7 @@ export * from './useDeleteProgram';
 export * from './useDeleteProgramSession';
 export * from './useDuplicateProgramSession';
 export * from './useReorderProgramSession';
+export * from './useAdjustProgramWeights';
 export * from './useDequeueProgram';
 export * from './useEnrollProgram';
 export * from './useQueuedPrograms';

--- a/src/api/useAdjustProgramWeights.ts
+++ b/src/api/useAdjustProgramWeights.ts
@@ -1,0 +1,76 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { QUERIES } from '~/constants';
+import { WeightUnit } from '~/types';
+
+import type { Json } from '../../types/supabase';
+
+import { supabase } from '../supabaseClient';
+import type { MovementWeight } from './useEnrollProgram';
+import { useProgramMutationErrorHandler } from './useProgramMutationErrorHandler';
+
+export interface AdjustProgramWeightsArgs {
+  /** The active enrollment whose upcoming sessions get the new weights. */
+  userProgramId: string;
+  /**
+   * New shared bell pair for complexSet programs, mirroring workout_options'
+   * sharedWeightOne/Two value+unit shape. Provide either these or
+   * `movementWeights`, matching the enrollment picker for the program.
+   */
+  sharedWeightOneValue?: number | null;
+  sharedWeightOneUnit?: WeightUnit | null;
+  sharedWeightTwoValue?: number | null;
+  sharedWeightTwoUnit?: WeightUnit | null;
+  /**
+   * New working weight per non-bodyweight movement — the same shape
+   * `enroll_in_program` takes, re-based onto every session not yet completed.
+   */
+  movementWeights?: MovementWeight[];
+}
+
+/**
+ * Rewrites the weights on every not-yet-completed session of an active
+ * enrollment via the `adjust_program_weights` RPC — the mid-program
+ * counterpart to the enrollment starting-weight picker. Authored per-session
+ * offsets (test days heavier, deloads lighter) are preserved; completed
+ * sessions and their logged workouts are untouched.
+ *
+ * Returns the number of sessions rewritten.
+ */
+export const useAdjustProgramWeights = () => {
+  const queryClient = useQueryClient();
+  const onError = useProgramMutationErrorHandler();
+
+  return useMutation({
+    mutationFn: async ({
+      userProgramId,
+      sharedWeightOneValue,
+      sharedWeightOneUnit,
+      sharedWeightTwoValue,
+      sharedWeightTwoUnit,
+      movementWeights,
+    }: AdjustProgramWeightsArgs): Promise<number> => {
+      const { data, error } = await supabase.rpc('adjust_program_weights', {
+        p_user_program_id: userProgramId,
+        p_shared_weight_one_value: sharedWeightOneValue ?? undefined,
+        p_shared_weight_one_unit: sharedWeightOneUnit ?? undefined,
+        p_shared_weight_two_value: sharedWeightTwoValue ?? undefined,
+        p_shared_weight_two_unit: sharedWeightTwoUnit ?? undefined,
+        // Cast: the generated RPC arg is `Json`, which a typed interface can't
+        // satisfy structurally (no index signature). The shape is asserted by
+        // MovementWeight and by the adjust-weights e2e cases.
+        p_movement_weights: movementWeights?.length
+          ? (movementWeights as unknown as Json)
+          : undefined,
+      });
+
+      if (error) throw error;
+      return data as number;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: [QUERIES.PROGRAM_PROGRESS] });
+      queryClient.invalidateQueries({ queryKey: [QUERIES.ACTIVE_PROGRAM] });
+    },
+    onError,
+  });
+};

--- a/src/pages/ProgramDetailsPage/ProgramDetailsPage.tsx
+++ b/src/pages/ProgramDetailsPage/ProgramDetailsPage.tsx
@@ -77,7 +77,7 @@ const groupByWeek = (
  * only for double loading — a two-hand program carries `null` there and a
  * single-bell one carries `0`, neither of which is user-editable.
  */
-const WeightSlots = ({
+export const WeightSlots = ({
   weight,
   onChange,
   namePrefix,

--- a/src/pages/ProgramProgressPage/ProgramProgressPage.test.tsx
+++ b/src/pages/ProgramProgressPage/ProgramProgressPage.test.tsx
@@ -5,17 +5,26 @@ import { vi } from 'vitest';
 
 import { ProgramProgressPage } from './ProgramProgressPage';
 
-const { mockUseProgramProgress, mockSetAutoRepeat, mockUseQueuedPrograms } =
-  vi.hoisted(() => ({
-    mockUseProgramProgress: vi.fn(),
-    mockSetAutoRepeat: { mutate: vi.fn(), isPending: false },
-    mockUseQueuedPrograms: vi.fn(),
-  }));
+const {
+  mockUseProgramProgress,
+  mockSetAutoRepeat,
+  mockUseQueuedPrograms,
+  mockAdjustMutate,
+} = vi.hoisted(() => ({
+  mockUseProgramProgress: vi.fn(),
+  mockSetAutoRepeat: { mutate: vi.fn(), isPending: false },
+  mockUseQueuedPrograms: vi.fn(),
+  mockAdjustMutate: vi.fn(),
+}));
 
 vi.mock('~/api', () => ({
   useProgramProgress: mockUseProgramProgress,
   useSetProgramAutoRepeat: () => mockSetAutoRepeat,
   useQueuedPrograms: mockUseQueuedPrograms,
+  useAdjustProgramWeights: () => ({
+    mutate: mockAdjustMutate,
+    isPending: false,
+  }),
 }));
 
 const session = (seq: number, week: number, day: number, title: string) => ({
@@ -99,6 +108,7 @@ describe('ProgramProgressPage', () => {
     mockSetAutoRepeat.mutate.mockReset();
     mockSetAutoRepeat.isPending = false;
     mockUseQueuedPrograms.mockReturnValue({ data: [] });
+    mockAdjustMutate.mockReset();
   });
 
   it('renders the summary, week groups, and session states', () => {
@@ -295,6 +305,97 @@ describe('ProgramProgressPage', () => {
     expect(
       screen.getByText('Next up: Armor Building Complex'),
     ).toBeInTheDocument();
+  });
+
+  it('opens the adjust-weights dialog and submits per-movement weights', async () => {
+    const user = userEvent.setup();
+    // Sessions carry real workoutOptions so the dialog can derive one control
+    // per movement (swing loaded, pull-up bodyweight).
+    const withMovements = {
+      ...progressData,
+      weeks: progressData.weeks.map((week) => ({
+        ...week,
+        sessions: week.sessions.map((item) => ({
+          ...item,
+          session: {
+            ...item.session,
+            workoutOptions: {
+              complexSet: false,
+              sharedWeightOneValue: null,
+              sharedWeightOneUnit: null,
+              sharedWeightTwoValue: null,
+              sharedWeightTwoUnit: null,
+              movements: [
+                {
+                  movementName: 'Kettlebell Swing',
+                  repScheme: [10],
+                  weightOneValue: 24,
+                  weightOneUnit: 'kilograms',
+                  weightTwoValue: null,
+                  weightTwoUnit: null,
+                },
+                {
+                  movementName: 'Pull-Up',
+                  repScheme: [5],
+                  weightOneValue: null,
+                  weightOneUnit: null,
+                  weightTwoValue: null,
+                  weightTwoUnit: null,
+                },
+              ],
+            } as never,
+          },
+        })),
+      })),
+    };
+    mockUseProgramProgress.mockReturnValue({
+      data: withMovements,
+      isLoading: false,
+      isError: false,
+    });
+
+    renderPage();
+
+    await user.click(screen.getByRole('button', { name: 'Adjust weights' }));
+    expect(
+      screen.getByRole('heading', { name: 'Adjust weights' }),
+    ).toBeInTheDocument();
+    // One editable control for the swing; the bodyweight pull-up is labeled only.
+    expect(screen.getByText('Kettlebell Swing')).toBeInTheDocument();
+    expect(screen.getByText('Pull-Up')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Update weights' }));
+
+    expect(mockAdjustMutate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userProgramId: 'up-1',
+        movementWeights: [
+          expect.objectContaining({
+            movementName: 'Kettlebell Swing',
+            weightOneValue: 24,
+            weightOneUnit: 'kilograms',
+          }),
+        ],
+      }),
+      expect.anything(),
+    );
+  });
+
+  it('hides the adjust-weights button when the enrollment is not active', () => {
+    mockUseProgramProgress.mockReturnValue({
+      data: {
+        ...progressData,
+        enrollment: { id: 'up-1', status: 'completed' },
+      },
+      isLoading: false,
+      isError: false,
+    });
+
+    renderPage();
+
+    expect(
+      screen.queryByRole('button', { name: 'Adjust weights' }),
+    ).toBeNull();
   });
 
   it('renders a not-found state on error', () => {

--- a/src/pages/ProgramProgressPage/ProgramProgressPage.tsx
+++ b/src/pages/ProgramProgressPage/ProgramProgressPage.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import { Link, useNavigate, useParams } from 'react-router-dom';
 
 import {
@@ -15,6 +16,8 @@ import { Label } from '~/components/ui/label';
 import { Switch } from '~/components/ui/switch';
 import { cn } from '~/lib/utils';
 import { ProgramSession } from '~/types';
+
+import { AdjustWeightsDialog } from './components/AdjustWeightsDialog';
 
 /** Glyph + label + chip styling for each session state. */
 const STATE_META: Record<SessionState, { icon: string; className: string }> = {
@@ -39,6 +42,7 @@ export const ProgramProgressPage = () => {
   const { data, isLoading, isError } = useProgramProgress(id);
   const setAutoRepeat = useSetProgramAutoRepeat();
   const { data: queuedPrograms = [] } = useQueuedPrograms();
+  const [adjustingWeights, setAdjustingWeights] = useState(false);
 
   if (isLoading) {
     return (
@@ -166,6 +170,16 @@ export const ProgramProgressPage = () => {
               />
             </div>
           )}
+          {canStartSessions && (
+            <Button
+              variant="secondary"
+              size="sm"
+              className="mt-1 self-start"
+              onClick={() => setAdjustingWeights(true)}
+            >
+              Adjust weights
+            </Button>
+          )}
           {enrollment?.status === 'active' && nextQueued && (
             <p className="text-xs text-muted-foreground">
               Next up: {nextQueued.program.title}
@@ -174,6 +188,17 @@ export const ProgramProgressPage = () => {
           )}
         </CardContent>
       </Card>
+
+      {enrollment && adjustingWeights && (
+        <AdjustWeightsDialog
+          open={adjustingWeights}
+          onOpenChange={setAdjustingWeights}
+          userProgramId={enrollment.id}
+          sessions={weeks.flatMap((week) =>
+            week.sessions.map((item) => item.session),
+          )}
+        />
+      )}
 
       {weeks.map((week) => (
         <WeekRow

--- a/src/pages/ProgramProgressPage/components/AdjustWeightsDialog.tsx
+++ b/src/pages/ProgramProgressPage/components/AdjustWeightsDialog.tsx
@@ -1,0 +1,170 @@
+import { useMemo, useState } from 'react';
+
+import { useAdjustProgramWeights } from '~/api';
+import type { MovementWeight } from '~/api';
+import { Button } from '~/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '~/components/ui/dialog';
+import { useToast } from '~/contexts';
+import { ProgramSession } from '~/types';
+import { WEIGHT_MODE_LABELS } from '~/utils';
+
+import { WeightSlots } from '~/pages/ProgramDetailsPage/ProgramDetailsPage';
+import {
+  deriveMovementWeights,
+  isComplexProgram,
+} from '~/pages/ProgramDetailsPage/utils/deriveMovementWeights';
+import {
+  deriveStartingWeight,
+  StartingWeight,
+} from '~/pages/ProgramDetailsPage/utils/deriveWeightGroups';
+
+interface AdjustWeightsDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** The active enrollment the new weights apply to. */
+  userProgramId: string;
+  /** All of the enrollment's cloned sessions, in program order. */
+  sessions: ProgramSession[];
+}
+
+/**
+ * Mid-program counterpart to the enrollment starting-weight picker: change the
+ * working weight(s) of an active program for every session not yet completed.
+ * Pre-fills from the clone's current weights, so what you see is what the
+ * upcoming sessions carry now.
+ */
+export const AdjustWeightsDialog = ({
+  open,
+  onOpenChange,
+  userProgramId,
+  sessions,
+}: AdjustWeightsDialogProps) => {
+  const adjust = useAdjustProgramWeights();
+  const { showToast } = useToast();
+
+  const complex = useMemo(() => isComplexProgram(sessions), [sessions]);
+  const movementControls = useMemo(
+    () => deriveMovementWeights(sessions),
+    [sessions],
+  );
+  const currentShared = useMemo(
+    () => deriveStartingWeight(sessions),
+    [sessions],
+  );
+
+  // Seeded lazily from the clone's current weights; remounting the content on
+  // each open (via `open &&` below) re-seeds after an outside data change.
+  const [sharedWeight, setSharedWeight] =
+    useState<StartingWeight>(currentShared);
+  const [movementWeights, setMovementWeights] = useState<
+    Record<string, StartingWeight>
+  >({});
+
+  const handleSave = () => {
+    const payload: MovementWeight[] = movementControls
+      .filter((control) => control.mode !== 'none')
+      .map((control) => {
+        const chosen =
+          movementWeights[control.movementName] ?? control.modalWeight;
+        return {
+          movementName: control.movementName,
+          weightOneValue: chosen.sharedWeightOneValue,
+          weightOneUnit: chosen.sharedWeightOneUnit,
+          weightTwoValue: chosen.sharedWeightTwoValue,
+          weightTwoUnit: chosen.sharedWeightTwoUnit,
+        };
+      });
+
+    adjust.mutate(
+      {
+        userProgramId,
+        ...(complex
+          ? {
+              sharedWeightOneValue: sharedWeight.sharedWeightOneValue,
+              sharedWeightOneUnit: sharedWeight.sharedWeightOneUnit,
+              sharedWeightTwoValue: sharedWeight.sharedWeightTwoValue,
+              sharedWeightTwoUnit: sharedWeight.sharedWeightTwoUnit,
+            }
+          : { movementWeights: payload }),
+      },
+      {
+        onSuccess: (updatedCount) => {
+          showToast(
+            `Weights updated for ${updatedCount} upcoming session${updatedCount === 1 ? '' : 's'}`,
+          );
+          onOpenChange(false);
+        },
+      },
+    );
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-h-[85vh] overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle>Adjust weights</DialogTitle>
+          <DialogDescription>
+            Sets the working weight for every session you haven&apos;t done
+            yet. Heavier and lighter days keep their offsets; completed
+            workouts aren&apos;t changed.
+          </DialogDescription>
+        </DialogHeader>
+
+        {/* min-w-0: the weight strip's intrinsic width must not stretch the
+            dialog's grid column past its max width. */}
+        <div className="flex min-w-0 flex-col gap-2">
+          {complex ? (
+            <WeightSlots
+              weight={sharedWeight}
+              onChange={setSharedWeight}
+              namePrefix="Working weight"
+            />
+          ) : (
+            movementControls.map((control) => (
+              <div key={control.movementName} className="flex flex-col gap-1">
+                <h2 className="text-sm font-semibold">
+                  {control.movementName}
+                </h2>
+                {control.mode === 'none' ? (
+                  <p className="text-sm text-muted-foreground">
+                    {WEIGHT_MODE_LABELS.none}
+                  </p>
+                ) : (
+                  <WeightSlots
+                    weight={
+                      movementWeights[control.movementName] ??
+                      control.modalWeight
+                    }
+                    onChange={(next) =>
+                      setMovementWeights((current) => ({
+                        ...current,
+                        [control.movementName]: next,
+                      }))
+                    }
+                    namePrefix={control.movementName}
+                  />
+                )}
+              </div>
+            ))
+          )}
+        </div>
+
+        <DialogFooter>
+          <Button variant="secondary" onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button onClick={handleSave} disabled={adjust.isPending}>
+            Update weights
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/supabase/migrations/20260729120000_adjust_program_weights.sql
+++ b/supabase/migrations/20260729120000_adjust_program_weights.sql
@@ -1,0 +1,257 @@
+-- Program Tracking: adjust an active enrollment's weights for all workouts
+-- going forward (PROD-237).
+--
+-- enroll_in_program bakes the enrollee's chosen weights into the cloned
+-- program_sessions.workout_options once, at enroll time
+-- (20260724000004_enroll_in_program_per_movement_weights.sql). Mid-program the
+-- lifter outgrows a bell (or overreached) and needs to move every UPCOMING
+-- session to a new working weight without touching what's already logged.
+--
+-- This RPC re-applies the enroll resolution to the enrollment's own cloned
+-- program, scoped to sessions that have no completion row for the enrollment
+-- (robust under skips and out-of-order starts):
+--
+--   * Non-complex sessions with p_movement_weights -> rebuild each movement in
+--     its own config shape, offset from that movement's modal across the
+--     CLONE's sessions. The clone's weights are the previous choice plus the
+--     authored per-session offsets, so recomputing the modal over the clone
+--     preserves those offsets (test days stay heavier, deloads lighter) while
+--     re-basing on the new working weight.
+--   * complexSet sessions, or a caller passing only p_shared_weight_* -> the
+--     uniform shared fold, offset from the clone-level modal (movements->0).
+--
+-- The modal spans ALL of the clone's sessions -- completed and upcoming -- so
+-- the picker's pre-fill (client deriveMovementWeights over the same full
+-- session list) equals the baseline the fold shifts from. Completed sessions'
+-- history lives in workout_logs and is never touched.
+--
+-- Ownership: the enrollment must belong to the caller and be active. The
+-- UPDATE targets the caller's own cloned program (or their own program for a
+-- self-authored enrollment); SECURITY INVOKER + the program_sessions owner RLS
+-- policy enforce that a second time.
+--
+-- Returns the number of sessions rewritten.
+DROP FUNCTION IF EXISTS public.adjust_program_weights(UUID, NUMERIC, TEXT, NUMERIC, TEXT, JSONB);
+
+CREATE FUNCTION public.adjust_program_weights(
+  p_user_program_id         UUID,
+  p_shared_weight_one_value NUMERIC DEFAULT NULL,
+  p_shared_weight_one_unit  TEXT    DEFAULT NULL,
+  p_shared_weight_two_value NUMERIC DEFAULT NULL,
+  p_shared_weight_two_unit  TEXT    DEFAULT NULL,
+  p_movement_weights        JSONB   DEFAULT NULL
+)
+RETURNS INTEGER
+LANGUAGE plpgsql
+SECURITY INVOKER
+SET search_path = public
+AS $$
+DECLARE
+  v_user_id   UUID := auth.uid();
+  v_program   UUID;
+  v_modal_one NUMERIC;
+  v_modal_two NUMERIC;
+  v_updated   INTEGER;
+BEGIN
+  IF v_user_id IS NULL THEN
+    RAISE EXCEPTION 'Not authenticated';
+  END IF;
+
+  IF p_shared_weight_one_value IS NULL AND p_movement_weights IS NULL THEN
+    RAISE EXCEPTION 'No weights provided';
+  END IF;
+
+  SELECT program_id INTO v_program
+  FROM user_programs
+  WHERE id = p_user_program_id
+    AND user_id = v_user_id
+    AND status = 'active';
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'No active enrollment % for this user', p_user_program_id;
+  END IF;
+
+  -- Clone-level modal (weightOne, weightTwo) pair, used by the shared-fold
+  -- path. Ties break toward the lighter pair, mirroring deriveStartingWeight.
+  SELECT one_val, two_val INTO v_modal_one, v_modal_two
+  FROM (
+    SELECT (workout_options->'movements'->0->>'weightOneValue')::NUMERIC AS one_val,
+           (workout_options->'movements'->0->>'weightTwoValue')::NUMERIC AS two_val,
+           COUNT(*) AS cnt
+    FROM program_sessions
+    WHERE program_id = v_program
+    GROUP BY one_val, two_val
+    ORDER BY cnt DESC, one_val, two_val
+    LIMIT 1
+  ) modal;
+
+  UPDATE program_sessions ps
+  SET workout_options = sub.new_options
+  FROM (
+    -- Per-movement modal weight across the clone, one row per movement name.
+    -- Bodyweight movements (null weight one) never form a modal, so they have
+    -- no row and their elements are kept untouched below. Tie-break mirrors
+    -- the client's deriveMovementWeights so pre-fill equals the new baseline.
+    WITH movement_modal AS (
+      SELECT DISTINCT ON (name)
+        name, one_val, two_val
+      FROM (
+        SELECT
+          mv->>'movementName' AS name,
+          (mv->>'weightOneValue')::NUMERIC AS one_val,
+          (mv->>'weightTwoValue')::NUMERIC AS two_val,
+          COUNT(*) AS cnt
+        FROM program_sessions ps2,
+             jsonb_array_elements(ps2.workout_options->'movements') AS mv
+        WHERE ps2.program_id = v_program
+          AND (mv->>'weightOneValue') IS NOT NULL
+        GROUP BY name, one_val, two_val
+      ) per_pair
+      ORDER BY name, cnt DESC, one_val, two_val
+    )
+    SELECT
+      ps2.id,
+      CASE
+        -- non-complex with per-movement weights: rebuild each element in its
+        -- own config shape, offset from that movement's modal.
+        WHEN p_movement_weights IS NOT NULL
+             AND ps2.workout_options->>'complexSet' IS DISTINCT FROM 'true'
+          THEN jsonb_set(
+                 ps2.workout_options,
+                 '{movements}',
+                 (
+                   SELECT jsonb_agg(
+                            CASE
+                              WHEN mw.value IS NULL THEN elem
+                              ELSE elem || jsonb_build_object(
+                                'weightOneValue',
+                                  COALESCE(to_jsonb(
+                                    CASE
+                                      WHEN (mw.value->>'weightOneValue')::NUMERIC IS NULL
+                                        OR r.one_delta = 0
+                                        THEN (mw.value->>'weightOneValue')::NUMERIC
+                                      ELSE GREATEST((mw.value->>'weightOneValue')::NUMERIC + r.one_delta, 1)
+                                    END), 'null'::jsonb),
+                                'weightOneUnit',
+                                  COALESCE(to_jsonb(mw.value->>'weightOneUnit'), 'null'::jsonb),
+                                'weightTwoValue',
+                                  COALESCE(to_jsonb(
+                                    CASE
+                                      WHEN (mw.value->>'weightTwoValue')::NUMERIC IS NULL
+                                        OR r.two_delta = 0
+                                        THEN (mw.value->>'weightTwoValue')::NUMERIC
+                                      ELSE GREATEST((mw.value->>'weightTwoValue')::NUMERIC + r.two_delta, 1)
+                                    END), 'null'::jsonb),
+                                'weightTwoUnit',
+                                  COALESCE(to_jsonb(mw.value->>'weightTwoUnit'), 'null'::jsonb)
+                              )
+                            END
+                            ORDER BY ord
+                          )
+                   FROM jsonb_array_elements(ps2.workout_options->'movements')
+                          WITH ORDINALITY AS e(elem, ord)
+                   LEFT JOIN LATERAL (
+                     SELECT o.value
+                     FROM jsonb_array_elements(p_movement_weights) AS o(value)
+                     WHERE o.value->>'movementName' = elem->>'movementName'
+                     LIMIT 1
+                   ) mw ON TRUE
+                   LEFT JOIN movement_modal mm ON mm.name = elem->>'movementName'
+                   CROSS JOIN LATERAL (
+                     SELECT
+                       -- Offset only when the movement's cloned unit matches
+                       -- the chosen unit; a cross-unit choice passes through
+                       -- (delta 0) rather than doing cross-unit arithmetic.
+                       CASE WHEN elem->>'weightOneUnit'
+                                 IS NOT DISTINCT FROM mw.value->>'weightOneUnit'
+                            THEN COALESCE((elem->>'weightOneValue')::NUMERIC, 0)
+                                 - COALESCE(mm.one_val, 0)
+                            ELSE 0 END AS one_delta,
+                       CASE WHEN elem->>'weightTwoUnit'
+                                 IS NOT DISTINCT FROM mw.value->>'weightTwoUnit'
+                            THEN COALESCE((elem->>'weightTwoValue')::NUMERIC, 0)
+                                 - COALESCE(mm.two_val, 0)
+                            ELSE 0 END AS two_delta
+                   ) r
+                 ))
+        -- complexSet (one bell pair for the whole complex), or a caller that
+        -- passed only p_shared_weight_*: the uniform fold. COALESCE(...,
+        -- 'null'::jsonb): jsonb_set is strict and to_jsonb(NULL) is SQL NULL,
+        -- so an unset slot must be coerced to a JSON null.
+        ELSE jsonb_set(
+               jsonb_set(
+                 jsonb_set(
+                   jsonb_set(
+                     jsonb_set(
+                       ps2.workout_options,
+                       '{sharedWeightOneValue}',
+                       COALESCE(to_jsonb(w.one_value), 'null'::jsonb)),
+                     '{sharedWeightOneUnit}',
+                     COALESCE(to_jsonb(w.one_unit), 'null'::jsonb)),
+                   '{sharedWeightTwoValue}',
+                   COALESCE(to_jsonb(w.two_value), 'null'::jsonb)),
+                 '{sharedWeightTwoUnit}',
+                 COALESCE(to_jsonb(w.two_unit), 'null'::jsonb)),
+               '{movements}',
+               (
+                 SELECT jsonb_agg(
+                          m || jsonb_build_object(
+                            'weightOneValue', COALESCE(to_jsonb(w.one_value), 'null'::jsonb),
+                            'weightOneUnit',  COALESCE(to_jsonb(w.one_unit),  'null'::jsonb),
+                            'weightTwoValue', COALESCE(to_jsonb(w.two_value), 'null'::jsonb),
+                            'weightTwoUnit',  COALESCE(to_jsonb(w.two_unit),  'null'::jsonb)
+                          )
+                        )
+                 FROM jsonb_array_elements(ps2.workout_options->'movements') AS m
+               ))
+      END AS new_options
+    FROM program_sessions ps2
+    -- Per-session shared weight for the fold path: the chosen weight shifted
+    -- by this session's offset from the clone modal. A zero delta passes the
+    -- chosen value through untouched -- notably it must NOT hit the >= 1
+    -- clamp, since a single-bell program carries weight two = 0.
+    CROSS JOIN LATERAL (
+      SELECT
+        CASE
+          WHEN p_shared_weight_one_value IS NULL OR d.one_delta = 0
+            THEN p_shared_weight_one_value
+          ELSE GREATEST(p_shared_weight_one_value + d.one_delta, 1)
+        END AS one_value,
+        CASE
+          WHEN p_shared_weight_two_value IS NULL OR d.two_delta = 0
+            THEN p_shared_weight_two_value
+          ELSE GREATEST(p_shared_weight_two_value + d.two_delta, 1)
+        END AS two_value,
+        p_shared_weight_one_unit AS one_unit,
+        p_shared_weight_two_unit AS two_unit
+      FROM (
+        SELECT
+          COALESCE(
+            CASE WHEN ps2.workout_options->'movements'->0->>'weightOneUnit'
+                      IS NOT DISTINCT FROM p_shared_weight_one_unit
+                 THEN (ps2.workout_options->'movements'->0->>'weightOneValue')::NUMERIC
+                      - v_modal_one
+            END, 0) AS one_delta,
+          COALESCE(
+            CASE WHEN ps2.workout_options->'movements'->0->>'weightTwoUnit'
+                      IS NOT DISTINCT FROM p_shared_weight_two_unit
+                 THEN (ps2.workout_options->'movements'->0->>'weightTwoValue')::NUMERIC
+                      - v_modal_two
+            END, 0) AS two_delta
+      ) d
+    ) w
+    WHERE ps2.program_id = v_program
+      AND NOT EXISTS (
+        SELECT 1 FROM program_session_completions c
+        WHERE c.user_program_id = p_user_program_id
+          AND c.program_session_id = ps2.id
+      )
+  ) sub
+  WHERE ps.id = sub.id;
+
+  GET DIAGNOSTICS v_updated = ROW_COUNT;
+  RETURN v_updated;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.adjust_program_weights(UUID, NUMERIC, TEXT, NUMERIC, TEXT, JSONB) FROM public;
+GRANT EXECUTE ON FUNCTION public.adjust_program_weights(UUID, NUMERIC, TEXT, NUMERIC, TEXT, JSONB) TO authenticated;

--- a/types/supabase.ts
+++ b/types/supabase.ts
@@ -796,6 +796,17 @@ export type Database = {
           users_with_first_workout: number
         }[]
       }
+      adjust_program_weights: {
+        Args: {
+          p_movement_weights?: Json
+          p_shared_weight_one_unit?: string
+          p_shared_weight_one_value?: number
+          p_shared_weight_two_unit?: string
+          p_shared_weight_two_value?: number
+          p_user_program_id: string
+        }
+        Returns: number
+      }
       complete_program_session: {
         Args: {
           p_program_session_id: string


### PR DESCRIPTION
## Why

Enrollment bakes the chosen weights into the cloned program sessions once, at enroll time (#175). Mid-program a lifter outgrows a bell (or overreached) and has no way to move every upcoming session to a new working weight — the PROD-237 "adjust weights going forward" criterion.

## What

Adds an `adjust_program_weights` RPC that re-applies the enroll fold math to an active enrollment's not-yet-completed sessions — per-movement re-base with authored offsets preserved (test days stay heavier, deloads lighter), or the complexSet shared-pair fold — plus an **Adjust weights** dialog on the program progress page, seeded from the clone's current weights. Completed sessions and their logged workouts are untouched.

## How to test

- `npm run test:e2e -- e2e/program-adjust-weights.spec.ts` — Easy Strength per-movement re-base (offsets preserved, completed session untouched, unlisted/bodyweight movements untouched), ABC complexSet uniform fold, and ownership/no-weights guards. All passing against local Supabase.
- `npm test` (566), `npm run compile:ts`, `npm run lint` — clean.
- Drove the dialog in the dev preview: enrolled in Easy Strength, bumped the swing, saved, confirmed the clone's uncompleted sessions rewrote in the DB and the toast reported the session count.

## Gallery

Progress page with the new control:

![progress page](https://github.com/user-attachments/assets/11c4c00e-403c-4c4e-9586-fac3b5e406d6)

Adjust weights dialog (pre-filled from the clone's current weights):

![adjust weights dialog](https://github.com/user-attachments/assets/cee9f237-1c69-423b-bef4-1f1aa3c987ef)

## Deploy notes

- New migration `20260728000000_adjust_program_weights.sql` (new RPC only, no table changes). `types/supabase.ts` regenerated and committed.

## Tradeoffs

- Scope is "sessions with no completion row" rather than `sequence_index >= next` — robust when sessions were skipped or done out of order.
- The modal baseline spans all of the clone's sessions (completed included) so the dialog's pre-fill equals the fold's baseline; a rewrite scoped to remaining sessions only could skew the baseline toward a deload block.

Part of PROD-237.
