### PR TITLE
feat(programs): extend stage ladders to Plan 025 rep progression

### DIFF
--- a/docs/program-tracking.md
+++ b/docs/program-tracking.md
@@ -136,15 +136,21 @@ session — atomic), and the PROD-219 editing pair `reorder_program_sessions` /
   `user_programs.current_stage_index` (default 0). The `set_program_stage`
   RPC (`useSetProgramStage`, StageCard on `ProgramProgressPage`) takes an
   absolute index — one function serves Advance and Go back — and rewrites
-  every session of the clone with no completion for the enrollment: title
-  (`'Deload · ' + title` on `weight_label = 'Deload weeks'` rows), movements
-  stamped with each session's OWN `sharedWeightOne/Two` (deloads stay light;
-  `adjust_program_weights` remains the sole weight authority), and
-  `preWorkoutNotes` (deload variant on deload rows). Goal/interval/rest are
-  untouched, completed sessions never rewritten. v1 assumes shared-weight
-  complexSet programs; the only shipped ladder is A+A's five stages
-  (C+J → … → C+J+C+J+C+J), seeded in `*_seed_aa_protocol_stages.sql`.
-  Backend coverage in `e2e/program-stages.spec.ts`.
+  every session of the clone with no completion for the enrollment. Weights
+  are decided per session: complexSet sessions with shared weights get every
+  stage movement stamped with the session's OWN `sharedWeightOne/Two` and the
+  stage's title (`'Deload · ' + title` on `weight_label = 'Deload weeks'`
+  rows); non-complex sessions keep their own title (day labels like
+  High/Medium/Low volume) and each stage movement inherits the weight fields
+  of the session's same-named movement (null weights if it had none). Either
+  way `adjust_program_weights` remains the sole weight authority, and
+  `preWorkoutNotes` swaps to the stage's (deload variant on deload rows).
+  Goal/interval/rest are untouched, completed sessions never rewritten.
+  Shipped ladders: A+A's five complexes (C+J → … → C+J+C+J+C+J,
+  `*_seed_aa_protocol_stages.sql`) and Strong Endurance Plan 025's six rep
+  counts (Sets of 5 → Sets of 10, `*_seed_se025_stages.sql` — uniform
+  repScheme because 025 scales its days by set count, not reps). Backend
+  coverage in `e2e/program-stages.spec.ts`.
 - **Program CRUD (PROD-237, owned programs only):** `ProgramsPage`'s "My programs"
   surface adds three actions. **Cancel** = `useCancelProgram` flips the active
   enrollment to `abandoned` (reusing the existing status — no new value), freeing

--- a/e2e/program-stages.spec.ts
+++ b/e2e/program-stages.spec.ts
@@ -10,8 +10,10 @@ import { expect, test } from '@playwright/test';
 const SUPABASE_URL = process.env.VITE_SUPABASE_URL!;
 const SUPABASE_ANON_KEY = process.env.VITE_SUPABASE_ANON_KEY!;
 const AA_SLUG = 'aa-protocol-plan-a';
+const SE025_SLUG = 'strong-endurance-plan-025';
 const CLEAN = 'One-Arm Kettlebell Clean';
 const JERK = 'One-Arm Kettlebell Jerk';
