### PR TITLE
fix(nav): detect keyboard via VisualViewport API

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
     <link rel="icon" type="image/png" href="/favicon.ico" />
     <meta
       name="viewport"
-      content="width=device-width, initial-scale=1.0, viewport-fit=cover"
+      content="width=device-width, initial-scale=1.0, viewport-fit=cover, interactive-widget=resizes-content"
       id="viewport-meta"
     />
     <title>BellSkill</title>
@@ -61,7 +61,7 @@
           if (viewportMeta) {
             viewportMeta.setAttribute(
               'content',
-              'width=device-width, initial-scale=1.0, viewport-fit=cover, user-scalable=no, maximum-scale=1.0',
+              'width=device-width, initial-scale=1.0, viewport-fit=cover, interactive-widget=resizes-content, user-scalable=no, maximum-scale=1.0',
             );
           }
 

--- a/src/components/BottomNav/useIsKeyboardOpen.test.tsx
+++ b/src/components/BottomNav/useIsKeyboardOpen.test.tsx
@@ -1,0 +1,115 @@
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { useIsKeyboardOpen } from './useIsKeyboardOpen';
+
+const focusEvent = (
+  type: 'focusin' | 'focusout',
+  target: HTMLElement,
+  relatedTarget: HTMLElement | null = null,
+) => {
+  const event = new FocusEvent(type, { bubbles: true, relatedTarget });
+  Object.defineProperty(event, 'target', { value: target });
+  document.dispatchEvent(event);
+};
+
+describe('useIsKeyboardOpen', () => {
+  describe('focus fallback (no visualViewport)', () => {
+    it('opens when a text input gains focus and closes when it blurs', () => {
+      const input = document.createElement('input');
+      const { result } = renderHook(() => useIsKeyboardOpen());
+      expect(result.current).toBe(false);
+
+      act(() => focusEvent('focusin', input));
+      expect(result.current).toBe(true);
+
+      act(() => focusEvent('focusout', input));
+      expect(result.current).toBe(false);
+    });
+
+    it('ignores non-text inputs', () => {
+      const checkbox = document.createElement('input');
+      checkbox.type = 'checkbox';
+      const { result } = renderHook(() => useIsKeyboardOpen());
+
+      act(() => focusEvent('focusin', checkbox));
+      expect(result.current).toBe(false);
+    });
+
+    it('stays open when focus moves between text fields', () => {
+      const first = document.createElement('input');
+      const second = document.createElement('textarea');
+      const { result } = renderHook(() => useIsKeyboardOpen());
+
+      act(() => focusEvent('focusin', first));
+      act(() => focusEvent('focusout', first, second));
+      expect(result.current).toBe(true);
+    });
+  });
+
+  describe('visualViewport signal', () => {
+    let viewportHeight: number;
+    let listeners: Set<() => void>;
+
+    beforeEach(() => {
+      viewportHeight = window.innerHeight;
+      listeners = new Set();
+      vi.stubGlobal('visualViewport', {
+        get height() {
+          return viewportHeight;
+        },
+        addEventListener: (_: string, listener: () => void) => {
+          listeners.add(listener);
+        },
+        removeEventListener: (_: string, listener: () => void) => {
+          listeners.delete(listener);
+        },
+      });
+      vi.stubGlobal('requestAnimationFrame', (callback: () => void) => {
+        callback();
+        return 0;
+      });
+      vi.stubGlobal('cancelAnimationFrame', () => {});
+    });
+
+    afterEach(() => {
+      vi.unstubAllGlobals();
+    });
+
+    const resizeTo = (height: number) => {
+      viewportHeight = height;
+      listeners.forEach((listener) => listener());
+    };
+
+    it('opens when the viewport shrinks by more than the keyboard threshold', () => {
+      const { result } = renderHook(() => useIsKeyboardOpen());
+      expect(result.current).toBe(false);
+
+      act(() => resizeTo(window.innerHeight - 300));
+      expect(result.current).toBe(true);
+    });
+
+    it('closes when the viewport height is restored', () => {
+      const { result } = renderHook(() => useIsKeyboardOpen());
+
+      act(() => resizeTo(window.innerHeight - 300));
+      act(() => resizeTo(window.innerHeight));
+      expect(result.current).toBe(false);
+    });
+
+    it('ignores small shrinks like the URL bar', () => {
+      const { result } = renderHook(() => useIsKeyboardOpen());
+
+      act(() => resizeTo(window.innerHeight - 60));
+      expect(result.current).toBe(false);
+    });
+
+    it('ignores text-input focus when visualViewport is available', () => {
+      const input = document.createElement('input');
+      const { result } = renderHook(() => useIsKeyboardOpen());
+
+      act(() => focusEvent('focusin', input));
+      expect(result.current).toBe(false);
+    });
+  });
+});

--- a/src/components/BottomNav/useIsKeyboardOpen.ts
+++ b/src/components/BottomNav/useIsKeyboardOpen.ts
@@ -24,25 +24,36 @@ const isTextInput = (target: EventTarget | null): boolean => {
   return false;
 };
 
