### PR TITLE
feat(programs): restructure the progress page around status and settings

### DIFF
--- a/src/pages/ProgramDetailsPage/ProgramDetailsPage.test.tsx
+++ b/src/pages/ProgramDetailsPage/ProgramDetailsPage.test.tsx
@@ -149,10 +149,10 @@ describe('ProgramDetailsPage', () => {
     expect(screen.getByText('Week 2')).toBeInTheDocument();
     expect(screen.getByText('Day 1 · Press Ladders')).toBeInTheDocument();
     expect(screen.getByText('Day 1 · Clean & Press')).toBeInTheDocument();
-    // Movement summary + goal label appear per session (both sessions share them).
+    // The movements read once for the program; the goal still reads per session.
     expect(
-      screen.getAllByText('Double Kettlebell Press · Kettlebell Swing'),
-    ).toHaveLength(2);
+      screen.getByText('Double Kettlebell Press · Kettlebell Swing'),
+    ).toBeInTheDocument();
     expect(screen.getAllByText('20 min')).toHaveLength(2);
   });
 
@@ -441,6 +441,79 @@ describe('ProgramDetailsPage', () => {
         programId: 'dfw-1',
         replaceUserProgramId: 'up-1',
         movementWeights: expect.any(Array),
+      }),
+      expect.anything(),
+    );
+  });
+
+  it('queues instead of replacing from the at-the-cap prompt', () => {
+    enrollMutate.mockImplementation((_input, { onSuccess }) => onSuccess());
+    mockUseActivePrograms.mockReturnValue({
+      data: [
+        activeProgram('up-1', 'Least Recent'),
+        activeProgram('up-2', 'Middle'),
+        activeProgram('up-3', 'Most Recent'),
+      ],
+    });
+
+    renderPage();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Start program' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Queue instead' }));
+
+    // Queueing claims no slot, so nothing is displaced.
+    expect(enrollMutate).toHaveBeenCalledWith(
+      expect.objectContaining({ programId: 'dfw-1', queue: true }),
+      expect.anything(),
+    );
+    expect(enrollMutate.mock.calls[0][0]).not.toHaveProperty(
+      'replaceUserProgramId',
+    );
+  });
+
+  it('replaces a different running program when the choice is moved', () => {
+    mockUseActivePrograms.mockReturnValue({
+      data: [
+        activeProgram('up-1', 'Least Recent'),
+        activeProgram('up-2', 'Middle'),
+        activeProgram('up-3', 'Most Recent'),
+      ],
+    });
+
+    renderPage();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Start program' }));
+    fireEvent.click(screen.getByRole('radio', { name: /Most Recent/ }));
+    fireEvent.click(screen.getByRole('button', { name: 'Replace program' }));
+
+    expect(enrollMutate).toHaveBeenCalledWith(
+      expect.objectContaining({ replaceUserProgramId: 'up-3' }),
+      expect.anything(),
+    );
+  });
+
+  it('switches every movement to the unit chosen once for the screen', () => {
+    renderPage();
+
+    // Radix tabs commit on pointer-down, not click.
+    fireEvent.mouseDown(screen.getByRole('tab', { name: 'lb' }));
+
+    fireEvent.click(screen.getByRole('button', { name: 'Start program' }));
+
+    expect(enrollMutate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        movementWeights: [
+          expect.objectContaining({
+            movementName: 'Double Kettlebell Press',
+            weightOneUnit: 'pounds',
+            weightTwoUnit: 'pounds',
+          }),
+          expect.objectContaining({
+            movementName: 'Kettlebell Swing',
+            weightOneUnit: 'pounds',
+            weightTwoUnit: 'pounds',
+          }),
+        ],
       }),
       expect.anything(),
     );

--- a/src/pages/ProgramDetailsPage/ProgramDetailsPage.tsx
+++ b/src/pages/ProgramDetailsPage/ProgramDetailsPage.tsx
@@ -11,23 +11,13 @@ import type { MovementWeight } from '~/api';
 import { ModifyCountButtons, Page, WeightUnitTabs } from '~/components';
 import { Button } from '~/components/ui/button';
 import { Card, CardContent } from '~/components/ui/card';
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from '~/components/ui/dialog';
 import { Label } from '~/components/ui/label';
 import { Switch } from '~/components/ui/switch';
 import { useSession } from '~/contexts';
