### PR TITLE
feat(programs): stage ladders for autoregulated progression

### DIFF
--- a/docs/program-tracking.md
+++ b/docs/program-tracking.md
@@ -126,6 +126,22 @@ session — atomic), and the PROD-219 editing pair `reorder_program_sessions` /
   are never rewritten. This deliberately overwrites per-session weight offsets
   on future sessions with the edited session's weights; `adjust_program_weights`
   is the offset-preserving counterpart for weight-only changes.
+- **Stages (autoregulated progression):** a program can carry an ordered ladder
+  in `programs.stages` (JSONB `ProgramStage[]`: `title`, `movements` as
+  name+repScheme only, `preWorkoutNotes`, `deloadPreWorkoutNotes`), copied to
+  the clone at enroll. The enrollment's position is
+  `user_programs.current_stage_index` (default 0). The `set_program_stage`
+  RPC (`useSetProgramStage`, StageCard on `ProgramProgressPage`) takes an
+  absolute index — one function serves Advance and Go back — and rewrites
+  every session of the clone with no completion for the enrollment: title
+  (`'Deload · ' + title` on `weight_label = 'Deload weeks'` rows), movements
+  stamped with each session's OWN `sharedWeightOne/Two` (deloads stay light;
+  `adjust_program_weights` remains the sole weight authority), and
+  `preWorkoutNotes` (deload variant on deload rows). Goal/interval/rest are
+  untouched, completed sessions never rewritten. v1 assumes shared-weight
+  complexSet programs; the only shipped ladder is A+A's five stages
+  (C+J → … → C+J+C+J+C+J), seeded in `*_seed_aa_protocol_stages.sql`.
+  Backend coverage in `e2e/program-stages.spec.ts`.
 - **Program CRUD (PROD-237, owned programs only):** `ProgramsPage`'s "My programs"
   surface adds three actions. **Cancel** = `useCancelProgram` flips the active
   enrollment to `abandoned` (reusing the existing status — no new value), freeing

