### PR TITLE
feat(programs): flip the auto-repeat switch optimistically

### DIFF
--- a/src/api/useSetProgramAutoRepeat.test.ts
+++ b/src/api/useSetProgramAutoRepeat.test.ts
@@ -1,0 +1,162 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { HttpResponse, http, delay } from 'msw';
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+import { QUERIES } from '~/constants';
+import { SessionProvider, ToastContext } from '~/contexts';
+import { server } from '~/mocks/server';
+
+import { VITE_SUPABASE_URL } from '../env';
+import { PROGRAM_MUTATION_ERROR_MESSAGE } from './useProgramMutationErrorHandler';
+import { ProgramProgressResult } from './useProgramProgress';
+import { useSetProgramAutoRepeat } from './useSetProgramAutoRepeat';
+
+const USER_PROGRAMS_URL = `${VITE_SUPABASE_URL}/rest/v1/user_programs`;
+
+const showToast = vi.fn();
+
+const mockSession = {
+  user: {
+    id: 'user-123',
+    app_metadata: {},
+    user_metadata: {},
+    created_at: '',
+    aud: '',
+  },
+  access_token: '',
+  refresh_token: '',
+  expires_in: 10000,
+  token_type: '',
+};
+
+const progressKey = [QUERIES.PROGRAM_PROGRESS, 'prog-1', 'user-123'];
+
+const progressEntry = {
+  enrollment: { id: 'up-1', status: 'active', autoRepeat: false },
+} as ProgramProgressResult;
+
+const makeWrapper = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  const wrapper = ({ children }: { children: React.ReactNode }) =>
+    React.createElement(
+      QueryClientProvider,
+      { client: queryClient },
+      React.createElement(
+        SessionProvider,
+        { value: mockSession },
+        React.createElement(
+          ToastContext.Provider,
+          { value: { showToast } },
+          children,
+        ),
+      ),
+    );
+  return { queryClient, wrapper };
+};
+
+describe('useSetProgramAutoRepeat', () => {
+  beforeEach(() => showToast.mockClear());
+
+  it('patches the enrollment with the new auto_repeat value', async () => {
+    let receivedBody: { auto_repeat?: boolean } = {};
+    let receivedUrl = '';
+    server.use(
+      http.patch(USER_PROGRAMS_URL, async ({ request }) => {
+        receivedBody = (await request.json()) as { auto_repeat?: boolean };
+        receivedUrl = request.url;
+        return new HttpResponse(null, { status: 204 });
+      }),
+    );
+
+    const { wrapper } = makeWrapper();
+    const { result } = renderHook(() => useSetProgramAutoRepeat(), {
+      wrapper,
+    });
+
+    await result.current.mutateAsync({ userProgramId: 'up-1', autoRepeat: true });
+
+    expect(receivedUrl).toContain('id=eq.up-1');
+    expect(receivedBody.auto_repeat).toBe(true);
+    expect(showToast).not.toHaveBeenCalled();
+  });
+
+  it('optimistically flips the cached progress enrollment before the request resolves', async () => {
+    server.use(
+      http.patch(USER_PROGRAMS_URL, async () => {
+        await delay(50);
+        return new HttpResponse(null, { status: 204 });
+      }),
+    );
+
+    const { queryClient, wrapper } = makeWrapper();
+    queryClient.setQueryData(progressKey, progressEntry);
+
+    const { result } = renderHook(() => useSetProgramAutoRepeat(), {
+      wrapper,
+    });
+
+    result.current.mutate({ userProgramId: 'up-1', autoRepeat: true });
+
+    await waitFor(() => {
+      const cached = queryClient.getQueryData<ProgramProgressResult>(progressKey);
+      expect(cached?.enrollment?.autoRepeat).toBe(true);
+    });
+    expect(result.current.isPending).toBe(true);
+  });
+
+  it('leaves other enrollments untouched', async () => {
+    server.use(
+      http.patch(USER_PROGRAMS_URL, async () => {
+        await delay(50);
+        return new HttpResponse(null, { status: 204 });
+      }),
+    );
+
+    const otherKey = [QUERIES.PROGRAM_PROGRESS, 'prog-2', 'user-123'];
+    const otherEntry = {
+      enrollment: { id: 'up-2', status: 'active', autoRepeat: false },
+    } as ProgramProgressResult;
+
+    const { queryClient, wrapper } = makeWrapper();
+    queryClient.setQueryData(otherKey, otherEntry);
+
+    const { result } = renderHook(() => useSetProgramAutoRepeat(), {
+      wrapper,
+    });
+
+    result.current.mutate({ userProgramId: 'up-1', autoRepeat: true });
+
+    await waitFor(() => expect(result.current.isPending).toBe(true));
+    expect(queryClient.getQueryData(otherKey)).toBe(otherEntry);
+  });
+
+  it('rolls back the optimistic flip and toasts on failure', async () => {
+    server.use(
+      http.patch(USER_PROGRAMS_URL, () =>
+        HttpResponse.json({ message: 'boom' }, { status: 400 }),
+      ),
+    );
+
+    const { queryClient, wrapper } = makeWrapper();
+    queryClient.setQueryData(progressKey, progressEntry);
+
+    const { result } = renderHook(() => useSetProgramAutoRepeat(), {
+      wrapper,
+    });
+
+    await expect(
+      result.current.mutateAsync({ userProgramId: 'up-1', autoRepeat: true }),
+    ).rejects.toBeTruthy();
+
+    await waitFor(() => {
+      const cached = queryClient.getQueryData<ProgramProgressResult>(progressKey);
+      expect(cached?.enrollment?.autoRepeat).toBe(false);
+    });
+    expect(showToast).toHaveBeenCalledWith(PROGRAM_MUTATION_ERROR_MESSAGE, {
+      variant: 'destructive',
+    });
+  });
+});

