### PR TITLE
ci(workflows): split unit and e2e tests into separate workflows

### DIFF
--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -1,0 +1,40 @@
+name: E2E Tests
+
+on:
+  push:
+    branches: ['main']
+  pull_request:
+    branches: ['main']
+
+jobs:
+  e2e-tests:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Use Node.js 24.x
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24.x
+          cache: 'npm'
+      - run: npm ci
+
+      - name: Set up Supabase CLI
+        uses: supabase/setup-cli@v1
+        with:
+          version: 2.109.1
+
+      - name: Start local Supabase
+        run: supabase start
+
+      - name: Install Playwright Chromium
+        run: npx playwright install --with-deps chromium
+
+      - name: Run e2e tests
+        run: npm run test:e2e
+        env:
+          VITE_SUPABASE_URL: http://localhost:54321
+          VITE_SUPABASE_ANON_KEY: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.MLAQ4IKp3RGVoKN-Kxw5sGtJFpV9UVInlrFZaKxcLyo
+          TEST_USER_EMAIL: test@example.com
+          TEST_USER_PASSWORD: testpassword123
+          CI: true

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -10,7 +10,7 @@ on:
     branches: ['main']
 
 jobs:
-  build:
+  unit-tests:
     runs-on: ubuntu-latest
 
     strategy:
@@ -28,35 +28,3 @@ jobs:
       - run: npm ci
       - run: npm run build
       - run: npm run test
-
-  integration-tests:
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v4
-      - name: Use Node.js 24.x
-        uses: actions/setup-node@v4
-        with:
-          node-version: 24.x
-          cache: 'npm'
-      - run: npm ci
-
-      - name: Set up Supabase CLI
-        uses: supabase/setup-cli@v1
-        with:
-          version: 2.109.1
-
-      - name: Start local Supabase
-        run: supabase start
-
-      - name: Install Playwright Chromium
-        run: npx playwright install --with-deps chromium
-
-      - name: Run e2e tests
-        run: npm run test:e2e
-        env:
-          VITE_SUPABASE_URL: http://localhost:54321
-          VITE_SUPABASE_ANON_KEY: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.MLAQ4IKp3RGVoKN-Kxw5sGtJFpV9UVInlrFZaKxcLyo
-          TEST_USER_EMAIL: test@example.com
-          TEST_USER_PASSWORD: testpassword123
-          CI: true


### PR DESCRIPTION
## Why

`main` has no branch protection today, so PRs can merge regardless of CI outcome. Fixing that starts with making the checks unambiguous: the old "Unit Tests" workflow bundled a vitest job and a Playwright e2e job under one misleading name, which makes it hard to require the right checks by name in branch protection.

## What

Splits `.github/workflows/unit-tests.yaml` into two workflows — `unit-tests.yaml` (vitest, job `unit-tests`) and `e2e-tests.yaml` (Playwright against local Supabase, job `e2e-tests`) — no logic changes, just the split and rename. Once this merges, branch protection on `main` can require both `unit-tests` and `e2e-tests` as passing status checks.

## How to test

Confirmed both jobs still run as before locally via `npm run test` and `npm run test:e2e`; CI on this PR will show two separate checks ("Unit Tests" and "E2E Tests") instead of one combined "Unit Tests" check.

## Deploy notes

None — CI config only. Branch protection on `main` will be enabled as a follow-up once these check names are live.