### PR TITLE
fix(workouts): show the shared weight on complex-set cards

### DIFF
--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -14,4 +14,12 @@ export const handlers = [
   http.get(`${VITE_SUPABASE_URL}/rest/v1/user_movements`, () => HttpResponse.json([])),
   http.post(`${VITE_SUPABASE_URL}/rest/v1/analytics_events`, () => HttpResponse.json([])),
   http.get(`${VITE_SUPABASE_URL}/rest/v1/analytics_events`, () => HttpResponse.json([])),
+  // Program tracking: no enrollments by default, which settles the Home program
+  // gate on "nothing active". Suites exercising a program override these.
+  http.get(`${VITE_SUPABASE_URL}/rest/v1/user_programs`, () => HttpResponse.json([])),
+  http.get(`${VITE_SUPABASE_URL}/rest/v1/programs`, () => HttpResponse.json([])),
+  http.get(`${VITE_SUPABASE_URL}/rest/v1/program_sessions`, () => HttpResponse.json([])),
+  http.get(`${VITE_SUPABASE_URL}/rest/v1/program_session_completions`, () =>
+    HttpResponse.json([]),
+  ),
 ];

--- a/src/pages/StartWorkoutPage/StartWorkoutPage.recommendations.test.jsx
+++ b/src/pages/StartWorkoutPage/StartWorkoutPage.recommendations.test.jsx
@@ -8,6 +8,7 @@ import { CURATED_WORKOUTS } from '~/constants';
 import {
   DEFAULT_WORKOUT_OPTIONS,
   EntitlementContext,
+  SessionProvider,
   WorkoutOptionsContext,
 } from '~/contexts';
 import { VITE_SUPABASE_URL } from '~/env';
@@ -55,20 +56,42 @@ const makeQueryClient = () =>
     defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
   });
 