--- a/src/api/useSetProgramAutoRepeat.ts
+++ b/src/api/useSetProgramAutoRepeat.ts
@@ -3,6 +3,7 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { QUERIES } from '~/constants';
 
 import { supabase } from '../supabaseClient';
+import { ProgramProgressResult } from './useProgramProgress';
 import { useProgramMutationErrorHandler } from './useProgramMutationErrorHandler';
 
 export interface SetProgramAutoRepeatInput {
@@ -20,7 +21,7 @@ export interface SetProgramAutoRepeatInput {
  */
 export const useSetProgramAutoRepeat = () => {
   const queryClient = useQueryClient();
-  const onError = useProgramMutationErrorHandler();
+  const handleError = useProgramMutationErrorHandler();
 
   return useMutation({
     mutationFn: async (input: SetProgramAutoRepeatInput): Promise<void> => {
@@ -30,11 +31,34 @@ export const useSetProgramAutoRepeat = () => {
         .eq('id', input.userProgramId);
       if (error) throw error;
     },
-    onSuccess: () => {
+    // Flip the cached progress entry immediately so the Switch doesn't wait on
+    // a refetch; roll back from the snapshot if the update fails.
+    onMutate: async ({ userProgramId, autoRepeat }) => {
+      await queryClient.cancelQueries({
+        queryKey: [QUERIES.PROGRAM_PROGRESS],
+      });
+      const snapshot = queryClient.getQueriesData<ProgramProgressResult>({
+        queryKey: [QUERIES.PROGRAM_PROGRESS],
+      });
+      queryClient.setQueriesData<ProgramProgressResult>(
+        { queryKey: [QUERIES.PROGRAM_PROGRESS] },
+        (data) =>
+          data?.enrollment?.id === userProgramId
+            ? { ...data, enrollment: { ...data.enrollment, autoRepeat } }
+            : data,
+      );
+      return { snapshot };
+    },
+    onError: (error, _input, context) => {
+      context?.snapshot.forEach(([queryKey, data]) => {
+        queryClient.setQueryData(queryKey, data);
+      });
+      handleError(error);
+    },
+    onSettled: () => {
       queryClient.invalidateQueries({ queryKey: [QUERIES.ACTIVE_PROGRAM] });
       queryClient.invalidateQueries({ queryKey: [QUERIES.PROGRAM_PROGRESS] });
       queryClient.invalidateQueries({ queryKey: [QUERIES.PROGRAMS] });
     },
-    onError,
   });
 };

--- a/src/pages/ProgramProgressPage/ProgramProgressPage.test.tsx
+++ b/src/pages/ProgramProgressPage/ProgramProgressPage.test.tsx
@@ -5,13 +5,14 @@ import { vi } from 'vitest';
 
 import { ProgramProgressPage } from './ProgramProgressPage';
 
-const { mockUseProgramProgress } = vi.hoisted(() => ({
+const { mockUseProgramProgress, mockSetAutoRepeat } = vi.hoisted(() => ({
   mockUseProgramProgress: vi.fn(),
+  mockSetAutoRepeat: { mutate: vi.fn(), isPending: false },
 }));
 
 vi.mock('~/api', () => ({
   useProgramProgress: mockUseProgramProgress,
-  useSetProgramAutoRepeat: () => ({ mutate: vi.fn(), isPending: false }),
+  useSetProgramAutoRepeat: () => mockSetAutoRepeat,
 }));
 
 const session = (seq: number, week: number, day: number, title: string) => ({
@@ -27,7 +28,7 @@ const session = (seq: number, week: number, day: number, title: string) => ({
 
 const progressData = {
   program: { id: 'prog-1', title: 'Dry Fighting Weight', numWeeks: 2 },
-  enrollment: { id: 'up-1', status: 'active' },
+  enrollment: { id: 'up-1', status: 'active', autoRepeat: false },
   weeks: [
     {
       weekNumber: 1,
@@ -92,6 +93,8 @@ const renderPage = () =>
 describe('ProgramProgressPage', () => {
   beforeEach(() => {
     mockUseProgramProgress.mockReset();
+    mockSetAutoRepeat.mutate.mockReset();
+    mockSetAutoRepeat.isPending = false;
   });
 
   it('renders the summary, week groups, and session states', () => {
@@ -216,6 +219,56 @@ describe('ProgramProgressPage', () => {
     renderPage();
 
     expect(screen.getByText('🎉 Program complete')).toBeInTheDocument();
+  });
+
+  it('toggles auto-repeat on the enrollment via the switch', async () => {
+    const user = userEvent.setup();
+    mockUseProgramProgress.mockReturnValue({
+      data: progressData,
+      isLoading: false,
+      isError: false,
+    });
+
+    renderPage();
+
+    const toggle = screen.getByRole('switch', {
+      name: 'Repeat automatically when finished',
+    });
+    expect(toggle).not.toBeChecked();
+
+    await user.click(toggle);
+
+    expect(mockSetAutoRepeat.mutate).toHaveBeenCalledWith({
+      userProgramId: 'up-1',
+      autoRepeat: true,
+    });
+  });
+
+  it('shows the repeating summary and disables the switch while saving', () => {
+    mockSetAutoRepeat.isPending = true;
+    mockUseProgramProgress.mockReturnValue({
+      data: {
+        ...progressData,
+        enrollment: {
+          id: 'up-1',
+          status: 'active',
+          autoRepeat: true,
+          cyclesCompleted: 2,
+        },
+      },
+      isLoading: false,
+      isError: false,
+    });
+
+    renderPage();
+
+    expect(screen.getByText('Repeating workout')).toBeInTheDocument();
+    expect(screen.getByText('2 cycles done')).toBeInTheDocument();
+    expect(
+      screen.getByRole('switch', {
+        name: 'Repeat automatically when finished',
+      }),
+    ).toBeDisabled();
   });
 
   it('renders a not-found state on error', () => {


### PR DESCRIPTION
## Why

The in-progress auto-repeat toggle on ProgramProgressPage only flipped after the mutation round-tripped and the progress query refetched, so the Switch felt dead for a beat after tapping it. The hook also had no unit test, and the page test never touched the toggle or the repeating-summary branch.

## What

`useSetProgramAutoRepeat` now flips the cached progress enrollment optimistically in `onMutate`, rolls back from a snapshot on error, and re-syncs via `onSettled` invalidations. Adds a unit test for the hook and page-test coverage for the toggle.

## How to test

- `npm test -- useSetProgramAutoRepeat ProgramProgressPage` — 13 passing. New cases: PATCH payload and `id=eq.` filter, optimistic flip lands while the request is still pending, unrelated enrollments untouched, 400 rolls back and toasts; page tests cover the Switch calling the mutation, the "Repeating workout / N cycles done" summary, and the disabled-while-pending state.
- `npm run compile:ts` and `npm run lint` clean.

## Tradeoffs

Only the `programProgress` cache is patched optimistically; `activeProgram` and `programs` caches still wait for the `onSettled` invalidation, since nothing user-visible reads repeat from them on this screen.