+// Above URL-bar show/hide deltas, below any soft-keyboard height.
+const KEYBOARD_HEIGHT_THRESHOLD = 100;
+
 /**
- * True while a text input, textarea, or contenteditable element is focused —
- * i.e. when the mobile soft keyboard is (or is about to be) open. Used to hide
- * the fixed bottom bar, which iOS Safari otherwise floats above the keyboard on
- * top of the field being edited.
+ * True while the mobile soft keyboard is open. Used to hide the fixed bottom
+ * bar, which iOS Safari otherwise floats above the keyboard on top of the
+ * field being edited.
+ *
+ * Primary signal is the VisualViewport API — the keyboard shrinks the visual
+ * viewport but not the layout viewport, so a large height gap means it is
+ * open. This also catches swipe-dismiss (no blur fires) and correctly ignores
+ * hardware keyboards. Environments without `visualViewport` (jsdom, legacy
+ * browsers) fall back to a text-input focus heuristic.
  */
 export const useIsKeyboardOpen = (): boolean => {
-  const [isOpen, setIsOpen] = useState(false);
+  const [isFocusedOnText, setIsFocusedOnText] = useState(false);
+  const [isViewportShrunk, setIsViewportShrunk] = useState(false);
+  const hasVisualViewport =
+    typeof window !== 'undefined' && !!window.visualViewport;
 
   useEffect(() => {
     const handleFocusIn = (event: FocusEvent) => {
-      if (isTextInput(event.target)) setIsOpen(true);
+      if (isTextInput(event.target)) setIsFocusedOnText(true);
     };
     const handleFocusOut = (event: FocusEvent) => {
       if (!isTextInput(event.target)) return;
       // Focus moving straight to another text input keeps the keyboard up, so
       // stay open to avoid the bar flickering back for a frame between fields.
       if (isTextInput(event.relatedTarget)) return;
-      setIsOpen(false);
+      setIsFocusedOnText(false);
     };
 
     document.addEventListener('focusin', handleFocusIn);
@@ -54,5 +65,29 @@ export const useIsKeyboardOpen = (): boolean => {
     };
   }, []);
 
-  return isOpen;
+  useEffect(() => {
+    const visualViewport = window.visualViewport;
+    if (!visualViewport) return;
+
+    let frame = 0;
+    const handleResize = () => {
+      cancelAnimationFrame(frame);
+      frame = requestAnimationFrame(() => {
+        setIsViewportShrunk(
+          window.innerHeight - visualViewport.height >
+            KEYBOARD_HEIGHT_THRESHOLD,
+        );
+      });
+    };
+
+    handleResize();
+    visualViewport.addEventListener('resize', handleResize);
+
+    return () => {
+      cancelAnimationFrame(frame);
+      visualViewport.removeEventListener('resize', handleResize);
+    };
+  }, []);
+
+  return hasVisualViewport ? isViewportShrunk : isFocusedOnText;
 };


### PR DESCRIPTION
## Why

The bottom nav hides whenever a text input is focused, inferred from `focusin`/`focusout` events. On iOS that heuristic breaks two ways: swipe-dismissing the keyboard fires no blur, so the nav stays hidden until you tap out, and hardware keyboards hide the nav even though nothing covers the screen. (The "nav floating mid-page" screenshot that prompted this turned out to be a full-page-capture artifact — the fixed positioning itself is correct.)

## What

`useIsKeyboardOpen` now uses the VisualViewport API as its primary signal — keyboard open when `window.innerHeight - visualViewport.height > 100px` — with the focus heuristic kept as fallback where `visualViewport` doesn't exist (jsdom, legacy browsers). Also adds `interactive-widget=resizes-content` to the viewport meta, which iOS ignores but lets Android resize the layout viewport under the keyboard.

## How to test

- 7 new unit tests in `useIsKeyboardOpen.test.tsx`: focus fallback under plain jsdom, and stubbed-VisualViewport cases (300px shrink opens, restore closes, 60px URL-bar shrink ignored, focus ignored when VV exists). All 29 BottomNav tests pass; `tsc` and eslint clean. The StartWorkoutPage failures in the full suite pre-exist on the branch base (verified by stashing).
- Live in the mobile-size preview: nav stays visible while typing in the builder title field (screenshots below).
- Still worth a real-device pass: focus the notes field, dismiss the keyboard via Done, tap-out, and swipe — the nav should return in all three.

## Gallery

| Before (typing hides the nav) | After (nav stays put) |
|---|---|
| ![before](https://github.com/user-attachments/assets/170069b0-f453-4fff-a0c7-3a1b9bb643ce) | ![after](https://github.com/user-attachments/assets/c8bbc584-3e70-4317-a823-f5d0454069e9) |

## Tradeoffs

Considered keeping focus-only detection and just listening for iOS's swipe-dismiss via `visualViewport` as a patch — simpler diff, and the focus signal is instant where VV resize lags a frame. But two sources of truth for one boolean invited drift, and VV alone already covers every case the focus heuristic did except environments that lack the API, which is exactly what the fallback handles.
