### PR TITLE
feat(programs): apply session edits to all future sessions

### DIFF
--- a/docs/program-tracking.md
+++ b/docs/program-tracking.md
@@ -115,6 +115,17 @@ session — atomic), and the PROD-219 editing pair `reorder_program_sessions` /
   rewriting title + `workout_options` only — sequence/week/day and the session id
   are untouched, so completions keep pointing at it). The add-mode session list
   gains a per-session **Edit** button (owner-gated, alongside Reorder/Delete).
+- **Apply-forward session edit:** saving an edit when later sessions exist asks
+  "This session only" vs "This and all future sessions". The forward path
+  (`useUpdateProgramSessionsForward`) rewrites the edited row in full, then the
+  `update_program_sessions_forward` RPC jsonb-merges only the movement
+  prescription — `movements`, `sharedWeightOne/Two` value+unit, `complexSet` —
+  into every later session of the program the caller hasn't completed (no
+  completion row via any of their enrollments), so each later session keeps its
+  own title, notes, goal, duration, and rest settings and completed sessions
+  are never rewritten. This deliberately overwrites per-session weight offsets
+  on future sessions with the edited session's weights; `adjust_program_weights`
+  is the offset-preserving counterpart for weight-only changes.
 - **Program CRUD (PROD-237, owned programs only):** `ProgramsPage`'s "My programs"
   surface adds three actions. **Cancel** = `useCancelProgram` flips the active
   enrollment to `abandoned` (reusing the existing status — no new value), freeing

