### PR TITLE
feat(workouts): use a textarea for pre-workout notes

### DIFF
--- a/src/pages/StartWorkoutPage/StartWorkoutPage.tsx
+++ b/src/pages/StartWorkoutPage/StartWorkoutPage.tsx
@@ -15,6 +15,7 @@ import { Loading, Page } from '~/components';
 import { Button } from '~/components/ui/button';
 import { Card } from '~/components/ui/card';
 import { Input } from '~/components/ui/input';
+import { Textarea } from '~/components/ui/textarea';
 import { Tabs, TabsList, TabsTrigger } from '~/components/ui/tabs';
 import { CURATED_WORKOUTS_VERSION } from '~/constants';
 import {
@@ -373,7 +374,7 @@ export const StartWorkoutPage = ({
   const [sharedWeightTwoUnit, setSharedWeightTwoUnit] =
     useState<WeightUnit | null>(workoutOptions.sharedWeightTwoUnit);
 
-  const notesRef = useRef<HTMLInputElement>(null);
+  const notesRef = useRef<HTMLTextAreaElement>(null);
 
   // Fan a set of workout options out to the builder's local state so the user
   // can review/edit before starting. Defined ahead of the gate so the nav-start
@@ -1075,12 +1076,13 @@ export const StartWorkoutPage = ({
           {preWorkoutNotes !== null && (
             <Card>
               <Section title="Pre-workout notes">
-                <Input
+                <Textarea
                   autoFocus
                   className="w-full"
                   defaultValue={preWorkoutNotes}
                   onBlur={handleBlurNotes}
                   ref={notesRef}
+                  rows={3}
                   placeholder="Goal, cues, things to keep in mind"
                 />
               </Section>


### PR DESCRIPTION
## Why

The pre-workout notes field was a single-line input, so anything longer than a short phrase scrolled out of view while writing goals and cues.

## What

Swap the notes `Input` for the shadcn `Textarea` with `rows={3}`, keeping autofocus, blur-save, and ref behavior unchanged.

## How to test

- `npm run compile:ts` — clean
- `npm test -- StartWorkoutPage` — 84 tests pass
- Toggled Notes on in the builder (dev server + Storybook) and confirmed the 3-row resizable field renders and saves on blur

## Gallery

| Before | After |
|--------|-------|
| ![before](https://github.com/user-attachments/assets/178ae729-0d7a-4e1b-a257-6573515aee93) | ![after](https://github.com/user-attachments/assets/1cf0ec47-8070-4da6-9fa9-e63f01c6e8d7) |