--- a/e2e/program-stages.spec.ts
+++ b/e2e/program-stages.spec.ts
@@ -1,0 +1,420 @@
+import { expect, test } from '@playwright/test';
+
+// Program stages: set_program_stage backend behavior against local Supabase
+// (auth + REST/RPC helpers mirror program-adjust-weights.spec.ts). Advancing an
+// enrollment rewrites every NOT-yet-completed cloned session to the stage's
+// title/movements/notes while each session keeps its own shared weights (work
+// stays at the enrolled load, deloads stay light), and never touches sessions
+// that already have a completion row.
+
+const SUPABASE_URL = process.env.VITE_SUPABASE_URL!;
+const SUPABASE_ANON_KEY = process.env.VITE_SUPABASE_ANON_KEY!;
+const AA_SLUG = 'aa-protocol-plan-a';
+const CLEAN = 'One-Arm Kettlebell Clean';
+const JERK = 'One-Arm Kettlebell Jerk';
+
+interface TestUser {
+  token: string;
+  uid: string;
+  email: string;
+}
+
+async function signUpThrowawayUser(): Promise<TestUser> {
+  const email = `progstage-${Date.now()}-${Math.floor(Math.random() * 1e9)}@example.com`;
+  const password = 'testpassword123';
+
+  const res = await fetch(`${SUPABASE_URL}/auth/v1/signup`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', apikey: SUPABASE_ANON_KEY },
+    body: JSON.stringify({ email, password }),
+  });
+  if (!res.ok)
+    throw new Error(`signup failed (${res.status}): ${await res.text()}`);
+
+  const body = (await res.json()) as {
+    access_token?: string;
+    user?: { id: string };
+  };
+  if (body.access_token && body.user) {
+    return { token: body.access_token, uid: body.user.id, email };
+  }
+  throw new Error('signup did not return a session');
+}
+
+interface RestOptions {
+  body?: unknown;
+  prefer?: string;
+}
+
+async function restJson<T = unknown>(
+  method: string,
+  path: string,
+  token: string,
+  opts: RestOptions = {},
+): Promise<T> {
+  const headers: Record<string, string> = {
+    apikey: SUPABASE_ANON_KEY,
+    Authorization: `Bearer ${token}`,
+  };
+  if (opts.body !== undefined) headers['Content-Type'] = 'application/json';
+  if (opts.prefer) headers['Prefer'] = opts.prefer;
+  const res = await fetch(`${SUPABASE_URL}/rest/v1/${path}`, {
+    method,
+    headers,
+    body: opts.body !== undefined ? JSON.stringify(opts.body) : undefined,
+  });
+  if (!res.ok) {
+    throw new Error(
+      `${method} ${path} failed (${res.status}): ${await res.text()}`,
+    );
+  }
+  return res.json() as Promise<T>;
+}
+
+async function rpc<T = unknown>(
+  fn: string,
+  token: string,
+  args: Record<string, unknown>,
+): Promise<T> {
+  const res = await fetch(`${SUPABASE_URL}/rest/v1/rpc/${fn}`, {
+    method: 'POST',
+    headers: {
+      apikey: SUPABASE_ANON_KEY,
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(args),
+  });
+  if (!res.ok)
+    throw new Error(`rpc ${fn} failed (${res.status}): ${await res.text()}`);
+  return res.json() as Promise<T>;
+}
+
+async function rpcError(
+  fn: string,
+  token: string,
+  args: Record<string, unknown>,
+): Promise<string> {
+  const res = await fetch(`${SUPABASE_URL}/rest/v1/rpc/${fn}`, {
+    method: 'POST',
+    headers: {
+      apikey: SUPABASE_ANON_KEY,
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(args),
+  });
+  expect(res.ok).toBe(false);
+  return res.text();
+}
+
+interface MovementOpt {
+  movementName: string;
+  repScheme: number[];
+  weightOneValue: number | null;
+  weightOneUnit: string | null;
+  weightTwoValue: number | null;
+  weightTwoUnit: string | null;
+}
+
+interface SessionRow {
+  id: string;
+  sequence_index: number;
+  title: string;
+  weight_label: string | null;
+  workout_options: {
+    complexSet: boolean;
+    workoutGoal: number;
+    intervalTimer: number;
+    preWorkoutNotes: string;
+    sharedWeightOneValue: number | null;
+    sharedWeightTwoValue: number | null;
+    movements: MovementOpt[];
+    [key: string]: unknown;
+  };
+}
+
+async function orderedSessions(
+  token: string,
+  programId: string,
+): Promise<SessionRow[]> {
+  return restJson<SessionRow[]>(
+    'GET',
+    `program_sessions?program_id=eq.${programId}&select=id,sequence_index,title,weight_label,workout_options&order=sequence_index.asc`,
+    token,
+  );
+}
+
+async function programIdBySlug(token: string, slug: string): Promise<string> {
+  const [row] = await restJson<Array<{ id: string }>>(
+    'GET',
+    `programs?slug=eq.${slug}&select=id`,
+    token,
+  );
+  return row.id;
+}
+
+interface EnrollmentRow {
+  program_id: string;
+  current_stage_index: number;
+}
+
+async function enrollmentRow(
+  token: string,
+  userProgramId: string,
+): Promise<EnrollmentRow> {
+  const [row] = await restJson<EnrollmentRow[]>(
+    'GET',
+    `user_programs?id=eq.${userProgramId}&select=program_id,current_stage_index`,
+    token,
+  );
+  return row;
+}
+
+async function insertWorkoutLog(user: TestUser): Promise<number> {
+  const [row] = await restJson<Array<{ id: number }>>(
+    'POST',
+    'workout_logs',
+    user.token,
+    {
+      prefer: 'return=representation',
+      body: {
+        user_id: user.uid,
+        started_at: new Date().toISOString(),
+        movements: [CLEAN, JERK],
+        completed_reps: 10,
+        completed_rounds: 1,
+        completed_rungs: 1,
+        workout_goal: 30,
+      },
+    },
+  );
+  return row.id;
+}
+
+async function completeSession(
+  user: TestUser,
+  userProgramId: string,
+  sessionId: string,
+): Promise<void> {
+  const logId = await insertWorkoutLog(user);
+  await rpc('complete_program_session', user.token, {
+    p_user_program_id: userProgramId,
+    p_program_session_id: sessionId,
+    p_workout_log_id: logId,
+  });
+}
+
+interface StageRow {
+  stages: Array<{
+    title: string;
+    movements: Array<{ movementName: string; repScheme: number[] }>;
+    preWorkoutNotes: string;
+    deloadPreWorkoutNotes: string;
+  }> | null;
+}
+
+test.describe('set_program_stage — A+A progression ladder', () => {
+  test('template carries the 5-stage ladder, and the enroll clone copies it at stage 0', async () => {
+    const user = await signUpThrowawayUser();
+    const aaId = await programIdBySlug(user.token, AA_SLUG);
+
+    const [template] = await restJson<StageRow[]>(
+      'GET',
+      `programs?id=eq.${aaId}&select=stages`,
+      user.token,
+    );
+    expect(template.stages).toHaveLength(5);
+    expect(template.stages!.map((s) => s.title)).toEqual([
+      'C+J',
+      'C+J+C',
+      'C+J+C+J',
+      'C+J+C+J+C',
+      'C+J+C+J+C+J',
+    ]);
+    // Alternating complex, surplus clean appended; reps stay [1] throughout.
+    const last = template.stages![4];
+    expect(last.movements.map((m) => m.movementName)).toEqual([
+      CLEAN, JERK, CLEAN, JERK, CLEAN, JERK,
+    ]);
+    for (const stage of template.stages!) {
+      for (const m of stage.movements) expect(m.repScheme).toEqual([1]);
+      expect(stage.preWorkoutNotes).toBeTruthy();
+      expect(stage.deloadPreWorkoutNotes).toContain('Deload');
+    }
+
+    const userProgramId = await rpc<string>('enroll_in_program', user.token, {
+      p_program_id: aaId,
+    });
+    const enrollment = await enrollmentRow(user.token, userProgramId);
+    expect(enrollment.current_stage_index).toBe(0);
+
+    const [clone] = await restJson<StageRow[]>(
+      'GET',
+      `programs?id=eq.${enrollment.program_id}&select=stages`,
+      user.token,
+    );
+    expect(clone.stages).toEqual(template.stages);
+  });
+
+  test('advancing rewrites uncompleted sessions only, keeping per-session weights and cadence', async () => {
+    const user = await signUpThrowawayUser();
+    const aaId = await programIdBySlug(user.token, AA_SLUG);
+    const userProgramId = await rpc<string>('enroll_in_program', user.token, {
+      p_program_id: aaId,
+    });
+    const { program_id: cloneId } = await enrollmentRow(
+      user.token,
+      userProgramId,
+    );
+
+    const before = await orderedSessions(user.token, cloneId);
+    const completedSession = before[0];
+    await completeSession(user, userProgramId, completedSession.id);
+
+    const updated = await rpc<number>('set_program_stage', user.token, {
+      p_user_program_id: userProgramId,
+      p_stage_index: 1,
+    });
+    expect(updated).toBe(before.length - 1);
+
+    const after = await orderedSessions(user.token, cloneId);
+    const enrollment = await enrollmentRow(user.token, userProgramId);
+    expect(enrollment.current_stage_index).toBe(1);
+
+    for (const session of after) {
+      const prior = before.find((s) => s.id === session.id)!;
+
+      if (session.id === completedSession.id) {
+        // Completed history is untouched — still the stage it was done at.
+        expect(session.title).toBe(prior.title);
+        expect(session.workout_options).toEqual(prior.workout_options);
+        continue;
+      }
+
+      const isDeload = session.weight_label === 'Deload weeks';
+      expect(session.title).toBe(isDeload ? 'Deload · C+J+C' : 'C+J+C');
+
+      // Stage 2 complex: clean, jerk, clean — at THIS session's shared weight.
+      expect(session.workout_options.movements.map((m) => m.movementName))
+        .toEqual([CLEAN, JERK, CLEAN]);
+      for (const m of session.workout_options.movements) {
+        expect(m.repScheme).toEqual([1]);
+        expect(m.weightOneValue).toBe(prior.workout_options.sharedWeightOneValue);
+        expect(m.weightTwoValue).toBe(prior.workout_options.sharedWeightTwoValue);
+      }
+      expect(session.workout_options.sharedWeightOneValue).toBe(
+        prior.workout_options.sharedWeightOneValue,
+      );
+
+      // Notes swap to the stage's; goal and cadence stay put.
+      expect(session.workout_options.preWorkoutNotes).toContain('C+J+C');
+      if (isDeload) {
+        expect(session.workout_options.preWorkoutNotes).toContain('Deload');
+      }
+      expect(session.workout_options.workoutGoal).toBe(
+        prior.workout_options.workoutGoal,
+      );
+      expect(session.workout_options.intervalTimer).toBe(
+        prior.workout_options.intervalTimer,
+      );
+      expect(session.workout_options.complexSet).toBe(true);
+    }
+
+    // Going back restores the first stage's shape on the same scope.
+    await rpc('set_program_stage', user.token, {
+      p_user_program_id: userProgramId,
+      p_stage_index: 0,
+    });
+    const reverted = await orderedSessions(user.token, cloneId);
+    for (const session of reverted) {
+      if (session.id === completedSession.id) continue;
+      const isDeload = session.weight_label === 'Deload weeks';
+      expect(session.title).toBe(isDeload ? 'Deload · C+J' : 'C+J');
+      expect(session.workout_options.movements.map((m) => m.movementName))
+        .toEqual([CLEAN, JERK]);
+    }
+    expect(
+      (await enrollmentRow(user.token, userProgramId)).current_stage_index,
+    ).toBe(0);
+  });
+
+  test('rejects out-of-range indexes, ladder-less programs, and foreign enrollments', async () => {
+    const user = await signUpThrowawayUser();
+    const aaId = await programIdBySlug(user.token, AA_SLUG);
+    const userProgramId = await rpc<string>('enroll_in_program', user.token, {
+      p_program_id: aaId,
+      p_queue: false,
+    });
+
+    expect(
+      await rpcError('set_program_stage', user.token, {
+        p_user_program_id: userProgramId,
+        p_stage_index: 5,
+      }),
+    ).toContain('STAGE_INDEX_OUT_OF_RANGE');
+    expect(
+      await rpcError('set_program_stage', user.token, {
+        p_user_program_id: userProgramId,
+        p_stage_index: -1,
+      }),
+    ).toContain('STAGE_INDEX_OUT_OF_RANGE');
+
+    // A different user cannot move this enrollment.
+    const stranger = await signUpThrowawayUser();
+    expect(
+      await rpcError('set_program_stage', stranger.token, {
+        p_user_program_id: userProgramId,
+        p_stage_index: 1,
+      }),
+    ).toContain('No active enrollment');
+
+    // A program without a ladder refuses stage moves.
+    const dfwId = await programIdBySlug(stranger.token, 'dry-fighting-weight');
+    const dfwEnrollment = await rpc<string>('enroll_in_program', stranger.token, {
+      p_program_id: dfwId,
+    });
+    expect(
+      await rpcError('set_program_stage', stranger.token, {
+        p_user_program_id: dfwEnrollment,
+        p_stage_index: 1,
+      }),
+    ).toContain('PROGRAM_HAS_NO_STAGES');
+  });
+
+  test('adjust_program_weights still folds correctly after an advance', async () => {
+    const user = await signUpThrowawayUser();
+    const aaId = await programIdBySlug(user.token, AA_SLUG);
+    const userProgramId = await rpc<string>('enroll_in_program', user.token, {
+      p_program_id: aaId,
+    });
+    const { program_id: cloneId } = await enrollmentRow(
+      user.token,
+      userProgramId,
+    );
+
+    await rpc('set_program_stage', user.token, {
+      p_user_program_id: userProgramId,
+      p_stage_index: 2,
+    });
+    await rpc('adjust_program_weights', user.token, {
+      p_user_program_id: userProgramId,
+      p_shared_weight_one_value: 28,
+      p_shared_weight_one_unit: 'kilograms',
+      p_shared_weight_two_value: 0,
+      p_shared_weight_two_unit: 'kilograms',
+    });
+
+    const after = await orderedSessions(user.token, cloneId);
+    for (const session of after) {
+      const isDeload = session.weight_label === 'Deload weeks';
+      // Work modal 24 -> 28; deloads keep their authored -8 offset (16 -> 20).
+      const expected = isDeload ? 20 : 28;
+      expect(session.workout_options.sharedWeightOneValue).toBe(expected);
+      expect(session.workout_options.movements).toHaveLength(4);
+      for (const m of session.workout_options.movements) {
+        expect(m.weightOneValue).toBe(expected);
+      }
+    }
+  });
+});

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -30,6 +30,7 @@ export * from './usePrograms';
 export * from './useSaveProgramSession';
 export * from './useSetProgramArchived';
 export * from './useSetProgramAutoRepeat';
+export * from './useSetProgramStage';
 export * from './useUpdateProgramSession';
 export * from './useUpdateProgramSessionsForward';
 export * from './useRecentRepeatableWorkouts';

--- a/src/api/program.ts
+++ b/src/api/program.ts
@@ -1,6 +1,7 @@
 import {
   Program,
   ProgramSession,
+  ProgramStage,
   ProgramSessionCompletion,
   ProgramSessionCompletionStatus,
   UserProgram,
@@ -33,6 +34,7 @@ export const mapProgramRow = (row: ProgramRow): Program => ({
   archivedAt: row.archived_at,
   defaultAutoRepeat: row.default_auto_repeat,
   releasedAt: row.released_at,
+  stages: row.stages as unknown as ProgramStage[] | null,
 });
 
 /**
@@ -83,4 +85,5 @@ export const mapUserProgramRow = (row: UserProgramRow): UserProgram => ({
   autoRepeat: row.auto_repeat,
   cyclesCompleted: row.cycles_completed,
   queuePosition: row.queue_position,
+  currentStageIndex: row.current_stage_index,
 });

--- a/src/api/useSetProgramStage.test.ts
+++ b/src/api/useSetProgramStage.test.ts
@@ -1,0 +1,99 @@
+import { renderHook } from '@testing-library/react';
+import { HttpResponse, http } from 'msw';
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+import { SessionProvider, ToastContext } from '~/contexts';
+import { server } from '~/mocks/server';
+
+import { VITE_SUPABASE_URL } from '../env';
+import { PROGRAM_MUTATION_ERROR_MESSAGE } from './useProgramMutationErrorHandler';
+import { useSetProgramStage } from './useSetProgramStage';
+
+const RPC_URL = `${VITE_SUPABASE_URL}/rest/v1/rpc/set_program_stage`;
+
+const showToast = vi.fn();
+
+const mockSession = {
+  user: {
+    id: 'user-123',
+    app_metadata: {},
+    user_metadata: {},
+    created_at: '',
+    aud: '',
+  },
+  access_token: '',
+  refresh_token: '',
+  expires_in: 10000,
+  token_type: '',
+};
+
+const makeWrapper = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return ({ children }: { children: React.ReactNode }) =>
+    React.createElement(
+      QueryClientProvider,
+      { client: queryClient },
+      React.createElement(
+        SessionProvider,
+        { value: mockSession },
+        React.createElement(
+          ToastContext.Provider,
+          { value: { showToast } },
+          children,
+        ),
+      ),
+    );
+};
+
+describe('useSetProgramStage', () => {
+  beforeEach(() => showToast.mockClear());
+
+  it('calls the set_program_stage RPC and resolves with the rewritten count', async () => {
+    let receivedBody: unknown;
+    server.use(
+      http.post(RPC_URL, async ({ request }) => {
+        receivedBody = await request.json();
+        return HttpResponse.json(6);
+      }),
+    );
+
+    const { result } = renderHook(() => useSetProgramStage(), {
+      wrapper: makeWrapper(),
+    });
+
+    const updated = await result.current.mutateAsync({
+      userProgramId: 'up-1',
+      stageIndex: 2,
+    });
+
+    expect(updated).toBe(6);
+    expect(receivedBody).toEqual({
+      p_user_program_id: 'up-1',
+      p_stage_index: 2,
+    });
+    expect(showToast).not.toHaveBeenCalled();
+  });
+
+  it('toasts the shared program error message on failure', async () => {
+    server.use(
+      http.post(RPC_URL, () =>
+        HttpResponse.json({ message: 'boom' }, { status: 400 }),
+      ),
+    );
+
+    const { result } = renderHook(() => useSetProgramStage(), {
+      wrapper: makeWrapper(),
+    });
+
+    await expect(
+      result.current.mutateAsync({ userProgramId: 'up-1', stageIndex: 1 }),
+    ).rejects.toBeTruthy();
+
+    expect(showToast).toHaveBeenCalledWith(PROGRAM_MUTATION_ERROR_MESSAGE, {
+      variant: 'destructive',
+    });
+  });
+});

--- a/src/api/useSetProgramStage.ts
+++ b/src/api/useSetProgramStage.ts
@@ -1,0 +1,48 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { QUERIES } from '~/constants';
+
+import { supabase } from '../supabaseClient';
+import { useProgramMutationErrorHandler } from './useProgramMutationErrorHandler';
+
+export interface SetProgramStageArgs {
+  /** The active enrollment to move along its program's stage ladder. */
+  userProgramId: string;
+  /** Absolute 0-based index into `Program.stages` — serves advance and go-back. */
+  stageIndex: number;
+}
+
+/**
+ * Moves an active enrollment to a stage on its program's progression ladder
+ * via the `set_program_stage` RPC. Every not-yet-completed session is
+ * rewritten to the stage's title, movements, and notes; each session keeps its
+ * own shared weights (deloads stay light), and completed sessions are never
+ * touched.
+ *
+ * Returns the number of sessions rewritten.
+ */
+export const useSetProgramStage = () => {
+  const queryClient = useQueryClient();
+  const onError = useProgramMutationErrorHandler();
+
+  return useMutation({
+    mutationFn: async ({
+      userProgramId,
+      stageIndex,
+    }: SetProgramStageArgs): Promise<number> => {
+      const { data, error } = await supabase.rpc('set_program_stage', {
+        p_user_program_id: userProgramId,
+        p_stage_index: stageIndex,
+      });
+
+      if (error) throw error;
+      return data as number;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: [QUERIES.PROGRAM_PROGRESS] });
+      queryClient.invalidateQueries({ queryKey: [QUERIES.ACTIVE_PROGRAM] });
+      queryClient.invalidateQueries({ queryKey: [QUERIES.PROGRAMS] });
+    },
+    onError,
+  });
+};

