### PR TITLE
fix(workouts): resume timer audio after switching apps

### DIFF
--- a/src/utils/timerSound.test.ts
+++ b/src/utils/timerSound.test.ts
@@ -1,28 +1,128 @@
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { setSoundEnabled } from './soundPreference';
-import { playDing, playStartCue, unlockAudio } from './timerSound';
+
+const createMockContext = (state = 'running') => ({
+  state,
+  resume: vi.fn().mockResolvedValue(undefined),
+  currentTime: 0,
+  createOscillator: vi.fn(() => ({
+    type: 'sine',
+    frequency: { setValueAtTime: vi.fn() },
+    connect: vi.fn(),
+    start: vi.fn(),
+    stop: vi.fn(),
+  })),
+  createGain: vi.fn(() => ({
+    gain: {
+      setValueAtTime: vi.fn(),
+      linearRampToValueAtTime: vi.fn(),
+      exponentialRampToValueAtTime: vi.fn(),
+    },
+    connect: vi.fn(),
+  })),
+  destination: {},
+});
+
+// The module caches its AudioContext, so each test imports a fresh copy.
+const importTimerSound = () => import('./timerSound');
 
 describe('timerSound', () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
   afterEach(() => {
     setSoundEnabled(true);
     vi.unstubAllGlobals();
   });
 
-  it('is a safe no-op when Web Audio is unavailable (jsdom)', () => {
-    // jsdom provides no AudioContext, so these must not throw.
+  it('is a safe no-op when Web Audio is unavailable (jsdom)', async () => {
+    const { playDing, playStartCue, unlockAudio } = await importTimerSound();
     expect(() => unlockAudio()).not.toThrow();
     expect(() => playDing()).not.toThrow();
     expect(() => playStartCue()).not.toThrow();
   });
 
-  it('does not attempt playback when sound is disabled', () => {
+  it('does not attempt playback when sound is disabled', async () => {
     const ctor = vi.fn();
     vi.stubGlobal('AudioContext', ctor);
+    const { playDing, playStartCue } = await importTimerSound();
 
     setSoundEnabled(false);
     playDing();
     playStartCue();
+
+    expect(ctor).not.toHaveBeenCalled();
+  });
+
+  it.each(['suspended', 'interrupted'])(
+    'unlockAudio resumes a %s context',
+    async (state) => {
+      const ctx = createMockContext(state);
+      vi.stubGlobal(
+        'AudioContext',
+        vi.fn(() => ctx),
+      );
+      const { unlockAudio } = await importTimerSound();
+
+      unlockAudio();
+
+      expect(ctx.resume).toHaveBeenCalled();
+    },
+  );
+
+  it('unlockAudio does not resume a running context', async () => {
+    const ctx = createMockContext('running');
+    vi.stubGlobal(
+      'AudioContext',
+      vi.fn(() => ctx),
+    );
+    const { unlockAudio } = await importTimerSound();
+
+    unlockAudio();
+
+    expect(ctx.resume).not.toHaveBeenCalled();
+  });
+
+  it('replaces a closed context with a fresh one on the next play', async () => {
+    const closed = createMockContext('closed');
+    const fresh = createMockContext('running');
+    const ctor = vi
+      .fn()
+      .mockReturnValueOnce(closed)
+      .mockReturnValueOnce(fresh);
+    vi.stubGlobal('AudioContext', ctor);
+    const { unlockAudio, playDing } = await importTimerSound();
+
+    unlockAudio(); // caches the context that later ends up closed
+    playDing();
+
+    expect(ctor).toHaveBeenCalledTimes(2);
+    expect(fresh.createOscillator).toHaveBeenCalled();
+  });
+
+  it('resumes an existing context when the page becomes visible again', async () => {
+    const ctx = createMockContext('running');
+    vi.stubGlobal(
+      'AudioContext',
+      vi.fn(() => ctx),
+    );
+    const { unlockAudio } = await importTimerSound();
+    unlockAudio();
+
+    ctx.state = 'interrupted';
+    document.dispatchEvent(new Event('visibilitychange'));
+
+    expect(ctx.resume).toHaveBeenCalled();
+  });
+
+  it('does not create a context from the visibility listener', async () => {
+    const ctor = vi.fn(() => createMockContext());
+    vi.stubGlobal('AudioContext', ctor);
+    await importTimerSound();
+
+    document.dispatchEvent(new Event('visibilitychange'));
 
     expect(ctor).not.toHaveBeenCalled();
   });

--- a/src/utils/timerSound.ts
+++ b/src/utils/timerSound.ts
@@ -20,12 +20,42 @@ const getAudioContextCtor = (): AudioContextConstructor | undefined => {
 
 let audioContext: AudioContext | null = null;
 
+// iOS reports the non-standard 'interrupted' state after backgrounding, so
+// resume on anything that isn't running rather than only 'suspended'.
+const resumeIfNotRunning = (ctx: AudioContext): void => {
+  if (ctx.state !== 'running') {
+    void ctx.resume?.().catch(() => {});
+  }
+};
+
+const handleVisibilityChange = (): void => {
+  if (document.visibilityState !== 'visible') return;
+  // Only resume an existing context — creating one here would be outside a
+  // user gesture and stay locked on mobile Safari.
+  if (audioContext && audioContext.state !== 'closed') {
+    resumeIfNotRunning(audioContext);
+  }
+};
+
+let visibilityListenerInstalled = false;
+
+const installVisibilityListener = (): void => {
+  if (visibilityListenerInstalled || typeof document === 'undefined') return;
+  document.addEventListener('visibilitychange', handleVisibilityChange);
+  visibilityListenerInstalled = true;
+};
+
 const getAudioContext = (): AudioContext | null => {
+  // iOS can close the context outright while backgrounded; recreate it.
+  if (audioContext && audioContext.state === 'closed') {
+    audioContext = null;
+  }
   if (audioContext) return audioContext;
   const Ctor = getAudioContextCtor();
   if (!Ctor) return null;
   try {
     audioContext = new Ctor();
+    installVisibilityListener();
   } catch {
     audioContext = null;
   }
@@ -39,9 +69,7 @@ const getAudioContext = (): AudioContext | null => {
 export const unlockAudio = (): void => {
   const ctx = getAudioContext();
   if (!ctx) return;
-  if (ctx.state === 'suspended') {
-    void ctx.resume().catch(() => {});
-  }
+  resumeIfNotRunning(ctx);
 };
 
 /** Play a single note with a quick attack + exponential decay envelope. */
@@ -84,7 +112,7 @@ export const playDing = (): void => {
   if (!isSoundEnabled()) return;
   const ctx = getAudioContext();
   if (!ctx) return;
-  void ctx.resume?.().catch(() => {});
+  resumeIfNotRunning(ctx);
 
   const now = ctx.currentTime;
   playTone(ctx, 880, now, 0.28); // A5
@@ -101,7 +129,7 @@ export const playStartCue = (): void => {
   if (!isSoundEnabled()) return;
   const ctx = getAudioContext();
   if (!ctx) return;
-  void ctx.resume?.().catch(() => {});
+  resumeIfNotRunning(ctx);
 
   const now = ctx.currentTime;
   playTone(ctx, 1046.5, now, 0.3); // C6


### PR DESCRIPTION
## Why

Switching to another app on the phone and back killed the interval timer audio. iOS moves the Web Audio context into the non-standard `interrupted` state when the app is backgrounded (or closes it outright), and nothing restarted it: `unlockAudio` only handled `suspended`, there was no `visibilitychange` handling, and a closed context was cached forever.

## What

`timerSound.ts` now resumes the context on any non-running state (covers `interrupted`), recreates the context if iOS closed it, and resumes the existing context when the page becomes visible again. The visibility listener never *creates* a context — that would happen outside a user gesture and stay locked on mobile Safari.

## How to test

- `npm test -- timerSound` — 8 tests, including interrupted/suspended resume, closed-context recreation, and the visibility listener (resumes existing context, never constructs one).
- `npm run compile:ts` clean.
- On-device: start an interval workout, switch apps for ~15s, return — the next ding should sound (it may fire late; see below).

## Tradeoffs

This fixes only the audio. The countdown itself still drifts behind wall-clock time when backgrounded (`useCountdownTimer` decrements via bare `setInterval`), so the ding after an app switch fires late. Timestamp-based ticking is spun off as its own task.