### PR TITLE
fix(seed): align demo and fixture movement names with the catalog

### DIFF
--- a/src/pages/ActiveWorkoutPage/ActiveWorkoutPage.stories.tsx
+++ b/src/pages/ActiveWorkoutPage/ActiveWorkoutPage.stories.tsx
@@ -15,7 +15,7 @@ import { ActiveWorkoutPage } from './ActiveWorkoutPage';
 const defaultWorkoutOptions: WorkoutOptions = {
   ...DEFAULT_WORKOUT_OPTIONS,
   movements: [
-    { ...DEFAULT_MOVEMENT_OPTIONS, movementName: 'Single Arm Clean & Press' },
+    { ...DEFAULT_MOVEMENT_OPTIONS, movementName: 'Kettlebell Clean and Press' },
   ],
   title: 'Example Workout',
   preWorkoutNotes: 'Example pre-workout notes',

--- a/src/pages/StartWorkoutPage/StartWorkoutPage.test.jsx
+++ b/src/pages/StartWorkoutPage/StartWorkoutPage.test.jsx
@@ -254,7 +254,7 @@ describe('start workout page', () => {
       await userEvent.click(screen.getByRole('tab', { name: 'Single' }));
       await userEvent.type(
         screen.getByLabelText('Movement Input'),
-        'Single Arm Press',
+        'One-Arm Kettlebell Military Press',
       );
       await userEvent.click(screen.getByRole('button', { name: /Start/i }));
 
@@ -263,7 +263,7 @@ describe('start workout page', () => {
           movements: [
             {
               ...DEFAULT_MOVEMENT_OPTIONS,
-              movementName: 'Single Arm Press',
+              movementName: 'One-Arm Kettlebell Military Press',
               weightTwoValue: 0,
             },
           ],

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -114,7 +114,7 @@ BEGIN
     test_user_id,
     NOW() - INTERVAL '2 days' - INTERVAL '1 hour',
     NOW() - INTERVAL '2 days',
-    ARRAY['Kettlebell Swing', 'Goblet Squat', 'Turkish Get-up'],
+    ARRAY['Kettlebell Swing', 'Goblet Squat', 'Kettlebell Turkish Get-Up'],
     ARRAY[20, 10, 5],
     35,
     8,
@@ -157,7 +157,7 @@ BEGIN
     test_user_id,
     NOW() - INTERVAL '1 day' - INTERVAL '45 minutes',
     NOW() - INTERVAL '1 day',
-    ARRAY['Push-up', 'Pull-up', 'Burpee'],
+    ARRAY['Push-Up', 'Pull-Up', 'Burpee'],
     ARRAY[15, 10, 10],
     35,
     10,
@@ -200,7 +200,7 @@ BEGIN
     test_user_id,
     NOW() - INTERVAL '5 hours',
     NOW() - INTERVAL '4 hours',
-    ARRAY['Deadlift', 'Bench Press', 'Squat'],
+    ARRAY['Kettlebell Deadlift', 'Kettlebell Bench Press', 'Bodyweight Squat'],
     ARRAY[5, 5, 5],
     15,
     3,
@@ -243,7 +243,7 @@ BEGIN
     test_user_id,
     NOW() - INTERVAL '3 days' - INTERVAL '30 minutes',
     NOW() - INTERVAL '3 days',
-    ARRAY['Walking', 'Light Stretching'],
+    ARRAY['Kettlebell Farmer''s Carry', 'Kettlebell Halo'],
     ARRAY[1, 1],
     2,
     1,
@@ -286,7 +286,7 @@ BEGIN
     test_user_id,
     NOW() - INTERVAL '4 days' - INTERVAL '1 hour 15 minutes',
     NOW() - INTERVAL '4 days',
-    ARRAY['Single Arm Swing', 'Single Arm Clean', 'Single Arm Press'],
+    ARRAY['One-Arm Kettlebell Swing', 'One-Arm Kettlebell Clean', 'One-Arm Kettlebell Military Press'],
     ARRAY[10, 5, 5],
     20,
     5,
@@ -305,19 +305,19 @@ BEGIN
   );
 
   -- Get the workout_log IDs for movement_logs by matching unique movement combinations
-  SELECT id INTO workout1_id FROM public.workout_logs 
-  WHERE user_id = test_user_id 
-    AND movements = ARRAY['Kettlebell Swing', 'Goblet Squat', 'Turkish Get-up']
+  SELECT id INTO workout1_id FROM public.workout_logs
+  WHERE user_id = test_user_id
+    AND movements = ARRAY['Kettlebell Swing', 'Goblet Squat', 'Kettlebell Turkish Get-Up']
     ORDER BY started_at DESC LIMIT 1;
   
-  SELECT id INTO workout2_id FROM public.workout_logs 
-  WHERE user_id = test_user_id 
-    AND movements = ARRAY['Push-up', 'Pull-up', 'Burpee']
+  SELECT id INTO workout2_id FROM public.workout_logs
+  WHERE user_id = test_user_id
+    AND movements = ARRAY['Push-Up', 'Pull-Up', 'Burpee']
     ORDER BY started_at DESC LIMIT 1;
   
-  SELECT id INTO workout3_id FROM public.workout_logs 
-  WHERE user_id = test_user_id 
-    AND movements = ARRAY['Deadlift', 'Bench Press', 'Squat']
+  SELECT id INTO workout3_id FROM public.workout_logs
+  WHERE user_id = test_user_id
+    AND movements = ARRAY['Kettlebell Deadlift', 'Kettlebell Bench Press', 'Bodyweight Squat']
     ORDER BY started_at DESC LIMIT 1;
 
   -- Add movement logs for workout 1 (kettlebell workout)
@@ -334,7 +334,7 @@ BEGIN
     ) VALUES
     (workout1_id, test_user_id, 'Kettlebell Swing', ARRAY[20]::smallint[], 24, 'kilograms', NULL, NULL),
     (workout1_id, test_user_id, 'Goblet Squat', ARRAY[10]::smallint[], 24, 'kilograms', NULL, NULL),
-    (workout1_id, test_user_id, 'Turkish Get-up', ARRAY[5]::smallint[], 16, 'kilograms', NULL, NULL);
+    (workout1_id, test_user_id, 'Kettlebell Turkish Get-Up', ARRAY[5]::smallint[], 16, 'kilograms', NULL, NULL);
   END IF;
 
   -- Add movement logs for workout 2 (bodyweight workout)
@@ -349,8 +349,8 @@ BEGIN
       weight_two_value,
       weight_two_unit
     ) VALUES
-    (workout2_id, test_user_id, 'Push-up', ARRAY[15]::smallint[], NULL, NULL, NULL, NULL),
-    (workout2_id, test_user_id, 'Pull-up', ARRAY[10]::smallint[], NULL, NULL, NULL, NULL),
+    (workout2_id, test_user_id, 'Push-Up', ARRAY[15]::smallint[], NULL, NULL, NULL, NULL),
+    (workout2_id, test_user_id, 'Pull-Up', ARRAY[10]::smallint[], NULL, NULL, NULL, NULL),
     (workout2_id, test_user_id, 'Burpee', ARRAY[10]::smallint[], NULL, NULL, NULL, NULL);
   END IF;
 
@@ -366,9 +366,9 @@ BEGIN
       weight_two_value,
       weight_two_unit
     ) VALUES
-    (workout3_id, test_user_id, 'Deadlift', ARRAY[5, 5, 5]::smallint[], 100, 'kilograms', NULL, NULL),
-    (workout3_id, test_user_id, 'Bench Press', ARRAY[5, 5, 5]::smallint[], 80, 'kilograms', NULL, NULL),
-    (workout3_id, test_user_id, 'Squat', ARRAY[5, 5, 5]::smallint[], 90, 'kilograms', NULL, NULL);
+    (workout3_id, test_user_id, 'Kettlebell Deadlift', ARRAY[5, 5, 5]::smallint[], 100, 'kilograms', NULL, NULL),
+    (workout3_id, test_user_id, 'Kettlebell Bench Press', ARRAY[5, 5, 5]::smallint[], 80, 'kilograms', NULL, NULL),
+    (workout3_id, test_user_id, 'Bodyweight Squat', ARRAY[5, 5, 5]::smallint[], 90, 'kilograms', NULL, NULL);
   END IF;
 
 END $$;


### PR DESCRIPTION
## Why

Audited every movement name referenced by the workout program seeds and the curated beginner workouts against the catalog (`scripts/data/movements.csv`). Those all check out — the three seeded names that don't appear in the CSV (`Front Squat With Two Kettlebells`, `Two-Arm Kettlebell Clean`, `Two-Arm Kettlebell Military Press`) are old names that the later rename migrations rewrite in `program_sessions`, and each rename sorts after its seed.

The gap was elsewhere: `supabase/seed.sql` and two test fixtures referenced names with no catalog row at all. A log against such a name leaves `user_movements.functional_movement_id` NULL, so local dev exercised an orphaned-movement path that production never hits — and the fixtures depicted a name shape a real lifter can no longer produce through the autocomplete.

## What

Renamed movement strings so every one exact-matches the first column of the catalog CSV. Names only — no rows added or removed, no schema changes, no migrations.

`supabase/seed.sql` (local-only demo data):

| Old | New |
| --- | --- |
| Turkish Get-up | Kettlebell Turkish Get-Up |
| Push-up / Pull-up | Push-Up / Pull-Up (casing) |
| Deadlift / Bench Press / Squat | Kettlebell Deadlift / Kettlebell Bench Press / Bodyweight Squat |
| Walking / Light Stretching | Kettlebell Farmer's Carry / Kettlebell Halo |
| Single Arm Swing / Clean / Press | One-Arm Kettlebell Swing / Clean / Military Press |

Fixtures:

- `StartWorkoutPage.test.jsx`: `Single Arm Press` → `One-Arm Kettlebell Military Press`
- `ActiveWorkoutPage.stories.tsx`: `Single Arm Clean & Press` → `Kettlebell Clean and Press`

Both replacements are Single Arm / 1 primary item, matching what each fixture depicts.

Within the seed, the `workout_logs.movements` arrays, the `WHERE movements = ARRAY[...]` lookups that join them to `movement_logs`, and the `movement_logs.movement_name` rows were updated together, so each demo workout stays internally coherent.

## How to test

- Diffed every movement string in the seed and fixtures against the CSV first column — all 14 exact-match, casing and punctuation included.
- Piped `supabase/seed.sql` into local Postgres wrapped in `BEGIN`/`ROLLBACK`: applies cleanly, no local data touched.
- `npm test` — 638/638 pass (92 files).
- `npm run compile:ts` — clean.

## Deploy notes

None. `supabase/seed.sql` is local-only and never reaches staging or production; the rest is test fixtures.

## Tradeoffs

Left `src/mocks/data.ts` alone — it still carries non-catalog names (`Clean and Press`, `Front Squat`, `Pull-Ups`) across ~15 rows. Those are MSW response fixtures for history/aggregation tests where the string is opaque payload rather than something the UI resolves against the catalog, so the same argument doesn't apply. Worth a follow-up sweep if we want one rule everywhere.