### PR TITLE
feat(programs): give the home hero one primary action

### DIFF
--- a/src/components/OverflowMenu.tsx
+++ b/src/components/OverflowMenu.tsx
@@ -9,6 +9,7 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from '~/components/ui/dropdown-menu';
+import { cn } from '~/lib/utils';
 
 export interface OverflowMenuAction {
   label: string;
@@ -26,10 +27,13 @@ export interface OverflowMenuAction {
 export const OverflowMenu = ({
   actions,
   menuLabel,
+  triggerClassName,
 }: {
   actions: OverflowMenuAction[];
   /** Names the thing being acted on, e.g. a program or session title. */
   menuLabel: string;
+  /** Retones the ⋯ for surfaces that aren't the default card background. */
+  triggerClassName?: string;
 }) => {
   // Every action here either navigates or opens a dialog, so restoring focus to
   // the trigger on close would yank it straight back out of what just opened.
@@ -55,7 +59,10 @@ export const OverflowMenu = ({
         <Button
           variant="ghost"
           size="icon"
-          className="-mr-0.5 -mt-0.5 shrink-0 text-muted-foreground"
+          className={cn(
+            '-mr-0.5 -mt-0.5 shrink-0 text-muted-foreground',
+            triggerClassName,
+          )}
           aria-label={`More actions for ${menuLabel}`}
         >
           <EllipsisHorizontalIcon className="h-2.5 w-2.5" aria-hidden />

--- a/src/pages/StartWorkoutPage/StartWorkoutPage.parallelPrograms.test.jsx
+++ b/src/pages/StartWorkoutPage/StartWorkoutPage.parallelPrograms.test.jsx
@@ -1,5 +1,5 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { fireEvent, render, screen } from '@testing-library/react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 
 import { DEFAULT_WORKOUT_OPTIONS, WorkoutOptionsContext } from '~/contexts';
@@ -116,7 +116,7 @@ describe('StartWorkoutPage parallel programs', () => {
     expect(screen.queryByText('Day 1')).not.toBeInTheDocument();
   });
 
-  test('skips the selected program, not the default one', () => {
+  test('skips the selected program, not the default one', async () => {
     mockUseActivePrograms.mockReturnValue({
       data: [
         activeProgram('up-1', 'Easy Strength', 'Day 1'),
@@ -130,7 +130,18 @@ describe('StartWorkoutPage parallel programs', () => {
     fireEvent.click(
       screen.getByRole('tab', { name: /Dry Fighting Weight/ }),
     );
-    fireEvent.click(screen.getByRole('button', { name: 'Skip' }));
+    // Skip now lives behind the hero's ⋯ menu and a confirm.
+    fireEvent.keyDown(
+      screen.getByRole('button', {
+        name: 'More actions for Dry Fighting Weight',
+      }),
+      { key: 'Enter' },
+    );
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Skip this session' }));
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Skip session' }));
 
     expect(mockSkipMutate).toHaveBeenCalledWith({
       userProgramId: 'up-2',

--- a/src/pages/StartWorkoutPage/components/ProgramSwitcherTabs.tsx
+++ b/src/pages/StartWorkoutPage/components/ProgramSwitcherTabs.tsx
@@ -24,7 +24,7 @@ export const ProgramSwitcherTabs = ({
     <div
       role="tablist"
       aria-label="Active programs"
-      className="flex gap-1"
+      className="flex gap-0.5 rounded-full bg-secondary p-px"
     >
       {programs.map(({ enrollment, program, progress }) => {
         const selected = enrollment.id === selectedEnrollmentId;
@@ -39,14 +39,14 @@ export const ProgramSwitcherTabs = ({
               // Titles truncate rather than scroll: at the 3-program cap, three
               // full titles overflow a phone viewport and the last pill lands
               // off-screen.
-              'flex min-w-0 flex-1 items-baseline gap-0.5 rounded border px-1 py-0.5 text-xs',
+              'flex min-w-0 flex-1 items-baseline justify-center gap-0.5 rounded-full px-1 py-0.5 text-xs transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring',
               selected
-                ? 'border-primary bg-primary text-primary-foreground'
-                : 'border-border text-muted-foreground hover:bg-secondary',
+                ? 'bg-primary text-primary-foreground shadow-sm'
+                : 'text-muted-foreground hover:text-foreground',
             )}
           >
             <span className="truncate font-medium">{program.title}</span>
-            <span className="shrink-0 opacity-75">
+            <span className="shrink-0 tabular-nums opacity-75">
               {progress.completed}/{progress.total}
             </span>
           </button>

--- a/src/pages/StartWorkoutPage/components/StartWorkoutHero.stories.tsx
+++ b/src/pages/StartWorkoutPage/components/StartWorkoutHero.stories.tsx
@@ -47,7 +47,7 @@ export const Program: Story = {
   ),
 };
 
-/** Skip in flight: both actions disabled. */
+/** Skip in flight: the CTA is disabled and the footer reports the skip. */
 export const ProgramSkipping: Story = {
   render: () => (
     <StartWorkoutHero

--- a/src/pages/StartWorkoutPage/components/StartWorkoutHero.test.tsx
+++ b/src/pages/StartWorkoutPage/components/StartWorkoutHero.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
 import { vi } from 'vitest';
 
 import { NextProgramSession, ProgramProgress } from '~/api';
@@ -53,9 +53,22 @@ const progress: ProgramProgress = {
   day: 2,
 };
 
+// Skip sits behind the hero's ⋯ menu and a confirm, and OverflowMenu defers the
+// selection a tick so the menu can close before the dialog mounts.
+const openSkipConfirm = async (programTitle: string) => {
+  fireEvent.keyDown(
+    screen.getByRole('button', { name: `More actions for ${programTitle}` }),
+    { key: 'Enter' },
+  );
+  fireEvent.click(screen.getByRole('menuitem', { name: 'Skip this session' }));
+  await act(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+};
+
 describe('StartWorkoutHero', () => {
   describe('program variant', () => {
-    it('renders the next session with title, chip, week/day, duration, progress and actions', () => {
+    it('renders the next session with title, chip, week/day, duration, progress and actions', async () => {
       const onStart = vi.fn();
       const onSkip = vi.fn();
 
@@ -89,8 +102,36 @@ describe('StartWorkoutHero', () => {
       );
       expect(onStart).toHaveBeenCalledTimes(1);
 
-      fireEvent.click(screen.getByRole('button', { name: 'Skip' }));
+      await openSkipConfirm('Dry Fighting Weight');
+      expect(onSkip).not.toHaveBeenCalled();
+
+      fireEvent.click(screen.getByRole('button', { name: 'Skip session' }));
       expect(onSkip).toHaveBeenCalledTimes(1);
+    });
+
+    it('leaves the session alone when the skip confirm is dismissed', async () => {
+      const onSkip = vi.fn();
+
+      render(
+        <StartWorkoutHero
+          variant="program"
+          programTitle="Dry Fighting Weight"
+          nextSession={nextSession}
+          progress={progress}
+          isComplete={false}
+          onStart={vi.fn()}
+          onSkip={onSkip}
+          skipping={false}
+        />,
+      );
+
+      await openSkipConfirm('Dry Fighting Weight');
+      fireEvent.click(screen.getByRole('button', { name: 'Keep this session' }));
+
+      expect(onSkip).not.toHaveBeenCalled();
+      expect(
+        screen.queryByRole('button', { name: 'Skip session' }),
+      ).not.toBeInTheDocument();
     });
 
     it('falls back to week/day as the title when the session has none', () => {
@@ -130,7 +171,17 @@ describe('StartWorkoutHero', () => {
       expect(
         screen.getByRole('button', { name: 'Start next workout' }),
       ).toBeDisabled();
-      expect(screen.getByRole('button', { name: 'Skipping…' })).toBeDisabled();
+      expect(screen.getByText('Skipping this session…')).toBeInTheDocument();
+
+      fireEvent.keyDown(
+        screen.getByRole('button', {
+          name: 'More actions for Dry Fighting Weight',
+        }),
+        { key: 'Enter' },
+      );
+      expect(
+        screen.getByRole('menuitem', { name: 'Skip this session' }),
+      ).toHaveAttribute('aria-disabled', 'true');
     });
 
     it('renders the complete state when the program is finished', () => {

--- a/src/pages/StartWorkoutPage/components/StartWorkoutHero.tsx
+++ b/src/pages/StartWorkoutPage/components/StartWorkoutHero.tsx
@@ -1,6 +1,8 @@
-import { ReactNode } from 'react';
+import { ReactNode, useState } from 'react';
 
 import { NextProgramSession, ProgramProgress } from '~/api';
+import { ConfirmDialog } from '~/components/ConfirmDialog';
+import { OverflowMenu } from '~/components/OverflowMenu';
 import { Button } from '~/components/ui/button';
 import { cn } from '~/lib/utils';
 import { WorkoutGoalUnits } from '~/types';
@@ -10,6 +12,10 @@ import { WorkoutGoalUnits } from '~/types';
  * a quiet bordered card; the hero is filled `primary` so "what am I training now"
  * is unmistakable. Two shapes share the shell: a running program's next session,
  * and a quick-start anchor for anyone without an active program.
+ *
+ * The program shape carries exactly one button — starting the next session.
+ * Skipping advances the program past a session, so it sits in the ⋯ menu behind
+ * a confirm rather than beside the CTA where a thumb can find it by accident.
  */
 export type StartWorkoutHeroProps =
   | ({ variant: 'program' } & ProgramHeroProps)
@@ -52,16 +58,25 @@ const HeroShell = ({ children }: { children: ReactNode }) => (
   </section>
 );
 
-const Eyebrow = ({ children }: { children: ReactNode }) => (
-  <span className="text-xs font-semibold uppercase tracking-wide text-primary-foreground/75">
+const Eyebrow = ({
+  children,
+  className,
+}: {
+  children: ReactNode;
+  className?: string;
+}) => (
+  <span
+    className={cn(
+      'text-xs font-semibold uppercase tracking-wide text-primary-foreground/75',
+      className,
+    )}
+  >
     {children}
   </span>
 );
 
 const primaryCta =
   'bg-primary-foreground text-primary shadow-none hover:bg-primary-foreground/90';
-const ghostCta =
-  'border border-primary-foreground/30 bg-transparent text-primary-foreground shadow-none hover:bg-primary-foreground/10';
 
 export const StartWorkoutHero = (props: StartWorkoutHeroProps) => {
   if (props.variant === 'quickStart') {
@@ -97,16 +112,20 @@ export const StartWorkoutHero = (props: StartWorkoutHeroProps) => {
     );
   }
 
-  const {
-    programTitle,
-    nextSession,
-    progress,
-    isComplete,
-    onStart,
-    onSkip,
-    skipping,
-    onViewProgress,
-  } = props;
+  return <ProgramHero {...props} />;
+};
+
+const ProgramHero = ({
+  programTitle,
+  nextSession,
+  progress,
+  isComplete,
+  onStart,
+  onSkip,
+  skipping,
+  onViewProgress,
+}: ProgramHeroProps) => {
+  const [confirmingSkip, setConfirmingSkip] = useState(false);
 
   const viewProgressLink = onViewProgress && (
     <button
@@ -150,11 +169,23 @@ export const StartWorkoutHero = (props: StartWorkoutHeroProps) => {
 
   return (
     <HeroShell>
-      <div className="flex items-center justify-between gap-1">
-        <Eyebrow>{programTitle}</Eyebrow>
-        <span className="shrink-0 rounded-full bg-primary-foreground/15 px-1 py-px text-xs font-medium">
+      <div className="flex items-center gap-1">
+        <Eyebrow className="min-w-0 truncate">{programTitle}</Eyebrow>
+        <span className="ml-auto shrink-0 rounded-full bg-primary-foreground/15 px-1 py-px text-xs font-medium">
           Session {sessionNumber} of {progress.total}
         </span>
+        <OverflowMenu
+          menuLabel={programTitle}
+          triggerClassName="text-primary-foreground/70 hover:bg-primary-foreground/10 hover:text-primary-foreground"
+          actions={[
+            {
+              label: 'Skip this session',
+              onSelect: () => setConfirmingSkip(true),
+              disabled: skipping,
+              destructive: true,
+            },
+          ]}
+        />
       </div>
 
       <div className="flex flex-col gap-0.5">
@@ -184,26 +215,38 @@ export const StartWorkoutHero = (props: StartWorkoutHeroProps) => {
         </span>
       </div>
 
-      <div className="mt-0.5 flex gap-1">
-        <Button
-          size="lg"
-          className={cn('flex-1 text-base', primaryCta)}
-          onClick={onStart}
-          disabled={skipping}
-        >
-          Start next workout
-        </Button>
-        <Button
-          size="lg"
-          className={cn('text-base', ghostCta)}
-          onClick={onSkip}
-          disabled={skipping}
-        >
-          {skipping ? 'Skipping…' : 'Skip'}
-        </Button>
-      </div>
+      {skipping ? (
+        <span className="self-start text-xs font-medium text-primary-foreground/80">
+          Skipping this session…
+        </span>
+      ) : (
+        viewProgressLink
+      )}
 
-      {viewProgressLink}
+      <Button
+        size="lg"
+        className={cn('mt-0.5 w-full text-base', primaryCta)}
+        onClick={onStart}
+        disabled={skipping}
+      >
+        Start next workout
+      </Button>
+
+      <ConfirmDialog
+        open={confirmingSkip}
+        onOpenChange={setConfirmingSkip}
+        title="Skip this session?"
+        description={`Session ${sessionNumber} won't be logged, and ${programTitle} moves on to the next one.`}
+        confirmLabel="Skip session"
+        confirmVariant="destructive"
+        dismissLabel="Keep this session"
+        onConfirm={() => {
+          setConfirmingSkip(false);
+          onSkip();
+        }}
+        onDismiss={() => setConfirmingSkip(false)}
+        isPending={skipping}
+      />
     </HeroShell>
   );
 };


### PR DESCRIPTION
## Why

The active-program hero put a full-size Skip button directly beside "Start next workout" — a one-mis-tap way to advance the program past a session — and ended with a stray "View progress" text link below the CTA row. The program switcher rendered as three loose bordered pills. Third surface of the programs design pass (after #206, #209).

## What

Gives the hero exactly one button: Skip moves into a ⋯ overflow menu as a destructive item behind a ConfirmDialog that names the consequence ("Session N won't be logged, and <program> moves on to the next one"). The layout reorders to header → title → progress → View progress → full-width CTA, so the primary action owns the thumb zone. ProgramSwitcherTabs becomes a single segmented control. The program branch of StartWorkoutHero is extracted into its own ProgramHero component.

## How to test

- `npm test` — 654 passing (94 StartWorkoutPage tests; skip assertions now drive menu → confirm, multi-program skip still asserts the exact enrollment/session payload; new dismiss-leaves-session-alone case).
- `npm run compile:ts`, `npm run lint` — clean.
- Verified live at 390×844: hero, menu open, skip confirm; Storybook for the 3-program switcher.

## Gallery

Before — Skip full-size beside the primary CTA:

<img src="https://github.com/user-attachments/assets/8dbfb7e8-3547-4668-b2d2-e2b98e2e451a" width="390" />

After — one CTA; Skip behind ⋯ + confirm:

<img src="https://github.com/user-attachments/assets/e843e011-ba67-44e9-a9b4-6991724ee1b8" width="390" />
<img src="https://github.com/user-attachments/assets/efea7167-8619-4441-845c-a56f703d5d9f" width="390" />
<img src="https://github.com/user-attachments/assets/4d06fd42-9df1-438b-a40e-f423c215ac84" width="390" />

## Tradeoffs

Considered a small ghost "Skip" under the CTA instead of the menu — fewer taps, but it keeps an irreversible action in the primary gesture path, and the ⋯ + confirm matches the pattern the ProgramsPage cards established. The switcher's hard title truncation at the 3-program cap is unchanged — pre-existing and documented in the code.