+const SWING = 'One-Arm Kettlebell Swing';
 
 interface TestUser {
   token: string;
@@ -415,6 +417,153 @@ test.describe('set_program_stage — A+A progression ladder', () => {
       for (const m of session.workout_options.movements) {
         expect(m.weightOneValue).toBe(expected);
       }
+    }
+  });
+});
+
+// Plan 025 exercises the generalized non-complex path: NULL shared weights,
+// per-movement loads, and day-label titles the stage must not clobber.
+test.describe('set_program_stage — Strong Endurance Plan 025 rep ladder', () => {
+  test('template carries the 6-stage rep ladder, and the enroll clone copies it at stage 0', async () => {
+    const user = await signUpThrowawayUser();
+    const seId = await programIdBySlug(user.token, SE025_SLUG);
+
+    const [template] = await restJson<StageRow[]>(
+      'GET',
+      `programs?id=eq.${seId}&select=stages`,
+      user.token,
+    );
+    expect(template.stages).toHaveLength(6);
+    expect(template.stages!.map((s) => s.title)).toEqual([
+      'Sets of 5',
+      'Sets of 6',
+      'Sets of 7',
+      'Sets of 8',
+      'Sets of 9',
+      'Sets of 10',
+    ]);
+    template.stages!.forEach((stage, i) => {
+      expect(stage.movements).toHaveLength(1);
+      expect(stage.movements[0].movementName).toBe(SWING);
+      expect(stage.movements[0].repScheme).toEqual([5 + i]);
+      // Day-agnostic note: high-day autoregulation plus Medium/Low derivation.
+      expect(stage.preWorkoutNotes).toContain('80%');
+      expect(stage.preWorkoutNotes).toContain('60%');
+      expect(stage.deloadPreWorkoutNotes).toBeUndefined();
+    });
+    expect(template.stages![2].preWorkoutNotes).toContain('sets of 8');
+    expect(template.stages![5].preWorkoutNotes).toContain('500 reps in 50 min');
+
+    const userProgramId = await rpc<string>('enroll_in_program', user.token, {
+      p_program_id: seId,
+    });
+    const enrollment = await enrollmentRow(user.token, userProgramId);
+    expect(enrollment.current_stage_index).toBe(0);
+
+    const [clone] = await restJson<StageRow[]>(
+      'GET',
+      `programs?id=eq.${enrollment.program_id}&select=stages`,
+      user.token,
+    );
+    expect(clone.stages).toEqual(template.stages);
+  });
+
+  test('advancing rewrites uncompleted repSchemes and notes, preserving per-movement weights and day titles', async () => {
+    const user = await signUpThrowawayUser();
+    const seId = await programIdBySlug(user.token, SE025_SLUG);
+    const userProgramId = await rpc<string>('enroll_in_program', user.token, {
+      p_program_id: seId,
+    });
+    const { program_id: cloneId } = await enrollmentRow(
+      user.token,
+      userProgramId,
+    );
+
+    const before = await orderedSessions(user.token, cloneId);
+    expect(before.map((s) => s.title)).toEqual([
+      'High volume',
+      'Medium volume',
+      'Low volume',
+    ]);
+    const completedSession = before[0];
+    await completeSession(user, userProgramId, completedSession.id);
+
+    const updated = await rpc<number>('set_program_stage', user.token, {
+      p_user_program_id: userProgramId,
+      p_stage_index: 1,
+    });
+    expect(updated).toBe(before.length - 1);
+    expect(
+      (await enrollmentRow(user.token, userProgramId)).current_stage_index,
+    ).toBe(1);
+
+    const after = await orderedSessions(user.token, cloneId);
+    for (const session of after) {
+      const prior = before.find((s) => s.id === session.id)!;
+
+      if (session.id === completedSession.id) {
+        expect(session.workout_options).toEqual(prior.workout_options);
+        continue;
+      }
+
+      // Day-label titles survive the stage change on the non-complex path.
+      expect(session.title).toBe(prior.title);
+
+      // The single swing moves to sets of 6 at ITS OWN prior weights,
+      // including weightTwoValue 0 (one-handed mode).
+      expect(session.workout_options.movements).toHaveLength(1);
+      const [swing] = session.workout_options.movements;
+      const [priorSwing] = prior.workout_options.movements;
+      expect(swing.movementName).toBe(SWING);
+      expect(swing.repScheme).toEqual([6]);
+      expect(swing.weightOneValue).toBe(priorSwing.weightOneValue);
+      expect(swing.weightOneUnit).toBe(priorSwing.weightOneUnit);
+      expect(swing.weightTwoValue).toBe(0);
+
+      // Shared weights stay null; notes swap to the stage's; cadence stays.
+      expect(session.workout_options.sharedWeightOneValue).toBeNull();
+      expect(session.workout_options.preWorkoutNotes).toContain('Sets of 6');
+      expect(session.workout_options.workoutGoal).toBe(
+        prior.workout_options.workoutGoal,
+      );
+      expect(session.workout_options.intervalTimer).toBe(
+        prior.workout_options.intervalTimer,
+      );
+      expect(session.workout_options.complexSet).toBe(false);
+    }
+
+    // Going back restores sets of 5 on the same scope.
+    await rpc('set_program_stage', user.token, {
+      p_user_program_id: userProgramId,
+      p_stage_index: 0,
+    });
+    for (const session of await orderedSessions(user.token, cloneId)) {
+      if (session.id === completedSession.id) continue;
+      expect(session.workout_options.movements[0].repScheme).toEqual([5]);
+    }
+  });
+
+  test('the final stage note says you graduated', async () => {
+    const user = await signUpThrowawayUser();
+    const seId = await programIdBySlug(user.token, SE025_SLUG);
+    const userProgramId = await rpc<string>('enroll_in_program', user.token, {
+      p_program_id: seId,
+    });
+    const { program_id: cloneId } = await enrollmentRow(
+      user.token,
+      userProgramId,
+    );
+
+    await rpc('set_program_stage', user.token, {
+      p_user_program_id: userProgramId,
+      p_stage_index: 5,
+    });
+    for (const session of await orderedSessions(user.token, cloneId)) {
+      expect(session.workout_options.movements[0].repScheme).toEqual([10]);
+      expect(session.workout_options.preWorkoutNotes).toContain(
+        '500 reps in 50 min',
+      );
+      expect(session.workout_options.preWorkoutNotes).toContain('heavier bell');
     }
   });
 });