--- a/src/examples/active-program.examples.ts
+++ b/src/examples/active-program.examples.ts
@@ -66,6 +66,7 @@ export const exampleActiveProgram = ({
       autoRepeat: false,
       cyclesCompleted: 0,
       queuePosition: null,
+      currentStageIndex: 0,
     },
     program: {
       id: `${id}-program`,
@@ -82,6 +83,7 @@ export const exampleActiveProgram = ({
       createdAt: '2026-07-01T00:00:00Z',
       defaultAutoRepeat: false,
       releasedAt: null,
+      stages: null,
     },
     nextSession: isComplete
       ? null

--- a/src/pages/ProgramProgressPage/ProgramProgressPage.test.tsx
+++ b/src/pages/ProgramProgressPage/ProgramProgressPage.test.tsx
@@ -25,6 +25,7 @@ vi.mock('~/api', () => ({
     mutate: mockAdjustMutate,
     isPending: false,
   }),
+  useSetProgramStage: () => ({ mutate: vi.fn(), isPending: false }),
 }));
 
 const session = (seq: number, week: number, day: number, title: string) => ({
@@ -396,6 +397,33 @@ describe('ProgramProgressPage', () => {
     expect(
       screen.queryByRole('button', { name: 'Adjust weights' }),
     ).toBeNull();
+  });
+
+  it('shows the stage card when the program has a stage ladder', () => {
+    mockUseProgramProgress.mockReturnValue({
+      data: {
+        ...progressData,
+        program: {
+          ...progressData.program,
+          stages: [
+            { title: 'C+J', movements: [] },
+            { title: 'C+J+C', movements: [] },
+          ],
+        },
+        enrollment: {
+          id: 'up-1',
+          status: 'active',
+          autoRepeat: false,
+          currentStageIndex: 1,
+        },
+      },
+      isLoading: false,
+      isError: false,
+    });
+
+    renderPage();
+
+    expect(screen.getByText('Stage 2 of 2: C+J+C')).toBeInTheDocument();
   });
 
   it('renders a not-found state on error', () => {

--- a/src/pages/ProgramProgressPage/ProgramProgressPage.tsx
+++ b/src/pages/ProgramProgressPage/ProgramProgressPage.tsx
@@ -18,6 +18,7 @@ import { cn } from '~/lib/utils';
 import { ProgramSession } from '~/types';
 
 import { AdjustWeightsDialog } from './components/AdjustWeightsDialog';
+import { StageCard } from './components/StageCard';
 
 /** Glyph + label + chip styling for each session state. */
 const STATE_META: Record<SessionState, { icon: string; className: string }> = {
@@ -188,6 +189,15 @@ export const ProgramProgressPage = () => {
           )}
         </CardContent>
       </Card>
+
+      {enrollment && !!program.stages?.length && (
+        <StageCard
+          userProgramId={enrollment.id}
+          stages={program.stages}
+          currentStageIndex={enrollment.currentStageIndex}
+          canAdvance={enrollment.status === 'active'}
+        />
+      )}
 
       {enrollment && adjustingWeights && (
         <AdjustWeightsDialog

--- a/src/pages/ProgramProgressPage/components/StageCard.test.tsx
+++ b/src/pages/ProgramProgressPage/components/StageCard.test.tsx
@@ -1,0 +1,146 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { HttpResponse, http } from 'msw';
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+import { SessionProvider, ToastContext } from '~/contexts';
+import { server } from '~/mocks/server';
+import { ProgramStage } from '~/types';
+
+import { VITE_SUPABASE_URL } from '../../../env';
+import { StageCard } from './StageCard';
+
+const RPC_URL = `${VITE_SUPABASE_URL}/rest/v1/rpc/set_program_stage`;
+
+const showToast = vi.fn();
+
+const mockSession = {
+  user: {
+    id: 'user-123',
+    app_metadata: {},
+    user_metadata: {},
+    created_at: '',
+    aud: '',
+  },
+  access_token: '',
+  refresh_token: '',
+  expires_in: 10000,
+  token_type: '',
+};
+
+const STAGES: ProgramStage[] = [
+  { title: 'C+J', movements: [] },
+  { title: 'C+J+C', movements: [] },
+  { title: 'C+J+C+J', movements: [] },
+];
+
+const renderCard = (
+  props: Partial<React.ComponentProps<typeof StageCard>> = {},
+) => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <SessionProvider value={mockSession}>
+        <ToastContext.Provider value={{ showToast }}>
+          <StageCard
+            userProgramId="up-1"
+            stages={STAGES}
+            currentStageIndex={0}
+            canAdvance
+            {...props}
+          />
+        </ToastContext.Provider>
+      </SessionProvider>
+    </QueryClientProvider>,
+  );
+};
+
+describe('StageCard', () => {
+  beforeEach(() => showToast.mockClear());
+
+  it('shows the current stage position and title', () => {
+    renderCard({ currentStageIndex: 1 });
+    expect(screen.getByText('Stage 2 of 3: C+J+C')).toBeInTheDocument();
+  });
+
+  it('advances to the next stage after confirming', async () => {
+    const user = userEvent.setup();
+    let receivedBody: unknown;
+    server.use(
+      http.post(RPC_URL, async ({ request }) => {
+        receivedBody = await request.json();
+        return HttpResponse.json(6);
+      }),
+    );
+
+    renderCard();
+
+    await user.click(screen.getByRole('button', { name: 'Advance stage' }));
+    expect(screen.getByText('Move to C+J+C?')).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: 'Move to C+J+C' }));
+
+    await waitFor(() =>
+      expect(receivedBody).toEqual({
+        p_user_program_id: 'up-1',
+        p_stage_index: 1,
+      }),
+    );
+    expect(showToast).toHaveBeenCalledWith(
+      'Moved to C+J+C — 6 upcoming sessions updated',
+    );
+  });
+
+  it('goes back a stage after confirming', async () => {
+    const user = userEvent.setup();
+    let receivedBody: unknown;
+    server.use(
+      http.post(RPC_URL, async ({ request }) => {
+        receivedBody = await request.json();
+        return HttpResponse.json(4);
+      }),
+    );
+
+    renderCard({ currentStageIndex: 2 });
+
+    await user.click(screen.getByRole('button', { name: 'Go back' }));
+    await user.click(screen.getByRole('button', { name: 'Move to C+J+C' }));
+
+    await waitFor(() =>
+      expect(receivedBody).toEqual({
+        p_user_program_id: 'up-1',
+        p_stage_index: 1,
+      }),
+    );
+  });
+
+  it('hides Go back at the first stage', () => {
+    renderCard({ currentStageIndex: 0 });
+    expect(
+      screen.queryByRole('button', { name: 'Go back' }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Advance stage' }),
+    ).toBeInTheDocument();
+  });
+
+  it('hides Advance at the last stage', () => {
+    renderCard({ currentStageIndex: 2 });
+    expect(
+      screen.queryByRole('button', { name: 'Advance stage' }),
+    ).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Go back' })).toBeInTheDocument();
+  });
+
+  it('hides both actions when the enrollment is not active', () => {
+    renderCard({ currentStageIndex: 1, canAdvance: false });
+    expect(
+      screen.queryByRole('button', { name: 'Advance stage' }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: 'Go back' }),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/src/pages/ProgramProgressPage/components/StageCard.tsx
+++ b/src/pages/ProgramProgressPage/components/StageCard.tsx
@@ -1,0 +1,126 @@
+import { useState } from 'react';
+
+import { useSetProgramStage } from '~/api';
+import { Button } from '~/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '~/components/ui/dialog';
+import { Card, CardContent } from '~/components/ui/card';
+import { useToast } from '~/contexts';
+import { ProgramStage } from '~/types';
+
+interface StageCardProps {
+  /** The active enrollment being moved along the ladder. */
+  userProgramId: string;
+  /** The program's full stage ladder, in order. */
+  stages: ProgramStage[];
+  /** The enrollment's current 0-based position on the ladder. */
+  currentStageIndex: number;
+  /** Whether the enrollment is active (stage moves are disabled otherwise). */
+  canAdvance: boolean;
+}
+
+/**
+ * The enrollment's position on its program's progression ladder, with
+ * confirm-gated Advance / Go back actions. Advancing rewrites every
+ * not-yet-completed session to the target stage's movements, title, and notes;
+ * weights are untouched (that's the Adjust weights flow).
+ */
+export const StageCard = ({
+  userProgramId,
+  stages,
+  currentStageIndex,
+  canAdvance,
+}: StageCardProps) => {
+  const setStage = useSetProgramStage();
+  const { showToast } = useToast();
+  const [targetIndex, setTargetIndex] = useState<number | null>(null);
+
+  const current = stages[currentStageIndex];
+  if (!current) return null;
+
+  const target = targetIndex === null ? null : stages[targetIndex];
+  const isLast = currentStageIndex >= stages.length - 1;
+  const isFirst = currentStageIndex <= 0;
+
+  const handleConfirm = () => {
+    if (targetIndex === null) return;
+    setStage.mutate(
+      { userProgramId, stageIndex: targetIndex },
+      {
+        onSuccess: (updatedCount) => {
+          showToast(
+            `Moved to ${stages[targetIndex].title} — ${updatedCount} upcoming session${updatedCount === 1 ? '' : 's'} updated`,
+          );
+          setTargetIndex(null);
+        },
+      },
+    );
+  };
+
+  return (
+    <Card>
+      <CardContent className="flex flex-col gap-1 pt-2">
+        <div className="flex items-baseline justify-between text-sm font-medium">
+          <span>
+            Stage {currentStageIndex + 1} of {stages.length}: {current.title}
+          </span>
+        </div>
+        {canAdvance && (
+          <div className="flex items-center gap-2">
+            {!isLast && (
+              <Button
+                variant="secondary"
+                size="sm"
+                onClick={() => setTargetIndex(currentStageIndex + 1)}
+              >
+                Advance stage
+              </Button>
+            )}
+            {!isFirst && (
+              <Button
+                variant="ghost"
+                size="sm"
+                className="text-muted-foreground"
+                onClick={() => setTargetIndex(currentStageIndex - 1)}
+              >
+                Go back
+              </Button>
+            )}
+          </div>
+        )}
+      </CardContent>
+
+      {target && (
+        <Dialog
+          open={targetIndex !== null}
+          onOpenChange={(open) => !open && setTargetIndex(null)}
+        >
+          <DialogContent>
+            <DialogHeader>
+              <DialogTitle>Move to {target.title}?</DialogTitle>
+              <DialogDescription>
+                Rewrites every session you haven&apos;t done yet to the{' '}
+                {target.title} complex. Weights aren&apos;t changed, and
+                completed workouts stay as they were.
+              </DialogDescription>
+            </DialogHeader>
+            <DialogFooter>
+              <Button variant="secondary" onClick={() => setTargetIndex(null)}>
+                Cancel
+              </Button>
+              <Button onClick={handleConfirm} disabled={setStage.isPending}>
+                Move to {target.title}
+              </Button>
+            </DialogFooter>
+          </DialogContent>
+        </Dialog>
+      )}
+    </Card>
+  );
+};

--- a/src/types/program.interface.ts
+++ b/src/types/program.interface.ts
@@ -7,6 +7,27 @@
  *
  * camelCase mirror of the generated `programs` row.
  */
+/** One movement of a {@link ProgramStage} complex — name and reps only; weights come from each session. */
+export interface ProgramStageMovement {
+  movementName: string;
+  repScheme: number[];
+}
+
+/**
+ * One rung of a program's milestone-gated progression ladder (e.g. A+A's
+ * C+J → C+J+C → … → 3 cleans + 3 jerks). Advancing an enrollment to a stage
+ * (`set_program_stage`) rewrites every not-yet-completed session's title,
+ * movements, and notes; each session keeps its own shared weights, so stages
+ * author none.
+ */
+export interface ProgramStage {
+  title: string;
+  movements: ProgramStageMovement[];
+  preWorkoutNotes?: string;
+  /** Notes variant for sessions in the 'Deload weeks' weight group. */
+  deloadPreWorkoutNotes?: string;
+}
+
 export interface Program {
   id: string;
   /** NULL for system/shared programs; the owning user otherwise. */
@@ -44,4 +65,10 @@ export interface Program {
    * clients only ever see timestamps here.
    */
   releasedAt: string | null;
+  /**
+   * Ordered progression ladder, or `null` for programs without one. Copied to
+   * the clone at enroll time; {@link UserProgram.currentStageIndex} tracks the
+   * enrollment's position.
+   */
+  stages: ProgramStage[] | null;
 }

--- a/src/types/user-program.interface.ts
+++ b/src/types/user-program.interface.ts
@@ -41,4 +41,9 @@ export interface UserProgram {
    * fine — promotion never renumbers. `null` on non-queued rows.
    */
   queuePosition: number | null;
+  /**
+   * Position on {@link Program.stages} (0-based). Always 0 for programs
+   * without a ladder; moved by the `set_program_stage` RPC.
+   */
+  currentStageIndex: number;
 }

--- a/supabase/migrations/20260802000000_add_program_stages.sql
+++ b/supabase/migrations/20260802000000_add_program_stages.sql
@@ -1,0 +1,322 @@
+-- Program stages: an ordered ladder of milestone-gated variants a program can
+-- progress through (PROD: A+A C+J -> C+J+C -> ... -> 3 cleans + 3 jerks).
+--
+-- `programs.stages` is a JSONB array of ProgramStage:
+--   { "title": "C+J+C",
+--     "movements": [{ "movementName": "...", "repScheme": [1] }, ...],
+--     "preWorkoutNotes": "...", "deloadPreWorkoutNotes": "..." }
+-- Stages author NO weights — set_program_stage rebuilds each session's
+-- movements from the session's own sharedWeightOne/Two, so work and deload
+-- loads survive a stage change and adjust_program_weights stays the sole
+-- weight authority. NULL stages = the program has no ladder (most programs).
+--
+-- `user_programs.current_stage_index` is the enrollment's position on the
+-- ladder, defaulting to 0 like a fresh enrollee (also correct for every
+-- pre-existing row).
+ALTER TABLE programs ADD COLUMN stages JSONB;
+
+ALTER TABLE user_programs
+  ADD COLUMN current_stage_index SMALLINT NOT NULL DEFAULT 0;
+
+-- Re-create enroll_in_program so the copy-on-enroll clone carries the
+-- template's stage ladder. Body carried over VERBATIM from
+-- 20260728100001_enroll_in_program_queue.sql; the only change is `stages` in
+-- both column lists of the clone INSERT.
+DROP FUNCTION IF EXISTS public.enroll_in_program(UUID, NUMERIC, TEXT, NUMERIC, TEXT, UUID, JSONB, BOOLEAN, BOOLEAN);
+
+CREATE FUNCTION public.enroll_in_program(
+  p_program_id UUID,
+  p_shared_weight_one_value NUMERIC DEFAULT NULL,
+  p_shared_weight_one_unit  TEXT    DEFAULT NULL,
+  p_shared_weight_two_value NUMERIC DEFAULT NULL,
+  p_shared_weight_two_unit  TEXT    DEFAULT NULL,
+  p_replace_user_program_id UUID    DEFAULT NULL,
+  p_movement_weights        JSONB   DEFAULT NULL,
+  p_auto_repeat             BOOLEAN  DEFAULT NULL,
+  p_queue                   BOOLEAN  DEFAULT false
+)
+RETURNS UUID
+LANGUAGE plpgsql
+SECURITY INVOKER
+SET search_path = public
+AS $$
+DECLARE
+  v_user_id            UUID    := auth.uid();
+  v_owner_id           UUID;
+  v_default_auto_repeat BOOLEAN;
+  v_target_program     UUID;
+  v_user_program_id    UUID;
+  v_modal_one          NUMERIC;
+  v_modal_two          NUMERIC;
+  v_slot               SMALLINT;
+  v_queue_position     INTEGER;
+  v_override           BOOLEAN := p_shared_weight_one_value IS NOT NULL
+                                 OR p_movement_weights IS NOT NULL;
+BEGIN
+  IF v_user_id IS NULL THEN
+    RAISE EXCEPTION 'Not authenticated';
+  END IF;
+
+  -- RLS on this SELECT already restricts to public-or-own; a NOT FOUND result
+  -- means the program does not exist or is not visible to the caller.
+  SELECT owner_id, default_auto_repeat INTO v_owner_id, v_default_auto_repeat
+  FROM programs WHERE id = p_program_id;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Program % not found or not accessible', p_program_id;
+  END IF;
+
+  -- One live cursor per program. `p.source_program_id = p_program_id` catches
+  -- re-enrolling in a shared program whose earlier clone is still running.
+  IF NOT p_queue AND EXISTS (
+    SELECT 1
+    FROM user_programs up
+    JOIN programs p ON p.id = up.program_id
+    WHERE up.user_id = v_user_id
+      AND up.status = 'active'
+      AND up.id IS DISTINCT FROM p_replace_user_program_id
+      AND (p.id = p_program_id OR p.source_program_id = p_program_id)
+  ) THEN
+    RAISE EXCEPTION 'PROGRAM_ALREADY_ACTIVE';
+  END IF;
+
+  IF p_queue THEN
+    -- Queued rows hold no slot; they take the next position in line. The
+    -- partial unique index serializes concurrent inserts per user.
+    SELECT COALESCE(MAX(queue_position), 0) + 1 INTO v_queue_position
+    FROM user_programs
+    WHERE user_id = v_user_id AND status = 'queued';
+  ELSE
+    -- Free the replaced slot first so the picker below can reuse it.
+    IF p_replace_user_program_id IS NOT NULL THEN
+      UPDATE user_programs
+        SET status = 'abandoned'
+        WHERE id = p_replace_user_program_id
+          AND user_id = v_user_id
+          AND status = 'active';
+      IF NOT FOUND THEN
+        RAISE EXCEPTION 'No active enrollment % to replace', p_replace_user_program_id;
+      END IF;
+    END IF;
+
+    SELECT s.slot INTO v_slot
+    FROM generate_series(1, 3) AS s(slot)
+    WHERE NOT EXISTS (
+      SELECT 1 FROM user_programs up
+      WHERE up.user_id = v_user_id
+        AND up.status = 'active'
+        AND up.active_slot = s.slot
+    )
+    ORDER BY s.slot
+    LIMIT 1;
+
+    IF v_slot IS NULL THEN
+      RAISE EXCEPTION 'PROGRAM_SLOTS_FULL';
+    END IF;
+  END IF;
+
+  IF v_owner_id = v_user_id THEN
+    v_target_program := p_program_id;                     -- own program: no clone
+  ELSE
+    INSERT INTO programs
+      (owner_id, source_program_id, slug, title, description, author_name,
+       num_weeks, days_per_week, is_public, default_auto_repeat, stages)
+    SELECT v_user_id, id, NULL, title, description, author_name,
+           num_weeks, days_per_week, false, default_auto_repeat, stages
+    FROM programs WHERE id = p_program_id
+    RETURNING id INTO v_target_program;
+
+    IF v_override THEN
+      -- The modal (weightOne, weightTwo) pair across the program's sessions:
+      -- the shared placeholder load every deliberately-different session is
+      -- offset from, used only by the complexSet uniform-fold path. Ties break
+      -- toward the lighter pair, mirroring deriveStartingWeight.
+      SELECT one_val, two_val INTO v_modal_one, v_modal_two
+      FROM (
+        SELECT (workout_options->'movements'->0->>'weightOneValue')::NUMERIC AS one_val,
+               (workout_options->'movements'->0->>'weightTwoValue')::NUMERIC AS two_val,
+               COUNT(*) AS cnt
+        FROM program_sessions
+        WHERE program_id = p_program_id
+        GROUP BY one_val, two_val
+        ORDER BY cnt DESC, one_val, two_val
+        LIMIT 1
+      ) modal;
+    END IF;
+
+    INSERT INTO program_sessions
+      (program_id, sequence_index, week_number, day_number, title,
+       workout_options, notes, weight_label)
+    -- Per-movement modal authored weight, one row per movement name. Rows with a
+    -- null weight one (bodyweight) never form a modal, so a bodyweight movement
+    -- has no row and its element is kept untouched below. Tie-break mirrors the
+    -- client's deriveMovementWeights so pre-fill equals the cloned value.
+    WITH movement_modal AS (
+      SELECT DISTINCT ON (name)
+        name, one_val, two_val
+      FROM (
+        SELECT
+          mv->>'movementName' AS name,
+          (mv->>'weightOneValue')::NUMERIC AS one_val,
+          (mv->>'weightTwoValue')::NUMERIC AS two_val,
+          COUNT(*) AS cnt
+        FROM program_sessions ps2,
+             jsonb_array_elements(ps2.workout_options->'movements') AS mv
+        WHERE ps2.program_id = p_program_id
+          AND (mv->>'weightOneValue') IS NOT NULL
+        GROUP BY name, one_val, two_val
+      ) per_pair
+      ORDER BY name, cnt DESC, one_val, two_val
+    )
+    SELECT
+      v_target_program, ps.sequence_index, ps.week_number, ps.day_number, ps.title,
+      CASE
+        WHEN NOT v_override THEN ps.workout_options
+        -- non-complex with per-movement weights: rebuild each element in its own
+        -- config shape, offset from that movement's modal.
+        WHEN p_movement_weights IS NOT NULL
+             AND ps.workout_options->>'complexSet' IS DISTINCT FROM 'true'
+          THEN jsonb_set(
+                 ps.workout_options,
+                 '{movements}',
+                 (
+                   SELECT jsonb_agg(
+                            CASE
+                              WHEN mw.value IS NULL THEN elem
+                              ELSE elem || jsonb_build_object(
+                                'weightOneValue',
+                                  COALESCE(to_jsonb(
+                                    CASE
+                                      WHEN (mw.value->>'weightOneValue')::NUMERIC IS NULL
+                                        OR r.one_delta = 0
+                                        THEN (mw.value->>'weightOneValue')::NUMERIC
+                                      ELSE GREATEST((mw.value->>'weightOneValue')::NUMERIC + r.one_delta, 1)
+                                    END), 'null'::jsonb),
+                                'weightOneUnit',
+                                  COALESCE(to_jsonb(mw.value->>'weightOneUnit'), 'null'::jsonb),
+                                'weightTwoValue',
+                                  COALESCE(to_jsonb(
+                                    CASE
+                                      WHEN (mw.value->>'weightTwoValue')::NUMERIC IS NULL
+                                        OR r.two_delta = 0
+                                        THEN (mw.value->>'weightTwoValue')::NUMERIC
+                                      ELSE GREATEST((mw.value->>'weightTwoValue')::NUMERIC + r.two_delta, 1)
+                                    END), 'null'::jsonb),
+                                'weightTwoUnit',
+                                  COALESCE(to_jsonb(mw.value->>'weightTwoUnit'), 'null'::jsonb)
+                              )
+                            END
+                            ORDER BY ord
+                          )
+                   FROM jsonb_array_elements(ps.workout_options->'movements')
+                          WITH ORDINALITY AS e(elem, ord)
+                   LEFT JOIN LATERAL (
+                     SELECT o.value
+                     FROM jsonb_array_elements(p_movement_weights) AS o(value)
+                     WHERE o.value->>'movementName' = elem->>'movementName'
+                     LIMIT 1
+                   ) mw ON TRUE
+                   LEFT JOIN movement_modal mm ON mm.name = elem->>'movementName'
+                   CROSS JOIN LATERAL (
+                     SELECT
+                       -- Offset only when the movement's authored unit matches the
+                       -- chosen unit; a cross-unit choice passes through (delta 0).
+                       CASE WHEN elem->>'weightOneUnit'
+                                 IS NOT DISTINCT FROM mw.value->>'weightOneUnit'
+                            THEN COALESCE((elem->>'weightOneValue')::NUMERIC, 0)
+                                 - COALESCE(mm.one_val, 0)
+                            ELSE 0 END AS one_delta,
+                       CASE WHEN elem->>'weightTwoUnit'
+                                 IS NOT DISTINCT FROM mw.value->>'weightTwoUnit'
+                            THEN COALESCE((elem->>'weightTwoValue')::NUMERIC, 0)
+                                 - COALESCE(mm.two_val, 0)
+                            ELSE 0 END AS two_delta
+                   ) r
+                 ))
+        -- complexSet (one bell pair for the whole complex, ABC), or a caller that
+        -- passed only p_shared_weight_* (the homogeneous shared-weight programs):
+        -- the prior uniform fold. COALESCE(..., 'null'::jsonb): jsonb_set is
+        -- strict and to_jsonb(NULL) is SQL NULL, so an unset slot must be coerced
+        -- to a JSON null. `m || jsonb_build_object(...)` overrides only the four
+        -- weight keys, preserving movementName / repScheme / etc.
+        ELSE jsonb_set(
+               jsonb_set(
+                 jsonb_set(
+                   jsonb_set(
+                     jsonb_set(
+                       ps.workout_options,
+                       '{sharedWeightOneValue}',
+                       COALESCE(to_jsonb(w.one_value), 'null'::jsonb)),
+                     '{sharedWeightOneUnit}',
+                     COALESCE(to_jsonb(w.one_unit), 'null'::jsonb)),
+                   '{sharedWeightTwoValue}',
+                   COALESCE(to_jsonb(w.two_value), 'null'::jsonb)),
+                 '{sharedWeightTwoUnit}',
+                 COALESCE(to_jsonb(w.two_unit), 'null'::jsonb)),
+               '{movements}',
+               (
+                 SELECT jsonb_agg(
+                          m || jsonb_build_object(
+                            'weightOneValue', COALESCE(to_jsonb(w.one_value), 'null'::jsonb),
+                            'weightOneUnit',  COALESCE(to_jsonb(w.one_unit),  'null'::jsonb),
+                            'weightTwoValue', COALESCE(to_jsonb(w.two_value), 'null'::jsonb),
+                            'weightTwoUnit',  COALESCE(to_jsonb(w.two_unit),  'null'::jsonb)
+                          )
+                        )
+                 FROM jsonb_array_elements(ps.workout_options->'movements') AS m
+               ))
+      END,
+      ps.notes,
+      ps.weight_label
+    FROM program_sessions ps
+    -- Per-session shared weight for the complexSet path: the enrollee's choice
+    -- shifted by this session's authored offset from the modal. A zero delta
+    -- passes the chosen value through untouched -- notably it must NOT hit the
+    -- >= 1 clamp, since a single-bell enrollment carries weight two = 0.
+    CROSS JOIN LATERAL (
+      SELECT
+        CASE
+          WHEN p_shared_weight_one_value IS NULL OR d.one_delta = 0
+            THEN p_shared_weight_one_value
+          ELSE GREATEST(p_shared_weight_one_value + d.one_delta, 1)
+        END AS one_value,
+        CASE
+          WHEN p_shared_weight_two_value IS NULL OR d.two_delta = 0
+            THEN p_shared_weight_two_value
+          ELSE GREATEST(p_shared_weight_two_value + d.two_delta, 1)
+        END AS two_value,
+        p_shared_weight_one_unit AS one_unit,
+        p_shared_weight_two_unit AS two_unit
+      FROM (
+        SELECT
+          COALESCE(
+            CASE WHEN ps.workout_options->'movements'->0->>'weightOneUnit'
+                      IS NOT DISTINCT FROM p_shared_weight_one_unit
+                 THEN (ps.workout_options->'movements'->0->>'weightOneValue')::NUMERIC
+                      - v_modal_one
+            END, 0) AS one_delta,
+          COALESCE(
+            CASE WHEN ps.workout_options->'movements'->0->>'weightTwoUnit'
+                      IS NOT DISTINCT FROM p_shared_weight_two_unit
+                 THEN (ps.workout_options->'movements'->0->>'weightTwoValue')::NUMERIC
+                      - v_modal_two
+            END, 0) AS two_delta
+      ) d
+    ) w
+    WHERE ps.program_id = p_program_id
+    ORDER BY ps.sequence_index;
+  END IF;
+
+  INSERT INTO user_programs
+    (user_id, program_id, status, active_slot, queue_position, auto_repeat)
+  VALUES (v_user_id, v_target_program,
+          CASE WHEN p_queue THEN 'queued' ELSE 'active' END,
+          v_slot, v_queue_position,
+          COALESCE(p_auto_repeat, v_default_auto_repeat, false))
+  RETURNING id INTO v_user_program_id;
+
+  RETURN v_user_program_id;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.enroll_in_program(UUID, NUMERIC, TEXT, NUMERIC, TEXT, UUID, JSONB, BOOLEAN, BOOLEAN) FROM public;
+GRANT EXECUTE ON FUNCTION public.enroll_in_program(UUID, NUMERIC, TEXT, NUMERIC, TEXT, UUID, JSONB, BOOLEAN, BOOLEAN) TO authenticated;

--- a/supabase/migrations/20260802000001_set_program_stage.sql
+++ b/supabase/migrations/20260802000001_set_program_stage.sql
@@ -1,0 +1,98 @@
+-- Move an active enrollment to a stage on its program's ladder.
+--
+-- Rewrites every session of the enrollment's cloned program that has no
+-- completion row for this enrollment (same scope as adjust_program_weights):
+--
+--   * title            -> the stage's title, prefixed 'Deload · ' on rows in
+--                         the 'Deload weeks' weight group.
+--   * movements        -> the stage's movements (name + repScheme), each
+--                         stamped with THAT session's own sharedWeightOne/Two
+--                         pair — so 24 kg work sessions and 16 kg deloads both
+--                         keep their loads across a stage change, and
+--                         adjust_program_weights remains the sole weight
+--                         authority.
+--   * preWorkoutNotes  -> the stage's notes (deloadPreWorkoutNotes on deload
+--                         rows), falling back to the session's existing note
+--                         when the stage doesn't author one.
+--
+-- The `||` merge leaves goal, duration, interval, and rest untouched.
+-- Completed sessions are never rewritten — history shows what was done at the
+-- stage it was done. Takes an absolute index so one function serves both
+-- "advance" and "go back". Stages v1 assumes shared-weight (complexSet)
+-- programs; the only ladder shipped is A+A.
+CREATE FUNCTION public.set_program_stage(
+  p_user_program_id UUID,
+  p_stage_index     INTEGER
+)
+RETURNS INTEGER
+LANGUAGE plpgsql
+SECURITY INVOKER
+SET search_path = public
+AS $$
+DECLARE
+  v_user_id UUID := auth.uid();
+  v_program UUID;
+  v_stages  JSONB;
+  v_stage   JSONB;
+  v_updated INTEGER;
+BEGIN
+  IF v_user_id IS NULL THEN
+    RAISE EXCEPTION 'Not authenticated';
+  END IF;
+
+  SELECT up.program_id, p.stages INTO v_program, v_stages
+  FROM user_programs up
+  JOIN programs p ON p.id = up.program_id
+  WHERE up.id = p_user_program_id
+    AND up.user_id = v_user_id
+    AND up.status = 'active';
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'No active enrollment % for this user', p_user_program_id;
+  END IF;
+  IF v_stages IS NULL OR jsonb_typeof(v_stages) <> 'array' THEN
+    RAISE EXCEPTION 'PROGRAM_HAS_NO_STAGES';
+  END IF;
+  IF p_stage_index < 0 OR p_stage_index >= jsonb_array_length(v_stages) THEN
+    RAISE EXCEPTION 'STAGE_INDEX_OUT_OF_RANGE';
+  END IF;
+
+  v_stage := v_stages -> p_stage_index;
+
+  UPDATE program_sessions ps
+  SET title = CASE WHEN ps.weight_label = 'Deload weeks'
+                   THEN 'Deload · ' || (v_stage->>'title')
+                   ELSE v_stage->>'title' END,
+      workout_options = ps.workout_options || jsonb_build_object(
+        'movements', (
+          SELECT jsonb_agg(
+                   m || jsonb_build_object(
+                     'weightOneUnit',  ps.workout_options->'sharedWeightOneUnit',
+                     'weightOneValue', ps.workout_options->'sharedWeightOneValue',
+                     'weightTwoUnit',  ps.workout_options->'sharedWeightTwoUnit',
+                     'weightTwoValue', ps.workout_options->'sharedWeightTwoValue')
+                   ORDER BY ord)
+          FROM jsonb_array_elements(v_stage->'movements')
+                 WITH ORDINALITY AS e(m, ord)),
+        'preWorkoutNotes', COALESCE(
+          CASE WHEN ps.weight_label = 'Deload weeks'
+               THEN v_stage->>'deloadPreWorkoutNotes' END,
+          v_stage->>'preWorkoutNotes',
+          ps.workout_options->>'preWorkoutNotes'))
+  WHERE ps.program_id = v_program
+    AND NOT EXISTS (
+      SELECT 1 FROM program_session_completions c
+      WHERE c.user_program_id = p_user_program_id
+        AND c.program_session_id = ps.id
+    );
+  GET DIAGNOSTICS v_updated = ROW_COUNT;
+
+  UPDATE user_programs
+  SET current_stage_index = p_stage_index
+  WHERE id = p_user_program_id;
+
+  RETURN v_updated;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.set_program_stage(UUID, INTEGER) FROM public;
+GRANT EXECUTE ON FUNCTION public.set_program_stage(UUID, INTEGER) TO authenticated;

--- a/supabase/migrations/20260802000002_seed_aa_protocol_stages.sql
+++ b/supabase/migrations/20260802000002_seed_aa_protocol_stages.sql
@@ -1,0 +1,113 @@
+-- Seed the A+A Protocol Plan A stage ladder: C+J -> C+J+C -> C+J+C+J ->
+-- C+J+C+J+C -> C+J+C+J+C+J (up to three cleans + three jerks every 30s).
+--
+-- The refit migration (20260724000005) shipped only the first stage as encoded
+-- sessions and left the escalation as prose; set_program_stage now makes it a
+-- real mechanism. Each stage authors title, movements (name + repScheme [1] —
+-- single-element repScheme keeps the complex runtime's one-tap-per-round
+-- behavior), and work/deload notes; weights are never authored here.
+--
+-- Backfills existing clones too: safe exception to the never-refit-clones
+-- rule, because it only fills the new nullable `stages` column — sessions are
+-- untouched, and current_stage_index defaults to 0 (everyone is on C+J).
+--
+-- pg_temp helpers are prefixed aa_stage_ to avoid colliding with the other
+-- aa_* helpers earlier migrations define in CI's single-session apply.
+
+-- One decomposed lift in the complex: name + one rep, no weights.
+CREATE OR REPLACE FUNCTION pg_temp.aa_stage_mv(p_name TEXT)
+RETURNS JSONB LANGUAGE sql IMMUTABLE AS $$
+  SELECT jsonb_build_object(
+    'movementName', p_name,
+    'repScheme', to_jsonb(ARRAY[1]::INT[]));
+$$;
+
+-- A complex of p_cleans cleans and p_jerks jerks, alternating C,J,C,J,...
+-- with any surplus clean appended at the end (the source escalates by adding
+-- a clean first, then a jerk).
+CREATE OR REPLACE FUNCTION pg_temp.aa_stage_complex(p_cleans INT, p_jerks INT)
+RETURNS JSONB LANGUAGE sql IMMUTABLE AS $$
+  SELECT jsonb_agg(mv ORDER BY ord)
+  FROM (
+    SELECT pg_temp.aa_stage_mv('One-Arm Kettlebell Clean') AS mv, i * 2 AS ord
+    FROM generate_series(1, p_cleans) AS i
+    UNION ALL
+    SELECT pg_temp.aa_stage_mv('One-Arm Kettlebell Jerk'), i * 2 + 1
+    FROM generate_series(1, p_jerks) AS i
+  ) parts;
+$$;
+
+-- Work-session note for a stage: the autoregulation rule plus the progression
+-- tail (what to add once 30 min is owned).
+CREATE OR REPLACE FUNCTION pg_temp.aa_stage_work_note(p_complex TEXT, p_tail TEXT)
+RETURNS TEXT LANGUAGE sql IMMUTABLE AS $$
+  SELECT p_complex || ' - one bell, one set every 30s, alternating hands: '
+    'left on the minute, right 30s later. Carry on until you cannot pass the '
+    'talk test right before the next set; stop then, or at 30 min, whichever '
+    'comes first. ' || p_tail;
+$$;
+
+-- Deload note for a stage: same complex, one bell size lighter.
+CREATE OR REPLACE FUNCTION pg_temp.aa_stage_deload_note(p_complex TEXT)
+RETURNS TEXT LANGUAGE sql IMMUTABLE AS $$
+  SELECT 'Deload week - one kettlebell size lighter (-8 kg gentlemen, -4 kg '
+    'ladies), same ' || p_complex || ' complex and same 30s left/right '
+    'cadence. Duration stays autoregulated: carry on until the talk test '
+    'fails, up to 30 min. Explode, and keep it easy.';
+$$;
+
+CREATE OR REPLACE FUNCTION pg_temp.aa_stage(
+  p_title TEXT, p_cleans INT, p_jerks INT, p_tail TEXT
+)
+RETURNS JSONB LANGUAGE sql IMMUTABLE AS $$
+  SELECT jsonb_build_object(
+    'title', p_title,
+    'movements', pg_temp.aa_stage_complex(p_cleans, p_jerks),
+    'preWorkoutNotes', pg_temp.aa_stage_work_note(p_title, p_tail),
+    'deloadPreWorkoutNotes', pg_temp.aa_stage_deload_note(p_title));
+$$;
+
+DO $$
+DECLARE
+  v_template UUID;
+  v_stages   JSONB;
+  v_clones   INT;
+BEGIN
+  SELECT id INTO v_template
+  FROM programs
+  WHERE slug = 'aa-protocol-plan-a' AND owner_id IS NULL;
+
+  IF v_template IS NULL THEN
+    RAISE NOTICE 'A+A Protocol template not found; no stages seeded.';
+    RETURN;
+  END IF;
+
+  v_stages := jsonb_build_array(
+    pg_temp.aa_stage('C+J', 1, 1,
+      'Once 30 min is repeatable with a clean talk test, advance the stage: '
+      'add a second clean to each set (C+J+C).'),
+    pg_temp.aa_stage('C+J+C', 2, 1,
+      'Once 30 min is repeatable with a clean talk test, advance the stage: '
+      'add a second jerk to each set (C+J+C+J).'),
+    pg_temp.aa_stage('C+J+C+J', 2, 2,
+      'Once 30 min is repeatable with a clean talk test, advance the stage: '
+      'add a third clean to each set (C+J+C+J+C).'),
+    pg_temp.aa_stage('C+J+C+J+C', 3, 2,
+      'Once 30 min is repeatable with a clean talk test, advance the stage: '
+      'add a third jerk to each set (C+J+C+J+C+J).'),
+    pg_temp.aa_stage('C+J+C+J+C+J', 3, 3,
+      'This is the final stage - three clean & jerks every 30 seconds. Once '
+      '30 min is repeatable with a clean talk test, you own the protocol: '
+      'move up a bell size and restart at C+J.'));
+
+  UPDATE programs SET stages = v_stages WHERE id = v_template;
+
+  -- Existing enrollees' clones get the ladder too (sessions untouched).
+  UPDATE programs c
+  SET stages = v_stages
+  WHERE c.source_program_id = v_template
+    AND c.stages IS NULL;
+  GET DIAGNOSTICS v_clones = ROW_COUNT;
+
+  RAISE NOTICE 'A+A stages seeded on template and % clone(s).', v_clones;
+END $$;

--- a/types/supabase.ts
+++ b/types/supabase.ts
@@ -381,6 +381,7 @@ export type Database = {
           released_at: string | null
           slug: string | null
           source_program_id: string | null
+          stages: Json | null
           title: string
         }
         Insert: {
@@ -397,6 +398,7 @@ export type Database = {
           released_at?: string | null
           slug?: string | null
           source_program_id?: string | null
+          stages?: Json | null
           title: string
         }
         Update: {
@@ -413,6 +415,7 @@ export type Database = {
           released_at?: string | null
           slug?: string | null
           source_program_id?: string | null
+          stages?: Json | null
           title?: string
         }
         Relationships: [
@@ -541,6 +544,7 @@ export type Database = {
           auto_repeat: boolean
           completed_at: string | null
           config: Json
+          current_stage_index: number
           cycles_completed: number
           id: string
           program_id: string
@@ -554,6 +558,7 @@ export type Database = {
           auto_repeat?: boolean
           completed_at?: string | null
           config?: Json
+          current_stage_index?: number
           cycles_completed?: number
           id?: string
           program_id: string
@@ -567,6 +572,7 @@ export type Database = {
           auto_repeat?: boolean
           completed_at?: string | null
           config?: Json
+          current_stage_index?: number
           cycles_completed?: number
           id?: string
           program_id?: string
@@ -862,6 +868,10 @@ export type Database = {
       resume_program: {
         Args: { p_replace_user_program_id?: string; p_user_program_id: string }
         Returns: string
+      }
+      set_program_stage: {
+        Args: { p_stage_index: number; p_user_program_id: string }
+        Returns: number
       }
       update_program_sessions_forward: {
         Args: { p_forward_options: Json; p_session_id: string }


### PR DESCRIPTION
## Why

The A+A Protocol escalates its complex — C+J → C+J+C → C+J+C+J → up to three cleans + three jerks — when the athlete owns 30 minutes, not on a scheduled week, so the progression only existed as prose. Editing the next workout and applying it forward left every later session with a stale \"C+J\" title and stale notes, because the forward RPC deliberately skips both.

## What

Programs can carry an ordered stage ladder (`programs.stages` JSONB); enrollments track their position (`user_programs.current_stage_index`). The `set_program_stage` RPC rewrites every not-yet-completed session of the clone to the target stage's title, movements, and notes — each movement stamped with that session's own shared weight, so working loads and deload loads both survive and `adjust_program_weights` stays the sole weight authority. A StageCard on the progress page exposes confirm-gated Advance / Go back. The A+A template and existing clones get the five-stage ladder.

## How to test

- `npm test` — 631 unit tests pass, including new `useSetProgramStage`, `StageCard`, and ProgramProgressPage stage-card coverage.
- `npx playwright test e2e/program-stages.spec.ts e2e/program-adjust-weights.spec.ts e2e/program-aa-protocol.spec.ts` against local Supabase — 8 passing. Covers: clone carries the ladder at stage 0; advancing skips completed sessions and preserves per-session weights (deloads stay at 16 kg); go-back restores; out-of-range / foreign-enrollment / ladder-less calls raise; `adjust_program_weights` still folds correctly after an advance.
- Manually: enrolled the local test user in A+A, advanced to C+J+C in the browser (all chips retitled, deloads to \"Deload · C+J+C\"), went back to C+J.

## Gallery

Stage card on the progress page (new UI):

![stage card](https://github.com/user-attachments/assets/e864bc11-3f5b-4bc3-b334-ec65db76a895)

Confirm dialog before a stage move:

![confirm dialog](https://github.com/user-attachments/assets/0488aa7e-0e4f-4f1d-849d-8bf63034bb72)

## Deploy notes

- Three migrations: schema (`stages` + `current_stage_index`, `enroll_in_program` re-created to copy stages to clones), the `set_program_stage` RPC, and the A+A ladder seed (backfills existing clones' `stages` column only — sessions untouched, everyone stays on stage 1).
- `types/supabase.ts` regenerated and committed.

## Tradeoffs

- Stages author no weights and v1 assumes shared-weight complexSet programs (A+A is the only ladder shipped); per-movement-weight programs would need a per-movement stage shape later.
- Considered extending the apply-forward edit to carry title/notes instead — smaller, but it models a one-off edit, not a resumable ladder with a visible position, and each advance would mean hand-rebuilding the complex.
- Advancement is fully manual; a \"you finished 30 min — advance?\" nudge is a possible follow-up.