### PR TITLE
fix(programs): preserve deload and test-day offsets on Adjust weights

### DIFF
--- a/docs/program-tracking.md
+++ b/docs/program-tracking.md
@@ -128,7 +128,13 @@ session — atomic), and the PROD-219 editing pair `reorder_program_sessions` /
   own title, notes, goal, duration, and rest settings and completed sessions
   are never rewritten. This deliberately overwrites per-session weight offsets
   on future sessions with the edited session's weights; `adjust_program_weights`
-  is the offset-preserving counterpart for weight-only changes.
+  is the offset-preserving counterpart for weight-only changes. Its modal
+  baseline is the mode over **unlabeled working sessions** (`weight_label IS
+  NULL`): incomplete first, else completed (so A+A week-4 deload-only still
+  offsets from the last working load), else incomplete when every session is
+  labeled. That keeps authored deltas (A+A deload −8 kg, DFW test day +4 kg)
+  stable across mid-program and repeated adjusts; the Adjust Weights dialog
+  prefills via the same rule (`selectWeightModalSessions`).
 - **Stages (autoregulated progression):** a program can carry an ordered ladder
   in `programs.stages` (JSONB `ProgramStage[]`: `title`, `movements` as
   name+repScheme only, `preWorkoutNotes`, `deloadPreWorkoutNotes`), copied to

--- a/e2e/program-adjust-weights.spec.ts
+++ b/e2e/program-adjust-weights.spec.ts
@@ -12,7 +12,12 @@ const SUPABASE_URL = process.env.VITE_SUPABASE_URL!;
 const SUPABASE_ANON_KEY = process.env.VITE_SUPABASE_ANON_KEY!;
 const ES_SLUG = 'easy-strength';
 const ABC_SLUG = 'armor-building-complex';
+const AA_SLUG = 'aa-protocol-plan-a';
+const DFW_SLUG = 'dry-fighting-weight';
 const SWING = 'Kettlebell Swing';
