### PR TITLE
fix(ui): stop number pickers desyncing from their value

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -12,6 +12,12 @@
       "runtimeExecutable": "npm",
       "runtimeArgs": ["run", "storybook"],
       "port": 6006
+    },
+    {
+      "name": "bellskill-storybook-alt",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": ["run", "storybook", "--", "-p", "6016"],
+      "port": 6016
     }
   ]
 }

--- a/src/components/ModifyCountButtons.test.tsx
+++ b/src/components/ModifyCountButtons.test.tsx
@@ -70,6 +70,25 @@ describe('ModifyCountButtons', () => {
     expect(screen.getByRole('tab', { name: 'lb' })).toBeInTheDocument();
   });
 
+  it('keeps the center display on the value after a stray settle', () => {
+    const { container } = setup({ min: 1, max: 40, value: 24 });
+    const track = container.querySelector<HTMLDivElement>(
+      'div[aria-hidden="true"].no-select',
+    )!;
+    Object.defineProperty(track, 'clientWidth', {
+      value: 240,
+      configurable: true,
+    });
+
+    // The browser can fire a settle at position 0 before the strip is placed;
+    // the display must not drift off the committed value.
+    track.scrollLeft = 0;
+    fireEvent.scroll(track);
+    fireEvent(track, new Event('scrollend'));
+
+    expect(screen.getByRole('spinbutton')).toHaveValue(24);
+  });
+
   it('color-codes the strip only when a bell unit is given', () => {
     const { container, unmount } = setup({
       min: 20,

--- a/src/components/ValueCarousel/ValueCarousel.test.tsx
+++ b/src/components/ValueCarousel/ValueCarousel.test.tsx
@@ -191,6 +191,109 @@ describe('ValueCarousel', () => {
       expect(onChange).not.toHaveBeenCalled();
     });
 
+    it('commits a fling even when the fallback timer settles early', () => {
+      // iOS Safari has no scrollend, so settles come from a timer that can
+      // fire mid-fling — the fling's real landing must still commit.
+      const descriptor = Object.getOwnPropertyDescriptor(
+        window,
+        'onscrollend',
+      )!;
+      delete (window as { onscrollend?: unknown }).onscrollend;
+
+      try {
+        const onChange = vi.fn();
+        const { container } = render(
+          <ValueCarousel
+            min={1}
+            max={40}
+            step={1}
+            value={24}
+            onChange={onChange}
+          />,
+        );
+        const track = layoutTrack(container);
+
+        fireEvent.pointerDown(track);
+        track.scrollLeft = 23 * ITEM_WIDTH;
+        fireEvent.scroll(track);
+        vi.advanceTimersByTime(200); // premature settle, still at the value
+        track.scrollLeft = 31 * ITEM_WIDTH;
+        fireEvent.scroll(track);
+        vi.advanceTimersByTime(200); // the fling's real landing
+
+        expect(onChange).toHaveBeenCalledWith(32);
+      } finally {
+        Object.defineProperty(window, 'onscrollend', descriptor);
+      }
+    });
+
+    it('disarms a gesture that never scrolled', () => {
+      const onChange = vi.fn();
+      const { container } = render(
+        <ValueCarousel
+          min={1}
+          max={40}
+          step={1}
+          value={24}
+          onChange={onChange}
+        />,
+      );
+      const track = layoutTrack(container);
+
+      // A tap that moves nothing must not turn the next settle — e.g. from a
+      // programmatic scroll after a +/- press — into a user commit.
+      fireEvent.pointerDown(track);
+      fireEvent.pointerUp(track);
+      settleAt(track, 31);
+
+      expect(onChange).not.toHaveBeenCalled();
+    });
+
+    it('snaps the display back after a settle it did not cause', () => {
+      const onChange = vi.fn();
+      const onFocusChange = vi.fn();
+      const { container } = render(
+        <ValueCarousel
+          min={1}
+          max={40}
+          step={1}
+          value={24}
+          onChange={onChange}
+          onFocusChange={onFocusChange}
+        />,
+      );
+
+      settleAt(layoutTrack(container), 0);
+
+      expect(onChange).not.toHaveBeenCalled();
+      expect(onFocusChange).toHaveBeenLastCalledWith(24);
+    });
+
+    it('keeps trying to position the strip until it has width', () => {
+      const { container } = render(
+        <ValueCarousel min={1} max={40} step={1} value={24} onChange={vi.fn()} />,
+      );
+      const track = container.querySelector<HTMLDivElement>(
+        '[aria-hidden="true"]',
+      )!;
+      const scrollTo = vi.fn();
+      Object.defineProperty(track, 'scrollTo', {
+        value: scrollTo,
+        configurable: true,
+      });
+
+      vi.advanceTimersByTime(100); // frames pass with no layout — keep waiting
+      expect(scrollTo).not.toHaveBeenCalled();
+
+      layoutTrack(container);
+      vi.advanceTimersByTime(100);
+
+      expect(scrollTo).toHaveBeenCalledWith({
+        left: 23 * ITEM_WIDTH,
+        behavior: 'auto',
+      });
+    });
+
     it('does not re-commit a value it was just given', () => {
       const onChange = vi.fn();
       const { container } = render(

--- a/src/components/ValueCarousel/useSnapScrollValue.ts
+++ b/src/components/ValueCarousel/useSnapScrollValue.ts
@@ -10,7 +10,9 @@ const USER_SCROLL_EVENTS = [
   'keydown',
 ] as const;
 
-const supportsScrollEnd =
+// Checked per-mount rather than at module load so tests can exercise the
+// no-scrollend fallback (iOS Safari) by removing the property.
+const supportsScrollEnd = () =>
   typeof window !== 'undefined' && 'onscrollend' in window;
 
 const clamp = (value: number, min: number, max: number) =>
@@ -64,6 +66,7 @@ export const useSnapScrollValue = ({
   const syncedIndex = useRef(nearestIndex(values, value));
   const hasPositioned = useRef(false);
   const pendingUserScroll = useRef(false);
+  const programmaticScroll = useRef(false);
   const [focusedIndex, setFocusedIndex] = useState(syncedIndex.current);
 
   // Reported live during a swipe so the consumer's center display can track the
@@ -92,64 +95,133 @@ export const useSnapScrollValue = ({
     syncedIndex.current = index;
     setFocusedIndex(index);
 
-    const scrollToSynced = (behavior: ScrollBehavior) =>
+    const scrollToSynced = (behavior: ScrollBehavior) => {
+      programmaticScroll.current = true;
       trackRef.current?.scrollTo?.({ left: index * itemWidth, behavior });
+    };
 
-    // On the first commit the track has no laid-out width yet, so scrollTo is a
-    // no-op — place it on the next frame instead, and instantly, since there is
-    // nothing to animate away from.
+    // Until the track has laid-out width, scrollTo is a no-op, and even after
+    // that scroll snap can drag the strip off a target the items haven't laid
+    // out under yet. Re-assert the position each frame until it actually
+    // sticks (StrictMode remounts and off-screen mounts included), instantly,
+    // since there is nothing to animate away from.
     if (!hasPositioned.current) {
-      hasPositioned.current = true;
-      const frame = requestAnimationFrame(() => scrollToSynced('auto'));
+      const target = index * itemWidth;
+      let attempts = 0;
+      let frame = requestAnimationFrame(function position() {
+        const track = trackRef.current;
+        if (pendingUserScroll.current || attempts++ > 120) return;
+        if (track && track.clientWidth > 0) {
+          if (Math.abs(track.scrollLeft - target) < 1) {
+            hasPositioned.current = true;
+            return;
+          }
+          track.scrollTo?.({ left: target, behavior: 'auto' });
+        }
+        frame = requestAnimationFrame(position);
+      });
       return () => cancelAnimationFrame(frame);
     }
 
     scrollToSynced(prefersReducedMotion() ? 'auto' : 'smooth');
   }, [itemWidth, value, values]);
 
-  const handleSettle = useCallback(() => {
-    const index = indexFromScroll();
-    if (index === null) return;
-    focus(index);
-    // A settle the user did not cause is the tail of our own scroll, or a
-    // browser-fired one at position 0 before the strip was placed. Committing
-    // either would overwrite the real value with whatever happens to be centered.
-    const userDriven = pendingUserScroll.current;
-    pendingUserScroll.current = false;
-    if (!userDriven || index === syncedIndex.current) return;
-    syncedIndex.current = index;
-    onChange(values[index]);
-  }, [focus, indexFromScroll, onChange, values]);
+  // `final` distinguishes a scrollend (the scroll is truly over) from the
+  // fallback timer, which can fire mid-fling — only a final settle may clear
+  // the gesture flags, or a fling's real landing would be treated as our own
+  // scroll and never commit.
+  const handleSettle = useCallback(
+    (final: boolean) => {
+      const index = indexFromScroll();
+      if (index === null) return;
+
+      const userDriven = pendingUserScroll.current;
+      const programmatic = programmaticScroll.current;
+      if (final) {
+        pendingUserScroll.current = false;
+        programmaticScroll.current = false;
+      }
+
+      if (index === syncedIndex.current) {
+        focus(index);
+        return;
+      }
+
+      if (userDriven) {
+        focus(index);
+        syncedIndex.current = index;
+        onChange(values[index]);
+        return;
+      }
+
+      // Mid-flight tail of our own smooth scroll — let it finish on its own.
+      if (programmatic) return;
+
+      // A settle the user did not cause, away from the synced value — e.g. a
+      // browser-fired one at position 0 before the strip was placed. Committing
+      // it would overwrite the real value, so snap back to the value instead.
+      focus(syncedIndex.current);
+      trackRef.current?.scrollTo?.({
+        left: syncedIndex.current * itemWidth,
+        behavior: 'auto',
+      });
+    },
+    [focus, indexFromScroll, itemWidth, onChange, values],
+  );
 
   useEffect(() => {
     const track = trackRef.current;
     if (!track) return;
+    const scrollEndSupported = supportsScrollEnd();
+
+    // A gesture arms the user flag, but only sticks if it actually scrolls:
+    // a tap or dead drag disarms on release, or a later programmatic scroll's
+    // settle would read as user-driven and commit whatever it landed on.
+    let scrolledSinceGesture = false;
 
     const markUserScroll = () => {
       pendingUserScroll.current = true;
+      scrolledSinceGesture = false;
+    };
+
+    const releaseGesture = () => {
+      if (!scrolledSinceGesture) pendingUserScroll.current = false;
     };
 
     const handleScroll = () => {
-      const index = indexFromScroll();
-      if (index !== null) focus(index);
-      if (supportsScrollEnd) return;
+      // Only track the finger. Focusing during our own smooth scroll re-windows
+      // the strip mid-flight, which shifts the spacers and lets scroll snap
+      // abort the animation short of the target.
+      if (pendingUserScroll.current) {
+        scrolledSinceGesture = true;
+        const index = indexFromScroll();
+        if (index !== null) focus(index);
+      }
+      if (scrollEndSupported) return;
       clearTimeout(settleTimer.current);
-      settleTimer.current = setTimeout(handleSettle, SETTLE_DELAY);
+      settleTimer.current = setTimeout(() => handleSettle(false), SETTLE_DELAY);
     };
+
+    const handleScrollEnd = () => handleSettle(true);
 
     USER_SCROLL_EVENTS.forEach((type) =>
       track.addEventListener(type, markUserScroll, { passive: true }),
     );
+    track.addEventListener('pointerup', releaseGesture, { passive: true });
+    track.addEventListener('pointercancel', releaseGesture, { passive: true });
     track.addEventListener('scroll', handleScroll, { passive: true });
-    if (supportsScrollEnd) track.addEventListener('scrollend', handleSettle);
+    if (scrollEndSupported)
+      track.addEventListener('scrollend', handleScrollEnd);
 
     return () => {
       clearTimeout(settleTimer.current);
       USER_SCROLL_EVENTS.forEach((type) =>
         track.removeEventListener(type, markUserScroll),
       );
+      track.removeEventListener('pointerup', releaseGesture);
+      track.removeEventListener('pointercancel', releaseGesture);
       track.removeEventListener('scroll', handleScroll);
-      track.removeEventListener('scrollend', handleSettle);
+      track.removeEventListener('scrollend', handleScrollEnd);
     };
   }, [focus, handleSettle, indexFromScroll]);
 


### PR DESCRIPTION
## Why

Two bugs seen on iOS, both in the shared carousel picker (`ModifyCountButtons` → `ValueCarousel` → `useSnapScrollValue`):

- The program **Starting weight** picker showed 1 kg instead of the seeded weight. Initial positioning was one-shot and marked itself done *before* the scroll ran, so a track with no layout on that frame (guaranteed under a StrictMode remount) never got placed — the strip sat on the minimum.
- The **Shared Weight** picker showed 48 while the footer said 24 kg. On browsers without `scrollend` (iOS Safari), the fallback settle timer can fire mid-fling; that premature settle consumed the user-scroll flag, so the fling's real landing was treated as the picker's own scroll and never committed — display and state drifted apart with nothing to resync them.

## What

Rework `useSnapScrollValue`: initial positioning retries every frame until the scroll actually sticks; settles distinguish final (`scrollend`) from provisional (timer) and only final ones clear the gesture flags, so flings always commit their landing; a settle nobody caused snaps the track back to the committed value instead of drifting; and a tap that never scrolls disarms the gesture flag. Also adds a port-6016 storybook entry to `.claude/launch.json` for parallel sessions.

## How to test

- `npx vitest run src/components/ValueCarousel src/components/ModifyCountButtons.test.tsx` — 24 pass, including 5 new regression tests; 4 of them fail on the old code (premature-settle fling, stray-settle snap-back, positioning retry, display drift, dead-tap disarm).
- In Storybook (`ModifyCountButtons / Kilograms`): mounts centered on the seeded 24, `+`/`−` move strip and display together, and an injected stray scroll (`track.scrollTo(0)`) snaps back with no drift and no bad commit.
- Full `npm test` / `compile:ts` failures are identical on the clean baseline — pre-existing on main, untouched here.

## Gallery

No visual changes — behavior only; the strip renders exactly as before. Worth a quick on-device check of the two affected screens (program starting weight, workout shared weight).

## Tradeoffs

Kept the existing rule that an out-of-range value (e.g. after a kg→lb switch) is left alone rather than snapped in — the snap-back only moves the track, never commits. A ResizeObserver would position slightly sooner than the rAF retry loop, but the loop also survives scroll-snap dragging the strip off a not-yet-laid-out target, which an observer wouldn't catch.