--- a/src/types/program.interface.ts
+++ b/src/types/program.interface.ts
@@ -15,10 +15,11 @@ export interface ProgramStageMovement {
 
 /**
  * One rung of a program's milestone-gated progression ladder (e.g. A+A's
- * C+J → C+J+C → … → 3 cleans + 3 jerks). Advancing an enrollment to a stage
- * (`set_program_stage`) rewrites every not-yet-completed session's title,
- * movements, and notes; each session keeps its own shared weights, so stages
- * author none.
+ * C+J → C+J+C → … → 3 cleans + 3 jerks, or Plan 025's Sets of 5 → Sets
+ * of 10). Advancing an enrollment to a stage (`set_program_stage`) rewrites
+ * every not-yet-completed session's movements and notes; weights come from
+ * each session (shared weights on complexSet sessions, per-movement weights —
+ * and the session's own title — otherwise), so stages author none.
  */
 export interface ProgramStage {
   title: string;

--- a/supabase/migrations/20260802000003_generalize_set_program_stage.sql
+++ b/supabase/migrations/20260802000003_generalize_set_program_stage.sql
@@ -1,0 +1,115 @@
+-- Generalize set_program_stage beyond shared-weight complexSet programs.
+--
+-- v1 stamped every stage movement with the session's sharedWeightOne/Two —
+-- correct for A+A, wrong for non-complex programs like Strong Endurance Plan
+-- 025, whose shared weights are NULL and whose loads live on each movement.
+-- Now the weight source is decided per session:
+--
+--   * complexSet with non-null sharedWeightOneValue -> shared-weight stamping,
+--     exactly as before (A+A work and deload sessions are unchanged).
+--   * otherwise -> each stage movement inherits the weight fields of the
+--     session's existing movement with the same movementName (preserving
+--     e.g. weightTwoValue 0 = one-handed mode), falling back to null weights
+--     for a movement the session did not have.
+--
+-- On that non-shared path the session also keeps its own title: A+A's titles
+-- ARE the complex, but a program like 025 uses titles as structural day labels
+-- ('High volume' / 'Medium volume' / 'Low volume') that a stage must not
+-- clobber — the enrollment's current rung is visible on the StageCard.
+-- Notes, scope (uncompleted sessions of the enrollment's clone only), and the
+-- goal/duration/interval/rest passthrough are unchanged.
+CREATE OR REPLACE FUNCTION public.set_program_stage(
+  p_user_program_id UUID,
+  p_stage_index     INTEGER
+)
+RETURNS INTEGER
+LANGUAGE plpgsql
+SECURITY INVOKER
+SET search_path = public
+AS $$
+DECLARE
+  v_user_id UUID := auth.uid();
+  v_program UUID;
+  v_stages  JSONB;
+  v_stage   JSONB;
+  v_updated INTEGER;
+BEGIN
+  IF v_user_id IS NULL THEN
+    RAISE EXCEPTION 'Not authenticated';
+  END IF;
+
+  SELECT up.program_id, p.stages INTO v_program, v_stages
+  FROM user_programs up
+  JOIN programs p ON p.id = up.program_id
+  WHERE up.id = p_user_program_id
+    AND up.user_id = v_user_id
+    AND up.status = 'active';
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'No active enrollment % for this user', p_user_program_id;
+  END IF;
+  IF v_stages IS NULL OR jsonb_typeof(v_stages) <> 'array' THEN
+    RAISE EXCEPTION 'PROGRAM_HAS_NO_STAGES';
+  END IF;
+  IF p_stage_index < 0 OR p_stage_index >= jsonb_array_length(v_stages) THEN
+    RAISE EXCEPTION 'STAGE_INDEX_OUT_OF_RANGE';
+  END IF;
+
+  v_stage := v_stages -> p_stage_index;
+
+  UPDATE program_sessions ps
+  SET title = CASE
+        WHEN NOT (COALESCE((ps.workout_options->>'complexSet')::boolean, false)
+                  AND ps.workout_options->'sharedWeightOneValue' IS NOT NULL
+                  AND ps.workout_options->'sharedWeightOneValue' <> 'null'::jsonb)
+          THEN ps.title
+        WHEN ps.weight_label = 'Deload weeks'
+          THEN 'Deload · ' || (v_stage->>'title')
+        ELSE v_stage->>'title' END,
+      workout_options = ps.workout_options || jsonb_build_object(
+        'movements', (
+          SELECT jsonb_agg(
+                   m || CASE
+                     WHEN COALESCE((ps.workout_options->>'complexSet')::boolean, false)
+                          AND ps.workout_options->'sharedWeightOneValue' IS NOT NULL
+                          AND ps.workout_options->'sharedWeightOneValue' <> 'null'::jsonb
+                     THEN jsonb_build_object(
+                            'weightOneUnit',  ps.workout_options->'sharedWeightOneUnit',
+                            'weightOneValue', ps.workout_options->'sharedWeightOneValue',
+                            'weightTwoUnit',  ps.workout_options->'sharedWeightTwoUnit',
+                            'weightTwoValue', ps.workout_options->'sharedWeightTwoValue')
+                     ELSE COALESCE(
+                       (SELECT jsonb_build_object(
+                                 'weightOneUnit',  em->'weightOneUnit',
+                                 'weightOneValue', em->'weightOneValue',
+                                 'weightTwoUnit',  em->'weightTwoUnit',
+                                 'weightTwoValue', em->'weightTwoValue')
+                        FROM jsonb_array_elements(ps.workout_options->'movements') em
+                        WHERE em->>'movementName' = m->>'movementName'
+                        LIMIT 1),
+                       jsonb_build_object(
+                         'weightOneUnit',  NULL, 'weightOneValue', NULL,
+                         'weightTwoUnit',  NULL, 'weightTwoValue', NULL))
+                   END
+                   ORDER BY ord)
+          FROM jsonb_array_elements(v_stage->'movements')
+                 WITH ORDINALITY AS e(m, ord)),
+        'preWorkoutNotes', COALESCE(
+          CASE WHEN ps.weight_label = 'Deload weeks'
+               THEN v_stage->>'deloadPreWorkoutNotes' END,
+          v_stage->>'preWorkoutNotes',
+          ps.workout_options->>'preWorkoutNotes'))
+  WHERE ps.program_id = v_program
+    AND NOT EXISTS (
+      SELECT 1 FROM program_session_completions c
+      WHERE c.user_program_id = p_user_program_id
+        AND c.program_session_id = ps.id
+    );
+  GET DIAGNOSTICS v_updated = ROW_COUNT;
+
+  UPDATE user_programs
+  SET current_stage_index = p_stage_index
+  WHERE id = p_user_program_id;
+
+  RETURN v_updated;
+END;
+$$;

--- a/supabase/migrations/20260802000004_seed_se025_stages.sql
+++ b/supabase/migrations/20260802000004_seed_se025_stages.sql
@@ -1,0 +1,83 @@
+-- Seed the Strong Endurance Plan 025 stage ladder: Sets of 5 -> ... -> Sets
+-- of 10, one rung per rep count.
+--
+-- The seed (20260727000006) left the "+1 rep once a high day hits 50 sets"
+-- progression as prose the athlete acted on by editing rep schemes;
+-- set_program_stage (generalized for non-complex programs in 20260802000003)
+-- now makes it a real mechanism. Each stage is the one seeded movement at that
+-- rep count; weights stay per-movement and are never authored here.
+--
+-- All three weekly sessions share one repScheme per stage: Plan 025 scales its
+-- days by SET COUNT (Medium = 80%, Low = 60% of the last high day's sets),
+-- never by reps, so a uniform rep count is faithful to the source. Because a
+-- stage authors one note stamped on every session, the note is day-agnostic:
+-- it carries the high-day autoregulation rule AND the Medium/Low percentage
+-- derivation, replacing the seed's per-day prose without losing its content.
+-- Session titles (High/Medium/Low volume) are structural day labels the
+-- generalized RPC leaves untouched. No deloadPreWorkoutNotes — 025 has no
+-- deload weight group.
+--
+-- Backfills existing clones via source_program_id, same safe exception to the
+-- never-refit-clones rule as the A+A backfill (20260802000002): only the
+-- nullable `stages` column is filled, sessions are untouched, and
+-- current_stage_index defaults to 0 (everyone is on sets of 5).
+
+CREATE OR REPLACE FUNCTION pg_temp.se025_stage(p_reps INT, p_tail TEXT)
+RETURNS JSONB LANGUAGE sql IMMUTABLE AS $$
+  SELECT jsonb_build_object(
+    'title', 'Sets of ' || p_reps,
+    'movements', jsonb_build_array(jsonb_build_object(
+      'movementName', 'One-Arm Kettlebell Swing',
+      'repScheme', to_jsonb(ARRAY[p_reps]::INT[]))),
+    'preWorkoutNotes',
+      'Sets of ' || p_reps || ' on the minute, alternating arms each minute; '
+      'walk and shake out between sets. High day: volume is autoregulated - '
+      'around 50s into each rest minute do the talk test (speak several short '
+      'sentences); the first time you cannot, or any StrongFirst Stop Sign '
+      'appears (power drops, technique changes, pauses between reps lengthen), '
+      'STOP and note your set count. Medium day: 80% of your last high day''s '
+      'sets. Low day: 60%. ' || p_tail);
+$$;
+
+DO $$
+DECLARE
+  v_template UUID;
+  v_stages   JSONB;
+  v_clones   INT;
+BEGIN
+  SELECT id INTO v_template
+  FROM programs
+  WHERE slug = 'strong-endurance-plan-025' AND owner_id IS NULL;
+
+  IF v_template IS NULL THEN
+    RAISE NOTICE 'Strong Endurance Plan 025 template not found; no stages seeded.';
+    RETURN;
+  END IF;
+
+  SELECT jsonb_agg(
+           pg_temp.se025_stage(
+             reps,
+             CASE WHEN reps < 10 THEN
+               'Once a high day reaches 50 sets at this rep count, advance the '
+               'stage: one more rep per set (sets of ' || reps + 1 || '). '
+               'Graduate at sets of 10.'
+             ELSE
+               'This is the final stage. Once a high day reaches 50 sets of 10 '
+               '- 500 reps in 50 min - you have graduated Plan 025: move up to '
+               'a heavier bell, or on to another Strong Endurance protocol.'
+             END)
+           ORDER BY reps)
+  INTO v_stages
+  FROM generate_series(5, 10) AS reps;
+
+  UPDATE programs SET stages = v_stages WHERE id = v_template;
+
+  -- Existing enrollees' clones get the ladder too (sessions untouched).
+  UPDATE programs c
+  SET stages = v_stages
+  WHERE c.source_program_id = v_template
+    AND c.stages IS NULL;
+  GET DIAGNOSTICS v_clones = ROW_COUNT;
+
+  RAISE NOTICE 'Plan 025 stages seeded on template and % clone(s).', v_clones;
+END $$;


### PR DESCRIPTION
## Why

PR #203 shipped stage ladders, but `set_program_stage` stamped every stage movement with the session's `sharedWeightOne/Two` — correct only for shared-weight complexSet programs like A+A. Strong Endurance Plan 025 is non-complex (NULL shared weights, per-movement loads), so its "+1 rep once a high day hits 50 sets" progression still lived only as prose the athlete acted on by hand-editing rep schemes.

## What

Three parts: generalize the RPC, seed the 025 ladder, and update the docs.

- **RPC** (`20260802000003`): the weight source is now decided per session. complexSet sessions with shared weights keep the exact v1 behavior; otherwise each stage movement inherits the weight fields of the session's same-named movement (preserving `weightTwoValue: 0` one-handed mode), with null weights for a movement the session didn't have. Non-complex sessions also keep their own titles — 025's High/Medium/Low volume labels are structural day names, not the complex name.
- **Seed** (`20260802000004`): six stages, Sets of 5 → Sets of 10, one one-arm swing rung each. Existing clones are backfilled via `source_program_id`, same pattern as the A+A backfill. All three weekly sessions share one repScheme per stage because 025 scales its days by **set count** (Medium = 80%, Low = 60% of the last high day's sets), never by reps; the stage note is day-agnostic and carries both the high-day autoregulation rule and the 80/60 derivation, so nothing from the seed's per-day prose is lost. The final stage's note declares graduation (500 reps in 50 min) and points at a heavier bell.
- **Docs**: `docs/program-tracking.md` stages bullet rewritten (the "v1 assumes shared-weight complexSet" caveat is gone) and the `ProgramStage` doc comment updated.

No schema change — `npm run gen:types` produced no diff.

## How to test

- `npx playwright test e2e/` with `.env.development` sourced: 84 passed, including three new 025 tests in `e2e/program-stages.spec.ts` (clone carries the ladder; advancing rewrites uncompleted repSchemes/notes while preserving per-movement weights, day titles, and null shared weights; final-stage graduation note) and the untouched A+A stage tests.
- `npm test` (629 passed), `npm run compile:ts`, `npm run lint` — all clean.
- `npx supabase db reset` applies both migrations and seeds the ladder.

## Gallery

025 progress page with the new stage card (new UI for this program — the card itself shipped in #203):

![025 stage card](https://github.com/user-attachments/assets/6f59d27d-8c8f-42af-b68f-77f75568699f)

## Deploy notes

Two migrations: `20260802000003_generalize_set_program_stage.sql` (CREATE OR REPLACE, same signature) and `20260802000004_seed_se025_stages.sql` (data-only, backfills clones). No `gen:types` needed.

## Tradeoffs

Per-day stage notes (e.g. a `preWorkoutNotesByTitle` map) would have kept the seed's tailored High/Medium/Low prose per session — genuinely nicer reading on any single day. Rejected because it grows the stage schema and RPC for one program when a single day-agnostic note conveys the same rules; if a future ladder truly needs per-day notes, that's the shape to add then.