+const DFW_PRESS = 'Double Kettlebell Clean and Press';
+const DELOAD_LABEL = 'Deload weeks';
+const TEST_DAY_LABEL = 'Test day';
 
 interface TestUser {
   token: string;
@@ -103,6 +108,7 @@ interface MovementOpt {
 interface SessionRow {
   id: string;
   sequence_index: number;
+  weight_label: string | null;
   workout_options: {
     complexSet: boolean;
     sharedWeightOneValue: number | null;
@@ -118,7 +124,7 @@ async function orderedSessions(
 ): Promise<SessionRow[]> {
   return restJson<SessionRow[]>(
     'GET',
-    `program_sessions?program_id=eq.${programId}&select=id,sequence_index,workout_options&order=sequence_index.asc`,
+    `program_sessions?program_id=eq.${programId}&select=id,sequence_index,weight_label,workout_options&order=sequence_index.asc`,
     token,
   );
 }
@@ -329,5 +335,189 @@ test.describe('adjust_program_weights — mid-program weight change', () => {
         p_user_program_id: userProgramId,
       }),
     ).rejects.toThrow(/No weights provided/);
+  });
+});
+
+/** Assert A+A work/deload absolute loads (shared + every movement). */
+function expectAaLoads(
+  sessions: SessionRow[],
+  workWeight: number,
+  deloadWeight: number,
+) {
+  for (const session of sessions) {
+    const isDeload = session.weight_label === DELOAD_LABEL;
+    const expected = isDeload ? deloadWeight : workWeight;
+    expect(session.workout_options.sharedWeightOneValue).toBe(expected);
+    expect(session.workout_options.sharedWeightTwoValue).toBe(0);
+    for (const m of session.workout_options.movements) {
+      expect(m.weightOneValue).toBe(expected);
+      expect(m.weightTwoValue).toBe(0);
+    }
+  }
+}
+
+async function adjustAaShared(
+  token: string,
+  userProgramId: string,
+  weight: number,
+): Promise<number> {
+  return rpc<number>('adjust_program_weights', token, {
+    p_user_program_id: userProgramId,
+    p_shared_weight_one_value: weight,
+    p_shared_weight_one_unit: 'kilograms',
+    p_shared_weight_two_value: 0,
+    p_shared_weight_two_unit: 'kilograms',
+  });
+}
+
+test.describe('adjust_program_weights — A+A Plan A deload offsets', () => {
+  test('enroll with shared weights then adjust keeps deload at chosen − 8', async () => {
+    const user = await signUpThrowawayUser();
+    const aaId = await programIdBySlug(user.token, AA_SLUG);
+    // UI-shaped enroll: pick a working bell (seed modal is 24; choose 20).
+    const userProgramId = await rpc<string>('enroll_in_program', user.token, {
+      p_program_id: aaId,
+      p_shared_weight_one_value: 20,
+      p_shared_weight_one_unit: 'kilograms',
+      p_shared_weight_two_value: 0,
+      p_shared_weight_two_unit: 'kilograms',
+    });
+    const cloneId = await cloneProgramId(user.token, userProgramId);
+    expectAaLoads(await orderedSessions(user.token, cloneId), 20, 12);
+
+    await adjustAaShared(user.token, userProgramId, 28);
+    expectAaLoads(await orderedSessions(user.token, cloneId), 28, 20);
+  });
+
+  test('mid-block re-adjust after completing work does not double-apply deltas', async () => {
+    const user = await signUpThrowawayUser();
+    const aaId = await programIdBySlug(user.token, AA_SLUG);
+    const userProgramId = await rpc<string>('enroll_in_program', user.token, {
+      p_program_id: aaId,
+    });
+    const cloneId = await cloneProgramId(user.token, userProgramId);
+    const before = await orderedSessions(user.token, cloneId);
+    // Complete 4 of 6 work sessions so stale completed 24s would outvote
+    // rebased upcoming work under the old all-sessions modal.
+    const work = before.filter((s) => s.weight_label !== DELOAD_LABEL);
+    expect(work).toHaveLength(6);
+    for (const session of work.slice(0, 4)) {
+      await completeSession(user, userProgramId, session.id);
+    }
+
+    await adjustAaShared(user.token, userProgramId, 28);
+    const afterFirst = await orderedSessions(user.token, cloneId);
+    // Completed rows untouched at enroll weight; upcoming work 28 / deload 20.
+    for (const session of afterFirst) {
+      const wasCompleted = work.slice(0, 4).some((w) => w.id === session.id);
+      if (wasCompleted) {
+        expect(session.workout_options.sharedWeightOneValue).toBe(24);
+      } else if (session.weight_label === DELOAD_LABEL) {
+        expect(session.workout_options.sharedWeightOneValue).toBe(20);
+      } else {
+        expect(session.workout_options.sharedWeightOneValue).toBe(28);
+      }
+    }
+
+    // Second adjust: label-aware modal is incomplete work at 28, not stale 24.
+    await adjustAaShared(user.token, userProgramId, 32);
+    const afterSecond = await orderedSessions(user.token, cloneId);
+    for (const session of afterSecond) {
+      const wasCompleted = work.slice(0, 4).some((w) => w.id === session.id);
+      if (wasCompleted) {
+        expect(session.workout_options.sharedWeightOneValue).toBe(24);
+      } else if (session.weight_label === DELOAD_LABEL) {
+        expect(session.workout_options.sharedWeightOneValue).toBe(24);
+      } else {
+        expect(session.workout_options.sharedWeightOneValue).toBe(32);
+      }
+    }
+  });
+
+  test('adjusting when only deload sessions remain keeps chosen − 8', async () => {
+    const user = await signUpThrowawayUser();
+    const aaId = await programIdBySlug(user.token, AA_SLUG);
+    const userProgramId = await rpc<string>('enroll_in_program', user.token, {
+      p_program_id: aaId,
+    });
+    const cloneId = await cloneProgramId(user.token, userProgramId);
+    const before = await orderedSessions(user.token, cloneId);
+    const work = before.filter((s) => s.weight_label !== DELOAD_LABEL);
+    for (const session of work) {
+      await completeSession(user, userProgramId, session.id);
+    }
+
+    // Naive incomplete-only modal would treat deload 16 as working and flatten.
+    await adjustAaShared(user.token, userProgramId, 28);
+    const after = await orderedSessions(user.token, cloneId);
+    for (const session of after) {
+      if (session.weight_label === DELOAD_LABEL) {
+        expect(session.workout_options.sharedWeightOneValue).toBe(20);
+        for (const m of session.workout_options.movements) {
+          expect(m.weightOneValue).toBe(20);
+        }
+      } else {
+        expect(session.workout_options.sharedWeightOneValue).toBe(24);
+      }
+    }
+  });
+});
+
+test.describe('adjust_program_weights — DFW test-day offset', () => {
+  test('per-movement adjust keeps Test day at chosen + 4', async () => {
+    const user = await signUpThrowawayUser();
+    const dfwId = await programIdBySlug(user.token, DFW_SLUG);
+    const userProgramId = await rpc<string>('enroll_in_program', user.token, {
+      p_program_id: dfwId,
+      p_movement_weights: [
+        {
+          movementName: DFW_PRESS,
+          weightOneValue: 20,
+          weightOneUnit: 'kilograms',
+          weightTwoValue: 20,
+          weightTwoUnit: 'kilograms',
+        },
+        {
+          movementName: 'Front Squat With Two Kettlebells',
+          weightOneValue: 20,
+          weightOneUnit: 'kilograms',
+          weightTwoValue: 20,
+          weightTwoUnit: 'kilograms',
+        },
+      ],
+    });
+    const cloneId = await cloneProgramId(user.token, userProgramId);
+    const enrolled = await orderedSessions(user.token, cloneId);
+    const testDay = enrolled.find((s) => s.weight_label === TEST_DAY_LABEL);
+    expect(testDay).toBeDefined();
+    const testPress = testDay!.workout_options.movements.find(
+      (m) => m.movementName === DFW_PRESS,
+    );
+    expect(testPress?.weightOneValue).toBe(24); // 20 + 4
+
+    await rpc<number>('adjust_program_weights', user.token, {
+      p_user_program_id: userProgramId,
+      p_movement_weights: [
+        {
+          movementName: DFW_PRESS,
+          weightOneValue: 28,
+          weightOneUnit: 'kilograms',
+          weightTwoValue: 28,
+          weightTwoUnit: 'kilograms',
+        },
+      ],
+    });
+
+    const after = await orderedSessions(user.token, cloneId);
+    for (const session of after) {
+      const press = session.workout_options.movements.find(
+        (m) => m.movementName === DFW_PRESS,
+      );
+      if (!press) continue;
+      const expected =
+        session.weight_label === TEST_DAY_LABEL ? 32 : 28; // +4 on test day
+      expect(press.weightOneValue).toBe(expected);
+      expect(press.weightTwoValue).toBe(expected);
+    }
   });
 });

