### PR TITLE
fix(workouts): derive countdown timers from wall-clock deadlines

### DIFF
--- a/src/hooks/useCountdownTimer.test.ts
+++ b/src/hooks/useCountdownTimer.test.ts
@@ -83,6 +83,34 @@ it('should use custom time format', () => {
   expect(result.current[0]).toBe('60.0');
 });
 
+it('should track wall-clock time when ticks are throttled', () => {
+  const { result } = renderHook(() => useCountdownTimer(1));
+
+  // simulate a backgrounded tab: the clock advances 5s but only one tick fires
+  vi.setSystemTime(Date.now() + 5000);
+  act(() => vi.advanceTimersByTime(100));
+
+  expect(result.current[1].milliseconds).toBe(54900);
+});
+
+it('should clamp at zero instead of going negative', () => {
+  const { result } = renderHook(() => useCountdownTimer(1));
+
+  act(() => vi.advanceTimersByTime(90000));
+
+  expect(result.current[0]).toBe('0:00');
+  expect(result.current[1].milliseconds).toBe(0);
+});
+
+it('should reach zero after expiring while backgrounded', () => {
+  const { result } = renderHook(() => useCountdownTimer(1));
+
+  vi.setSystemTime(Date.now() + 120000);
+  act(() => vi.advanceTimersByTime(100));
+
+  expect(result.current[1].milliseconds).toBe(0);
+});
+
 it('should not count when disabled', () => {
   const { result } = renderHook(() => useCountdownTimer(1, { disabled: true }));
 

--- a/src/hooks/useCountdownTimer.ts
+++ b/src/hooks/useCountdownTimer.ts
@@ -1,8 +1,9 @@
 import { Duration } from 'luxon';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 
 const DEFAULT_PAUSED = false;
 const TIME_FORMAT = 'm:ss';
+const TICK_MS = 100;
 
 interface CountdownTimerOptions {
   defaultPaused?: boolean;
@@ -10,6 +11,10 @@ interface CountdownTimerOptions {
   timeFormat?: string;
 }
 
+// Remaining time is derived from a wall-clock deadline rather than a
+// decremented counter: browsers throttle intervals in background tabs, so a
+// counter falls behind real time. Remaining is clamped at 0 — consumers key
+// completion off `milliseconds === 0`, and a timestamp jump may skip past it.
 export const useCountdownTimer = (
   /** Time to start counting down from in minutes */
   initialTimer: number,
@@ -25,18 +30,39 @@ export const useCountdownTimer = (
   const [paused, setPaused] = useState<boolean>(
     options?.defaultPaused || DEFAULT_PAUSED,
   );
+  const remainingRef = useRef<number>(initialTimer * 60000);
+  const resetCountRef = useRef<number>(0);
+  const [epoch, setEpoch] = useState<number>(0);
 
   useEffect(() => {
     if (options?.disabled || paused || initialTimer === 0) return;
 
+    const deadline = Date.now() + remainingRef.current;
+    const remainingNow = () => Math.max(0, deadline - Date.now());
+    const resetCount = resetCountRef.current;
+
     const timer = setInterval(() => {
-      setMilliseconds((s) => s - 100);
-    }, 100);
-    return () => clearInterval(timer);
-  }, [paused, options?.disabled, initialTimer]);
+      const remaining = remainingNow();
+      remainingRef.current = remaining;
+      setMilliseconds(remaining);
+      if (remaining === 0) clearInterval(timer);
+    }, TICK_MS);
+
+    return () => {
+      clearInterval(timer);
+      // capture sub-tick remaining for pause, unless a reset superseded it
+      if (resetCountRef.current === resetCount)
+        remainingRef.current = remainingNow();
+    };
+  }, [paused, options?.disabled, initialTimer, epoch]);
 
   const reset = useCallback(
-    (timer: number = initialTimer) => setMilliseconds(timer * 60000),
+    (timer: number = initialTimer) => {
+      remainingRef.current = timer * 60000;
+      resetCountRef.current += 1;
+      setMilliseconds(timer * 60000);
+      setEpoch((e) => e + 1); // re-anchor the deadline if already running
+    },
     [initialTimer],
   );
   const pause = useCallback(() => setPaused(true), []);

--- a/src/pages/ActiveWorkoutPage/ActiveWorkoutPage.tsx
+++ b/src/pages/ActiveWorkoutPage/ActiveWorkoutPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 import { useLogWorkout } from '~/api';
@@ -495,11 +495,17 @@ export const ActiveWorkoutPage = ({
     [completedRounds],
   );
 
+  const finishWorkoutRef = useRef(finishWorkout);
+  finishWorkoutRef.current = finishWorkout;
+
   useEffect(
     function handleMinutesGoalReached() {
       if (workoutGoalUnits !== 'minutes' || logWorkoutLoading) return;
-      // small delay for all rounds to be counted from interval timer
-      if (remainingMilliseconds <= -500) finishWorkout();
+      if (remainingMilliseconds > 0) return;
+      // small delay for all rounds to be counted from interval timer; the ref
+      // keeps the logged counts fresh across that delay
+      const grace = setTimeout(() => finishWorkoutRef.current(), 500);
+      return () => clearTimeout(grace);
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps -- fires only on each remainingMilliseconds tick; finishWorkout and the goal reads must stay fresh without retriggering
     [remainingMilliseconds],


### PR DESCRIPTION
## Why

Workout timers drifted behind real time whenever the app was backgrounded on mobile. `useCountdownTimer` decremented a counter on a 100ms `setInterval`, and browsers throttle or suspend intervals in background tabs — so on return the timer was behind the wall clock and end-of-interval cues fired late.

## What

Remaining time is now derived from a `Date.now()` deadline anchored on each start/resume instead of a decremented counter, clamped at 0 so the page's `milliseconds === 0` completion effects still fire exactly once even when a timer expired while backgrounded. Since the workout timer can no longer run negative, the minutes-goal grace period (`<= -500`) becomes an explicit 500ms timeout that calls `finishWorkout` through a latest-value ref, keeping the logged counts fresh across the delay.

## How to test

- `npm test` — all 597 tests pass, including three new hook tests: a throttled-tab simulation (clock jumps 5s with one tick fired), clamp-at-zero, and expiry-while-backgrounded reaching exactly 0.
- `npm run compile:ts` — clean.
- The existing timed-rung suite caught (and now guards) a reset-while-running edge: the effect cleanup must not clobber a remaining value a `reset()` just wrote, hence the reset-generation counter.

## Tradeoffs

Considered changing the consumers' `=== 0` checks to `<= 0` instead of clamping in the hook, but unclamped negative values would re-fire the completion effects on every subsequent tick, and the minutes-goal effect deliberately depended on negative time. Clamping keeps the hook's contract simple; the one negative-time consumer got an explicit timeout instead.