--- a/e2e/program-update-forward.spec.ts
+++ b/e2e/program-update-forward.spec.ts
@@ -1,0 +1,258 @@
+import { expect, test } from '@playwright/test';
+
+// update_program_sessions_forward backend behavior, hit directly against local
+// Supabase (auth + REST/RPC helpers mirror program-in-program-flow.spec.ts).
+// The RPC is the "this and all future sessions" half of the session-edit save:
+// the client rewrites the edited session in full, then the RPC jsonb-merges
+// only the movement prescription (movements, shared weights, complexSet) into
+// every LATER session the caller hasn't completed — each later session keeps
+// its own title, goal, and other workout_options keys, and completed sessions
+// are never touched.
+
+const SUPABASE_URL = process.env.VITE_SUPABASE_URL!;
+const SUPABASE_ANON_KEY = process.env.VITE_SUPABASE_ANON_KEY!;
+const DFW_SLUG = 'dry-fighting-weight';
+
+interface TestUser {
+  token: string;
+  uid: string;
+  email: string;
+}
+
+async function signUpThrowawayUser(): Promise<TestUser> {
+  const email = `progforward-${Date.now()}-${Math.floor(Math.random() * 1e9)}@example.com`;
+  const password = 'testpassword123';
+
+  const res = await fetch(`${SUPABASE_URL}/auth/v1/signup`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', apikey: SUPABASE_ANON_KEY },
+    body: JSON.stringify({ email, password }),
+  });
+  if (!res.ok)
+    throw new Error(`signup failed (${res.status}): ${await res.text()}`);
+
+  const body = (await res.json()) as {
+    access_token?: string;
+    user?: { id: string };
+  };
+  if (body.access_token && body.user) {
+    return { token: body.access_token, uid: body.user.id, email };
+  }
+  throw new Error('signup did not return a session');
+}
+
+interface RestOptions {
+  body?: unknown;
+  prefer?: string;
+}
+
+async function restJson<T = unknown>(
+  method: string,
+  path: string,
+  token: string,
+  opts: RestOptions = {},
+): Promise<T> {
+  const headers: Record<string, string> = {
+    apikey: SUPABASE_ANON_KEY,
+    Authorization: `Bearer ${token}`,
+  };
+  if (opts.body !== undefined) headers['Content-Type'] = 'application/json';
+  if (opts.prefer) headers['Prefer'] = opts.prefer;
+  const res = await fetch(`${SUPABASE_URL}/rest/v1/${path}`, {
+    method,
+    headers,
+    body: opts.body !== undefined ? JSON.stringify(opts.body) : undefined,
+  });
+  if (!res.ok) {
+    throw new Error(
+      `${method} ${path} failed (${res.status}): ${await res.text()}`,
+    );
+  }
+  return res.json() as Promise<T>;
+}
+
+async function rpcRaw(
+  fn: string,
+  token: string,
+  args: Record<string, unknown>,
+): Promise<Response> {
+  return fetch(`${SUPABASE_URL}/rest/v1/rpc/${fn}`, {
+    method: 'POST',
+    headers: {
+      apikey: SUPABASE_ANON_KEY,
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(args),
+  });
+}
+
+async function rpc<T = unknown>(
+  fn: string,
+  token: string,
+  args: Record<string, unknown>,
+): Promise<T> {
+  const res = await rpcRaw(fn, token, args);
+  if (!res.ok)
+    throw new Error(`rpc ${fn} failed (${res.status}): ${await res.text()}`);
+  return res.json() as Promise<T>;
+}
+
+interface SessionRow {
+  id: string;
+  sequence_index: number;
+  title: string;
+  workout_options: {
+    complexSet: boolean;
+    movements: Array<{ movementName: string; [key: string]: unknown }>;
+    workoutGoal?: number;
+    [key: string]: unknown;
+  };
+}
+
+async function orderedSessions(
+  token: string,
+  programId: string,
+): Promise<SessionRow[]> {
+  return restJson<SessionRow[]>(
+    'GET',
+    `program_sessions?program_id=eq.${programId}&select=id,sequence_index,title,workout_options&order=sequence_index.asc`,
+    token,
+  );
+}
+
+async function enrollInDfw(
+  user: TestUser,
+): Promise<{ userProgramId: string; cloneId: string }> {
+  const [dfw] = await restJson<Array<{ id: string }>>(
+    'GET',
+    `programs?slug=eq.${DFW_SLUG}&select=id`,
+    user.token,
+  );
+  const userProgramId = await rpc<string>('enroll_in_program', user.token, {
+    p_program_id: dfw.id,
+  });
+  const [enrollment] = await restJson<Array<{ program_id: string }>>(
+    'GET',
+    `user_programs?id=eq.${userProgramId}&select=program_id`,
+    user.token,
+  );
+  return { userProgramId, cloneId: enrollment.program_id };
+}
+
+async function completeSession(
+  user: TestUser,
+  userProgramId: string,
+  programSessionId: string,
+): Promise<void> {
+  const [log] = await restJson<Array<{ id: number }>>(
+    'POST',
+    'workout_logs',
+    user.token,
+    {
+      prefer: 'return=representation',
+      body: {
+        user_id: user.uid,
+        started_at: new Date().toISOString(),
+        movements: ['Clean and Press'],
+        completed_reps: 10,
+        completed_rounds: 1,
+        completed_rungs: 1,
+        workout_goal: 30,
+      },
+    },
+  );
+  await rpc('complete_program_session', user.token, {
+    p_user_program_id: userProgramId,
+    p_program_session_id: programSessionId,
+    p_workout_log_id: log.id,
+  });
+}
+
+// The propagated slice the client sends: a new movement prescription.
+const NEW_MOVEMENTS = [
+  {
+    movementName: 'Clean, Jerk, and Clean',
+    repScheme: [5],
+    weightOneValue: 24,
+    weightOneUnit: 'kilograms',
+    weightTwoValue: null,
+    weightTwoUnit: null,
+  },
+];
+const FORWARD_OPTIONS = {
+  movements: NEW_MOVEMENTS,
+  sharedWeightOneValue: 24,
+  sharedWeightOneUnit: 'kilograms',
+  sharedWeightTwoValue: null,
+  sharedWeightTwoUnit: null,
+  complexSet: false,
+};
+
+test.describe('update_program_sessions_forward', () => {
+  test('rewrites later incomplete sessions only, preserving their own titles and goals', async () => {
+    const user = await signUpThrowawayUser();
+    const { userProgramId, cloneId } = await enrollInDfw(user);
+    const before = await orderedSessions(user.token, cloneId);
+    expect(before.length).toBeGreaterThan(3);
+
+    // Session 0 completed; session 3 completed out of order (stays untouched).
+    await completeSession(user, userProgramId, before[0].id);
+    await completeSession(user, userProgramId, before[3].id);
+
+    // Editing session 1 forward.
+    const updated = await rpc<number>(
+      'update_program_sessions_forward',
+      user.token,
+      { p_session_id: before[1].id, p_forward_options: FORWARD_OPTIONS },
+    );
+    // Every session after index 1 except the completed one at index 3.
+    expect(updated).toBe(before.length - 3);
+
+    const after = await orderedSessions(user.token, cloneId);
+    for (const [i, session] of after.entries()) {
+      const original = before[i];
+      // Titles and non-propagated options always survive.
+      expect(session.title).toBe(original.title);
+      expect(session.workout_options.workoutGoal).toEqual(
+        original.workout_options.workoutGoal,
+      );
+
+      const untouched = i <= 1 || i === 3;
+      const expectedMovements = untouched
+        ? original.workout_options.movements
+        : NEW_MOVEMENTS;
+      expect(session.workout_options.movements).toEqual(expectedMovements);
+      if (!untouched) {
+        expect(session.workout_options.sharedWeightOneValue).toBe(24);
+        expect(session.workout_options.complexSet).toBe(false);
+      }
+    }
+  });
+
+  test('rejects a caller who does not own the program', async () => {
+    const owner = await signUpThrowawayUser();
+    const { cloneId } = await enrollInDfw(owner);
+    const [first] = await orderedSessions(owner.token, cloneId);
+
+    const stranger = await signUpThrowawayUser();
+    const res = await rpcRaw('update_program_sessions_forward', stranger.token, {
+      p_session_id: first.id,
+      p_forward_options: FORWARD_OPTIONS,
+    });
+    // The stranger can't even see the clone (RLS), so the session lookup fails.
+    expect(res.ok).toBe(false);
+  });
+
+  test('rejects empty options', async () => {
+    const user = await signUpThrowawayUser();
+    const { cloneId } = await enrollInDfw(user);
+    const [first] = await orderedSessions(user.token, cloneId);
+
+    const res = await rpcRaw('update_program_sessions_forward', user.token, {
+      p_session_id: first.id,
+      p_forward_options: {},
+    });
+    expect(res.ok).toBe(false);
+  });
+});

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -28,6 +28,7 @@ export * from './useSaveProgramSession';
 export * from './useSetProgramArchived';
 export * from './useSetProgramAutoRepeat';
 export * from './useUpdateProgramSession';
+export * from './useUpdateProgramSessionsForward';
 export * from './useRecentRepeatableWorkouts';
 export * from './useRecommendSession';
 export * from './useSelectRPE';

--- a/src/api/useUpdateProgramSessionsForward.ts
+++ b/src/api/useUpdateProgramSessionsForward.ts
@@ -1,0 +1,77 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { QUERIES } from '~/constants';
+import { WorkoutOptions } from '~/types';
+
+import type { Json } from '../../types/supabase';
+import { supabase } from '../supabaseClient';
+import { useProgramMutationErrorHandler } from './useProgramMutationErrorHandler';
+
+export interface UpdateProgramSessionsForwardInput {
+  sessionId: string;
+  /** The owning program — used to invalidate its cached fetch on success. */
+  programId: string;
+  title: string;
+  workoutOptions: Omit<WorkoutOptions, 'startedAt'>;
+}
+
+/**
+ * "This and all future sessions": rewrites the edited session in full (same as
+ * useUpdateProgramSession), then propagates only its movement prescription —
+ * movements, shared weights, complexSet — onto every later not-yet-completed
+ * session via the `update_program_sessions_forward` RPC. Each later session
+ * keeps its own title, notes, goal, duration, and rest settings.
+ *
+ * Returns the number of later sessions rewritten.
+ */
+export const useUpdateProgramSessionsForward = () => {
+  const queryClient = useQueryClient();
+  const onError = useProgramMutationErrorHandler();
+
+  return useMutation({
+    mutationFn: async (
+      input: UpdateProgramSessionsForwardInput,
+    ): Promise<number> => {
+      const { error: updateError } = await supabase
+        .from('program_sessions')
+        .update({
+          title: input.title,
+          workout_options: input.workoutOptions as unknown as Json,
+        })
+        .eq('id', input.sessionId);
+      if (updateError) throw updateError;
+
+      const { movements, ...options } = input.workoutOptions;
+      const forwardOptions = {
+        movements,
+        sharedWeightOneValue: options.sharedWeightOneValue,
+        sharedWeightOneUnit: options.sharedWeightOneUnit,
+        sharedWeightTwoValue: options.sharedWeightTwoValue,
+        sharedWeightTwoUnit: options.sharedWeightTwoUnit,
+        complexSet: options.complexSet,
+      };
+
+      const { data, error } = await supabase.rpc(
+        'update_program_sessions_forward',
+        {
+          p_session_id: input.sessionId,
+          // Cast: the generated RPC arg is `Json`, which a typed interface
+          // can't satisfy structurally (no index signature). The shape is
+          // asserted by the forward-apply e2e cases.
+          p_forward_options: forwardOptions as unknown as Json,
+        },
+      );
+      if (error) throw error;
+      return data as number;
+    },
+    onSuccess: (_data, variables) => {
+      queryClient.invalidateQueries({
+        queryKey: [QUERIES.PROGRAM, variables.programId],
+      });
+      queryClient.invalidateQueries({ queryKey: [QUERIES.PROGRAMS] });
+      queryClient.invalidateQueries({ queryKey: [QUERIES.ACTIVE_PROGRAM] });
+      queryClient.invalidateQueries({ queryKey: [QUERIES.PROGRAM_PROGRESS] });
+    },
+    onError,
+  });
+};

--- a/src/pages/ProgramSessionBuilderPage/ProgramSessionBuilderPage.test.tsx
+++ b/src/pages/ProgramSessionBuilderPage/ProgramSessionBuilderPage.test.tsx
@@ -12,7 +12,9 @@ const {
   mockUseDuplicateProgramSession,
   mockUseDuplicateProgramWeek,
   mockUseReorderProgramSessions,
+  mockUseUpdateProgramSessionsForward,
   updateMutate,
+  updateForwardMutate,
 } = vi.hoisted(() => ({
   mockUseProgram: vi.fn(),
   mockUseSaveProgramSession: vi.fn(),
@@ -21,7 +23,9 @@ const {
   mockUseDuplicateProgramSession: vi.fn(),
   mockUseDuplicateProgramWeek: vi.fn(),
   mockUseReorderProgramSessions: vi.fn(),
+  mockUseUpdateProgramSessionsForward: vi.fn(),
   updateMutate: vi.fn(),
+  updateForwardMutate: vi.fn(),
 }));
 
 vi.mock('~/api', () => ({
@@ -32,6 +36,7 @@ vi.mock('~/api', () => ({
   useDuplicateProgramSession: mockUseDuplicateProgramSession,
   useDuplicateProgramWeek: mockUseDuplicateProgramWeek,
   useReorderProgramSessions: mockUseReorderProgramSessions,
+  useUpdateProgramSessionsForward: mockUseUpdateProgramSessionsForward,
 }));
 
 vi.mock('~/contexts', async () => {
@@ -40,6 +45,7 @@ vi.mock('~/contexts', async () => {
   return {
     ...actual,
     useSession: () => ({ user: { id: 'owner-1' } }),
+    useToast: () => ({ showToast: vi.fn() }),
   };
 });
 
@@ -144,6 +150,11 @@ describe('ProgramSessionBuilderPage', () => {
     mockUseDuplicateProgramSession.mockReturnValue(idleMutation());
     mockUseDuplicateProgramWeek.mockReturnValue(idleMutation());
     mockUseReorderProgramSessions.mockReturnValue(idleMutation());
+    updateForwardMutate.mockReset();
+    mockUseUpdateProgramSessionsForward.mockReturnValue({
+      mutate: updateForwardMutate,
+      isPending: false,
+    });
   });
 
   it('offers an Edit control per session in add mode', () => {
@@ -173,6 +184,83 @@ describe('ProgramSessionBuilderPage', () => {
       },
       expect.anything(),
     );
+  });
+
+  describe('with later sessions in the program', () => {
+    const laterSession = {
+      ...session,
+      id: 's-2',
+      sequenceIndex: 1,
+      dayNumber: 2,
+      title: 'Ladders 1-2-3-4',
+    };
+
+    beforeEach(() => {
+      mockUseProgram.mockReturnValue({
+        data: { program: ownedProgram, sessions: [session, laterSession] },
+        isLoading: false,
+        isError: false,
+      });
+    });
+
+    it('asks whether to apply the edit forward instead of saving directly', () => {
+      renderAt('/programs/p-1/sessions/s-1/edit');
+
+      fireEvent.click(screen.getByRole('button', { name: 'stub-save' }));
+
+      expect(updateMutate).not.toHaveBeenCalled();
+      expect(screen.getByText('Apply changes to…')).toBeInTheDocument();
+    });
+
+    it('saves only the edited session when "This session only" is chosen', () => {
+      renderAt('/programs/p-1/sessions/s-1/edit');
+
+      fireEvent.click(screen.getByRole('button', { name: 'stub-save' }));
+      fireEvent.click(
+        screen.getByRole('button', { name: 'This session only' }),
+      );
+
+      expect(updateForwardMutate).not.toHaveBeenCalled();
+      expect(updateMutate).toHaveBeenCalledWith(
+        {
+          sessionId: 's-1',
+          programId: 'p-1',
+          title: 'Edited title',
+          workoutOptions: { opt: true },
+        },
+        expect.anything(),
+      );
+    });
+
+    it('applies forward when "This and all future sessions" is chosen', () => {
+      renderAt('/programs/p-1/sessions/s-1/edit');
+
+      fireEvent.click(screen.getByRole('button', { name: 'stub-save' }));
+      fireEvent.click(
+        screen.getByRole('button', { name: 'This and all future sessions' }),
+      );
+
+      expect(updateMutate).not.toHaveBeenCalled();
+      expect(updateForwardMutate).toHaveBeenCalledWith(
+        {
+          sessionId: 's-1',
+          programId: 'p-1',
+          title: 'Edited title',
+          workoutOptions: { opt: true },
+        },
+        expect.anything(),
+      );
+    });
+
+    it('saves the last session directly without asking', () => {
+      renderAt('/programs/p-1/sessions/s-2/edit');
+
+      fireEvent.click(screen.getByRole('button', { name: 'stub-save' }));
+
+      expect(screen.queryByText('Apply changes to…')).not.toBeInTheDocument();
+      expect(updateMutate).toHaveBeenCalled();
+      expect(updateForwardMutate).not.toHaveBeenCalled();
+    });
   });
 
   it('blocks editing a session that does not exist', () => {

--- a/src/pages/ProgramSessionBuilderPage/ProgramSessionBuilderPage.tsx
+++ b/src/pages/ProgramSessionBuilderPage/ProgramSessionBuilderPage.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import { Link, useNavigate, useParams } from 'react-router-dom';
 
 import {
@@ -8,11 +9,20 @@ import {
   useReorderProgramSessions,
   useSaveProgramSession,
   useUpdateProgramSession,
+  useUpdateProgramSessionsForward,
 } from '~/api';
 import { Page } from '~/components';
 import { Button } from '~/components/ui/button';
 import { Card, CardContent } from '~/components/ui/card';
-import { useSession } from '~/contexts';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '~/components/ui/dialog';
+import { useSession, useToast } from '~/contexts';
 import { ProgramSession, WorkoutOptions } from '~/types';
 
 import { StartWorkoutPage } from '../StartWorkoutPage';
@@ -43,9 +53,18 @@ export const ProgramSessionBuilderPage = () => {
   const { id, sessionId } = useParams<{ id: string; sessionId?: string }>();
   const navigate = useNavigate();
   const session = useSession();
+  const { showToast } = useToast();
   const { data, isLoading, isError } = useProgram(id);
   const saveSession = useSaveProgramSession();
   const updateSession = useUpdateProgramSession();
+  const updateForward = useUpdateProgramSessionsForward();
+
+  // Edit save stashed while the "this session only vs all future" choice
+  // dialog is open.
+  const [pendingSave, setPendingSave] = useState<{
+    options: Omit<WorkoutOptions, 'startedAt'>;
+    title: string;
+  } | null>(null);
   const duplicateSession = useDuplicateProgramSession();
   const duplicateWeek = useDuplicateProgramWeek();
   const reorderSessions = useReorderProgramSessions();
@@ -167,7 +186,11 @@ export const ProgramSessionBuilderPage = () => {
       );
     }
 
-    const handleUpdate = (
+    const laterSessionCount = sessions.filter(
+      (s) => s.sequenceIndex > editingSession.sequenceIndex,
+    ).length;
+
+    const updateThisSessionOnly = (
       options: Omit<WorkoutOptions, 'startedAt'>,
       title: string,
     ) => {
@@ -182,30 +205,114 @@ export const ProgramSessionBuilderPage = () => {
       );
     };
 
-    return (
-      <StartWorkoutPage
-        key={`edit-${editingSession.id}`}
-        programSaveMode={{
-          onSave: handleUpdate,
-          saving: updateSession.isPending,
-          initialSession: {
-            workoutOptions: editingSession.workoutOptions,
-            title: editingSession.title,
+    const updateThisAndFutureSessions = (
+      options: Omit<WorkoutOptions, 'startedAt'>,
+      title: string,
+    ) => {
+      updateForward.mutate(
+        {
+          sessionId: editingSession.id,
+          programId: program.id,
+          title: title || editingSession.title,
+          workoutOptions: options,
+        },
+        {
+          onSuccess: (updatedCount) => {
+            showToast(
+              updatedCount === 1
+                ? 'Updated 1 upcoming session'
+                : `Updated ${updatedCount} upcoming sessions`,
+            );
+            backToBuilder();
           },
-          beforeBuilder: (
-            <>
-              <button
-                type="button"
-                onClick={backToBuilder}
-                className="self-start text-xs font-medium text-muted-foreground"
+        },
+      );
+    };
+
+    // With later sessions, saving asks whether the movement change should
+    // carry forward; on the last session there's nothing ahead, so save
+    // directly.
+    const handleUpdate = (
+      options: Omit<WorkoutOptions, 'startedAt'>,
+      title: string,
+    ) => {
+      if (laterSessionCount > 0) setPendingSave({ options, title });
+      else updateThisSessionOnly(options, title);
+    };
+
+    const saving = updateSession.isPending || updateForward.isPending;
+
+    return (
+      <>
+        <Dialog
+          open={pendingSave !== null}
+          onOpenChange={(open) => {
+            if (!open && !saving) setPendingSave(null);
+          }}
+        >
+          <DialogContent>
+            <DialogHeader>
+              <DialogTitle>Apply changes to…</DialogTitle>
+              <DialogDescription>
+                Carry this session&apos;s movements and weights into the rest
+                of the program, or change just this session. Later sessions
+                keep their own titles, goals, and rep schemes; completed
+                sessions are never changed.
+              </DialogDescription>
+            </DialogHeader>
+            <DialogFooter className="flex-col gap-1 sm:flex-col">
+              <Button
+                disabled={saving}
+                onClick={() => {
+                  if (pendingSave)
+                    updateThisAndFutureSessions(
+                      pendingSave.options,
+                      pendingSave.title,
+                    );
+                }}
               >
-                ← Sessions
-              </button>
-              <div className="text-xl font-semibold">Edit session</div>
-            </>
-          ),
-        }}
-      />
+                This and all future sessions
+              </Button>
+              <Button
+                variant="secondary"
+                disabled={saving}
+                onClick={() => {
+                  if (pendingSave)
+                    updateThisSessionOnly(
+                      pendingSave.options,
+                      pendingSave.title,
+                    );
+                }}
+              >
+                This session only
+              </Button>
+            </DialogFooter>
+          </DialogContent>
+        </Dialog>
+        <StartWorkoutPage
+          key={`edit-${editingSession.id}`}
+          programSaveMode={{
+            onSave: handleUpdate,
+            saving,
+            initialSession: {
+              workoutOptions: editingSession.workoutOptions,
+              title: editingSession.title,
+            },
+            beforeBuilder: (
+              <>
+                <button
+                  type="button"
+                  onClick={backToBuilder}
+                  className="self-start text-xs font-medium text-muted-foreground"
+                >
+                  ← Sessions
+                </button>
+                <div className="text-xl font-semibold">Edit session</div>
+              </>
+            ),
+          }}
+        />
+      </>
     );
   }
 

--- a/supabase/migrations/20260728110000_update_program_sessions_forward.sql
+++ b/supabase/migrations/20260728110000_update_program_sessions_forward.sql
@@ -1,0 +1,80 @@
+-- Program Tracking: apply an edited session's movements to all later sessions.
+--
+-- Session editing rewrites one program_sessions row in place
+-- (useUpdateProgramSession), but a lifter mid-program who changes a movement —
+-- e.g. C+J to C+J+C in A+A Plan A — wants every UPCOMING session to carry the
+-- change without restarting the program. Enrollment clones the program
+-- (enroll_in_program), so the caller owns every affected row.
+--
+-- Scope and semantics:
+--   * Targets sessions of the same program with sequence_index > the edited
+--     session's, skipping any the caller has already completed (a
+--     program_session_completions row via one of their enrollments) — same
+--     never-touch-completed rule as adjust_program_weights.
+--   * p_forward_options is jsonb-merged (||) into each session's
+--     workout_options. The client sends only the "what you do" keys
+--     (movements, sharedWeightOne/Two value+unit, complexSet), so each future
+--     session keeps its own title, notes, goal, duration, and rest settings —
+--     authored periodization survives the swap.
+--
+-- SECURITY INVOKER (house default): the UPDATE is additionally gated by the
+-- caller's own "... update sessions of own programs" RLS policy; ownership is
+-- also checked explicitly for a clear error instead of a silent 0-row update.
+--
+-- Returns the number of later sessions rewritten.
+CREATE FUNCTION public.update_program_sessions_forward(
+  p_session_id      UUID,
+  p_forward_options JSONB
+)
+RETURNS INTEGER
+LANGUAGE plpgsql
+SECURITY INVOKER
+SET search_path = public
+AS $$
+DECLARE
+  v_user_id    UUID := auth.uid();
+  v_program_id UUID;
+  v_seq        INT;
+  v_owner_id   UUID;
+  v_updated    INT;
+BEGIN
+  IF v_user_id IS NULL THEN
+    RAISE EXCEPTION 'Not authenticated';
+  END IF;
+
+  IF p_forward_options IS NULL OR p_forward_options = '{}'::jsonb THEN
+    RAISE EXCEPTION 'No options provided';
+  END IF;
+
+  SELECT ps.program_id, ps.sequence_index, p.owner_id
+    INTO v_program_id, v_seq, v_owner_id
+  FROM program_sessions ps
+  JOIN programs p ON p.id = ps.program_id
+  WHERE ps.id = p_session_id;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Program session % not found or not accessible', p_session_id;
+  END IF;
+
+  IF v_owner_id IS DISTINCT FROM v_user_id THEN
+    RAISE EXCEPTION 'Not permitted to update sessions of this program (not owner)';
+  END IF;
+
+  UPDATE program_sessions ps
+  SET workout_options = ps.workout_options || p_forward_options
+  WHERE ps.program_id = v_program_id
+    AND ps.sequence_index > v_seq
+    AND NOT EXISTS (
+      SELECT 1
+      FROM program_session_completions c
+      JOIN user_programs up ON up.id = c.user_program_id
+      WHERE c.program_session_id = ps.id
+        AND up.user_id = v_user_id
+    );
+
+  GET DIAGNOSTICS v_updated = ROW_COUNT;
+  RETURN v_updated;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.update_program_sessions_forward(UUID, JSONB) FROM public;
+GRANT EXECUTE ON FUNCTION public.update_program_sessions_forward(UUID, JSONB) TO authenticated;

--- a/types/supabase.ts
+++ b/types/supabase.ts
@@ -825,6 +825,10 @@ export type Database = {
         Args: { p_replace_user_program_id?: string; p_user_program_id: string }
         Returns: string
       }
+      update_program_sessions_forward: {
+        Args: { p_forward_options: Json; p_session_id: string }
+        Returns: number
+      }
     }
     Enums: {
       RPE: "noEffort" | "easy" | "ideal" | "hard" | "maxEffort"


### PR DESCRIPTION
## What

Saving an edit to a program session that has later sessions now asks "This session only" or "This and all future sessions" — the forward choice carries the edited movement prescription into every upcoming session, so a lifter can swap C+J for C+J+C mid-program without restarting.

## Why

Enrollment clones the program once, so a movement change today means cancelling and re-enrolling — losing all progress. This is the movement-prescription counterpart to #189's `adjust_program_weights`: same forward-only, never-touch-completed scoping.

## How

- New `update_program_sessions_forward` RPC (SECURITY INVOKER, owner-gated): jsonb-merges only `movements`, `sharedWeightOne/Two` value+unit, and `complexSet` into later sessions the caller hasn't completed. Each future session keeps its own title, notes, goal, and rep scheme, so authored periodization survives.
- `useUpdateProgramSessionsForward` rewrites the edited row in full, then calls the RPC; the builder's edit save opens a choice dialog when later sessions exist (last-session edits save directly, as before).
- Deliberately overwrites per-session weight offsets on future sessions with the edited session's weights — #189's Adjust Weights remains the offset-preserving tool for weight-only changes.

## How tested

- `npm test` (571 passing, incl. 4 new dialog/save-path tests), `npm run compile:ts`, `npm run lint`.
- New `e2e/program-update-forward.spec.ts` against local Supabase: forward apply skips completed sessions (including out-of-order completions) and preserves titles/goals; rejects non-owners and empty options.
- Manually: enrolled in A+A Plan A, completed session 1, edited the C+J session, applied forward — "Updated 6 upcoming sessions".

## Gallery

Save choice dialog | After applying forward
--- | ---
![apply-dialog](https://github.com/user-attachments/assets/25aec1b8-3845-4359-aca5-44630dee7a7f) | ![after-forward](https://github.com/user-attachments/assets/0d339c7a-4eb5-4578-af53-6b44e6635b9a)
