### PR TITLE
fix(workouts): use the shared weight for complex-set volume

### DIFF
--- a/src/pages/StartWorkoutPage/StartWorkoutPage.test.jsx
+++ b/src/pages/StartWorkoutPage/StartWorkoutPage.test.jsx
@@ -675,6 +675,24 @@ describe('Complex Mode', () => {
     );
   });
 
+  test('propagates an edited shared weight onto every movement at start', async () => {
+    await userEvent.click(screen.getByRole('button', { name: 'Complex, off' }));
+    await userEvent.type(screen.getByLabelText('Movement Input'), 'Clean');
+    await userEvent.click(screen.getByLabelText('+ kg'));
+    await userEvent.click(screen.getByRole('button', { name: /Start/i }));
+
+    const options = startWorkout.mock.calls[0][0];
+    expect(options.sharedWeightOneValue).not.toBe(
+      DEFAULT_MOVEMENT_OPTIONS.weightOneValue,
+    );
+    options.movements.forEach((movement) => {
+      expect(movement.weightOneValue).toBe(options.sharedWeightOneValue);
+      expect(movement.weightOneUnit).toBe(options.sharedWeightOneUnit);
+      expect(movement.weightTwoValue).toBe(options.sharedWeightTwoValue);
+      expect(movement.weightTwoUnit).toBe(options.sharedWeightTwoUnit);
+    });
+  });
+
   test('complex mode toggle is preserved when adding movements', async () => {
     await userEvent.click(screen.getByRole('button', { name: 'Complex, off' }));
     expect(screen.queryAllByRole('heading', { name: 'Load' })).toHaveLength(0);

--- a/src/pages/StartWorkoutPage/StartWorkoutPage.tsx
+++ b/src/pages/StartWorkoutPage/StartWorkoutPage.tsx
@@ -37,6 +37,7 @@ import {
   WorkoutOptions,
 } from '~/types';
 import {
+  applySharedWeights,
   getWeightRange,
   getWeightTabValue,
   getWeightUnitLabel,
@@ -799,7 +800,7 @@ export const StartWorkoutPage = ({
 
   const handleClickStart = () => {
     startWorkout(
-      {
+      applySharedWeights({
         complexSet,
         intervalTimer,
         movements,
@@ -813,7 +814,7 @@ export const StartWorkoutPage = ({
         preWorkoutNotes: preWorkoutNotes?.trim() || null,
         workoutGoal,
         workoutGoalUnits,
-      },
+      }),
       startSource,
       {
         ...startSourceProps,
@@ -829,7 +830,7 @@ export const StartWorkoutPage = ({
   // session instead of starting a workout.
   const handleSaveSession = () => {
     programSaveMode?.onSave(
-      {
+      applySharedWeights({
         complexSet,
         intervalTimer,
         movements,
@@ -843,7 +844,7 @@ export const StartWorkoutPage = ({
         preWorkoutNotes: preWorkoutNotes?.trim() || null,
         workoutGoal,
         workoutGoalUnits,
-      },
+      }),
       sessionTitle.trim(),
     );
   };

--- a/src/utils/applySharedWeights.test.ts
+++ b/src/utils/applySharedWeights.test.ts
@@ -1,0 +1,65 @@
+import { applySharedWeights } from './applySharedWeights';
+
+const movement = (overrides = {}) => ({
+  movementName: 'Clean',
+  repScheme: [5],
+  weightOneUnit: 'kilograms' as const,
+  weightOneValue: 24,
+  weightTwoUnit: null,
+  weightTwoValue: null,
+  ...overrides,
+});
+
+const options = (overrides = {}) => ({
+  complexSet: true,
+  movements: [movement(), movement({ movementName: 'Jerk' })],
+  sharedWeightOneUnit: 'kilograms' as const,
+  sharedWeightOneValue: 28,
+  sharedWeightTwoUnit: null,
+  sharedWeightTwoValue: null,
+  ...overrides,
+});
+
+describe('applySharedWeights', () => {
+  test('overrides every movement weight field with the shared weight when complex', () => {
+    const result = applySharedWeights(
+      options({
+        sharedWeightTwoUnit: 'pounds',
+        sharedWeightTwoValue: 35,
+      }),
+    );
+
+    result.movements.forEach((m) => {
+      expect(m.weightOneUnit).toBe('kilograms');
+      expect(m.weightOneValue).toBe(28);
+      expect(m.weightTwoUnit).toBe('pounds');
+      expect(m.weightTwoValue).toBe(35);
+    });
+  });
+
+  test('leaves non-complex options untouched', () => {
+    const input = options({ complexSet: false });
+    expect(applySharedWeights(input)).toBe(input);
+    expect(input.movements[0].weightOneValue).toBe(24);
+  });
+
+  test('null shared weights clear per-movement weights (bodyweight complex)', () => {
+    const result = applySharedWeights(
+      options({ sharedWeightOneUnit: null, sharedWeightOneValue: null }),
+    );
+
+    result.movements.forEach((m) => {
+      expect(m.weightOneUnit).toBeNull();
+      expect(m.weightOneValue).toBeNull();
+    });
+  });
+
+  test('preserves non-weight movement fields and options fields', () => {
+    const input = options();
+    const result = applySharedWeights(input);
+
+    expect(result.movements[0].movementName).toBe('Clean');
+    expect(result.movements[0].repScheme).toEqual([5]);
+    expect(result.sharedWeightOneValue).toBe(28);
+  });
+});

--- a/src/utils/applySharedWeights.ts
+++ b/src/utils/applySharedWeights.ts
@@ -1,0 +1,34 @@
+import { MovementOptions, WeightUnit } from '~/types';
+
+interface SharedWeightOptions {
+  complexSet: boolean;
+  movements: MovementOptions[];
+  sharedWeightOneUnit: WeightUnit | null;
+  sharedWeightOneValue: number | null;
+  sharedWeightTwoUnit: WeightUnit | null;
+  sharedWeightTwoValue: number | null;
+}
+
+/**
+ * Complex sets are loaded with one shared weight, but every consumer of
+ * {@link MovementOptions} (live volume accumulation, movement_logs persistence)
+ * reads the per-movement weight fields. Copy the shared weight onto each
+ * movement so the two stores can't disagree; non-complex options pass through
+ * untouched.
+ */
+export const applySharedWeights = <T extends SharedWeightOptions>(
+  options: T,
+): T => {
+  if (!options.complexSet) return options;
+
+  return {
+    ...options,
+    movements: options.movements.map((movement) => ({
+      ...movement,
+      weightOneUnit: options.sharedWeightOneUnit,
+      weightOneValue: options.sharedWeightOneValue,
+      weightTwoUnit: options.sharedWeightTwoUnit,
+      weightTwoValue: options.sharedWeightTwoValue,
+    })),
+  };
+};

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,3 +1,4 @@
+export * from './applySharedWeights';
 export * from './bellColors';
 export * from './formatRungDuration';
 export * from './formatVolume';

--- a/src/utils/workoutLogToWorkoutOptions.ts
+++ b/src/utils/workoutLogToWorkoutOptions.ts
@@ -1,5 +1,6 @@
 import { MovementLog, WorkoutLog, WorkoutOptions } from '~/types';
 
+import { applySharedWeights } from './applySharedWeights';
 import { resolveSharedWeights } from './resolveSharedWeights';
 
 /**
@@ -33,25 +34,17 @@ export const workoutLogToWorkoutOptions = (
     movementLogs,
   );
 
-  return {
+  return applySharedWeights({
     complexSet: isComplexSet,
     intervalTimer: workoutLog.intervalTimer,
     movements: movementLogs.map((movementLog) => ({
       movementName: movementLog.movementName,
       repScheme: movementLog.repScheme,
       timedRungs: movementLog.timedRungs ?? false,
-      weightOneUnit: isComplexSet
-        ? sharedWeights.weightOneUnit
-        : movementLog.weightOneUnit,
-      weightOneValue: isComplexSet
-        ? sharedWeights.weightOneValue
-        : movementLog.weightOneValue,
-      weightTwoUnit: isComplexSet
-        ? sharedWeights.weightTwoUnit
-        : movementLog.weightTwoUnit,
-      weightTwoValue: isComplexSet
-        ? sharedWeights.weightTwoValue
-        : movementLog.weightTwoValue,
+      weightOneUnit: movementLog.weightOneUnit,
+      weightOneValue: movementLog.weightOneValue,
+      weightTwoUnit: movementLog.weightTwoUnit,
+      weightTwoValue: movementLog.weightTwoValue,
     })),
     restTimer: workoutLog.restTimer,
     sharedWeightOneUnit: isComplexSet ? sharedWeights.weightOneUnit : null,
@@ -66,5 +59,5 @@ export const workoutLogToWorkoutOptions = (
     previousVolume,
     previousMinutes,
     previousRounds,
-  };
+  });
 };

--- a/supabase/migrations/20260729000000_fix_pattern_debt_complex_volume.sql
+++ b/supabase/migrations/20260729000000_fix_pattern_debt_complex_volume.sql
@@ -1,0 +1,204 @@
+-- Complex-set workouts kept two weight stores: the shared weight the user edits
+-- on workout_logs, and per-movement weights on movement_logs that could go
+-- stale (the builder hides them in complex mode). Volume math read the stale
+-- per-movement value. The client now syncs shared weight onto movements at
+-- start time; this migration repairs existing rows and makes
+-- pattern_debt_window compute volume the same way the client does.
+
+-- 1) Backfill: copy the session's shared weight onto complex-set movement rows.
+UPDATE movement_logs ml
+SET
+  weight_one_value = w.shared_weight_one_value,
+  weight_one_unit = w.shared_weight_one_unit,
+  weight_two_value = w.shared_weight_two_value,
+  weight_two_unit = w.shared_weight_two_unit
+FROM workout_logs w
+WHERE w.id = ml.workout_log_id
+  AND w.complex_set
+  AND w.shared_weight_one_value IS NOT NULL
+  AND (
+    ml.weight_one_value IS DISTINCT FROM w.shared_weight_one_value
+    OR ml.weight_one_unit IS DISTINCT FROM w.shared_weight_one_unit
+    OR ml.weight_two_value IS DISTINCT FROM w.shared_weight_two_value
+    OR ml.weight_two_unit IS DISTINCT FROM w.shared_weight_two_unit
+  );
+
+-- 2) Backfill: recompute completed_volume for complex-set sessions from the
+-- now-correct movement weights. Whole-rounds approximation: reps per ladder
+-- pass x completed rounds (partial final rounds are floored). One-handed
+-- (weight_two = 0) and mixed-weight movements mirror each rung left/right, so
+-- one round contributes two passes — the client's shouldMirrorReps rule.
+WITH recomputed AS (
+  SELECT
+    ml.workout_log_id,
+    round(
+      GREATEST(COALESCE(w.completed_rounds, 1), 1)
+      * SUM(
+          CASE WHEN ml.timed_rungs THEN 0 ELSE
+            (SELECT COALESCE(SUM(r), 0) FROM unnest(ml.rep_scheme) AS r)
+            * CASE
+                WHEN COALESCE(ml.weight_one_value, 0) > 0
+                  AND (ml.weight_two_value = 0
+                    OR (ml.weight_two_value > 0 AND ml.weight_two_value <> ml.weight_one_value))
+                THEN 2 ELSE 1
+              END
+            * (
+                CASE
+                  WHEN ml.weight_one_unit = 'pounds' THEN COALESCE(ml.weight_one_value, 0) * 0.45359237
+                  ELSE COALESCE(ml.weight_one_value, 0)
+                END
+                + CASE
+                  WHEN ml.weight_two_unit = 'pounds' THEN COALESCE(ml.weight_two_value, 0) * 0.45359237
+                  ELSE COALESCE(ml.weight_two_value, 0)
+                END
+              )
+          END
+        )
+    ) AS volume
+  FROM movement_logs ml
+  JOIN workout_logs w ON w.id = ml.workout_log_id
+  WHERE w.complex_set
+    AND w.shared_weight_one_value IS NOT NULL
+  GROUP BY ml.workout_log_id, w.completed_rounds
+)
+UPDATE workout_logs w
+SET completed_volume = recomputed.volume
+FROM recomputed
+WHERE w.id = recomputed.workout_log_id
+  AND w.completed_volume IS DISTINCT FROM recomputed.volume;
+
+-- 3) Fix pattern_debt_window's volume model:
+--    * complex sets read the session's shared weight (stale-row safety even
+--      after the backfill above);
+--    * weight_two counts (double-bell work was halved);
+--    * reps/sets/volume scale by completed rounds instead of one ladder pass;
+--    * timed rungs (rep_scheme holds seconds) contribute no reps or volume,
+--      matching the client accumulator.
+
+DROP FUNCTION IF EXISTS public.pattern_debt_window(int, int);
+
+CREATE FUNCTION public.pattern_debt_window(
+  p_window_days int DEFAULT 14,
+  p_baseline_days int DEFAULT 84
+)
+RETURNS TABLE (
+  pattern text,
+  last_trained_at timestamptz,
+  set_count bigint,
+  total_reps bigint,
+  total_volume_kg numeric,
+  baseline_volume_kg numeric,
+  hardest_rpe "RPE"
+)
+LANGUAGE sql
+STABLE
+SECURITY INVOKER
+SET search_path = public
+AS $$
+  WITH patterns(pattern) AS (
+    VALUES ('hinge'), ('squat'), ('push'), ('pull'), ('carry'), ('rotation'), ('get_up')
+  ),
+  logs AS (
+    SELECT
+      ml.created_at,
+      -- Collapse the catalog's granular Movement Pattern into a coarse bucket.
+      -- get-ups are detected by name (complex/combo movement, not a single tag)
+      -- and take precedence; everything else maps from Movement Pattern #1.
+      CASE
+        WHEN ml.movement_name ~* '(get[ -]?up|turkish)' THEN 'get_up'
+        WHEN m."Movement Pattern #1" IN ('Hip Hinge', 'Hip Dominant', 'Hip Extension') THEN 'hinge'
+        WHEN m."Movement Pattern #1" = 'Knee Dominant' THEN 'squat'
+        WHEN m."Movement Pattern #1" IN ('Vertical Push', 'Horizontal Push') THEN 'push'
+        WHEN m."Movement Pattern #1" IN ('Vertical Pull', 'Horizontal Pull') THEN 'pull'
+        WHEN m."Movement Pattern #1" = 'Loaded Carry' THEN 'carry'
+        WHEN m."Movement Pattern #1" IN ('Rotational', 'Spinal Rotational') THEN 'rotation'
+        ELSE NULL
+      END AS pattern,
+      reps.total_reps * rounds.passes AS total_reps,
+      reps.set_count * rounds.passes AS set_count,
+      -- Session RPE inherited onto each movement it logged; hardest wins below.
+      w.rpe,
+      -- Volume normalized to kilograms; bodyweight / null weight contributes 0.
+      -- Timed rungs hold seconds in rep_scheme, so they contribute no volume.
+      CASE WHEN ml.timed_rungs THEN 0 ELSE
+        reps.total_reps * rounds.passes * (
+          CASE
+            WHEN eff.weight_one_unit = 'pounds' THEN COALESCE(eff.weight_one_value, 0) * 0.45359237
+            ELSE COALESCE(eff.weight_one_value, 0)
+          END
+          + CASE
+            WHEN eff.weight_two_unit = 'pounds' THEN COALESCE(eff.weight_two_value, 0) * 0.45359237
+            ELSE COALESCE(eff.weight_two_value, 0)
+          END
+        )
+      END AS volume_kg
+    FROM movement_logs ml
+    LEFT JOIN workout_logs w ON w.id = ml.workout_log_id
+    LEFT JOIN user_movements um ON um.id = ml.user_movement_id
+    LEFT JOIN movements m ON m.id = um.functional_movement_id
+    CROSS JOIN LATERAL (
+      SELECT
+        CASE WHEN ml.timed_rungs THEN 0 ELSE COALESCE(SUM(r), 0) END::bigint AS total_reps,
+        COALESCE(COUNT(r), 0)::bigint AS set_count
+      FROM unnest(ml.rep_scheme) AS r
+    ) reps
+    CROSS JOIN LATERAL (
+      -- Complex sets load one shared weight; prefer it over the per-movement
+      -- copy so pre-backfill / stale rows still report the weight actually used.
+      -- shared_weight_* is double precision; keep the whole volume expression
+      -- numeric so round(x, 2) below stays valid.
+      SELECT
+        CASE WHEN w.complex_set THEN COALESCE(w.shared_weight_one_value::numeric, ml.weight_one_value) ELSE ml.weight_one_value END AS weight_one_value,
+        CASE WHEN w.complex_set THEN COALESCE(w.shared_weight_one_unit, ml.weight_one_unit) ELSE ml.weight_one_unit END AS weight_one_unit,
+        CASE WHEN w.complex_set AND w.shared_weight_one_value IS NOT NULL THEN w.shared_weight_two_value::numeric ELSE ml.weight_two_value END AS weight_two_value,
+        CASE WHEN w.complex_set AND w.shared_weight_one_value IS NOT NULL THEN w.shared_weight_two_unit ELSE ml.weight_two_unit END AS weight_two_unit
+    ) eff
+    CROSS JOIN LATERAL (
+      -- One ladder pass scaled by completed rounds, doubled for one-handed
+      -- (weight_two = 0) and mixed-weight movements, whose rungs mirror
+      -- left/right — the client's shouldMirrorReps rule.
+      SELECT
+        GREATEST(COALESCE(w.completed_rounds, 1), 1)::bigint
+        * CASE
+            WHEN COALESCE(eff.weight_one_value, 0) > 0
+              AND (eff.weight_two_value = 0
+                OR (eff.weight_two_value > 0 AND eff.weight_two_value <> eff.weight_one_value))
+            THEN 2 ELSE 1
+          END AS passes
+    ) rounds
+    WHERE ml.user_id = auth.uid()
+      AND ml.created_at >= now() - make_interval(days => p_baseline_days)
+  )
+  SELECT
+    p.pattern,
+    max(l.created_at) FILTER (
+      WHERE l.created_at >= now() - make_interval(days => p_window_days)
+    ) AS last_trained_at,
+    COALESCE(sum(l.set_count) FILTER (
+      WHERE l.created_at >= now() - make_interval(days => p_window_days)
+    ), 0) AS set_count,
+    COALESCE(sum(l.total_reps) FILTER (
+      WHERE l.created_at >= now() - make_interval(days => p_window_days)
+    ), 0) AS total_reps,
+    COALESCE(sum(l.volume_kg) FILTER (
+      WHERE l.created_at >= now() - make_interval(days => p_window_days)
+    ), 0) AS total_volume_kg,
+    -- Baseline = typical per-window volume: total over the baseline window,
+    -- scaled down to one window length. NULL when there is no baseline history.
+    CASE
+      WHEN sum(l.volume_kg) IS NULL THEN NULL
+      ELSE round(sum(l.volume_kg) * (p_window_days::numeric / p_baseline_days), 2)
+    END AS baseline_volume_kg,
+    -- Hardest exertion rating across sessions that trained the pattern in the
+    -- recent window; NULL when untrained or unrated.
+    max(l.rpe) FILTER (
+      WHERE l.created_at >= now() - make_interval(days => p_window_days)
+    ) AS hardest_rpe
+  FROM patterns p
+  LEFT JOIN logs l ON l.pattern = p.pattern
+  GROUP BY p.pattern;
+$$;
+
+-- RLS does the data scoping; only authenticated users may call it.
+REVOKE ALL ON FUNCTION public.pattern_debt_window(int, int) FROM public;
+GRANT EXECUTE ON FUNCTION public.pattern_debt_window(int, int) TO authenticated;


### PR DESCRIPTION
## Why

Complex-set workouts keep two weight stores: the shared weight edited in the builder and per-movement weights the builder hides. The live volume accumulator and `movement_logs` read the stale per-movement value, so a 120-rep A+A session at 28 kg logged 2880 kg (120 × the seeded 24) instead of 3360. Weekly Balance was further off — `pattern_debt_window` read the same stale weight, counted the planned ladder once (ignoring 30 completed rounds and L/R sides), and ignored the second bell, reporting 24 kg of hinge volume for that session.

## What

Sync shared weights onto every movement at workout start / session save (`applySharedWeights`, reused by the repeat path), and rebuild `pattern_debt_window` to use shared weights, count both bells, scale by completed rounds, double mirrored one-handed/mixed work, and skip timed rungs. The migration also backfills stale complex-set `movement_logs` weights and recomputes their `completed_volume` (whole-round approximation).

## How to test

- `npm test` (583 passing, incl. new `applySharedWeights` unit tests and a builder regression: bump shared weight → submitted movements carry it), `npm run compile:ts`, `npm run lint`.
- `supabase db reset`, then seeded the exact broken workout (stale 24 kg movements, shared 28 kg, 30 rounds one-handed): backfill produced weight 28 and volume 3360; `pattern_debt_window(14,84)` returned 1680 per movement (28 × 1 rep × 30 rounds × 2 sides) with RPE intact.
- Live run in the dev app: complex workout with a bumped shared weight — active-workout counter, Workout Log header, and persisted `movement_logs` all matched reps × shared weight (680 = 40 × 17).

## Deploy notes

Migration `20260729000000_fix_pattern_debt_complex_volume.sql` includes a data backfill (movement weights + complex `completed_volume`) that corrects historical logs on deploy. `npm run gen:types` produced no diff (function signature unchanged).

## Tradeoffs

Backfilled `completed_volume` uses rounds × ladder × sides, flooring partial final rounds — exact per-set history isn't stored, so precise recomputation isn't possible. The read-time shared-weight fallback in the SQL stays even after the backfill, as safety for any rows written between deploy of the function and the client.