-import {
-  MovementOptions,
-  ProgramSession,
-  WeightUnit,
-  WorkoutGoalUnits,
-} from '~/types';
+import { cn } from '~/lib/utils';
+import { ReplaceProgramDialog } from '~/pages/ProgramsPage/components/ReplaceProgramDialog';
+import { programSpanLabel } from '~/pages/ProgramsPage/utils';
+import { ProgramSession, WeightUnit, WorkoutGoalUnits } from '~/types';
 import {
   getWeightRange,
   getWeightUnitLabel,
@@ -53,11 +43,23 @@ const goalLabel = (goal: number, units: WorkoutGoalUnits): string | null => {
   return `${goal} kg`;
 };
 
-const movementsSummary = (movements: MovementOptions[]): string =>
-  movements
-    .map((movement) => movement.movementName)
-    .filter((name) => name.length > 0)
-    .join(' · ');
+/**
+ * The movements the whole program trains, in the order they first appear. Every
+ * session of a program tends to repeat the same short list, so it reads once
+ * above the week rails instead of once per day.
+ */
+const programMovements = (sessions: ProgramSession[]): string => {
+  const names = new Set<string>();
+  for (const session of sessions) {
+    for (const movement of session.workoutOptions.movements) {
+      if (movement.movementName.length > 0) names.add(movement.movementName);
+    }
+  }
+  return [...names].join(' · ');
+};
+
+/** Long blurbs collapse; the toggle only appears when there's something hidden. */
+const DESCRIPTION_CLAMP_LENGTH = 240;
 
 /** Sessions grouped by their 1-based week, preserving sequenceIndex order. */
 const groupByWeek = (
@@ -81,10 +83,16 @@ export const WeightSlots = ({
   weight,
   onChange,
   namePrefix,
+  showUnitTabs = true,
 }: {
   weight: StartingWeight;
   onChange: (weight: StartingWeight) => void;
   namePrefix: string;
+  /**
+   * Off when the surface hoists a single unit control above a stack of these —
+   * one kg/lb switch for the whole screen beats one per bell.
+   */
+  showUnitTabs?: boolean;
 }) => {
   const setSlot = (slot: 'One' | 'Two', value: number) =>
     onChange({ ...weight, [`sharedWeight${slot}Value`]: Math.max(1, value) });
@@ -113,12 +121,17 @@ export const WeightSlots = ({
             onClickPlus={() => setSlot(slot, value + 1)}
             unit={getWeightUnitLabel(unit)}
             unitTabs={
-              <WeightUnitTabs
-                value={unit}
-                onChange={(nextUnit) =>
-                  onChange({ ...weight, [`sharedWeight${slot}Unit`]: nextUnit })
-                }
-              />
+              showUnitTabs ? (
+                <WeightUnitTabs
+                  value={unit}
+                  onChange={(nextUnit) =>
+                    onChange({
+                      ...weight,
+                      [`sharedWeight${slot}Unit`]: nextUnit,
+                    })
+                  }
+                />
+              ) : undefined
             }
             value={value}
             onChange={(next) => setSlot(slot, next)}
@@ -146,6 +159,10 @@ export const ProgramDetailsPage = () => {
 
   const [seeded, setSeeded] = useState(false);
   const [pendingSwitch, setPendingSwitch] = useState(false);
+  const [replaceEnrollmentId, setReplaceEnrollmentId] = useState<string | null>(
+    null,
+  );
+  const [descriptionExpanded, setDescriptionExpanded] = useState(false);
   // Complex-set path: one shared bell pair for the whole complex.
   const [sharedWeightOneValue, setSharedWeightOneValue] = useState<
     number | null
@@ -260,9 +277,12 @@ export const ProgramDetailsPage = () => {
     (p) => p.enrollment.status === 'active',
   );
   const slotsFull = activeEnrollments.length >= MAX_ACTIVE_PROGRAMS;
-  // At the cap this program displaces the least-recently-worked one, which the
-  // confirm dialog names. Below it, enrolling just claims a free slot.
-  const displaced = slotsFull ? activeEnrollments[0] : null;
+  // At the cap one running program has to stop. The prompt pre-selects the
+  // least-recently-worked one and lets the choice move; below the cap,
+  // enrolling just claims a free slot and displaces nothing.
+  const displacedId = slotsFull
+    ? (replaceEnrollmentId ?? activeEnrollments[0]?.enrollment.id ?? null)
+    : null;
 
   // The chosen weights + auto-repeat, shared by an immediate start and a
   // queue-for-later (a queued clone bakes the same weights now).
@@ -284,7 +304,7 @@ export const ProgramDetailsPage = () => {
     enroll.mutate(
       {
         programId: id,
-        replaceUserProgramId: displaced?.enrollment.id,
+        replaceUserProgramId: displacedId ?? undefined,
         ...enrollmentConfig(),
       },
       { onSuccess: () => navigate('/') },
@@ -295,6 +315,7 @@ export const ProgramDetailsPage = () => {
   // Land on Programs, where "Up next" shows the new place in line.
   const queueForLater = () => {
     if (!id) return;
+    setPendingSwitch(false);
     enroll.mutate(
       { programId: id, queue: true, ...enrollmentConfig() },
       { onSuccess: () => navigate('/programs') },
@@ -302,11 +323,42 @@ export const ProgramDetailsPage = () => {
   };
 
   const handleStart = () => {
-    if (displaced) {
+    if (slotsFull) {
+      setReplaceEnrollmentId(
+        replaceEnrollmentId ?? activeEnrollments[0]?.enrollment.id ?? null,
+      );
       setPendingSwitch(true);
     } else {
       doEnroll();
     }
+  };
+
+  // The kg/lb switch is hoisted out of the individual bell controls: one unit
+  // for the screen, applied to every slot that carries a weight at all.
+  const displayUnit: WeightUnit =
+    (complex
+      ? sharedWeightOneUnit
+      : movementControls
+          .map((control) => movementWeights[control.movementName])
+          .find((weight) => weight?.sharedWeightOneUnit)
+          ?.sharedWeightOneUnit) ?? DEFAULT_WEIGHT_UNIT;
+
+  const retuneUnits = (weight: StartingWeight, unit: WeightUnit) => ({
+    ...weight,
+    sharedWeightOneUnit: weight.sharedWeightOneUnit === null ? null : unit,
+    sharedWeightTwoUnit: weight.sharedWeightTwoUnit === null ? null : unit,
+  });
+
+  const handleChangeUnit = (unit: WeightUnit) => {
+    handleChangeWorkingWeight(retuneUnits(workingWeight, unit));
+    setMovementWeights((current) =>
+      Object.fromEntries(
+        Object.entries(current).map(([name, weight]) => [
+          name,
+          retuneUnits(weight, unit),
+        ]),
+      ),
+    );
   };
 
   if (isLoading) {
@@ -332,7 +384,11 @@ export const ProgramDetailsPage = () => {
   // nothing rather than flashing a picker for a program you already configured.
   if (isOwnProgram) return null;
 
+
   const weeks = groupByWeek(data.sessions);
+  const movements = programMovements(data.sessions);
+  const description = data.program.description ?? '';
+  const clampable = description.length > DESCRIPTION_CLAMP_LENGTH;
 
   return (
     <Page title={data.program.title}>
@@ -344,162 +400,204 @@ export const ProgramDetailsPage = () => {
       </Link>
 
       <Card>
-        <CardContent className="flex flex-col gap-1 pt-2">
-          <p className="text-xs text-muted-foreground">
-            {data.program.authorName ? `${data.program.authorName} · ` : ''}
-            {programCadenceLabel(data.program) ?? 'No sessions yet'}
-          </p>
-          {data.program.description && (
-            <p className="text-sm text-muted-foreground">
-              {data.program.description}
+        <CardContent className="flex gap-1.5 pt-2">
+          {/* The same span monogram the catalog row carried, so the program you
+              tapped still looks like itself here. */}
+          <span
+            aria-hidden
+            className="flex h-4 w-4 shrink-0 items-center justify-center rounded-md bg-primary/10 text-sm font-semibold tabular-nums text-primary"
+          >
+            {programSpanLabel(data.program)}
+          </span>
+          <div className="flex min-w-0 flex-col gap-0.5">
+            <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+              {data.program.authorName ? `${data.program.authorName} · ` : ''}
+              {programCadenceLabel(data.program) ?? 'No sessions yet'}
             </p>
-          )}
+            {description && (
+              <>
+                <p
+                  className={cn(
+                    'text-sm text-muted-foreground',
+                    clampable && !descriptionExpanded && 'line-clamp-4',
+                  )}
+                >
+                  {description}
+                </p>
+                {clampable && (
+                  <button
+                    type="button"
+                    className="self-start text-xs font-medium text-primary"
+                    onClick={() => setDescriptionExpanded((open) => !open)}
+                  >
+                    {descriptionExpanded ? 'Show less' : 'Read more'}
+                  </button>
+                )}
+              </>
+            )}
+          </div>
         </CardContent>
       </Card>
 
       {weeks.length > 0 && (
-        <div className="flex flex-col gap-2">
-          <h2 className="text-sm font-semibold">Sessions</h2>
+        <section className="flex flex-col gap-1.5">
+          <h2 className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+            Sessions
+          </h2>
+          {movements && (
+            <p className="-mt-1 text-xs text-muted-foreground">{movements}</p>
+          )}
           {weeks.map((week) => (
             <div key={week.weekNumber} className="flex flex-col gap-0.5">
-              <span className="text-xs font-medium text-muted-foreground">
+              <span className="flex items-center gap-1 text-xs font-medium text-muted-foreground">
                 Week {week.weekNumber}
+                <span aria-hidden className="h-px flex-1 bg-border" />
               </span>
-              <Card className="divide-y">
+              <div className="flex flex-wrap gap-1">
                 {week.sessions.map((programSession) => {
-                  const { movements, workoutGoal, workoutGoalUnits } =
+                  const { workoutGoal, workoutGoalUnits } =
                     programSession.workoutOptions;
                   const goal = goalLabel(workoutGoal, workoutGoalUnits);
-                  const summary = movementsSummary(movements);
                   return (
-                    <div
+                    <span
                       key={programSession.id}
-                      className="flex flex-col gap-0.5 p-2"
+                      className="flex max-w-full items-center gap-1 rounded-md border border-border/60 px-1.5 py-1 text-xs"
                     >
-                      <div className="flex items-baseline justify-between gap-1">
-                        <span className="text-sm font-medium">
-                          Day {programSession.dayNumber} ·{' '}
-                          {programSession.title}
-                        </span>
-                        {goal && (
-                          <span className="text-xs text-muted-foreground">
-                            {goal}
-                          </span>
-                        )}
-                      </div>
-                      {summary && (
-                        <span className="text-xs text-muted-foreground">
-                          {summary}
+                      <span className="truncate font-medium">
+                        Day {programSession.dayNumber} ·{' '}
+                        {programSession.title}
+                      </span>
+                      {goal && (
+                        <span className="shrink-0 tabular-nums text-muted-foreground">
+                          {goal}
                         </span>
                       )}
-                    </div>
+                    </span>
                   );
                 })}
-              </Card>
+              </div>
             </div>
           ))}
-        </div>
+        </section>
       )}
 
-      <div className="flex flex-col gap-1">
-        <h2 className="text-sm font-semibold">Starting weight</h2>
-        <p className="text-xs text-muted-foreground">
-          Set the weight your working sessions start with. You can still adjust
-          it session by session once you&apos;re in the program.
-        </p>
-        {!seeded && <p className="text-sm text-muted-foreground">Loading…</p>}
-        {/* Complex sets share one bell pair for the whole complex, so a single
-            picker; every other program gets one control per movement. */}
-        {seeded && complex && (
-          <WeightSlots
-            weight={workingWeight}
-            onChange={handleChangeWorkingWeight}
-            namePrefix="Starting weight"
-          />
-        )}
-      </div>
-
-      {seeded &&
-        !complex &&
-        movementControls.map((control) => (
-          <div key={control.movementName} className="flex flex-col gap-1">
-            <h2 className="text-sm font-semibold">{control.movementName}</h2>
-            {control.mode === 'none' ? (
-              <p className="text-sm text-muted-foreground">
-                {WEIGHT_MODE_LABELS.none}
-              </p>
-            ) : (
-              <WeightSlots
-                weight={
-                  movementWeights[control.movementName] ?? control.modalWeight
-                }
-                onChange={(next) =>
-                  handleChangeMovementWeight(control.movementName, next)
-                }
-                namePrefix={control.movementName}
-              />
-            )}
+      <Card>
+        <CardContent className="flex min-w-0 flex-col gap-1.5 pt-2">
+          <div className="flex items-center justify-between gap-1">
+            <h2 className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+              Starting weight
+            </h2>
+            <WeightUnitTabs value={displayUnit} onChange={handleChangeUnit} />
           </div>
-        ))}
+          <p className="text-xs text-muted-foreground">
+            What your working sessions start with. You can still adjust it
+            session by session once you&apos;re in the program.
+          </p>
 
-      <div className="flex items-start justify-between gap-2">
-        <div className="flex flex-col gap-0.5">
-          <Label htmlFor="auto-repeat">Repeat automatically</Label>
-          <span id="auto-repeat-help" className="text-xs text-muted-foreground">
-            When on, finishing the last session starts the program over instead
-            of ending it. Progress by adding weight over time.
-          </span>
-        </div>
-        <Switch
-          id="auto-repeat"
-          className="mt-0.5"
-          aria-describedby="auto-repeat-help"
-          checked={autoRepeat}
-          onCheckedChange={setAutoRepeat}
-        />
+          {!seeded && <p className="text-sm text-muted-foreground">Loading…</p>}
+
+          {/* Complex sets share one bell pair for the whole complex, so a single
+              picker; every other program gets one control per movement. */}
+          {seeded && complex && (
+            <WeightSlots
+              weight={workingWeight}
+              onChange={handleChangeWorkingWeight}
+              namePrefix="Starting weight"
+              showUnitTabs={false}
+            />
+          )}
+
+          {seeded &&
+            !complex &&
+            movementControls.map((control) => (
+              <div
+                key={control.movementName}
+                className="flex flex-col gap-0.5 border-t border-border pt-1.5"
+              >
+                <h3 className="text-sm font-medium">{control.movementName}</h3>
+                {control.mode === 'none' ? (
+                  <p className="text-xs text-muted-foreground">
+                    {WEIGHT_MODE_LABELS.none}
+                  </p>
+                ) : (
+                  <WeightSlots
+                    weight={
+                      movementWeights[control.movementName] ??
+                      control.modalWeight
+                    }
+                    onChange={(next) =>
+                      handleChangeMovementWeight(control.movementName, next)
+                    }
+                    namePrefix={control.movementName}
+                    showUnitTabs={false}
+                  />
+                )}
+              </div>
+            ))}
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardContent className="flex flex-col gap-1 pt-2">
+          <h2 className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+            Program settings
+          </h2>
+          <div className="flex items-start justify-between gap-2">
+            <div className="flex flex-col gap-px">
+              <Label htmlFor="auto-repeat" size="small">
+                Repeat automatically
+              </Label>
+              <span
+                id="auto-repeat-help"
+                className="text-xs text-muted-foreground"
+              >
+                Finishing the last session starts the program over instead of
+                ending it. Progress by adding weight over time.
+              </span>
+            </div>
+            <Switch
+              id="auto-repeat"
+              className="mt-0.5"
+              aria-describedby="auto-repeat-help"
+              checked={autoRepeat}
+              onCheckedChange={setAutoRepeat}
+            />
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* One primary decision — start it. Queueing is the same commitment made
+          later, so it reads as the quiet alternative rather than a peer CTA. */}
+      <div className="flex flex-col gap-0.5">
+        <Button onClick={handleStart} disabled={enroll.isPending || !seeded}>
+          Start program
+        </Button>
+        <Button
+          variant="ghost"
+          className="text-muted-foreground"
+          onClick={queueForLater}
+          disabled={enroll.isPending || !seeded}
+        >
+          Queue for later
+        </Button>
+        <p className="text-center text-xs text-muted-foreground">
+          Queued programs start when an active program finishes.
+        </p>
       </div>
 
-      <Button onClick={handleStart} disabled={enroll.isPending || !seeded}>
-        Start program
-      </Button>
-      <Button
-        variant="secondary"
-        onClick={queueForLater}
-        disabled={enroll.isPending || !seeded}
-      >
-        Queue for later
-      </Button>
-      <p className="-mt-1 text-center text-xs text-muted-foreground">
-        Queued programs start when an active program finishes.
-      </p>
-
-      <Dialog
+      <ReplaceProgramDialog
         open={pendingSwitch}
         onOpenChange={(open) => {
           if (!open) setPendingSwitch(false);
         }}
-      >
-        <DialogContent>
-          <DialogHeader>
-            <DialogTitle>Replace a program?</DialogTitle>
-            <DialogDescription>
-              You&apos;re already running {MAX_ACTIVE_PROGRAMS} programs — the
-              most you can have at once. Starting this one stops
-              {displaced ? ` ${displaced.program.title}` : ' your oldest one'},
-              the program you&apos;ve worked least recently. Its logged workouts
-              are kept, but its place in the program is cleared.
-            </DialogDescription>
-          </DialogHeader>
-          <DialogFooter>
-            <Button variant="secondary" onClick={() => setPendingSwitch(false)}>
-              Cancel
-            </Button>
-            <Button onClick={doEnroll} disabled={enroll.isPending}>
-              Replace program
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
+        activeEnrollments={activeEnrollments}
+        replaceEnrollmentId={replaceEnrollmentId}
+        onSelectReplace={setReplaceEnrollmentId}
+        onCancel={() => setPendingSwitch(false)}
+        onQueueInstead={queueForLater}
+        onConfirm={doEnroll}
+        isPending={enroll.isPending}
+      />
     </Page>
   );
 };

--- a/src/pages/ProgramProgressPage/ProgramProgressPage.test.tsx
+++ b/src/pages/ProgramProgressPage/ProgramProgressPage.test.tsx
@@ -127,6 +127,25 @@ describe('ProgramProgressPage', () => {
     expect(screen.getByText('Week 1')).toBeInTheDocument();
     expect(screen.getByText('Week 2')).toBeInTheDocument();
     expect(screen.getByText('W1D1')).toBeInTheDocument();
+    // The status eyebrow names the enrollment's state above the headline.
+    expect(screen.getByText('In progress')).toBeInTheDocument();
+    expect(screen.getByText('Program settings')).toBeInTheDocument();
+  });
+
+  it('gives each session state its own affordance', () => {
+    mockUseProgramProgress.mockReturnValue({
+      data: progressData,
+      isLoading: false,
+      isError: false,
+    });
+
+    renderPage();
+
+    // Done reads as done, upcoming as tappable, skipped as inert.
+    expect(screen.getByText('W1D1').closest('a')).toBeInTheDocument();
+    expect(screen.getByText('W2D1').closest('button')).toBeInTheDocument();
+    const skipped = screen.getByText('W1D2').closest('div');
+    expect(skipped).toHaveClass('border-dashed');
   });
 
   it('links a completed session chip to its logged workout', () => {
@@ -234,6 +253,7 @@ describe('ProgramProgressPage', () => {
     renderPage();
 
     expect(screen.getByText('🎉 Program complete')).toBeInTheDocument();
+    expect(screen.getByText('Complete')).toBeInTheDocument();
   });
 
   it('toggles auto-repeat on the enrollment via the switch', async () => {
@@ -278,6 +298,7 @@ describe('ProgramProgressPage', () => {
     renderPage();
 
     expect(screen.getByText('Repeating workout')).toBeInTheDocument();
+    expect(screen.getByText('Repeating')).toBeInTheDocument();
     expect(screen.getByText('2 cycles done')).toBeInTheDocument();
     expect(
       screen.getByRole('switch', {

--- a/src/pages/ProgramProgressPage/ProgramProgressPage.tsx
+++ b/src/pages/ProgramProgressPage/ProgramProgressPage.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { ReactNode, useState } from 'react';
 import { Link, useNavigate, useParams } from 'react-router-dom';
 
 import {
@@ -20,21 +20,19 @@ import { ProgramSession } from '~/types';
 import { AdjustWeightsDialog } from './components/AdjustWeightsDialog';
 import { StageCard } from './components/StageCard';
 
-/** Glyph + label + chip styling for each session state. */
-const STATE_META: Record<SessionState, { icon: string; className: string }> = {
-  done: {
-    icon: '✓',
-    className:
-      'border-primary bg-primary/10 text-foreground hover:bg-primary/20',
-  },
-  skipped: {
-    icon: '⊘',
-    className: 'border-dashed border-muted-foreground/40 text-muted-foreground',
-  },
-  upcoming: {
-    icon: '',
-    className: 'border-border text-muted-foreground',
-  },
+/**
+ * Three session states, three different-looking chips. A done chip is filled and
+ * settled, an actionable chip is raised and carries a play glyph, and an inert
+ * chip (skipped, or upcoming with no active enrollment) is flat and dimmed — so
+ * "what can I tap" is answerable without reading a single label.
+ */
+const CHIP_STYLES: Record<SessionState | 'inert', string> = {
+  done: 'border-transparent bg-primary/10 text-foreground',
+  upcoming:
+    'border-border bg-card text-foreground shadow-sm hover:border-primary hover:bg-primary/5 active:translate-y-px',
+  skipped:
+    'border-dashed border-muted-foreground/30 bg-transparent text-muted-foreground',
+  inert: 'border-border/60 bg-transparent text-muted-foreground',
 };
 
 export const ProgramProgressPage = () => {
@@ -121,23 +119,42 @@ export const ProgramProgressPage = () => {
 
       <Card>
         <CardContent className="flex flex-col gap-1 pt-2">
-          <div className="flex items-baseline justify-between text-sm font-medium">
-            <span>
+          <span
+            className={cn(
+              'flex items-center gap-0.5 text-xs font-medium uppercase tracking-wide',
+              isComplete && !isRepeating
+                ? 'text-status-success'
+                : 'text-muted-foreground',
+            )}
+          >
+            <span
+              aria-hidden
+              className={cn(
+                'h-0.5 w-0.5 rounded-full',
+                isComplete && !isRepeating ? 'bg-status-success' : 'bg-primary',
+              )}
+            />
+            {isRepeating ? 'Repeating' : isComplete ? 'Complete' : 'In progress'}
+          </span>
+
+          <div className="flex items-baseline justify-between gap-1">
+            <span className="text-lg font-semibold leading-tight">
               {isRepeating
                 ? 'Repeating workout'
                 : isComplete
                   ? '🎉 Program complete'
                   : `Week ${currentWeek} of ${totalWeeks}`}
             </span>
-            <span className="text-muted-foreground">
+            <span className="shrink-0 text-xs tabular-nums text-muted-foreground">
               {isRepeating
                 ? `${cyclesCompleted} ${cyclesCompleted === 1 ? 'cycle' : 'cycles'} done`
                 : `${completedCount} of ${totalCount} sessions`}
             </span>
           </div>
+
           {showProgressBar && (
             <div
-              className="h-0.5 w-full overflow-hidden rounded-full bg-secondary"
+              className="mt-0.5 h-1 w-full overflow-hidden rounded-full bg-secondary"
               role="progressbar"
               aria-valuenow={completedCount}
               aria-valuemin={0}
@@ -149,15 +166,32 @@ export const ProgramProgressPage = () => {
               />
             </div>
           )}
-          {enrollment && (
-            <div className="mt-1 flex items-center justify-between gap-2">
-              <Label
-                htmlFor="auto-repeat"
-                size="small"
-                className="text-muted-foreground"
-              >
-                Repeat automatically when finished
-              </Label>
+
+          {enrollment?.status === 'active' && nextQueued && (
+            <p className="mt-1 border-t border-border pt-1 text-xs text-muted-foreground">
+              Next up: {nextQueued.program.title}
+              {isRepeating ? ' (queued programs start before a repeat)' : ''}
+            </p>
+          )}
+        </CardContent>
+      </Card>
+
+      {enrollment && (
+        <Card>
+          <CardContent className="flex flex-col gap-1.5 pt-2">
+            <h2 className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+              Program settings
+            </h2>
+
+            <div className="flex items-start justify-between gap-2">
+              <div className="flex flex-col gap-px">
+                <Label htmlFor="auto-repeat" size="small">
+                  Repeat automatically when finished
+                </Label>
+                <span className="text-xs text-muted-foreground">
+                  Starts a fresh cycle instead of ending the program.
+                </span>
+              </div>
               <Switch
                 id="auto-repeat"
                 checked={isRepeating}
@@ -170,25 +204,25 @@ export const ProgramProgressPage = () => {
                 }
               />
             </div>
-          )}
-          {canStartSessions && (
-            <Button
-              variant="secondary"
-              size="sm"
-              className="mt-1 self-start"
-              onClick={() => setAdjustingWeights(true)}
-            >
-              Adjust weights
-            </Button>
-          )}
-          {enrollment?.status === 'active' && nextQueued && (
-            <p className="text-xs text-muted-foreground">
-              Next up: {nextQueued.program.title}
-              {isRepeating ? ' (queued programs start before a repeat)' : ''}
-            </p>
-          )}
-        </CardContent>
-      </Card>
+
+            {canStartSessions && (
+              <div className="flex flex-col gap-0.5 border-t border-border pt-1.5">
+                <span className="text-xs text-muted-foreground">
+                  Change the working weight on every session you haven&apos;t
+                  done yet.
+                </span>
+                <Button
+                  variant="secondary"
+                  className="w-full"
+                  onClick={() => setAdjustingWeights(true)}
+                >
+                  Adjust weights
+                </Button>
+              </div>
+            )}
+          </CardContent>
+        </Card>
+      )}
 
       {enrollment && !!program.stages?.length && (
         <StageCard
@@ -210,14 +244,19 @@ export const ProgramProgressPage = () => {
         />
       )}
 
-      {weeks.map((week) => (
-        <WeekRow
-          key={week.weekNumber}
-          week={week}
-          canStartSessions={canStartSessions}
-          onStartSession={handleStartSession}
-        />
-      ))}
+      <section className="flex flex-col gap-1.5">
+        <h2 className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+          Sessions
+        </h2>
+        {weeks.map((week) => (
+          <WeekRow
+            key={week.weekNumber}
+            week={week}
+            canStartSessions={canStartSessions}
+            onStartSession={handleStartSession}
+          />
+        ))}
+      </section>
     </Page>
   );
 };
@@ -230,8 +269,9 @@ interface WeekRowProps {
 
 const WeekRow = ({ week, canStartSessions, onStartSession }: WeekRowProps) => (
   <div className="flex flex-col gap-0.5">
-    <span className="text-xs font-medium text-muted-foreground">
+    <span className="flex items-center gap-1 text-xs font-medium text-muted-foreground">
       Week {week.weekNumber}
+      <span aria-hidden className="h-px flex-1 bg-border" />
     </span>
     <div className="flex flex-wrap gap-1">
       {week.sessions.map((item) => (
@@ -254,47 +294,91 @@ interface SessionChipProps {
 
 const SessionChip = ({ item, canStart, onStart }: SessionChipProps) => {
   const { session, state, workoutLogId } = item;
-  const meta = STATE_META[state];
+  const isStartable = state === 'upcoming' && canStart;
+  const isDoneLink = state === 'done' && workoutLogId !== null;
 
-  const label = (
+  const chipLabel = (glyph: ReactNode, muted?: boolean) => (
     <>
-      {meta.icon && <span aria-hidden>{meta.icon}</span>}
-      <span className="font-medium">Day {session.dayNumber}</span>
+      {glyph}
+      <span className={cn('font-medium', muted && 'line-through')}>
+        Day {session.dayNumber}
+      </span>
       <span className="truncate opacity-80">{session.title}</span>
     </>
   );
 
-  const baseClassName = cn(
-    'flex max-w-full items-center gap-0.5 rounded-md border px-1 py-0.5 text-xs',
-    meta.className,
-  );
+  const baseClassName =
+    'flex max-w-full items-center gap-0.5 rounded-md border px-1.5 py-1 text-xs transition-colors';
 
   // Completed sessions link to their logged workout.
-  if (state === 'done' && workoutLogId !== null) {
+  if (isDoneLink) {
     return (
       <Link
         to={`/history/${workoutLogId}`}
-        className={cn(baseClassName, 'hover:cursor-pointer')}
+        className={cn(
+          baseClassName,
+          CHIP_STYLES.done,
+          'hover:cursor-pointer hover:bg-primary/20',
+        )}
       >
-        {label}
+        {chipLabel(
+          <span
+            aria-hidden
+            className="flex h-1.5 w-1.5 items-center justify-center rounded-full bg-primary text-[9px] font-bold leading-none text-primary-foreground"
+          >
+            ✓
+          </span>,
+        )}
       </Link>
     );
   }
 
   // Upcoming sessions are startable while enrolled — tap any one to start it.
-  if (state === 'upcoming' && canStart) {
+  if (isStartable) {
     return (
       <button
         type="button"
         aria-label={`Start Day ${session.dayNumber} ${session.title}`}
         onClick={() => onStart(session)}
-        className={cn(baseClassName, 'hover:cursor-pointer hover:bg-secondary')}
+        className={cn(
+          baseClassName,
+          CHIP_STYLES.upcoming,
+          'hover:cursor-pointer',
+        )}
       >
-        {label}
+        {chipLabel(
+          <span aria-hidden className="text-[9px] text-primary">
+            ▶
+          </span>,
+        )}
       </button>
     );
   }
 
   // Skipped sessions (and upcoming ones with no active enrollment) are static.
-  return <div className={baseClassName}>{label}</div>;
+  return (
+    <div
+      className={cn(
+        baseClassName,
+        state === 'done'
+          ? CHIP_STYLES.done
+          : state === 'skipped'
+            ? CHIP_STYLES.skipped
+            : CHIP_STYLES.inert,
+      )}
+    >
+      {chipLabel(
+        state === 'skipped' ? (
+          <span aria-hidden className="opacity-70">
+            ⊘
+          </span>
+        ) : state === 'done' ? (
+          <span aria-hidden className="text-primary">
+            ✓
+          </span>
+        ) : null,
+        state === 'skipped',
+      )}
+    </div>
+  );
 };

--- a/src/pages/ProgramProgressPage/components/AdjustWeightsDialog.tsx
+++ b/src/pages/ProgramProgressPage/components/AdjustWeightsDialog.tsx
@@ -128,7 +128,10 @@ export const AdjustWeightsDialog = ({
             />
           ) : (
             movementControls.map((control) => (
-              <div key={control.movementName} className="flex flex-col gap-1">
+              <div
+                key={control.movementName}
+                className="flex flex-col gap-1 border-t border-border pt-2 first:border-t-0 first:pt-0"
+              >
                 <h2 className="text-sm font-semibold">
                   {control.movementName}
                 </h2>


### PR DESCRIPTION
## Why

The progress page packed the progress bar, auto-repeat switch, Adjust weights button, and queued-program line into one card — with Adjust weights as a small easy-to-miss button under a switch row — and rendered done/skipped/upcoming session chips as three visually near-identical outlines. Fourth surface of the programs design pass (after #206, #209, #212).

## What

Splits the summary into a status-only progress card (state eyebrow, promoted headline, session counter) and a labeled Program settings card where auto-repeat gets a one-line explanation and Adjust weights becomes a full-width button under its own description. Session chips get three distinct affordances — done is filled with a check disc (links to history), upcoming is raised with a ▶ glyph (tappable), skipped is dashed and struck-through (inert) — plus a quieter fourth style when the program isn't active. Weeks render as labeled rails under a Sessions heading. AdjustWeightsDialog gains hairline separators between movements.

## How to test

- `npm test` — 655 passing (20 ProgramProgressPage tests: every prior behavioral assertion kept; new test pins the chip affordances — done → link, upcoming → button, skipped → inert).
- `npm run compile:ts`, `npm run lint` — clean.
- Verified live at 390×844 against local Supabase: in-progress state, settings card, Adjust weights dialog.

## Gallery

Before:

<img src="https://github.com/user-attachments/assets/e654d3d5-964f-4008-8be3-74e064fc945e" width="390" />

After — split cards and differentiated chips; tidied dialog:

<img src="https://github.com/user-attachments/assets/12eb8889-630b-4de1-b4be-354d3a8c131c" width="390" />
<img src="https://github.com/user-attachments/assets/a6425148-b09a-45ee-b3d4-4dd44246b9e9" width="390" />

## Tradeoffs

Considered moving auto-repeat and Adjust weights into a ⋯ menu like the other surfaces — but the complaint here was discoverability, and this page has no destructive actions to demote; a labeled settings group fixes discoverability without hiding the one mid-program control people actually reach for.
