### PR TITLE
feat(launchpad): add Start a program card to the un-enrolled home

### DIFF
--- a/src/pages/StartWorkoutPage/StartWorkoutPage.startProgramCard.test.jsx
+++ b/src/pages/StartWorkoutPage/StartWorkoutPage.startProgramCard.test.jsx
@@ -1,0 +1,107 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+
+import { DEFAULT_WORKOUT_OPTIONS, WorkoutOptionsContext } from '~/contexts';
+
+import { StartWorkoutPage } from './StartWorkoutPage';
+
+// The un-enrolled home offers a quiet "Start a program" card into the catalog,
+// in the same slot BuildCustomCard occupies for enrolled users. It only exists
+// when the programs feature is on and the user has no active program.
+const { mockUseActivePrograms, mockUseFeatures } = vi.hoisted(() => ({
+  mockUseActivePrograms: vi.fn(),
+  mockUseFeatures: vi.fn(),
+}));
+vi.mock('~/api', async (importOriginal) => ({
+  ...(await importOriginal()),
+  useActivePrograms: mockUseActivePrograms,
+}));
+vi.mock('~/hooks', async (importOriginal) => ({
+  ...(await importOriginal()),
+  useFeatures: mockUseFeatures,
+}));
+
+const BASE_FEATURES = {
+  bottomNav: false,
+  complexMode: false,
+  explore: false,
+  premium: false,
+  programs: true,
+  weeklyBalance: false,
+};
+
+const activeProgram = {
+  enrollment: { id: 'up-1', programId: 'p-1', status: 'active' },
+  program: { id: 'p-1', title: 'Dry Fighting Weight' },
+  nextSession: {
+    session: {
+      id: 'ps-0',
+      sequenceIndex: 0,
+      weekNumber: 1,
+      dayNumber: 1,
+      title: 'Ladders 1-2-3',
+      workoutOptions: DEFAULT_WORKOUT_OPTIONS,
+    },
+    workoutOptions: DEFAULT_WORKOUT_OPTIONS,
+  },
+  progress: { completed: 0, total: 3, week: 1, day: 1 },
+  isComplete: false,
+  lastWorkedAt: null,
+};
+
+const renderPage = () =>
+  render(
+    <QueryClientProvider
+      client={
+        new QueryClient({ defaultOptions: { queries: { retry: false } } })
+      }
+    >
+      <MemoryRouter initialEntries={['/']}>
+        <WorkoutOptionsContext.Provider
+          value={[DEFAULT_WORKOUT_OPTIONS, vi.fn()]}
+        >
+          <StartWorkoutPage />
+        </WorkoutOptionsContext.Provider>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+
+describe('StartWorkoutPage — Start a program card', () => {
+  beforeEach(() => {
+    mockUseFeatures.mockReturnValue(BASE_FEATURES);
+  });
+
+  test('shows the card linking to /programs when un-enrolled', () => {
+    mockUseActivePrograms.mockReturnValue({ data: [], isError: false });
+
+    renderPage();
+
+    const link = screen.getByRole('link', { name: /start a program/i });
+    expect(link).toHaveAttribute('href', '/programs');
+  });
+
+  test('hides the card when a program is active', () => {
+    mockUseActivePrograms.mockReturnValue({
+      data: [activeProgram],
+      isError: false,
+    });
+
+    renderPage();
+
+    expect(
+      screen.queryByRole('link', { name: /start a program/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  test('hides the card when the programs feature is off', () => {
+    mockUseFeatures.mockReturnValue({ ...BASE_FEATURES, programs: false });
+    mockUseActivePrograms.mockReturnValue({ data: [], isError: false });
+
+    renderPage();
+
+    expect(
+      screen.queryByRole('link', { name: /start a program/i }),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/src/pages/StartWorkoutPage/StartWorkoutPage.tsx
+++ b/src/pages/StartWorkoutPage/StartWorkoutPage.tsx
@@ -54,6 +54,7 @@ import {
   RecommendSessionSection,
   RecommendedWorkoutsSection,
   Section,
+  StartProgramCard,
   StartWorkoutHero,
   WeightModeTabs,
   WeightUnitTabs,
@@ -942,8 +943,10 @@ export const StartWorkoutPage = ({
             />
           )}
 
-          {primaryProgram && (
+          {primaryProgram ? (
             <BuildCustomCard onClick={handleClickBuildCustom} />
+          ) : (
+            features.programs && <StartProgramCard />
           )}
         </>
       )}

--- a/src/pages/StartWorkoutPage/components/StartProgramCard.stories.tsx
+++ b/src/pages/StartWorkoutPage/components/StartProgramCard.stories.tsx
@@ -1,0 +1,22 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { MemoryRouter } from 'react-router-dom';
+
+import { StartProgramCard } from './StartProgramCard';
+
+const meta = {
+  component: StartProgramCard,
+  decorators: [
+    (Story) => (
+      <MemoryRouter>
+        <div className="max-w-md p-2">
+          <Story />
+        </div>
+      </MemoryRouter>
+    ),
+  ],
+} satisfies Meta<typeof StartProgramCard>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/src/pages/StartWorkoutPage/components/StartProgramCard.tsx
+++ b/src/pages/StartWorkoutPage/components/StartProgramCard.tsx
@@ -1,0 +1,35 @@
+import { ArrowRightIcon, MapIcon } from '@heroicons/react/24/outline';
+import { Link } from 'react-router-dom';
+
+import { Card } from '~/components/ui/card';
+
+/**
+ * The un-enrolled counterpart to BuildCustomCard: a quiet bordered entry into
+ * the programs catalog, kept calm so the quick-start hero stays the focus.
+ */
+export const StartProgramCard = () => {
+  return (
+    <Card>
+      <Link to="/programs" className="flex w-full items-center gap-2 p-2">
+        <span
+          aria-hidden="true"
+          className="flex h-4 w-4 shrink-0 items-center justify-center rounded-full bg-primary/10 text-primary"
+        >
+          <MapIcon className="h-2.5 w-2.5" />
+        </span>
+        <span className="flex flex-1 flex-col gap-0.5">
+          <span className="text-sm font-semibold leading-none">
+            Start a program
+          </span>
+          <span className="text-sm text-muted-foreground">
+            Follow a structured plan, week by week.
+          </span>
+        </span>
+        <ArrowRightIcon
+          className="h-2.5 w-2.5 shrink-0 text-muted-foreground"
+          aria-hidden="true"
+        />
+      </Link>
+    </Card>
+  );
+};

--- a/src/pages/StartWorkoutPage/components/index.ts
+++ b/src/pages/StartWorkoutPage/components/index.ts
@@ -13,6 +13,7 @@ export * from './MovementSummaryChips';
 export * from './ProgramSwitcherTabs';
 export * from './RecommendedWorkoutCard';
 export * from './RecommendedWorkoutsSection';
+export * from './StartProgramCard';
 export * from './StartWorkoutHero';
 export * from './WorkoutAddonToggle';
 export * from './MovementAutocomplete';


### PR DESCRIPTION
## Why

The home page adapts to enrollment, but the un-enrolled view had no way to discover or start a program — the only paths to the catalog were the header and bottom nav. New users landing on the hub never see programs exist.

## What

Adds a quiet "Start a program" card to the un-enrolled home, linking to `/programs`. It fills the same slot `BuildCustomCard` occupies for enrolled users and is gated on the `programs` feature flag.

## How to test

- `npx vitest run src/pages/StartWorkoutPage` — 87 tests pass, including a new suite covering: un-enrolled → card visible and links to `/programs`; enrolled → absent; flag off → absent.
- `npm run compile:ts` clean.
- Rendered the new story in Storybook (screenshot below).

## Gallery

New un-enrolled home card (Storybook):

![Start a program card](https://github.com/user-attachments/assets/3f7c0554-1a25-4c4c-b75e-a4eb7e68d901)

## Tradeoffs

Considered folding the CTA into the quick-start hero as a tertiary link, but the hero already carries two actions; a sibling card mirrors the enrolled layout's rhythm and keeps the hero focused.