+// App only mounts this page behind a resolved session, so the program queries
+// always have a user id. Without one they stay disabled and the program gate
+// never settles, leaving the page on its loading state.
+const mockSession = {
+  user: {
+    id: 'user-123',
+    app_metadata: {},
+    user_metadata: {},
+    created_at: '',
+    aud: '',
+  },
+  access_token: '',
+  refresh_token: '',
+  expires_in: 10000,
+  token_type: '',
+};
+
 const renderPage = (updateWorkoutOptions = vi.fn()) => {
   render(
     <QueryClientProvider client={makeQueryClient()}>
       <MemoryRouter initialEntries={['/']}>
-        <EntitlementContext.Provider value={freeEntitlement}>
-          <WorkoutOptionsContext.Provider
-            value={[DEFAULT_WORKOUT_OPTIONS, updateWorkoutOptions]}
-          >
-            <Routes>
-              <Route path="/" element={<StartWorkoutPage />} />
-              <Route path="/active" element={<div>active workout page</div>} />
-            </Routes>
-          </WorkoutOptionsContext.Provider>
-        </EntitlementContext.Provider>
+        <SessionProvider value={mockSession}>
+          <EntitlementContext.Provider value={freeEntitlement}>
+            <WorkoutOptionsContext.Provider
+              value={[DEFAULT_WORKOUT_OPTIONS, updateWorkoutOptions]}
+            >
+              <Routes>
+                <Route path="/" element={<StartWorkoutPage />} />
+                <Route
+                  path="/active"
+                  element={<div>active workout page</div>}
+                />
+              </Routes>
+            </WorkoutOptionsContext.Provider>
+          </EntitlementContext.Provider>
+        </SessionProvider>
       </MemoryRouter>
     </QueryClientProvider>,
   );

--- a/src/pages/StartWorkoutPage/StartWorkoutPage.stories.tsx
+++ b/src/pages/StartWorkoutPage/StartWorkoutPage.stories.tsx
@@ -6,6 +6,7 @@ import {
   DEFAULT_WORKOUT_OPTIONS,
   EntitlementContext,
   EntitlementContextValue,
+  SessionProvider,
   WorkoutOptionsContext,
 } from '~/contexts';
 
@@ -27,6 +28,23 @@ const freeEntitlement: EntitlementContextValue = {
   refetch: () => {},
 };
 
+// App only mounts this page behind a resolved session, so the program queries
+// always have a user id. Without one they stay disabled and the program gate
+// never settles, leaving the page on its loading state.
+const mockSession = {
+  user: {
+    id: 'user-123',
+    app_metadata: {},
+    user_metadata: {},
+    created_at: '',
+    aud: '',
+  },
+  access_token: '',
+  refresh_token: '',
+  expires_in: 10000,
+  token_type: '',
+};
+
 export default {
   component: StartWorkoutPage,
   decorators: [
@@ -37,18 +55,20 @@ export default {
     ),
     (Story, { parameters }) => (
       <QueryClientProvider client={queryClient}>
-        <EntitlementContext.Provider
-          value={parameters.entitlement || freeEntitlement}
-        >
-          <WorkoutOptionsContext.Provider
-            value={[
-              parameters.workoutOptions || DEFAULT_WORKOUT_OPTIONS,
-              parameters.updateWorkoutOptions,
-            ]}
+        <SessionProvider value={parameters.session ?? mockSession}>
+          <EntitlementContext.Provider
+            value={parameters.entitlement || freeEntitlement}
           >
-            <Story />
-          </WorkoutOptionsContext.Provider>
-        </EntitlementContext.Provider>
+            <WorkoutOptionsContext.Provider
+              value={[
+                parameters.workoutOptions || DEFAULT_WORKOUT_OPTIONS,
+                parameters.updateWorkoutOptions,
+              ]}
+            >
+              <Story />
+            </WorkoutOptionsContext.Provider>
+          </EntitlementContext.Provider>
+        </SessionProvider>
       </QueryClientProvider>
     ),
   ],

--- a/src/pages/StartWorkoutPage/StartWorkoutPage.test.jsx
+++ b/src/pages/StartWorkoutPage/StartWorkoutPage.test.jsx
@@ -8,6 +8,7 @@ import {
   DEFAULT_MOVEMENT_OPTIONS,
   DEFAULT_WORKOUT_OPTIONS,
   EntitlementContext,
+  SessionProvider,
   WorkoutOptionsContext,
 } from '~/contexts';
 
@@ -52,6 +53,41 @@ function makeQueryClient() {
   });
 }
 