--- a/src/api/useAdjustProgramWeights.ts
+++ b/src/api/useAdjustProgramWeights.ts
@@ -32,8 +32,9 @@ export interface AdjustProgramWeightsArgs {
  * Rewrites the weights on every not-yet-completed session of an active
  * enrollment via the `adjust_program_weights` RPC — the mid-program
  * counterpart to the enrollment starting-weight picker. Authored per-session
- * offsets (test days heavier, deloads lighter) are preserved; completed
- * sessions and their logged workouts are untouched.
+ * offsets (test days heavier, deloads lighter) are preserved via a
+ * label-aware working-weight modal; completed sessions and their logged
+ * workouts are untouched.
  *
  * Returns the number of sessions rewritten.
  */

--- a/src/pages/ProgramDetailsPage/utils/selectWeightModalSessions.test.ts
+++ b/src/pages/ProgramDetailsPage/utils/selectWeightModalSessions.test.ts
@@ -1,0 +1,119 @@
+import { ProgramSession, WorkoutOptions } from '~/types';
+
+import {
+  selectWeightModalSessions,
+  SessionWithState,
+} from './selectWeightModalSessions';
+
+const session = (
+  id: string,
+  weight: number,
+  weightLabel: string | null = null,
+): ProgramSession => ({
+  id,
+  programId: 'p',
+  sequenceIndex: 0,
+  weekNumber: 1,
+  dayNumber: 1,
+  title: 't',
+  notes: null,
+  weightLabel,
+  workoutOptions: {
+    complexSet: true,
+    intervalTimer: 30,
+    restTimer: 0,
+    title: null,
+    preWorkoutNotes: null,
+    workoutGoal: 30,
+    workoutGoalUnits: 'minutes',
+    sharedWeightOneValue: weight,
+    sharedWeightOneUnit: 'kilograms',
+    sharedWeightTwoValue: 0,
+    sharedWeightTwoUnit: 'kilograms',
+    movements: [
+      {
+        movementName: 'Clean',
+        repScheme: [1],
+        weightOneValue: weight,
+        weightOneUnit: 'kilograms',
+        weightTwoValue: 0,
+        weightTwoUnit: 'kilograms',
+      },
+    ],
+  } as Omit<WorkoutOptions, 'startedAt'>,
+});
+
+const item = (
+  id: string,
+  weight: number,
+  state: SessionWithState['state'],
+  weightLabel: string | null = null,
+): SessionWithState => ({
+  session: session(id, weight, weightLabel),
+  state,
+});
+
+describe('selectWeightModalSessions', () => {
+  it('prefers incomplete unlabeled work (A+A mid-block after a rebase)', () => {
+    const items = [
+      item('w1', 24, 'done'),
+      item('w2', 24, 'done'),
+      item('w3', 24, 'done'),
+      item('w4', 24, 'done'),
+      // Rebased upcoming work at 28 — must win over stale completed 24s.
+      item('w5', 28, 'upcoming'),
+      item('w6', 28, 'upcoming'),
+      item('d1', 20, 'upcoming', 'Deload weeks'),
+      item('d2', 20, 'upcoming', 'Deload weeks'),
+    ];
+
+    const modal = selectWeightModalSessions(items);
+    expect(modal.map((s) => s.id)).toEqual(['w5', 'w6']);
+  });
+
+  it('falls back to completed unlabeled work when only deload remains (A+A week 4)', () => {
+    const items = [
+      item('w1', 28, 'done'),
+      item('w2', 28, 'done'),
+      item('w3', 28, 'done'),
+      item('w4', 28, 'done'),
+      item('w5', 28, 'done'),
+      item('w6', 28, 'done'),
+      item('d1', 20, 'upcoming', 'Deload weeks'),
+      item('d2', 20, 'upcoming', 'Deload weeks'),
+    ];
+
+    const modal = selectWeightModalSessions(items);
+    expect(modal.map((s) => s.id)).toEqual([
+      'w1',
+      'w2',
+      'w3',
+      'w4',
+      'w5',
+      'w6',
+    ]);
+  });
+
+  it('uses all incomplete sessions when every session is unlabeled', () => {
+    const items = [
+      item('a', 24, 'done'),
+      item('b', 28, 'upcoming'),
+      item('c', 28, 'upcoming'),
+    ];
+
+    const modal = selectWeightModalSessions(items);
+    expect(modal.map((s) => s.id)).toEqual(['b', 'c']);
+  });
+
+  it('falls back to incomplete when every session is labeled (Snatch Test)', () => {
+    const items = [
+      item('h1', 28, 'done', 'Heavy days'),
+      item('m1', 24, 'upcoming', 'Medium days'),
+      item('l1', 20, 'upcoming', 'Light days'),
+      item('h2', 28, 'upcoming', 'Heavy days'),
+    ];
+
+    const modal = selectWeightModalSessions(items);
+    expect(modal.map((s) => s.id)).toEqual(['m1', 'l1', 'h2']);
+  });
+});

--- a/src/pages/ProgramDetailsPage/utils/selectWeightModalSessions.ts
+++ b/src/pages/ProgramDetailsPage/utils/selectWeightModalSessions.ts
@@ -1,0 +1,39 @@
+import type { SessionState } from '~/api';
+import { ProgramSession } from '~/types';
+
+/** A program session paired with its enrollment progress state. */
+export interface SessionWithState {
+  session: ProgramSession;
+  /** `upcoming` = incomplete; `done` / `skipped` = has a completion row. */
+  state: SessionState;
+}
+
+/**
+ * Sessions that form the working-weight modal for `adjust_program_weights` and
+ * the Adjust Weights dialog prefill. Mirrors the RPC's label-aware baseline:
+ *
+ *   1. Incomplete + unlabeled (`weightLabel` null), if any
+ *   2. Else any unlabeled (completed work — A+A deload-week case)
+ *   3. Else incomplete (all-labeled programs like Snatch Test)
+ *
+ * Offset groups (`'Deload weeks'`, `'Test day'`, …) are excluded from tiers 1–2
+ * so their authored deltas stay relative to the true working load.
+ */
+export const selectWeightModalSessions = (
+  items: SessionWithState[],
+): ProgramSession[] => {
+  const incomplete = items.filter((item) => item.state === 'upcoming');
+  const unlabeledIncomplete = incomplete.filter(
+    (item) => item.session.weightLabel == null,
+  );
+  if (unlabeledIncomplete.length > 0) {
+    return unlabeledIncomplete.map((item) => item.session);
+  }
+
+  const unlabeled = items.filter((item) => item.session.weightLabel == null);
+  if (unlabeled.length > 0) {
+    return unlabeled.map((item) => item.session);
+  }
+
+  return incomplete.map((item) => item.session);
+};

--- a/src/pages/ProgramProgressPage/ProgramProgressPage.tsx
+++ b/src/pages/ProgramProgressPage/ProgramProgressPage.tsx
@@ -204,8 +204,11 @@ export const ProgramProgressPage = () => {
           open={adjustingWeights}
           onOpenChange={setAdjustingWeights}
           userProgramId={enrollment.id}
-          sessions={weeks.flatMap((week) =>
-            week.sessions.map((item) => item.session),
+          sessionItems={weeks.flatMap((week) =>
+            week.sessions.map((item) => ({
+              session: item.session,
+              state: item.state,
+            })),
           )}
         />
       )}

--- a/src/pages/ProgramProgressPage/components/AdjustWeightsDialog.tsx
+++ b/src/pages/ProgramProgressPage/components/AdjustWeightsDialog.tsx
@@ -12,7 +12,6 @@ import {
   DialogTitle,
 } from '~/components/ui/dialog';
 import { useToast } from '~/contexts';
-import { ProgramSession } from '~/types';
 import { WEIGHT_MODE_LABELS } from '~/utils';
 
 import { WeightSlots } from '~/pages/ProgramDetailsPage/ProgramDetailsPage';
@@ -24,39 +23,60 @@ import {
   deriveStartingWeight,
   StartingWeight,
 } from '~/pages/ProgramDetailsPage/utils/deriveWeightGroups';
+import {
+  selectWeightModalSessions,
+  SessionWithState,
+} from '~/pages/ProgramDetailsPage/utils/selectWeightModalSessions';
 
 interface AdjustWeightsDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   /** The active enrollment the new weights apply to. */
   userProgramId: string;
-  /** All of the enrollment's cloned sessions, in program order. */
-  sessions: ProgramSession[];
+  /**
+   * Clone sessions with progress state. Prefill uses the label-aware working
+   * baseline (same rule as `adjust_program_weights`), not every session.
+   */
+  sessionItems: SessionWithState[];
 }
 
 /**
  * Mid-program counterpart to the enrollment starting-weight picker: change the
  * working weight(s) of an active program for every session not yet completed.
- * Pre-fills from the clone's current weights, so what you see is what the
- * upcoming sessions carry now.
+ * Pre-fills from the clone's label-aware working baseline so heavier/lighter
+ * days keep their offsets when the RPC re-bases.
  */
 export const AdjustWeightsDialog = ({
   open,
   onOpenChange,
   userProgramId,
-  sessions,
+  sessionItems,
 }: AdjustWeightsDialogProps) => {
   const adjust = useAdjustProgramWeights();
   const { showToast } = useToast();
 
-  const complex = useMemo(() => isComplexProgram(sessions), [sessions]);
+  const modalSessions = useMemo(
+    () => selectWeightModalSessions(sessionItems),
+    [sessionItems],
+  );
+  // complexSet is a program-level property — check the full clone, not just the
+  // modal subset (week-4 A+A would otherwise look non-complex if only completed
+  // work were somehow empty and we fell through oddly).
+  const allSessions = useMemo(
+    () => sessionItems.map((item) => item.session),
+    [sessionItems],
+  );
+  const complex = useMemo(
+    () => isComplexProgram(allSessions),
+    [allSessions],
+  );
   const movementControls = useMemo(
-    () => deriveMovementWeights(sessions),
-    [sessions],
+    () => deriveMovementWeights(modalSessions),
+    [modalSessions],
   );
   const currentShared = useMemo(
-    () => deriveStartingWeight(sessions),
-    [sessions],
+    () => deriveStartingWeight(modalSessions),
+    [modalSessions],
   );
 
   // Seeded lazily from the clone's current weights; remounting the content on

--- a/supabase/migrations/20260803120000_adjust_program_weights_label_aware_modal.sql
+++ b/supabase/migrations/20260803120000_adjust_program_weights_label_aware_modal.sql
@@ -1,0 +1,279 @@
+-- adjust_program_weights: label-aware working-weight modal (A+A deload / DFW
+-- test day).
+--
+-- The previous modal spanned EVERY clone session. After a mid-program adjust,
+-- completed rows keep the old absolute load and can outvote rebased upcoming
+-- work on a short program (A+A: 6 work + 2 deload), so a later Adjust
+-- double-applies deltas. A naive "incomplete only" modal would instead flatten
+-- A+A week 4: once only deload sessions remain, the deload load becomes the
+-- mode and chosen + 0 wipes the -8 kg offset.
+--
+-- Working sessions are those with weight_label IS NULL. Labeled groups
+-- ('Deload weeks', 'Test day', snatch light/medium/heavy) are offset groups.
+-- Modal session set (lowest tier that has rows):
+--   1. Incomplete + unlabeled
+--   2. Any unlabeled (completed work — A+A deload-week case)
+--   3. Incomplete (all-labeled programs; unlabeled-only programs hit tier 1)
+--
+-- Prefill on AdjustWeightsDialog uses the same rule via selectWeightModalSessions.
+-- Offset math, completed-session exclusion, unit mismatch, and clamps are unchanged.
+CREATE OR REPLACE FUNCTION public.adjust_program_weights(
+  p_user_program_id         UUID,
+  p_shared_weight_one_value NUMERIC DEFAULT NULL,
+  p_shared_weight_one_unit  TEXT    DEFAULT NULL,
+  p_shared_weight_two_value NUMERIC DEFAULT NULL,
+  p_shared_weight_two_unit  TEXT    DEFAULT NULL,
+  p_movement_weights        JSONB   DEFAULT NULL
+)
+RETURNS INTEGER
+LANGUAGE plpgsql
+SECURITY INVOKER
+SET search_path = public
+AS $$
+DECLARE
+  v_user_id   UUID := auth.uid();
+  v_program   UUID;
+  v_modal_one NUMERIC;
+  v_modal_two NUMERIC;
+  v_updated   INTEGER;
+BEGIN
+  IF v_user_id IS NULL THEN
+    RAISE EXCEPTION 'Not authenticated';
+  END IF;
+
+  IF p_shared_weight_one_value IS NULL AND p_movement_weights IS NULL THEN
+    RAISE EXCEPTION 'No weights provided';
+  END IF;
+
+  SELECT program_id INTO v_program
+  FROM user_programs
+  WHERE id = p_user_program_id
+    AND user_id = v_user_id
+    AND status = 'active';
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'No active enrollment % for this user', p_user_program_id;
+  END IF;
+
+  -- Shared-fold modal from the label-aware working baseline. Ties break toward
+  -- the lighter pair, mirroring deriveStartingWeight / selectWeightModalSessions.
+  WITH ranked AS (
+    SELECT
+      ps.workout_options,
+      CASE
+        WHEN ps.weight_label IS NULL
+             AND NOT EXISTS (
+               SELECT 1 FROM program_session_completions c
+               WHERE c.user_program_id = p_user_program_id
+                 AND c.program_session_id = ps.id
+             )
+          THEN 1
+        WHEN ps.weight_label IS NULL
+          THEN 2
+        WHEN NOT EXISTS (
+               SELECT 1 FROM program_session_completions c
+               WHERE c.user_program_id = p_user_program_id
+                 AND c.program_session_id = ps.id
+             )
+          THEN 3
+        ELSE NULL
+      END AS tier
+    FROM program_sessions ps
+    WHERE ps.program_id = v_program
+  ),
+  baseline AS (
+    SELECT r.workout_options
+    FROM ranked r
+    WHERE r.tier = (SELECT MIN(tier) FROM ranked WHERE tier IS NOT NULL)
+  )
+  SELECT one_val, two_val INTO v_modal_one, v_modal_two
+  FROM (
+    SELECT (workout_options->'movements'->0->>'weightOneValue')::NUMERIC AS one_val,
+           (workout_options->'movements'->0->>'weightTwoValue')::NUMERIC AS two_val,
+           COUNT(*) AS cnt
+    FROM baseline
+    GROUP BY one_val, two_val
+    ORDER BY cnt DESC, one_val, two_val
+    LIMIT 1
+  ) modal;
+
+  UPDATE program_sessions ps
+  SET workout_options = sub.new_options
+  FROM (
+    -- Same label-aware baseline, then per-movement modal over those sessions.
+    WITH ranked AS (
+      SELECT
+        ps_b.id,
+        ps_b.workout_options,
+        CASE
+          WHEN ps_b.weight_label IS NULL
+               AND NOT EXISTS (
+                 SELECT 1 FROM program_session_completions c
+                 WHERE c.user_program_id = p_user_program_id
+                   AND c.program_session_id = ps_b.id
+               )
+            THEN 1
+          WHEN ps_b.weight_label IS NULL
+            THEN 2
+          WHEN NOT EXISTS (
+                 SELECT 1 FROM program_session_completions c
+                 WHERE c.user_program_id = p_user_program_id
+                   AND c.program_session_id = ps_b.id
+               )
+            THEN 3
+          ELSE NULL
+        END AS tier
+      FROM program_sessions ps_b
+      WHERE ps_b.program_id = v_program
+    ),
+    baseline AS (
+      SELECT r.id, r.workout_options
+      FROM ranked r
+      WHERE r.tier = (SELECT MIN(tier) FROM ranked WHERE tier IS NOT NULL)
+    ),
+    movement_modal AS (
+      SELECT DISTINCT ON (name)
+        name, one_val, two_val
+      FROM (
+        SELECT
+          mv->>'movementName' AS name,
+          (mv->>'weightOneValue')::NUMERIC AS one_val,
+          (mv->>'weightTwoValue')::NUMERIC AS two_val,
+          COUNT(*) AS cnt
+        FROM baseline b,
+             jsonb_array_elements(b.workout_options->'movements') AS mv
+        WHERE (mv->>'weightOneValue') IS NOT NULL
+        GROUP BY name, one_val, two_val
+      ) per_pair
+      ORDER BY name, cnt DESC, one_val, two_val
+    )
+    SELECT
+      ps2.id,
+      CASE
+        WHEN p_movement_weights IS NOT NULL
+             AND ps2.workout_options->>'complexSet' IS DISTINCT FROM 'true'
+          THEN jsonb_set(
+                 ps2.workout_options,
+                 '{movements}',
+                 (
+                   SELECT jsonb_agg(
+                            CASE
+                              WHEN mw.value IS NULL THEN elem
+                              ELSE elem || jsonb_build_object(
+                                'weightOneValue',
+                                  COALESCE(to_jsonb(
+                                    CASE
+                                      WHEN (mw.value->>'weightOneValue')::NUMERIC IS NULL
+                                        OR r.one_delta = 0
+                                        THEN (mw.value->>'weightOneValue')::NUMERIC
+                                      ELSE GREATEST((mw.value->>'weightOneValue')::NUMERIC + r.one_delta, 1)
+                                    END), 'null'::jsonb),
+                                'weightOneUnit',
+                                  COALESCE(to_jsonb(mw.value->>'weightOneUnit'), 'null'::jsonb),
+                                'weightTwoValue',
+                                  COALESCE(to_jsonb(
+                                    CASE
+                                      WHEN (mw.value->>'weightTwoValue')::NUMERIC IS NULL
+                                        OR r.two_delta = 0
+                                        THEN (mw.value->>'weightTwoValue')::NUMERIC
+                                      ELSE GREATEST((mw.value->>'weightTwoValue')::NUMERIC + r.two_delta, 1)
+                                    END), 'null'::jsonb),
+                                'weightTwoUnit',
+                                  COALESCE(to_jsonb(mw.value->>'weightTwoUnit'), 'null'::jsonb)
+                              )
+                            END
+                            ORDER BY ord
+                          )
+                   FROM jsonb_array_elements(ps2.workout_options->'movements')
+                          WITH ORDINALITY AS e(elem, ord)
+                   LEFT JOIN LATERAL (
+                     SELECT o.value
+                     FROM jsonb_array_elements(p_movement_weights) AS o(value)
+                     WHERE o.value->>'movementName' = elem->>'movementName'
+                     LIMIT 1
+                   ) mw ON TRUE
+                   LEFT JOIN movement_modal mm ON mm.name = elem->>'movementName'
+                   CROSS JOIN LATERAL (
+                     SELECT
+                       CASE WHEN elem->>'weightOneUnit'
+                                 IS NOT DISTINCT FROM mw.value->>'weightOneUnit'
+                            THEN COALESCE((elem->>'weightOneValue')::NUMERIC, 0)
+                                 - COALESCE(mm.one_val, 0)
+                            ELSE 0 END AS one_delta,
+                       CASE WHEN elem->>'weightTwoUnit'
+                                 IS NOT DISTINCT FROM mw.value->>'weightTwoUnit'
+                            THEN COALESCE((elem->>'weightTwoValue')::NUMERIC, 0)
+                                 - COALESCE(mm.two_val, 0)
+                            ELSE 0 END AS two_delta
+                   ) r
+                 ))
+        ELSE jsonb_set(
+               jsonb_set(
+                 jsonb_set(
+                   jsonb_set(
+                     jsonb_set(
+                       ps2.workout_options,
+                       '{sharedWeightOneValue}',
+                       COALESCE(to_jsonb(w.one_value), 'null'::jsonb)),
+                     '{sharedWeightOneUnit}',
+                     COALESCE(to_jsonb(w.one_unit), 'null'::jsonb)),
+                   '{sharedWeightTwoValue}',
+                   COALESCE(to_jsonb(w.two_value), 'null'::jsonb)),
+                 '{sharedWeightTwoUnit}',
+                 COALESCE(to_jsonb(w.two_unit), 'null'::jsonb)),
+               '{movements}',
+               (
+                 SELECT jsonb_agg(
+                          m || jsonb_build_object(
+                            'weightOneValue', COALESCE(to_jsonb(w.one_value), 'null'::jsonb),
+                            'weightOneUnit',  COALESCE(to_jsonb(w.one_unit),  'null'::jsonb),
+                            'weightTwoValue', COALESCE(to_jsonb(w.two_value), 'null'::jsonb),
+                            'weightTwoUnit',  COALESCE(to_jsonb(w.two_unit),  'null'::jsonb)
+                          )
+                        )
+                 FROM jsonb_array_elements(ps2.workout_options->'movements') AS m
+               ))
+      END AS new_options
+    FROM program_sessions ps2
+    CROSS JOIN LATERAL (
+      SELECT
+        CASE
+          WHEN p_shared_weight_one_value IS NULL OR d.one_delta = 0
+            THEN p_shared_weight_one_value
+          ELSE GREATEST(p_shared_weight_one_value + d.one_delta, 1)
+        END AS one_value,
+        CASE
+          WHEN p_shared_weight_two_value IS NULL OR d.two_delta = 0
+            THEN p_shared_weight_two_value
+          ELSE GREATEST(p_shared_weight_two_value + d.two_delta, 1)
+        END AS two_value,
+        p_shared_weight_one_unit AS one_unit,
+        p_shared_weight_two_unit AS two_unit
+      FROM (
+        SELECT
+          COALESCE(
+            CASE WHEN ps2.workout_options->'movements'->0->>'weightOneUnit'
+                      IS NOT DISTINCT FROM p_shared_weight_one_unit
+                 THEN (ps2.workout_options->'movements'->0->>'weightOneValue')::NUMERIC
+                      - v_modal_one
+            END, 0) AS one_delta,
+          COALESCE(
+            CASE WHEN ps2.workout_options->'movements'->0->>'weightTwoUnit'
+                      IS NOT DISTINCT FROM p_shared_weight_two_unit
+                 THEN (ps2.workout_options->'movements'->0->>'weightTwoValue')::NUMERIC
+                      - v_modal_two
+            END, 0) AS two_delta
+      ) d
+    ) w
+    WHERE ps2.program_id = v_program
+      AND NOT EXISTS (
+        SELECT 1 FROM program_session_completions c
+        WHERE c.user_program_id = p_user_program_id
+          AND c.program_session_id = ps2.id
+      )
+  ) sub
+  WHERE ps.id = sub.id;
+
+  GET DIAGNOSTICS v_updated = ROW_COUNT;
+  RETURN v_updated;
+END;
+$$;


### PR DESCRIPTION
## Why

Adjust weights re-based from a modal over **all** clone sessions. After a mid-program change, completed rows keep the old load and can outvote rebased work on short programs like A+A (6 work + 2 deload), so a later Adjust double-applies deltas or lands deload flat. Naive “incomplete only” would also wipe A+A’s −8 kg once only deload week remains.

## What

`adjust_program_weights` and the Adjust Weights dialog now share a label-aware working modal: incomplete unlabeled sessions first, else any unlabeled (completed work), else incomplete. Authored offsets (A+A deload −8 kg, DFW test day +4 kg) survive mid-program and repeated adjusts.

## How to test

- `npm test -- --run src/pages/ProgramDetailsPage/utils/selectWeightModalSessions.test.ts src/pages/ProgramProgressPage/ProgramProgressPage.test.tsx`
- With local Supabase + migration applied:
  - `npx playwright test e2e/program-adjust-weights.spec.ts`
  - A+A: enroll with a chosen bell → Adjust → deload stays chosen−8; complete 4 work → Adjust twice → no double-apply; complete all work → Adjust on deload week → still chosen−8
  - DFW: Adjust press → Test day stays chosen+4
- Manually: active A+A on Progress → Adjust weights → confirm week-4 deload chips/start weight stay one size lighter

## Deploy notes

- Apply migration `20260803120000_adjust_program_weights_label_aware_modal.sql` (`CREATE OR REPLACE` of `adjust_program_weights`).

## Tradeoffs

- Relies on `weight_label` to distinguish working vs offset groups (already seeded for A+A / DFW / Snatch). Unlabeled-only programs fall through to incomplete sessions.
- Considered storing working weight on `user_programs`; label-aware baseline avoids a schema change while covering the A+A week-4 case.

Made with [Cursor](https://cursor.com)