### PR TITLE
feat(programs): categorize programs and advise on stack fit

### DIFF
--- a/src/api/program.ts
+++ b/src/api/program.ts
@@ -1,7 +1,9 @@
 import {
   Program,
+  ProgramFocusTag,
   ProgramSession,
   ProgramStage,
+  ProgramSystemicDemand,
   ProgramSessionCompletion,
   ProgramSessionCompletionStatus,
   UserProgram,
@@ -35,6 +37,8 @@ export const mapProgramRow = (row: ProgramRow): Program => ({
   defaultAutoRepeat: row.default_auto_repeat,
   releasedAt: row.released_at,
   stages: row.stages as unknown as ProgramStage[] | null,
+  focusTags: row.focus_tags as ProgramFocusTag[],
+  systemicDemand: row.systemic_demand as ProgramSystemicDemand | null,
 });
 
 /**

--- a/src/components/ProgramTags/ProgramTags.stories.tsx
+++ b/src/components/ProgramTags/ProgramTags.stories.tsx
@@ -1,0 +1,23 @@
+import { ProgramTags } from './ProgramTags';
+
+export default {
+  component: ProgramTags,
+};
+
+export const Default = {
+  args: { tags: ['strength', 'hypertrophy', 'conditioning'] },
+};
+
+/** Tags render in PROGRAM_FOCUS_TAGS order, not the order they were passed. */
+export const Reordered = {
+  args: { tags: ['mobility', 'power', 'strength'] },
+};
+
+export const SingleTag = {
+  args: { tags: ['endurance'] },
+};
+
+/** User-authored programs carry no tags and render nothing. */
+export const Untagged = {
+  args: { tags: [] },
+};

--- a/src/components/ProgramTags/ProgramTags.tsx
+++ b/src/components/ProgramTags/ProgramTags.tsx
@@ -1,0 +1,41 @@
+import { PROGRAM_FOCUS_TAGS, ProgramFocusTag } from '~/types';
+
+const TAG_LABELS: Record<ProgramFocusTag, string> = {
+  strength: 'Strength',
+  hypertrophy: 'Hypertrophy',
+  power: 'Power',
+  conditioning: 'Conditioning',
+  endurance: 'Endurance',
+  skill: 'Skill',
+  mobility: 'Mobility',
+};
+
+interface Props {
+  tags: ProgramFocusTag[];
+  className?: string;
+}
+
+/**
+ * The focus-tag chips under a program's title. Rendered in
+ * {@link PROGRAM_FOCUS_TAGS} order rather than each program's own order, so a
+ * list of cards reads consistently. Renders nothing for an untagged program.
+ */
+export const ProgramTags = ({ tags, className }: Props) => {
+  const ordered = PROGRAM_FOCUS_TAGS.filter((tag) => tags.includes(tag));
+  if (ordered.length === 0) return null;
+
+  return (
+    <ul className={`flex flex-wrap items-center gap-0.5 ${className ?? ''}`}>
+      {ordered.map((tag) => (
+        <li
+          key={tag}
+          // Bordered rather than bg-secondary: the browse rows use bg-secondary
+          // as their hover state, which would swallow a filled chip.
+          className="rounded border px-0.5 text-xs font-normal text-muted-foreground"
+        >
+          {TAG_LABELS[tag]}
+        </li>
+      ))}
+    </ul>
+  );
+};

--- a/src/components/ProgramTags/index.ts
+++ b/src/components/ProgramTags/index.ts
@@ -1,0 +1,1 @@
+export * from './ProgramTags';

--- a/src/components/StackFitNote/StackFitNote.stories.tsx
+++ b/src/components/StackFitNote/StackFitNote.stories.tsx
@@ -1,0 +1,55 @@
+import { Program } from '~/types';
+
+import { StackFitNote } from './StackFitNote';
+
+const program = (
+  title: string,
+  focusTags: Program['focusTags'],
+  systemicDemand: Program['systemicDemand'],
+) => ({ id: title, title, focusTags, systemicDemand }) as Program;
+
+const dfw = program(
+  'Dry Fighting Weight',
+  ['strength', 'hypertrophy', 'conditioning'],
+  'high',
+);
+const swings = program(
+  '10,000 Swing Challenge',
+  ['conditioning', 'endurance', 'power'],
+  'high',
+);
+const easyStrength = program('Easy Strength', ['strength', 'skill'], 'low');
+const aaProtocol = program(
+  'A+A Protocol "Plan A"',
+  ['power', 'endurance', 'conditioning'],
+  'moderate',
+);
+const kettlebellMile = program(
+  'The Kettlebell Mile',
+  ['endurance', 'conditioning'],
+  'moderate',
+);
+
+export default {
+  component: StackFitNote,
+};
+
+/** Two high-demand programs: over the recovery budget. */
+export const Conflict = {
+  args: { candidate: swings, active: [dfw] },
+};
+
+/** The classic hard/easy pairing — workable, but the budget is full. */
+export const AtBudget = {
+  args: { candidate: dfw, active: [easyStrength] },
+};
+
+/** Same adaptation bought twice. */
+export const Redundant = {
+  args: { candidate: kettlebellMile, active: [aaProtocol] },
+};
+
+/** A clean pairing renders nothing at all. */
+export const GoodPairing = {
+  args: { candidate: easyStrength, active: [program('Simple & Sinister', ['power', 'strength', 'mobility'], 'low')] },
+};

--- a/src/components/StackFitNote/StackFitNote.tsx
+++ b/src/components/StackFitNote/StackFitNote.tsx
@@ -1,0 +1,47 @@
+import { Card, CardContent } from '~/components/ui/card';
+import { Program } from '~/types';
+import { assessStackFit, stackFitHeadline } from '~/utils';
+
+interface Props {
+  candidate: Program;
+  /** Programs already running. Empty means there's nothing to stack against. */
+  active: Program[];
+}
+
+/**
+ * Pre-enroll advice on adding one more concurrent program. Renders nothing when
+ * there's nothing to say — the first program, an unrated candidate, or a stack
+ * with no issues worth a paragraph.
+ *
+ * Advisory only: it sits above the enroll buttons and never disables them.
+ */
+export const StackFitNote = ({ candidate, active }: Props) => {
+  const fit = assessStackFit(candidate, active);
+  if (!fit || fit.verdict === 'good') return null;
+
+  const conflict = fit.verdict === 'conflict';
+
+  return (
+    <Card
+      className={conflict ? 'border-destructive' : undefined}
+      role="note"
+      aria-label="Stacking advice"
+    >
+      <CardContent className="flex flex-col gap-0.5 pt-2">
+        <p
+          className={`text-sm font-medium ${conflict ? 'text-destructive' : ''}`}
+        >
+          {stackFitHeadline(fit)}
+        </p>
+        {fit.reasons.map((reason) => (
+          <p key={reason} className="text-xs text-muted-foreground">
+            {reason}
+          </p>
+        ))}
+        <p className="text-xs text-muted-foreground">
+          You can start it anyway — this is a heads-up, not a rule.
+        </p>
+      </CardContent>
+    </Card>
+  );
+};

--- a/src/components/StackFitNote/index.ts
+++ b/src/components/StackFitNote/index.ts
@@ -1,0 +1,1 @@
+export * from './StackFitNote';

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -8,6 +8,7 @@ export * from './ModifyCountButtons';
 export * from './PWAInstallPrompt';
 export * from './Page';
 export * from './PremiumGate';
+export * from './ProgramTags';
 export * from './SafeAreaWrapper';
 export * from './Sidebar';
 export * from './TrialStatusPill';

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -11,6 +11,7 @@ export * from './PremiumGate';
 export * from './ProgramTags';
 export * from './SafeAreaWrapper';
 export * from './Sidebar';
+export * from './StackFitNote';
 export * from './TrialStatusPill';
 export * from './ValueCarousel';
 export * from './WeeklyBalance';

--- a/src/examples/active-program.examples.ts
+++ b/src/examples/active-program.examples.ts
@@ -84,6 +84,8 @@ export const exampleActiveProgram = ({
       defaultAutoRepeat: false,
       releasedAt: null,
       stages: null,
+      focusTags: [],
+      systemicDemand: null,
     },
     nextSession: isComplete
       ? null

--- a/src/pages/ProgramDetailsPage/ProgramDetailsPage.test.tsx
+++ b/src/pages/ProgramDetailsPage/ProgramDetailsPage.test.tsx
@@ -94,6 +94,7 @@ const dfw = {
   isPublic: true,
   createdAt: '',
   archivedAt: null,
+  focusTags: ['strength', 'hypertrophy', 'conditioning'],
 };
 
 // Two double-bell movements at a flat 24 kg.

--- a/src/pages/ProgramDetailsPage/ProgramDetailsPage.test.tsx
+++ b/src/pages/ProgramDetailsPage/ProgramDetailsPage.test.tsx
@@ -95,6 +95,7 @@ const dfw = {
   createdAt: '',
   archivedAt: null,
   focusTags: ['strength', 'hypertrophy', 'conditioning'],
+  systemicDemand: 'high',
 };
 
 // Two double-bell movements at a flat 24 kg.
@@ -390,10 +391,48 @@ describe('ProgramDetailsPage', () => {
     );
   });
 
-  const activeProgram = (id: string, title: string) => ({
+  const activeProgram = (
+    id: string,
+    title: string,
+    // Defaults to an unrated program so these enroll-routing cases stay silent
+    // on stacking advice; the StackFitNote cases below opt in.
+    focusTags: string[] = [],
+    systemicDemand: string | null = null,
+  ) => ({
     enrollment: { id, programId: `${id}-program`, status: 'active' },
-    program: { title },
+    program: { title, focusTags, systemicDemand },
     progress: { completed: 0, total: 3 },
+  });
+
+  it('warns before stacking onto a program that overloads recovery, without blocking it', () => {
+    // dfw is high demand; another high-demand program puts the stack at 6.
+    mockUseActivePrograms.mockReturnValue({
+      data: [
+        activeProgram('up-1', '10,000 Swing Challenge', ['conditioning'], 'high'),
+      ],
+    });
+
+    renderPage();
+
+    const note = screen.getByRole('note', { name: 'Stacking advice' });
+    expect(note).toHaveTextContent('Heavy stack');
+    expect(note).toHaveTextContent('more hard training');
+    // Advisory only — the enroll button stays live.
+    expect(screen.getByRole('button', { name: 'Start program' })).toBeEnabled();
+  });
+
+  it('stays silent rather than guessing when an active program is unrated', () => {
+    // A user-authored program carries no tags or demand, so any verdict about
+    // the stack it's part of would be made up.
+    mockUseActivePrograms.mockReturnValue({
+      data: [activeProgram('up-1', 'My Program')],
+    });
+
+    renderPage();
+
+    expect(
+      screen.queryByRole('note', { name: 'Stacking advice' }),
+    ).not.toBeInTheDocument();
   });
 
   it('starts alongside an existing program with no prompt while a slot is free', () => {

--- a/src/pages/ProgramDetailsPage/ProgramDetailsPage.tsx
+++ b/src/pages/ProgramDetailsPage/ProgramDetailsPage.tsx
@@ -8,7 +8,12 @@ import {
   useProgram,
 } from '~/api';
 import type { MovementWeight } from '~/api';
-import { ModifyCountButtons, Page, WeightUnitTabs } from '~/components';
+import {
+  ModifyCountButtons,
+  Page,
+  ProgramTags,
+  WeightUnitTabs,
+} from '~/components';
 import { Button } from '~/components/ui/button';
 import { Card, CardContent } from '~/components/ui/card';
 import {
@@ -349,6 +354,7 @@ export const ProgramDetailsPage = () => {
             {data.program.authorName ? `${data.program.authorName} · ` : ''}
             {programCadenceLabel(data.program) ?? 'No sessions yet'}
           </p>
+          <ProgramTags tags={data.program.focusTags} />
           {data.program.description && (
             <p className="text-sm text-muted-foreground">
               {data.program.description}

--- a/src/pages/ProgramDetailsPage/ProgramDetailsPage.tsx
+++ b/src/pages/ProgramDetailsPage/ProgramDetailsPage.tsx
@@ -12,6 +12,7 @@ import {
   ModifyCountButtons,
   Page,
   ProgramTags,
+  StackFitNote,
   WeightUnitTabs,
 } from '~/components';
 import { Button } from '~/components/ui/button';
@@ -464,6 +465,13 @@ export const ProgramDetailsPage = () => {
           onCheckedChange={setAutoRepeat}
         />
       </div>
+
+      {program && (
+        <StackFitNote
+          candidate={program}
+          active={activeEnrollments.map((a) => a.program)}
+        />
+      )}
 
       <Button onClick={handleStart} disabled={enroll.isPending || !seeded}>
         Start program

--- a/src/pages/ProgramsPage/ProgramsPage.test.tsx
+++ b/src/pages/ProgramsPage/ProgramsPage.test.tsx
@@ -92,6 +92,7 @@ const dfw = {
   isPublic: true,
   createdAt: '',
   releasedAt: null,
+  focusTags: ['strength', 'hypertrophy', 'conditioning'],
 };
 
 const armor = {
@@ -107,6 +108,7 @@ const armor = {
   isPublic: true,
   createdAt: '',
   releasedAt: null,
+  focusTags: ['hypertrophy', 'strength', 'conditioning'],
 };
 
 const myProgram = {
@@ -122,6 +124,7 @@ const myProgram = {
   isPublic: false,
   createdAt: '',
   releasedAt: null,
+  focusTags: [],
 };
 
 const renderPage = () =>
@@ -324,6 +327,22 @@ describe('ProgramsPage', () => {
     expect(cards[0]).toHaveTextContent('Active');
     expect(cards[1]).toHaveTextContent('Ready');
     expect(cards[2]).toHaveTextContent('Draft');
+  });
+
+  it('chips a shared program’s focus tags in taxonomy order, and none for an untagged one', () => {
+    mockUsePrograms.mockReturnValue({
+      data: [{ ...dfw, focusTags: ['conditioning', 'strength'] }, myProgram],
+      isLoading: false,
+    });
+
+    renderPage();
+    expandBrowse();
+
+    // Taxonomy order (strength before conditioning), not the order authored.
+    const chips = screen.getAllByRole('listitem').map((li) => li.textContent);
+    expect(chips).toEqual(['Strength', 'Conditioning']);
+    // myProgram is untagged, so its card contributes no chips at all.
+    expect(screen.getByText('My Program')).toBeInTheDocument();
   });
 
   it('labels a repeating workout and badges it, instead of a week cadence', () => {

--- a/src/pages/ProgramsPage/components/BrowseProgramsList.tsx
+++ b/src/pages/ProgramsPage/components/BrowseProgramsList.tsx
@@ -1,6 +1,7 @@
 import { ChevronRightIcon } from '@heroicons/react/24/outline';
 import { Link } from 'react-router-dom';
 
+import { ProgramTags } from '~/components';
 import { Card } from '~/components/ui/card';
 import { Program } from '~/types';
 import { programCadenceLabel } from '~/utils';
@@ -54,6 +55,7 @@ export const BrowseProgramsList = ({
             {program.authorName ? `${program.authorName} · ` : ''}
             {programCadenceLabel(program) ?? 'No sessions yet'}
           </p>
+          <ProgramTags tags={program.focusTags} className="mt-0.5" />
         </div>
         <ChevronRightIcon
           aria-hidden

--- a/src/pages/ProgramsPage/components/BrowseProgramsSection.stories.tsx
+++ b/src/pages/ProgramsPage/components/BrowseProgramsSection.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react';
 import { useState } from 'react';
 import { MemoryRouter } from 'react-router-dom';
 
-import { Program } from '~/types';
+import { Program, ProgramFocusTag } from '~/types';
 
 import { BrowseProgramsSection } from './BrowseProgramsSection';
 
@@ -12,6 +12,7 @@ const shared = (
   authorName: string,
   numWeeks: number | null,
   daysPerWeek: number | null,
+  focusTags: ProgramFocusTag[],
   defaultAutoRepeat = false,
 ): Program => ({
   id,
@@ -29,14 +30,21 @@ const shared = (
   releasedAt: null,
   defaultAutoRepeat,
   stages: null,
+  focusTags,
+  systemicDemand: null,
 });
 
 const programs = [
-  shared('ss', 'Simple & Sinister', 'Pavel Tsatsouline', null, null, true),
-  shared('kb-mile', 'The Kettlebell Mile', 'Dr. Mike Prevost', 8, 1),
-  shared('easy-strength', 'Easy Strength', 'Dan John', 2, 5),
-  shared('abc', 'Armor Building Complex', 'Dan John', 5, 4),
-  shared('dfw', 'Dry Fighting Weight', 'Geoff Neupert', 5, 3),
+  shared('ss', 'Simple & Sinister', 'Pavel Tsatsouline', null, null,
+    ['power', 'strength', 'mobility'], true),
+  shared('kb-mile', 'The Kettlebell Mile', 'Dr. Mike Prevost', 8, 1,
+    ['endurance', 'conditioning']),
+  shared('easy-strength', 'Easy Strength', 'Dan John', 2, 5,
+    ['strength', 'skill']),
+  shared('abc', 'Armor Building Complex', 'Dan John', 5, 4,
+    ['hypertrophy', 'strength', 'conditioning']),
+  shared('dfw', 'Dry Fighting Weight', 'Geoff Neupert', 5, 3,
+    ['strength', 'hypertrophy', 'conditioning']),
 ];
 
 const meta = {

--- a/src/pages/ProgramsPage/components/MyProgramCard.stories.tsx
+++ b/src/pages/ProgramsPage/components/MyProgramCard.stories.tsx
@@ -21,6 +21,8 @@ const program: Program = {
   releasedAt: null,
   defaultAutoRepeat: false,
   stages: null,
+  focusTags: ['strength', 'hypertrophy', 'conditioning'],
+  systemicDemand: 'high',
 };
 
 const meta = {

--- a/src/pages/ProgramsPage/components/MyProgramCard.tsx
+++ b/src/pages/ProgramsPage/components/MyProgramCard.tsx
@@ -1,5 +1,6 @@
 import { Link } from 'react-router-dom';
 
+import { ProgramTags } from '~/components';
 import { Button, ButtonProps } from '~/components/ui/button';
 import { Card } from '~/components/ui/card';
 import { cn } from '~/lib/utils';
@@ -205,6 +206,7 @@ export const MyProgramCard = ({
           <p className="truncate text-xs text-muted-foreground">
             {cadence ?? 'No sessions yet'}
           </p>
+          <ProgramTags tags={program.focusTags} className="mt-0.5" />
         </div>
 
         <ProgramCardMenu actions={menuActions} programTitle={program.title} />

--- a/src/types/program.interface.ts
+++ b/src/types/program.interface.ts
@@ -29,6 +29,30 @@ export interface ProgramStage {
   deloadPreWorkoutNotes?: string;
 }
 
+/**
+ * What a program trains. Ordered as chips should render, so this array — not a
+ * program's own tag order — is the display source of truth.
+ */
+export const PROGRAM_FOCUS_TAGS = [
+  'strength',
+  'hypertrophy',
+  'power',
+  'conditioning',
+  'endurance',
+  'skill',
+  'mobility',
+] as const;
+
+export type ProgramFocusTag = (typeof PROGRAM_FOCUS_TAGS)[number];
+
+/**
+ * A program's recovery cost as written, not the difficulty of its movements.
+ * This is the binding constraint when stacking: two `high` programs collide even
+ * with disjoint {@link Program.focusTags}, while a `low` one stacks with almost
+ * anything.
+ */
+export type ProgramSystemicDemand = 'low' | 'moderate' | 'high';
+
 export interface Program {
   id: string;
   /** NULL for system/shared programs; the owning user otherwise. */
@@ -72,4 +96,12 @@ export interface Program {
    * enrollment's position.
    */
   stages: ProgramStage[] | null;
+  /**
+   * Up to three focus tags describing what the program trains. Empty for
+   * user-authored programs, which carry no editorial categorization. Overlap
+   * between two stacked programs signals redundant work.
+   */
+  focusTags: ProgramFocusTag[];
+  /** Editorial demand rating, or `null` on user-authored programs. */
+  systemicDemand: ProgramSystemicDemand | null;
 }

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -12,6 +12,7 @@ export * from './resolveAuthSession';
 export * from './resolveMovementWeights';
 export * from './resolveSharedWeights';
 export * from './soundPreference';
+export * from './stackFit';
 export * from './timerSound';
 export * from './weightUnits';
 export * from './workoutLogToWorkoutOptions';

--- a/src/utils/stackFit.test.ts
+++ b/src/utils/stackFit.test.ts
@@ -1,0 +1,140 @@
+import { Program, ProgramFocusTag, ProgramSystemicDemand } from '~/types';
+
+import { assessStackFit } from './stackFit';
+
+/** A program carrying only the fields the fit model reads. */
+const program = (
+  title: string,
+  focusTags: ProgramFocusTag[],
+  systemicDemand: ProgramSystemicDemand | null,
+): Program =>
+  ({
+    id: title,
+    title,
+    focusTags,
+    systemicDemand,
+  }) as Program;
+
+// The seeded shared programs, as stamped by 20260803000000.
+const easyStrength = program('Easy Strength', ['strength', 'skill'], 'low');
+const simpleSinister = program(
+  'Simple & Sinister',
+  ['power', 'strength', 'mobility'],
+  'low',
+);
+const dfw = program(
+  'Dry Fighting Weight',
+  ['strength', 'hypertrophy', 'conditioning'],
+  'high',
+);
+const swings = program(
+  '10,000 Swing Challenge',
+  ['conditioning', 'endurance', 'power'],
+  'high',
+);
+const kettlebellMile = program(
+  'The Kettlebell Mile',
+  ['endurance', 'conditioning'],
+  'moderate',
+);
+const aaProtocol = program(
+  'A+A Protocol',
+  ['power', 'endurance', 'conditioning'],
+  'moderate',
+);
+const untagged = program('My Program', [], null);
+
+describe('assessStackFit — nothing to say', () => {
+  test('the first program is never a stacking question', () => {
+    expect(assessStackFit(dfw, [])).toBeNull();
+  });
+
+  test('an untagged, unrated candidate cannot be assessed', () => {
+    expect(assessStackFit(untagged, [dfw])).toBeNull();
+  });
+});
+
+describe('assessStackFit — recovery cost', () => {
+  test('two high-demand programs blow the budget', () => {
+    const fit = assessStackFit(dfw, [swings])!;
+    expect(fit.verdict).toBe('conflict');
+    expect(fit.load).toBe(6);
+    expect(fit.reasons[0]).toContain('more hard training');
+  });
+
+  test('the classic hard/easy pairing sits at the budget, not over it', () => {
+    // Dry Fighting Weight (3) + Easy Strength (1) = 4.
+    const fit = assessStackFit(dfw, [easyStrength])!;
+    expect(fit.verdict).toBe('caution');
+    expect(fit.load).toBe(4);
+    expect(fit.reasons[0]).toContain('recovery budget');
+  });
+
+  test('two low-demand programs leave room to spare', () => {
+    const fit = assessStackFit(easyStrength, [simpleSinister])!;
+    expect(fit.verdict).toBe('good');
+    expect(fit.load).toBe(2);
+    expect(fit.reasons).toEqual([]);
+  });
+
+  test('three moderates exceed the budget even with no single hard program', () => {
+    const third = program('Snatch Test', ['skill'], 'moderate');
+    const fit = assessStackFit(third, [kettlebellMile, aaProtocol])!;
+    expect(fit.verdict).toBe('conflict');
+    expect(fit.load).toBe(6);
+  });
+
+  test('an unrated active program suppresses the budget verdict rather than understating it', () => {
+    // untagged contributes 0, so a naive sum would read 3 and pass.
+    const fit = assessStackFit(dfw, [untagged])!;
+    expect(fit.verdict).toBe('good');
+    expect(fit.reasons).toEqual([]);
+  });
+});
+
+describe('assessStackFit — redundancy', () => {
+  test('two programs sharing two tags are buying the same adaptation', () => {
+    // Kettlebell Mile and A+A share endurance + conditioning; both moderate, so
+    // load is 4 and the budget note fires too.
+    const fit = assessStackFit(kettlebellMile, [aaProtocol])!;
+    expect(fit.verdict).toBe('caution');
+    expect(fit.reasons.some((r) => r.includes('same qualities twice'))).toBe(true);
+    expect(fit.reasons.some((r) => r.includes('Endurance'))).toBe(false);
+    expect(fit.reasons.some((r) => r.includes('endurance'))).toBe(true);
+  });
+
+  test('a single shared tag is not redundancy', () => {
+    // Easy Strength and Simple & Sinister share only `strength`.
+    expect(assessStackFit(easyStrength, [simpleSinister])!.reasons).toEqual([]);
+  });
+
+  test('names every redundant program, not just the first', () => {
+    const other = program('Other Mile', ['endurance', 'conditioning'], 'low');
+    const fit = assessStackFit(kettlebellMile, [aaProtocol, other])!;
+    const redundancy = fit.reasons.find((r) => r.includes('same qualities twice'))!;
+    expect(redundancy).toContain('A+A Protocol');
+    expect(redundancy).toContain('Other Mile');
+  });
+});
+
+describe('assessStackFit — verdict precedence', () => {
+  test('two high programs sharing one tag are a budget problem, not a redundancy one', () => {
+    // Swings and DFW overlap only on `conditioning`.
+    const fit = assessStackFit(swings, [dfw])!;
+    expect(fit.verdict).toBe('conflict');
+    expect(fit.reasons).toHaveLength(1);
+  });
+
+  test('over budget outranks redundancy, and both issues are reported', () => {
+    const heavyTwin = program(
+      'Heavy Twin',
+      ['strength', 'hypertrophy', 'conditioning'],
+      'high',
+    );
+    const fit = assessStackFit(heavyTwin, [dfw])!;
+    expect(fit.verdict).toBe('conflict');
+    expect(fit.reasons).toHaveLength(2);
+    expect(fit.reasons[0]).toContain('more hard training');
+    expect(fit.reasons[1]).toContain('same qualities twice');
+  });
+});

--- a/src/utils/stackFit.ts
+++ b/src/utils/stackFit.ts
@@ -1,0 +1,119 @@
+// Stack fit: does adding one more concurrent program to what's already running
+// make sense? Reads the editorial metadata stamped on programs
+// (`focus_tags`, `systemic_demand`) and answers on two independent axes.
+//
+// 1. Recovery cost. Demand is the binding constraint — two `high` programs
+//    collide even when they train nothing in common. Each program spends from a
+//    shared weekly budget.
+// 2. Redundancy. Two programs sharing most of their focus tags are buying the
+//    same adaptation twice, which is wasteful rather than dangerous.
+//
+// Advisory only: this never blocks an enrollment. A lifter who knows their own
+// recovery gets to overrule it.
+//
+// Pure + deterministic, like patternDebt, so the scoring can be unit-tested here
+// and reused as-is if a recommender edge function ever wants it.
+
+import { Program, ProgramFocusTag, ProgramSystemicDemand } from '~/types';
+
+export type StackVerdict = 'good' | 'caution' | 'conflict';
+
+export interface StackFit {
+  verdict: StackVerdict;
+  /** Total demand spent by the candidate plus everything already active. */
+  load: number;
+  /** One plain-language sentence per issue found. Empty on a clean 'good'. */
+  reasons: string[];
+}
+
+// Tunable model constants.
+
+/** Weekly recovery cost of one program, by its editorial demand rating. */
+const DEMAND_COST: Record<ProgramSystemicDemand, number> = {
+  low: 1,
+  moderate: 2,
+  high: 3,
+};
+
+/**
+ * Demand a lifter can carry across every concurrent program before the stack is
+ * more than the sum of its parts. Calibrated against pairings that are known to
+ * work and known not to: Dry Fighting Weight (3) + Easy Strength (1) is the
+ * classic hard/easy pairing and lands at 4; two `high` programs land at 6.
+ */
+const STACK_BUDGET = 5;
+
+/** At or above the budget, but not over it — workable, worth a warning. */
+const CAUTION_LOAD = 4;
+
+/** Shared focus tags before two programs count as buying the same adaptation. */
+const REDUNDANT_TAG_OVERLAP = 2;
+
+const demandCost = (program: Program): number =>
+  program.systemicDemand ? DEMAND_COST[program.systemicDemand] : 0;
+
+const sharedTags = (a: Program, b: Program): ProgramFocusTag[] =>
+  a.focusTags.filter((tag) => b.focusTags.includes(tag));
+
+/** Joins names as "A", "A and B", "A, B, and C". */
+const listNames = (names: string[]): string => {
+  if (names.length <= 1) return names[0] ?? '';
+  if (names.length === 2) return `${names[0]} and ${names[1]}`;
+  return `${names.slice(0, -1).join(', ')}, and ${names[names.length - 1]}`;
+};
+
+/**
+ * Assess adding `candidate` on top of the programs already running.
+ *
+ * Returns `null` when there is nothing to say: no active programs (the first
+ * program is never a stacking question), or the candidate carries no editorial
+ * metadata (every user-authored program), which would make any verdict a guess.
+ */
+export const assessStackFit = (
+  candidate: Program,
+  active: Program[],
+): StackFit | null => {
+  if (active.length === 0) return null;
+  if (!candidate.systemicDemand && candidate.focusTags.length === 0) return null;
+
+  const load = demandCost(candidate) + active.reduce((sum, p) => sum + demandCost(p), 0);
+  const reasons: string[] = [];
+
+  // Recovery cost. Only meaningful once every program in the stack is rated —
+  // an unrated program contributes 0, which would understate a real total.
+  const fullyRated =
+    !!candidate.systemicDemand && active.every((p) => !!p.systemicDemand);
+  const overBudget = fullyRated && load > STACK_BUDGET;
+
+  if (overBudget) {
+    reasons.push(
+      `This is more hard training than most people recover from at once. ${candidate.title} is ${candidate.systemicDemand} demand on top of ${listNames(active.map((p) => p.title))}.`,
+    );
+  } else if (fullyRated && load >= CAUTION_LOAD) {
+    reasons.push(
+      `This fills your recovery budget. It works if the rest of your week is easy, but there's no room left for a third.`,
+    );
+  }
+
+  // Redundancy, per already-active program.
+  const redundant = active.filter(
+    (p) => sharedTags(candidate, p).length >= REDUNDANT_TAG_OVERLAP,
+  );
+  if (redundant.length > 0) {
+    const overlap = sharedTags(candidate, redundant[0]);
+    reasons.push(
+      `${listNames(redundant.map((p) => p.title))} already covers ${listNames(overlap)}. You'd be training the same qualities twice.`,
+    );
+  }
+
+  if (overBudget) return { verdict: 'conflict', load, reasons };
+  if (reasons.length > 0) return { verdict: 'caution', load, reasons };
+  return { verdict: 'good', load, reasons };
+};
+
+/** Headline for a fit, suitable as a card title. */
+export const stackFitHeadline = (fit: StackFit): string => {
+  if (fit.verdict === 'conflict') return 'Heavy stack';
+  if (fit.verdict === 'caution') return 'Workable stack';
+  return 'Good pairing';
+};

--- a/supabase/migrations/20260803000000_add_program_categories.sql
+++ b/supabase/migrations/20260803000000_add_program_categories.sql
@@ -1,0 +1,350 @@
+-- Program categories: what a program trains and what it costs to run (PROD).
+--
+-- Stacking already allows up to three concurrent programs (one_program_per_active_slot),
+-- but nothing in the model says whether two programs complement or collide.
+--
+-- `programs.focus_tags` is what the program trains -- up to three of strength,
+-- hypertrophy, power, conditioning, endurance, skill, mobility. Overlap between
+-- two stacked programs signals redundancy.
+--
+-- `programs.systemic_demand` is the program's recovery cost as written, not the
+-- difficulty of its movements. This is the real stacking constraint: two `high`
+-- programs collide even with disjoint tags, while a `low` program (Easy Strength,
+-- Simple & Sinister) pairs with almost anything. NULL for user-authored programs,
+-- which carry no editorial judgement.
+ALTER TABLE programs
+  ADD COLUMN focus_tags TEXT[] NOT NULL DEFAULT '{}',
+  ADD COLUMN systemic_demand TEXT;
+
+ALTER TABLE programs
+  ADD CONSTRAINT programs_focus_tags_valid CHECK (
+    focus_tags <@ ARRAY['strength','hypertrophy','power','conditioning',
+                        'endurance','skill','mobility']::TEXT[]
+    AND COALESCE(array_length(focus_tags, 1), 0) <= 3
+  ),
+  ADD CONSTRAINT programs_systemic_demand_valid CHECK (
+    systemic_demand IS NULL OR systemic_demand IN ('low','moderate','high')
+  );
+
+-- Stamp the seeded shared programs. Tags are ordered most- to least-defining;
+-- display order is the client's concern (PROGRAM_FOCUS_TAGS).
+UPDATE programs p
+  SET focus_tags = v.tags, systemic_demand = v.demand
+  FROM (VALUES
+    ('easy-strength',                ARRAY['strength','skill'],                        'low'),
+    ('simple-and-sinister',          ARRAY['power','strength','mobility'],             'low'),
+    ('onnit-beginner-full-body',     ARRAY['strength','conditioning'],                 'low'),
+    ('aa-protocol-plan-a',           ARRAY['power','endurance','conditioning'],        'moderate'),
+    ('strong-endurance-plan-025',    ARRAY['endurance','power','conditioning'],        'moderate'),
+    ('strongfirst-snatch-test-plan', ARRAY['endurance','conditioning','power'],        'moderate'),
+    ('armor-building-complex',       ARRAY['hypertrophy','strength','conditioning'],   'moderate'),
+    ('kettlebell-mile',              ARRAY['endurance','conditioning'],                'moderate'),
+    ('dry-fighting-weight',          ARRAY['strength','hypertrophy','conditioning'],   'high'),
+    ('10000-swing-challenge',        ARRAY['conditioning','endurance','power'],        'high')
+  ) AS v(slug, tags, demand)
+  WHERE p.slug = v.slug AND p.owner_id IS NULL;
+
+-- Re-create enroll_in_program so the copy-on-enroll clone carries the template's
+-- categories. Body carried over VERBATIM from 20260802000000_add_program_stages.sql;
+-- the only change is `focus_tags, systemic_demand` in both column lists of the
+-- clone INSERT.
+DROP FUNCTION IF EXISTS public.enroll_in_program(UUID, NUMERIC, TEXT, NUMERIC, TEXT, UUID, JSONB, BOOLEAN, BOOLEAN);
+
+CREATE FUNCTION public.enroll_in_program(
+  p_program_id UUID,
+  p_shared_weight_one_value NUMERIC DEFAULT NULL,
+  p_shared_weight_one_unit  TEXT    DEFAULT NULL,
+  p_shared_weight_two_value NUMERIC DEFAULT NULL,
+  p_shared_weight_two_unit  TEXT    DEFAULT NULL,
+  p_replace_user_program_id UUID    DEFAULT NULL,
+  p_movement_weights        JSONB   DEFAULT NULL,
+  p_auto_repeat             BOOLEAN  DEFAULT NULL,
+  p_queue                   BOOLEAN  DEFAULT false
+)
+RETURNS UUID
+LANGUAGE plpgsql
+SECURITY INVOKER
+SET search_path = public
+AS $$
+DECLARE
+  v_user_id            UUID    := auth.uid();
+  v_owner_id           UUID;
+  v_default_auto_repeat BOOLEAN;
+  v_target_program     UUID;
+  v_user_program_id    UUID;
+  v_modal_one          NUMERIC;
+  v_modal_two          NUMERIC;
+  v_slot               SMALLINT;
+  v_queue_position     INTEGER;
+  v_override           BOOLEAN := p_shared_weight_one_value IS NOT NULL
+                                 OR p_movement_weights IS NOT NULL;
+BEGIN
+  IF v_user_id IS NULL THEN
+    RAISE EXCEPTION 'Not authenticated';
+  END IF;
+
+  -- RLS on this SELECT already restricts to public-or-own; a NOT FOUND result
+  -- means the program does not exist or is not visible to the caller.
+  SELECT owner_id, default_auto_repeat INTO v_owner_id, v_default_auto_repeat
+  FROM programs WHERE id = p_program_id;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Program % not found or not accessible', p_program_id;
+  END IF;
+
+  -- One live cursor per program. `p.source_program_id = p_program_id` catches
+  -- re-enrolling in a shared program whose earlier clone is still running.
+  IF NOT p_queue AND EXISTS (
+    SELECT 1
+    FROM user_programs up
+    JOIN programs p ON p.id = up.program_id
+    WHERE up.user_id = v_user_id
+      AND up.status = 'active'
+      AND up.id IS DISTINCT FROM p_replace_user_program_id
+      AND (p.id = p_program_id OR p.source_program_id = p_program_id)
+  ) THEN
+    RAISE EXCEPTION 'PROGRAM_ALREADY_ACTIVE';
+  END IF;
+
+  IF p_queue THEN
+    -- Queued rows hold no slot; they take the next position in line. The
+    -- partial unique index serializes concurrent inserts per user.
+    SELECT COALESCE(MAX(queue_position), 0) + 1 INTO v_queue_position
+    FROM user_programs
+    WHERE user_id = v_user_id AND status = 'queued';
+  ELSE
+    -- Free the replaced slot first so the picker below can reuse it.
+    IF p_replace_user_program_id IS NOT NULL THEN
+      UPDATE user_programs
+        SET status = 'abandoned'
+        WHERE id = p_replace_user_program_id
+          AND user_id = v_user_id
+          AND status = 'active';
+      IF NOT FOUND THEN
+        RAISE EXCEPTION 'No active enrollment % to replace', p_replace_user_program_id;
+      END IF;
+    END IF;
+
+    SELECT s.slot INTO v_slot
+    FROM generate_series(1, 3) AS s(slot)
+    WHERE NOT EXISTS (
+      SELECT 1 FROM user_programs up
+      WHERE up.user_id = v_user_id
+        AND up.status = 'active'
+        AND up.active_slot = s.slot
+    )
+    ORDER BY s.slot
+    LIMIT 1;
+
+    IF v_slot IS NULL THEN
+      RAISE EXCEPTION 'PROGRAM_SLOTS_FULL';
+    END IF;
+  END IF;
+
+  IF v_owner_id = v_user_id THEN
+    v_target_program := p_program_id;                     -- own program: no clone
+  ELSE
+    INSERT INTO programs
+      (owner_id, source_program_id, slug, title, description, author_name,
+       num_weeks, days_per_week, is_public, default_auto_repeat, stages,
+       focus_tags, systemic_demand)
+    SELECT v_user_id, id, NULL, title, description, author_name,
+           num_weeks, days_per_week, false, default_auto_repeat, stages,
+           focus_tags, systemic_demand
+    FROM programs WHERE id = p_program_id
+    RETURNING id INTO v_target_program;
+
+    IF v_override THEN
+      -- The modal (weightOne, weightTwo) pair across the program's sessions:
+      -- the shared placeholder load every deliberately-different session is
+      -- offset from, used only by the complexSet uniform-fold path. Ties break
+      -- toward the lighter pair, mirroring deriveStartingWeight.
+      SELECT one_val, two_val INTO v_modal_one, v_modal_two
+      FROM (
+        SELECT (workout_options->'movements'->0->>'weightOneValue')::NUMERIC AS one_val,
+               (workout_options->'movements'->0->>'weightTwoValue')::NUMERIC AS two_val,
+               COUNT(*) AS cnt
+        FROM program_sessions
+        WHERE program_id = p_program_id
+        GROUP BY one_val, two_val
+        ORDER BY cnt DESC, one_val, two_val
+        LIMIT 1
+      ) modal;
+    END IF;
+
+    INSERT INTO program_sessions
+      (program_id, sequence_index, week_number, day_number, title,
+       workout_options, notes, weight_label)
+    -- Per-movement modal authored weight, one row per movement name. Rows with a
+    -- null weight one (bodyweight) never form a modal, so a bodyweight movement
+    -- has no row and its element is kept untouched below. Tie-break mirrors the
+    -- client's deriveMovementWeights so pre-fill equals the cloned value.
+    WITH movement_modal AS (
+      SELECT DISTINCT ON (name)
+        name, one_val, two_val
+      FROM (
+        SELECT
+          mv->>'movementName' AS name,
+          (mv->>'weightOneValue')::NUMERIC AS one_val,
+          (mv->>'weightTwoValue')::NUMERIC AS two_val,
+          COUNT(*) AS cnt
+        FROM program_sessions ps2,
+             jsonb_array_elements(ps2.workout_options->'movements') AS mv
+        WHERE ps2.program_id = p_program_id
+          AND (mv->>'weightOneValue') IS NOT NULL
+        GROUP BY name, one_val, two_val
+      ) per_pair
+      ORDER BY name, cnt DESC, one_val, two_val
+    )
+    SELECT
+      v_target_program, ps.sequence_index, ps.week_number, ps.day_number, ps.title,
+      CASE
+        WHEN NOT v_override THEN ps.workout_options
+        -- non-complex with per-movement weights: rebuild each element in its own
+        -- config shape, offset from that movement's modal.
+        WHEN p_movement_weights IS NOT NULL
+             AND ps.workout_options->>'complexSet' IS DISTINCT FROM 'true'
+          THEN jsonb_set(
+                 ps.workout_options,
+                 '{movements}',
+                 (
+                   SELECT jsonb_agg(
+                            CASE
+                              WHEN mw.value IS NULL THEN elem
+                              ELSE elem || jsonb_build_object(
+                                'weightOneValue',
+                                  COALESCE(to_jsonb(
+                                    CASE
+                                      WHEN (mw.value->>'weightOneValue')::NUMERIC IS NULL
+                                        OR r.one_delta = 0
+                                        THEN (mw.value->>'weightOneValue')::NUMERIC
+                                      ELSE GREATEST((mw.value->>'weightOneValue')::NUMERIC + r.one_delta, 1)
+                                    END), 'null'::jsonb),
+                                'weightOneUnit',
+                                  COALESCE(to_jsonb(mw.value->>'weightOneUnit'), 'null'::jsonb),
+                                'weightTwoValue',
+                                  COALESCE(to_jsonb(
+                                    CASE
+                                      WHEN (mw.value->>'weightTwoValue')::NUMERIC IS NULL
+                                        OR r.two_delta = 0
+                                        THEN (mw.value->>'weightTwoValue')::NUMERIC
+                                      ELSE GREATEST((mw.value->>'weightTwoValue')::NUMERIC + r.two_delta, 1)
+                                    END), 'null'::jsonb),
+                                'weightTwoUnit',
+                                  COALESCE(to_jsonb(mw.value->>'weightTwoUnit'), 'null'::jsonb)
+                              )
+                            END
+                            ORDER BY ord
+                          )
+                   FROM jsonb_array_elements(ps.workout_options->'movements')
+                          WITH ORDINALITY AS e(elem, ord)
+                   LEFT JOIN LATERAL (
+                     SELECT o.value
+                     FROM jsonb_array_elements(p_movement_weights) AS o(value)
+                     WHERE o.value->>'movementName' = elem->>'movementName'
+                     LIMIT 1
+                   ) mw ON TRUE
+                   LEFT JOIN movement_modal mm ON mm.name = elem->>'movementName'
+                   CROSS JOIN LATERAL (
+                     SELECT
+                       -- Offset only when the movement's authored unit matches the
+                       -- chosen unit; a cross-unit choice passes through (delta 0).
+                       CASE WHEN elem->>'weightOneUnit'
+                                 IS NOT DISTINCT FROM mw.value->>'weightOneUnit'
+                            THEN COALESCE((elem->>'weightOneValue')::NUMERIC, 0)
+                                 - COALESCE(mm.one_val, 0)
+                            ELSE 0 END AS one_delta,
+                       CASE WHEN elem->>'weightTwoUnit'
+                                 IS NOT DISTINCT FROM mw.value->>'weightTwoUnit'
+                            THEN COALESCE((elem->>'weightTwoValue')::NUMERIC, 0)
+                                 - COALESCE(mm.two_val, 0)
+                            ELSE 0 END AS two_delta
+                   ) r
+                 ))
+        -- complexSet (one bell pair for the whole complex, ABC), or a caller that
+        -- passed only p_shared_weight_* (the homogeneous shared-weight programs):
+        -- the prior uniform fold. COALESCE(..., 'null'::jsonb): jsonb_set is
+        -- strict and to_jsonb(NULL) is SQL NULL, so an unset slot must be coerced
+        -- to a JSON null. `m || jsonb_build_object(...)` overrides only the four
+        -- weight keys, preserving movementName / repScheme / etc.
+        ELSE jsonb_set(
+               jsonb_set(
+                 jsonb_set(
+                   jsonb_set(
+                     jsonb_set(
+                       ps.workout_options,
+                       '{sharedWeightOneValue}',
+                       COALESCE(to_jsonb(w.one_value), 'null'::jsonb)),
+                     '{sharedWeightOneUnit}',
+                     COALESCE(to_jsonb(w.one_unit), 'null'::jsonb)),
+                   '{sharedWeightTwoValue}',
+                   COALESCE(to_jsonb(w.two_value), 'null'::jsonb)),
+                 '{sharedWeightTwoUnit}',
+                 COALESCE(to_jsonb(w.two_unit), 'null'::jsonb)),
+               '{movements}',
+               (
+                 SELECT jsonb_agg(
+                          m || jsonb_build_object(
+                            'weightOneValue', COALESCE(to_jsonb(w.one_value), 'null'::jsonb),
+                            'weightOneUnit',  COALESCE(to_jsonb(w.one_unit),  'null'::jsonb),
+                            'weightTwoValue', COALESCE(to_jsonb(w.two_value), 'null'::jsonb),
+                            'weightTwoUnit',  COALESCE(to_jsonb(w.two_unit),  'null'::jsonb)
+                          )
+                        )
+                 FROM jsonb_array_elements(ps.workout_options->'movements') AS m
+               ))
+      END,
+      ps.notes,
+      ps.weight_label
+    FROM program_sessions ps
+    -- Per-session shared weight for the complexSet path: the enrollee's choice
+    -- shifted by this session's authored offset from the modal. A zero delta
+    -- passes the chosen value through untouched -- notably it must NOT hit the
+    -- >= 1 clamp, since a single-bell enrollment carries weight two = 0.
+    CROSS JOIN LATERAL (
+      SELECT
+        CASE
+          WHEN p_shared_weight_one_value IS NULL OR d.one_delta = 0
+            THEN p_shared_weight_one_value
+          ELSE GREATEST(p_shared_weight_one_value + d.one_delta, 1)
+        END AS one_value,
+        CASE
+          WHEN p_shared_weight_two_value IS NULL OR d.two_delta = 0
+            THEN p_shared_weight_two_value
+          ELSE GREATEST(p_shared_weight_two_value + d.two_delta, 1)
+        END AS two_value,
+        p_shared_weight_one_unit AS one_unit,
+        p_shared_weight_two_unit AS two_unit
+      FROM (
+        SELECT
+          COALESCE(
+            CASE WHEN ps.workout_options->'movements'->0->>'weightOneUnit'
+                      IS NOT DISTINCT FROM p_shared_weight_one_unit
+                 THEN (ps.workout_options->'movements'->0->>'weightOneValue')::NUMERIC
+                      - v_modal_one
+            END, 0) AS one_delta,
+          COALESCE(
+            CASE WHEN ps.workout_options->'movements'->0->>'weightTwoUnit'
+                      IS NOT DISTINCT FROM p_shared_weight_two_unit
+                 THEN (ps.workout_options->'movements'->0->>'weightTwoValue')::NUMERIC
+                      - v_modal_two
+            END, 0) AS two_delta
+      ) d
+    ) w
+    WHERE ps.program_id = p_program_id
+    ORDER BY ps.sequence_index;
+  END IF;
+
+  INSERT INTO user_programs
+    (user_id, program_id, status, active_slot, queue_position, auto_repeat)
+  VALUES (v_user_id, v_target_program,
+          CASE WHEN p_queue THEN 'queued' ELSE 'active' END,
+          v_slot, v_queue_position,
+          COALESCE(p_auto_repeat, v_default_auto_repeat, false))
+  RETURNING id INTO v_user_program_id;
+
+  RETURN v_user_program_id;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.enroll_in_program(UUID, NUMERIC, TEXT, NUMERIC, TEXT, UUID, JSONB, BOOLEAN, BOOLEAN) FROM public;
+GRANT EXECUTE ON FUNCTION public.enroll_in_program(UUID, NUMERIC, TEXT, NUMERIC, TEXT, UUID, JSONB, BOOLEAN, BOOLEAN) TO authenticated;

--- a/types/supabase.ts
+++ b/types/supabase.ts
@@ -374,6 +374,7 @@ export type Database = {
           days_per_week: number | null
           default_auto_repeat: boolean
           description: string | null
+          focus_tags: string[]
           id: string
           is_public: boolean
           num_weeks: number | null
@@ -382,6 +383,7 @@ export type Database = {
           slug: string | null
           source_program_id: string | null
           stages: Json | null
+          systemic_demand: string | null
           title: string
         }
         Insert: {
@@ -391,6 +393,7 @@ export type Database = {
           days_per_week?: number | null
           default_auto_repeat?: boolean
           description?: string | null
+          focus_tags?: string[]
           id?: string
           is_public?: boolean
           num_weeks?: number | null
@@ -399,6 +402,7 @@ export type Database = {
           slug?: string | null
           source_program_id?: string | null
           stages?: Json | null
+          systemic_demand?: string | null
           title: string
         }
         Update: {
@@ -408,6 +412,7 @@ export type Database = {
           days_per_week?: number | null
           default_auto_repeat?: boolean
           description?: string | null
+          focus_tags?: string[]
           id?: string
           is_public?: boolean
           num_weeks?: number | null
@@ -416,6 +421,7 @@ export type Database = {
           slug?: string | null
           source_program_id?: string | null
           stages?: Json | null
+          systemic_demand?: string | null
           title?: string
         }
         Relationships: [


### PR DESCRIPTION
## Why

Stacking already allows three concurrent programs (`one_program_per_active_slot`, `MAX_ACTIVE_PROGRAMS`) plus a queue, but nothing in the data model said what a program *trains* or what it *costs*. Nothing stopped a user from stacking 10,000 Swings on top of Dry Fighting Weight, and nothing told them it was a bad idea.

Two commits: the first adds the metadata, the second reads it.

## What

**1. Categories (`ff08853`).** Adds `focus_tags text[]` (up to three of `strength`, `hypertrophy`, `power`, `conditioning`, `endurance`, `skill`, `mobility`) and `systemic_demand text` (`low`/`moderate`/`high`) to `programs`, both CHECK-constrained per the `user_programs.status` house pattern. All ten shared seeds stamped; tags chipped in the catalog and details header.

| Program | Tags | Demand |
|---|---|---|
| Easy Strength | strength, skill | low |
| Simple & Sinister | power, strength, mobility | low |
| Onnit Beginner Full-Body | strength, conditioning | low |
| A+A Protocol "Plan A" | power, endurance, conditioning | moderate |
| Strong Endurance Plan 025 | endurance, power, conditioning | moderate |
| StrongFirst Snatch Test | endurance, conditioning, power | moderate |
| Armor Building Complex | hypertrophy, strength, conditioning | moderate |
| The Kettlebell Mile | endurance, conditioning | moderate |
| Dry Fighting Weight | strength, hypertrophy, conditioning | high |
| 10,000 Swing Challenge | conditioning, endurance, power | high |

`enroll_in_program` is re-created so the copy-on-enroll clone carries both columns, following `20260802000000_add_program_stages.sql`. The body is verbatim; the only change is the two columns in both lists of the clone `INSERT`.

**2. Stack fit recommender (`a0027ba`).** `assessStackFit(candidate, active)` in `src/utils/stackFit.ts` — pure and deterministic like `patternDebt`, so it can be reused by a recommender edge function later. Two independent axes:

- **Recovery cost.** Each program spends from a shared weekly budget by demand rating (low 1, moderate 2, high 3; budget 5). Over budget is a `conflict`; at 4–5 is a `caution`. Calibrated against known pairings — Dry Fighting Weight + Easy Strength is the classic hard/easy stack and lands at 4, two high-demand programs land at 6.
- **Redundancy.** Two programs sharing 2+ focus tags are buying the same adaptation twice. Wasteful rather than dangerous, so it caps at `caution`.

`StackFitNote` renders the verdict on the details page above the enroll buttons. It renders nothing for the first program, a clean pairing, or any stack containing an unrated program — a verdict there would be a guess.

## How to test

- `npm run compile:ts`, `npm run lint` clean. Full suite green: 93 files / 653 tests.
- 12 new unit tests in `src/utils/stackFit.test.ts` drive the model with the real seeded programs: two highs conflict at load 6, hard/easy cautions at 4, three moderates conflict at 6, two lows pass at 2, an unrated active suppresses the budget verdict instead of understating it.
- 2 new `ProgramDetailsPage` tests: the note appears with `Start program` still enabled, and stays absent when an active program is unrated.
- Constraints reject a fourth tag, an unknown tag (`cardio`), and `systemic_demand = 'extreme'`; a valid two-tag insert succeeds.
- Called `enroll_in_program` as the seeded test user and confirmed the clone carried `{power,endurance,conditioning}` / `moderate`.
- Drove the real app against local Supabase with A+A + Dry Fighting Weight active, then opened the 10,000 Swing Challenge — both the budget and redundancy reasons rendered, no console errors. Repeated with A+A alone for the caution case, and Easy Strength for the silent case.

## Gallery

**Programs list — before / after**

<img width="390" src="https://github.com/user-attachments/assets/7dc6c8d1-5a11-4e8b-b205-d718b3d88e52" /> <img width="390" src="https://github.com/user-attachments/assets/200818f5-68e2-4d9a-b184-b75466a57418" />

**Program details header — after**

<img width="390" src="https://github.com/user-attachments/assets/9bf47c02-1ba9-4572-8f0d-a2feaf2fb7f3" />

**Stack fit — conflict (A+A + Dry Fighting Weight active) and caution (A+A active)**

<img width="390" src="https://github.com/user-attachments/assets/7d3baacf-e6e1-412b-97cf-0d2301c6042e" /> <img width="390" src="https://github.com/user-attachments/assets/f464fe95-300e-499f-9de5-e35e2cbe77d7" />

## Deploy notes

- New migration `20260803000000_add_program_categories.sql`. It re-creates `enroll_in_program`, so it must land before anything else touching that function.
- `types/supabase.ts` regenerated and committed.
- No feature flag: the programs surface is already behind the existing `programs` flag.

## Tradeoffs

**Tags alone vs. tags + demand.** The original ask was just focus categories. Tag overlap is the more legible signal — easy to explain, no editorial judgement required. But it only catches redundancy, never fatigue: two `high` programs collide with disjoint tags, and a `low` program stacks with almost anything. Demand is a subjective per-program rating, which is its real cost, but without it the recommender could only say "these overlap," never "this will bury you."

**Advisory vs. blocking.** Gating the enroll button would guarantee nobody accidentally overreaches, and for a novice that's a real safeguard. It's also wrong often enough to be insulting — the model knows a program's rating, not the user's sleep, training age, or whether they're deliberately running a hard block. It advises and gets out of the way, with "Queue for later" sitting right below as the honest alternative.

**Demand stored but unrendered.** Showing "High demand" on a card is honest and nearly free. Without stacking context it reads as a warning label on a program that's hard on purpose, so it stays data the recommender frames.

**`conditioning` vs. `cardio`.** `cardio` is more familiar, but it collapses glycolytic complex work and long-duration aerobic work, and several seeded programs are firmly one and not the other.

**Chips bordered, not filled.** The browse rows use `bg-secondary` as their hover state, which would swallow a `bg-secondary` chip mid-hover.