+// App only mounts this page behind a resolved session, so the program queries
+// always have a user id. Without one they stay disabled and the program gate
+// never settles, leaving the page on its loading state.
+const mockSession = {
+  user: {
+    id: 'user-123',
+    app_metadata: {},
+    user_metadata: {},
+    created_at: '',
+    aud: '',
+  },
+  access_token: '',
+  refresh_token: '',
+  expires_in: 10000,
+  token_type: '',
+};
+
+/** The page under the providers App gives it, for tests not driving a story. */
+const renderStartWorkoutPage = (workoutOptions, startWorkout) =>
+  render(
+    <QueryClientProvider client={makeQueryClient()}>
+      <MemoryRouter>
+        <SessionProvider value={mockSession}>
+          <EntitlementContext.Provider value={freeEntitlement}>
+            <WorkoutOptionsContext.Provider
+              value={[workoutOptions, startWorkout]}
+            >
+              <StartWorkoutPage />
+            </WorkoutOptionsContext.Provider>
+          </EntitlementContext.Provider>
+        </SessionProvider>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+
 const { Default, WithoutPreviousVolume } = composeStories(stories);
 
 const startedAt = new Date();
@@ -60,8 +96,12 @@ vi.setSystemTime(startedAt);
 // The builder is a secondary state behind the hub. With no active program the
 // hub shows the quick-start hero, whose "Build a workout" action opens the
 // builder; reveal it before exercising the builder controls.
-const enterBuildMode = () =>
-  userEvent.click(screen.getByRole('button', { name: /build a workout/i }));
+// The program gate resolves asynchronously, so wait the hub out rather than
+// querying the still-pending loading state.
+const enterBuildMode = async () =>
+  userEvent.click(
+    await screen.findByRole('button', { name: /build a workout/i }),
+  );
 
 describe('start workout page', () => {
   let startWorkout;
@@ -693,6 +733,26 @@ describe('Complex Mode', () => {
     });
   });
 
+  test('movement card shows the shared weight, not its own, while Complex is on', async () => {
+    await userEvent.type(screen.getByLabelText('Movement Input'), 'Clean');
+    // The suggestion list hides the weight summary while it's open.
+    const closeSuggestions = () =>
+      userEvent.click(screen.getByRole('heading', { name: 'Movements' }));
+    await closeSuggestions();
+    const ownWeight = `${DEFAULT_MOVEMENT_OPTIONS.weightOneValue} kg (2h)`;
+    expect(screen.getByText(ownWeight)).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole('button', { name: 'Complex, off' }));
+    await userEvent.click(screen.getByLabelText('+ kg'));
+
+    const sharedWeight = screen.getByText(/kg \(2h\)/).textContent;
+    expect(sharedWeight).not.toBe(ownWeight);
+
+    await userEvent.click(screen.getByRole('button', { name: 'Complex, on' }));
+
+    expect(screen.getByText(ownWeight)).toBeInTheDocument();
+  });
+
   test('complex mode toggle is preserved when adding movements', async () => {
     await userEvent.click(screen.getByRole('button', { name: 'Complex, off' }));
     expect(screen.queryAllByRole('heading', { name: 'Load' })).toHaveLength(0);
@@ -805,19 +865,7 @@ describe('integration tests for previous volume retrieval', () => {
       previousVolume: 1500, // Custom previous volume
     };
 
-    render(
-      <QueryClientProvider client={makeQueryClient()}>
-        <MemoryRouter>
-          <EntitlementContext.Provider value={freeEntitlement}>
-            <WorkoutOptionsContext.Provider
-              value={[customWorkoutOptions, startWorkout]}
-            >
-              <StartWorkoutPage />
-            </WorkoutOptionsContext.Provider>
-          </EntitlementContext.Provider>
-        </MemoryRouter>
-      </QueryClientProvider>,
-    );
+    renderStartWorkoutPage(customWorkoutOptions, startWorkout);
 
     await enterBuildMode();
     await userEvent.type(
@@ -847,19 +895,7 @@ describe('integration tests for previous volume retrieval', () => {
       previousVolume: 1200, // Volume from completed workout
     };
 
-    render(
-      <QueryClientProvider client={makeQueryClient()}>
-        <MemoryRouter>
-          <EntitlementContext.Provider value={freeEntitlement}>
-            <WorkoutOptionsContext.Provider
-              value={[workoutOptionsAfterCompletion, startWorkout]}
-            >
-              <StartWorkoutPage />
-            </WorkoutOptionsContext.Provider>
-          </EntitlementContext.Provider>
-        </MemoryRouter>
-      </QueryClientProvider>,
-    );
+    renderStartWorkoutPage(workoutOptionsAfterCompletion, startWorkout);
 
     await enterBuildMode();
     await userEvent.type(
@@ -892,19 +928,7 @@ describe('integration tests for previous volume retrieval', () => {
       previousRounds: 20,
     };
 
-    render(
-      <QueryClientProvider client={makeQueryClient()}>
-        <MemoryRouter>
-          <EntitlementContext.Provider value={freeEntitlement}>
-            <WorkoutOptionsContext.Provider
-              value={[workoutOptionsWithAllPrevious, startWorkout]}
-            >
-              <StartWorkoutPage />
-            </WorkoutOptionsContext.Provider>
-          </EntitlementContext.Provider>
-        </MemoryRouter>
-      </QueryClientProvider>,
-    );
+    renderStartWorkoutPage(workoutOptionsWithAllPrevious, startWorkout);
 
     await enterBuildMode();
     await userEvent.type(

--- a/src/pages/StartWorkoutPage/StartWorkoutPage.tsx
+++ b/src/pages/StartWorkoutPage/StartWorkoutPage.tsx
@@ -1020,6 +1020,12 @@ export const StartWorkoutPage = ({
               movement={movement}
               complexSet={complexSet}
               sharedWeightTabValue={sharedWeightTabValue}
+              sharedWeights={{
+                sharedWeightOneUnit,
+                sharedWeightOneValue,
+                sharedWeightTwoUnit,
+                sharedWeightTwoValue,
+              }}
               expanded={!collapsedMovements.has(index)}
               intervalActive={intervalTimer > 0}
               onToggleExpanded={() => handleToggleMovementExpanded(index)}

--- a/src/pages/StartWorkoutPage/components/MovementCard.stories.tsx
+++ b/src/pages/StartWorkoutPage/components/MovementCard.stories.tsx
@@ -4,7 +4,7 @@ import { useState } from 'react';
 
 import { MovementOptions } from '~/types';
 
-import { MovementCard } from './MovementCard';
+import { MovementCard, MovementCardProps } from './MovementCard';
 
 const queryClient = new QueryClient({
   defaultOptions: { queries: { retry: false } },
@@ -37,6 +37,12 @@ const meta = {
     movement: swing,
     complexSet: false,
     sharedWeightTabValue: 'none',
+    sharedWeights: {
+      sharedWeightOneValue: null,
+      sharedWeightOneUnit: null,
+      sharedWeightTwoValue: null,
+      sharedWeightTwoUnit: null,
+    },
     intervalActive: false,
     onToggleExpanded: noop,
     onRemove: noop,
@@ -60,6 +66,24 @@ type Story = StoryObj<typeof MovementCard>;
 export const Expanded: Story = { args: { expanded: true } };
 
 export const Collapsed: Story = { args: { expanded: false } };
+
+/** In a complex set the card shows the shared 24 kg, not the movement's own 16 kg. */
+const complexArgs = {
+  complexSet: true,
+  sharedWeightTabValue: '2h',
+  sharedWeights: {
+    sharedWeightOneValue: 24,
+    sharedWeightOneUnit: 'kilograms',
+    sharedWeightTwoValue: null,
+    sharedWeightTwoUnit: null,
+  },
+} satisfies Partial<MovementCardProps>;
+
+export const ComplexSet: Story = { args: { ...complexArgs, expanded: true } };
+
+export const ComplexSetCollapsed: Story = {
+  args: { ...complexArgs, expanded: false },
+};
 
 /** The two states side by side, driven by the real collapse toggle. */
 export const Interactive: Story = {

--- a/src/pages/StartWorkoutPage/components/MovementCard.test.tsx
+++ b/src/pages/StartWorkoutPage/components/MovementCard.test.tsx
@@ -1,0 +1,122 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen } from '@testing-library/react';
+import { HttpResponse, http } from 'msw';
+import React from 'react';
+
+import { SessionProvider } from '~/contexts';
+import { VITE_SUPABASE_URL } from '~/env';
+import { server } from '~/mocks/server';
+import { MovementOptions } from '~/types';
+
+import { MovementCard, MovementCardProps } from './MovementCard';
+
+const mockSession = {
+  user: {
+    id: 'user-123',
+    app_metadata: {},
+    user_metadata: {},
+    created_at: '',
+    aud: '',
+  },
+  access_token: '',
+  refresh_token: '',
+  expires_in: 10000,
+  token_type: '',
+};
+
+const movement: MovementOptions = {
+  movementName: 'Clean',
+  repScheme: [5],
+  weightOneValue: 16,
+  weightOneUnit: 'kilograms',
+  weightTwoValue: null,
+  weightTwoUnit: null,
+};
+
+const noop = () => {};
+
+const baseProps: MovementCardProps = {
+  index: 0,
+  movement,
+  complexSet: false,
+  sharedWeightTabValue: '2h',
+  sharedWeights: {
+    sharedWeightOneValue: 24,
+    sharedWeightOneUnit: 'kilograms',
+    sharedWeightTwoValue: null,
+    sharedWeightTwoUnit: null,
+  },
+  expanded: true,
+  intervalActive: false,
+  onToggleExpanded: noop,
+  onRemove: noop,
+  onChangeName: noop,
+  onChangeWeightTab: noop,
+  onChangeWeightOneValue: noop,
+  onChangeWeightOneUnit: noop,
+  onChangeWeightTwoValue: noop,
+  onChangeWeightTwoUnit: noop,
+  onChangeRung: noop,
+  onRemoveRung: noop,
+  onAddRung: noop,
+  onToggleTimed: noop,
+};
+
+const renderCard = (overrides: Partial<MovementCardProps> = {}) => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  const wrapper = ({ children }: { children: React.ReactNode }) =>
+    React.createElement(
+      QueryClientProvider,
+      { client: queryClient },
+      React.createElement(SessionProvider, { value: mockSession }, children),
+    );
+
+  return render(<MovementCard {...baseProps} {...overrides} />, { wrapper });
+};
+
+describe('MovementCard weight display', () => {
+  beforeEach(() => {
+    server.use(
+      http.get(`${VITE_SUPABASE_URL}/rest/v1/movements_catalog`, () =>
+        HttpResponse.json([]),
+      ),
+      http.get(`${VITE_SUPABASE_URL}/rest/v1/movements`, () =>
+        HttpResponse.json([]),
+      ),
+      http.get(`${VITE_SUPABASE_URL}/rest/v1/user_movements`, () =>
+        HttpResponse.json([]),
+      ),
+    );
+  });
+
+  test('shows the movement own weight when not a complex set', () => {
+    renderCard();
+
+    expect(screen.getByText('16 kg (2h)')).toBeInTheDocument();
+  });
+
+  test('shows the shared weight instead of the movement own when complex', () => {
+    renderCard({ complexSet: true });
+
+    expect(screen.getByText('24 kg (2h)')).toBeInTheDocument();
+    expect(screen.queryByText('16 kg (2h)')).not.toBeInTheDocument();
+  });
+
+  test('collapsed chips track the shared weight when complex', () => {
+    renderCard({ complexSet: true, expanded: false });
+
+    expect(screen.getByText('24 kg')).toBeInTheDocument();
+    expect(screen.queryByText('16 kg')).not.toBeInTheDocument();
+  });
+
+  test('toggling complex off restores the movement own weight', () => {
+    const { rerender } = renderCard({ complexSet: true });
+    expect(screen.getByText('24 kg (2h)')).toBeInTheDocument();
+
+    rerender(<MovementCard {...baseProps} complexSet={false} />);
+
+    expect(screen.getByText('16 kg (2h)')).toBeInTheDocument();
+  });
+});

--- a/src/pages/StartWorkoutPage/components/MovementCard.tsx
+++ b/src/pages/StartWorkoutPage/components/MovementCard.tsx
@@ -9,10 +9,12 @@ import { Card } from '~/components/ui/card';
 import { getWeightsDisplayValue } from '~/pages/CompletedWorkoutPage/utils/displayValues';
 import { MovementOptions, WeightTabValue, WeightUnit } from '~/types';
 import {
+  SharedWeightOptions,
   WEIGHT_MODE_LABELS,
   getWeightRange,
   getWeightTabValue,
   getWeightUnitLabel,
+  resolveMovementWeights,
 } from '~/utils';
 
 import { FieldLabel } from './FieldLabel';
@@ -29,6 +31,8 @@ export interface MovementCardProps {
   complexSet: boolean;
   /** For complex sets the whole card reflects the shared-weight mode. */
   sharedWeightTabValue: WeightTabValue;
+  /** The complex set's shared weight, displayed in place of the movement's own. */
+  sharedWeights: Omit<SharedWeightOptions, 'complexSet'>;
   expanded: boolean;
   /** The interval timer is on, so timed rungs must be disabled. */
   intervalActive: boolean;
@@ -51,6 +55,7 @@ export const MovementCard = ({
   movement,
   complexSet,
   sharedWeightTabValue,
+  sharedWeights,
   expanded,
   intervalActive,
   onToggleExpanded,
@@ -69,12 +74,16 @@ export const MovementCard = ({
   const weightTabValue = getWeightTabValue(movement);
   const activeWeightMode = complexSet ? sharedWeightTabValue : weightTabValue;
   const named = movement.movementName.length > 0;
+  const displayedMovement = resolveMovementWeights(movement, {
+    complexSet,
+    ...sharedWeights,
+  });
   const weightSummary = named
     ? getWeightsDisplayValue(
-        movement.weightOneValue,
-        movement.weightOneUnit,
-        movement.weightTwoValue,
-        movement.weightTwoUnit,
+        displayedMovement.weightOneValue,
+        displayedMovement.weightOneUnit,
+        displayedMovement.weightTwoValue,
+        displayedMovement.weightTwoUnit,
       )
     : null;
   const showLoad = !complexSet && weightTabValue !== 'none';
@@ -121,7 +130,7 @@ export const MovementCard = ({
               </div>
               <div className="mt-0.5">
                 <MovementSummaryChips
-                  movement={movement}
+                  movement={displayedMovement}
                   weightMode={activeWeightMode}
                 />
               </div>

--- a/src/utils/applySharedWeights.ts
+++ b/src/utils/applySharedWeights.ts
@@ -1,13 +1,9 @@
-import { MovementOptions, WeightUnit } from '~/types';
+import { MovementOptions } from '~/types';
 
-interface SharedWeightOptions {
-  complexSet: boolean;
-  movements: MovementOptions[];
-  sharedWeightOneUnit: WeightUnit | null;
-  sharedWeightOneValue: number | null;
-  sharedWeightTwoUnit: WeightUnit | null;
-  sharedWeightTwoValue: number | null;
-}
+import {
+  SharedWeightOptions,
+  resolveMovementWeights,
+} from './resolveMovementWeights';
 
 /**
  * Complex sets are loaded with one shared weight, but every consumer of
@@ -16,19 +12,17 @@ interface SharedWeightOptions {
  * movement so the two stores can't disagree; non-complex options pass through
  * untouched.
  */
-export const applySharedWeights = <T extends SharedWeightOptions>(
+export const applySharedWeights = <
+  T extends SharedWeightOptions & { movements: MovementOptions[] },
+>(
   options: T,
 ): T => {
   if (!options.complexSet) return options;
 
   return {
     ...options,
-    movements: options.movements.map((movement) => ({
-      ...movement,
-      weightOneUnit: options.sharedWeightOneUnit,
-      weightOneValue: options.sharedWeightOneValue,
-      weightTwoUnit: options.sharedWeightTwoUnit,
-      weightTwoValue: options.sharedWeightTwoValue,
-    })),
+    movements: options.movements.map((movement) =>
+      resolveMovementWeights(movement, options),
+    ),
   };
 };

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -9,6 +9,7 @@ export * from './programCadenceLabel';
 export * from './patternDebt';
 export * from './rankMovements';
 export * from './resolveAuthSession';
+export * from './resolveMovementWeights';
 export * from './resolveSharedWeights';
 export * from './soundPreference';
 export * from './timerSound';

--- a/src/utils/resolveMovementWeights.test.ts
+++ b/src/utils/resolveMovementWeights.test.ts
@@ -1,0 +1,58 @@
+import { resolveMovementWeights } from './resolveMovementWeights';
+
+const movement = (overrides = {}) => ({
+  movementName: 'Clean',
+  repScheme: [5],
+  weightOneUnit: 'kilograms' as const,
+  weightOneValue: 24,
+  weightTwoUnit: null,
+  weightTwoValue: null,
+  ...overrides,
+});
+
+const shared = (overrides = {}) => ({
+  complexSet: true,
+  sharedWeightOneUnit: 'kilograms' as const,
+  sharedWeightOneValue: 28,
+  sharedWeightTwoUnit: null,
+  sharedWeightTwoValue: null,
+  ...overrides,
+});
+
+describe('resolveMovementWeights', () => {
+  test('returns the shared weight when the movement is part of a complex set', () => {
+    const result = resolveMovementWeights(
+      movement(),
+      shared({ sharedWeightTwoUnit: 'pounds', sharedWeightTwoValue: 35 }),
+    );
+
+    expect(result.weightOneUnit).toBe('kilograms');
+    expect(result.weightOneValue).toBe(28);
+    expect(result.weightTwoUnit).toBe('pounds');
+    expect(result.weightTwoValue).toBe(35);
+  });
+
+  test('leaves the movement untouched when not complex', () => {
+    const input = movement();
+    expect(resolveMovementWeights(input, shared({ complexSet: false }))).toBe(
+      input,
+    );
+  });
+
+  test('null shared weights read as bodyweight', () => {
+    const result = resolveMovementWeights(
+      movement(),
+      shared({ sharedWeightOneUnit: null, sharedWeightOneValue: null }),
+    );
+
+    expect(result.weightOneUnit).toBeNull();
+    expect(result.weightOneValue).toBeNull();
+  });
+
+  test('preserves non-weight movement fields', () => {
+    const result = resolveMovementWeights(movement(), shared());
+
+    expect(result.movementName).toBe('Clean');
+    expect(result.repScheme).toEqual([5]);
+  });
+});

--- a/src/utils/resolveMovementWeights.ts
+++ b/src/utils/resolveMovementWeights.ts
@@ -1,0 +1,29 @@
+import { MovementOptions, WeightUnit } from '~/types';
+
+export interface SharedWeightOptions {
+  complexSet: boolean;
+  sharedWeightOneUnit: WeightUnit | null;
+  sharedWeightOneValue: number | null;
+  sharedWeightTwoUnit: WeightUnit | null;
+  sharedWeightTwoValue: number | null;
+}
+
+/**
+ * The weights a movement will actually be performed at: its own, or the shared
+ * weight when it's part of a complex set. Read-only — the movement keeps its own
+ * weight fields so toggling complex off restores what the user had.
+ */
+export const resolveMovementWeights = <T extends MovementOptions>(
+  movement: T,
+  options: SharedWeightOptions,
+): T => {
+  if (!options.complexSet) return movement;
+
+  return {
+    ...movement,
+    weightOneUnit: options.sharedWeightOneUnit,
+    weightOneValue: options.sharedWeightOneValue,
+    weightTwoUnit: options.sharedWeightTwoUnit,
+    weightTwoValue: options.sharedWeightTwoValue,
+  };
+};

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -9,6 +9,18 @@ export default mergeConfig(
     test: {
       globals: true,
       environment: 'jsdom',
+      // Vite loads a developer's `.env.local` in every mode, and it outranks
+      // `.env.test` — so an unrelated local flag could silently change what the
+      // suite renders. Pin every build-time flag here (matching `.env.test`) so
+      // runs are identical on every machine and in CI.
+      env: {
+        VITE_FEATURE_BOTTOMNAV: 'false',
+        VITE_FEATURE_COMPLEX_MODE: 'true',
+        VITE_FEATURE_EXPLORE: 'true',
+        VITE_FEATURE_PREMIUM: 'false',
+        VITE_FEATURE_PROGRAMS: 'true',
+        VITE_FEATURE_WEEKLY_BALANCE: 'true',
+      },
       setupFiles: './config/vitest.setup.ts',
       exclude: ['**/node_modules/**', 'e2e/**', '**/.claude/**'],
       // Reduce test output verbosity


### PR DESCRIPTION
## Why

Turning on **Complex set** hid the per-movement Load steppers and showed a single Shared Weight card, but the weight readouts on each movement card kept reading the movement's own `weightOne*/weightTwo*` fields. A card could render `16 kg, 16 kg` directly above the hint `Using shared weight: Two-Hand`. The collapsed chips and the competition-color bell dot had the same divergence.

The shared weight was correct everywhere it was persisted — `applySharedWeights` copies it onto every movement at start/save. The bug was purely render-time: the builder had no equivalent resolver, so what you saw disagreed with what would be logged.

## What

Three parts:

1. **The fix.** New `resolveMovementWeights` is the single rule for a movement's effective weights; `applySharedWeights` now maps through it so the display and persistence paths can't drift again. `MovementCard` derives a `displayedMovement` for the weight summary and the summary chips, while the editing controls stay bound to the raw movement — toggling complex off restores the user's own weights.

2. **Hermetic test env.** Vite loads a developer's `.env.local` in every mode and it outranks `.env.test`. A local `VITE_FEATURE_PROGRAMS=true` silently enabled the programs query, which had no MSW handler, so the Home program gate never settled and all 44 `StartWorkoutPage` tests failed on that machine while CI stayed green. `vitest.config.ts` now pins every build-time flag.

3. **Programs on for tests.** Rather than pin the flag off, the gated path is now actually covered: default empty handlers for the four program tables, plus the session `App` always mounts this page behind. Without a user id `useActivePrograms` stays disabled, `data` never resolves, and the gate hangs on the loading state — which is also why the `StartWorkoutPage` Storybook story was stuck on a spinner in dev.

## How to test

- `npm test` — 629 passing, 0 failing (was 574 passing / 54 failing locally).
- `npm run compile:ts`, `npm run lint` — clean.
- New `resolveMovementWeights.test.ts` (4 cases: complex override, passthrough, null/bodyweight shared, field preservation) and `MovementCard.test.tsx` (4 cases: own weight when not complex, shared weight when complex, collapsed chips, restore on toggle off).
- Both the card tests and the new page-level Complex Mode test were confirmed to fail against the pre-fix component and pass after, so they genuinely pin the behavior.
- Storybook: new `ComplexSet` / `ComplexSetCollapsed` stories on `MovementCard`, captured below.

## Gallery

Movement card in a complex set — movement's own weight is 16 kg, shared weight is 24 kg.

| Before | After |
|---|---|
| ![before](https://github.com/user-attachments/assets/ad9652a6-c387-4b1c-a955-2f82a9d9a01d) | ![after](https://github.com/user-attachments/assets/a0f3240b-309e-4f07-9689-99b2435c17ed) |

## Deploy notes

None. `VITE_FEATURE_PROGRAMS` is pinned in `vitest.config.ts` only — no runtime or deploy config changes.

## Tradeoffs

**Pinning flags in `vitest.config.ts` rather than `.env.test`.** Setting them in `.env.test` would keep all env config in one place, which is where a reader would look first. It doesn't work, though: `.env.local` outranks `.env.test`, so the leak would survive. (`.env*` is also off-limits per `CLAUDE.md`.) The config pin is the only version that actually holds.

**Adding a session to the tests rather than changing the gate.** My first read was that a session-less render hanging forever was a product bug worth fixing in `programGatePending`. But `App.tsx` only mounts the router when `session` is truthy, so the page never renders without one — the gate is right and the tests were the unfaithful part. Loosening the gate would have papered over that and reintroduced the builder→card flash the gate exists to prevent.
