### PR TITLE
feat(programs): tighten the details page into cards with one CTA

### DIFF
--- a/src/pages/ProgramDetailsPage/ProgramDetailsPage.test.tsx
+++ b/src/pages/ProgramDetailsPage/ProgramDetailsPage.test.tsx
@@ -149,10 +149,10 @@ describe('ProgramDetailsPage', () => {
     expect(screen.getByText('Week 2')).toBeInTheDocument();
     expect(screen.getByText('Day 1 · Press Ladders')).toBeInTheDocument();
     expect(screen.getByText('Day 1 · Clean & Press')).toBeInTheDocument();
-    // Movement summary + goal label appear per session (both sessions share them).
+    // The movements read once for the program; the goal still reads per session.
     expect(
-      screen.getAllByText('Double Kettlebell Press · Kettlebell Swing'),
-    ).toHaveLength(2);
+      screen.getByText('Double Kettlebell Press · Kettlebell Swing'),
+    ).toBeInTheDocument();
     expect(screen.getAllByText('20 min')).toHaveLength(2);
   });
 
@@ -441,6 +441,79 @@ describe('ProgramDetailsPage', () => {
         programId: 'dfw-1',
         replaceUserProgramId: 'up-1',
         movementWeights: expect.any(Array),
+      }),
+      expect.anything(),
+    );
+  });
+
+  it('queues instead of replacing from the at-the-cap prompt', () => {
+    enrollMutate.mockImplementation((_input, { onSuccess }) => onSuccess());
+    mockUseActivePrograms.mockReturnValue({
+      data: [
+        activeProgram('up-1', 'Least Recent'),
+        activeProgram('up-2', 'Middle'),
+        activeProgram('up-3', 'Most Recent'),
+      ],
+    });
+
+    renderPage();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Start program' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Queue instead' }));
+
+    // Queueing claims no slot, so nothing is displaced.
+    expect(enrollMutate).toHaveBeenCalledWith(
+      expect.objectContaining({ programId: 'dfw-1', queue: true }),
+      expect.anything(),
+    );
+    expect(enrollMutate.mock.calls[0][0]).not.toHaveProperty(
+      'replaceUserProgramId',
+    );
+  });
+
+  it('replaces a different running program when the choice is moved', () => {
+    mockUseActivePrograms.mockReturnValue({
+      data: [
+        activeProgram('up-1', 'Least Recent'),
+        activeProgram('up-2', 'Middle'),
+        activeProgram('up-3', 'Most Recent'),
+      ],
+    });
+
+    renderPage();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Start program' }));
+    fireEvent.click(screen.getByRole('radio', { name: /Most Recent/ }));
+    fireEvent.click(screen.getByRole('button', { name: 'Replace program' }));
+
+    expect(enrollMutate).toHaveBeenCalledWith(
+      expect.objectContaining({ replaceUserProgramId: 'up-3' }),
+      expect.anything(),
+    );
+  });
+
+  it('switches every movement to the unit chosen once for the screen', () => {
+    renderPage();
+
+    // Radix tabs commit on pointer-down, not click.
+    fireEvent.mouseDown(screen.getByRole('tab', { name: 'lb' }));
+
+    fireEvent.click(screen.getByRole('button', { name: 'Start program' }));
+
+    expect(enrollMutate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        movementWeights: [
+          expect.objectContaining({
+            movementName: 'Double Kettlebell Press',
+            weightOneUnit: 'pounds',
+            weightTwoUnit: 'pounds',
+          }),
+          expect.objectContaining({
+            movementName: 'Kettlebell Swing',
+            weightOneUnit: 'pounds',
+            weightTwoUnit: 'pounds',
+          }),
+        ],
       }),
       expect.anything(),
     );

--- a/src/pages/ProgramDetailsPage/ProgramDetailsPage.tsx
+++ b/src/pages/ProgramDetailsPage/ProgramDetailsPage.tsx
@@ -11,23 +11,13 @@ import type { MovementWeight } from '~/api';
 import { ModifyCountButtons, Page, WeightUnitTabs } from '~/components';
 import { Button } from '~/components/ui/button';
 import { Card, CardContent } from '~/components/ui/card';
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from '~/components/ui/dialog';
 import { Label } from '~/components/ui/label';
 import { Switch } from '~/components/ui/switch';
 import { useSession } from '~/contexts';
-import {
-  MovementOptions,
-  ProgramSession,
-  WeightUnit,
-  WorkoutGoalUnits,
-} from '~/types';
+import { cn } from '~/lib/utils';
+import { ReplaceProgramDialog } from '~/pages/ProgramsPage/components/ReplaceProgramDialog';
+import { programSpanLabel } from '~/pages/ProgramsPage/utils';
+import { ProgramSession, WeightUnit, WorkoutGoalUnits } from '~/types';
 import {
   getWeightRange,
   getWeightUnitLabel,
@@ -53,11 +43,23 @@ const goalLabel = (goal: number, units: WorkoutGoalUnits): string | null => {
   return `${goal} kg`;
 };
 
-const movementsSummary = (movements: MovementOptions[]): string =>
-  movements
-    .map((movement) => movement.movementName)
-    .filter((name) => name.length > 0)
-    .join(' · ');
+/**
+ * The movements the whole program trains, in the order they first appear. Every
+ * session of a program tends to repeat the same short list, so it reads once
+ * above the week rails instead of once per day.
+ */
+const programMovements = (sessions: ProgramSession[]): string => {
+  const names = new Set<string>();
+  for (const session of sessions) {
+    for (const movement of session.workoutOptions.movements) {
+      if (movement.movementName.length > 0) names.add(movement.movementName);
+    }
+  }
+  return [...names].join(' · ');
+};
+
+/** Long blurbs collapse; the toggle only appears when there's something hidden. */
+const DESCRIPTION_CLAMP_LENGTH = 240;
 
 /** Sessions grouped by their 1-based week, preserving sequenceIndex order. */
 const groupByWeek = (
@@ -81,10 +83,16 @@ export const WeightSlots = ({
   weight,
   onChange,
   namePrefix,
+  showUnitTabs = true,
 }: {
   weight: StartingWeight;
   onChange: (weight: StartingWeight) => void;
   namePrefix: string;
+  /**
+   * Off when the surface hoists a single unit control above a stack of these —
+   * one kg/lb switch for the whole screen beats one per bell.
+   */
+  showUnitTabs?: boolean;
 }) => {
   const setSlot = (slot: 'One' | 'Two', value: number) =>
     onChange({ ...weight, [`sharedWeight${slot}Value`]: Math.max(1, value) });
@@ -113,12 +121,17 @@ export const WeightSlots = ({
             onClickPlus={() => setSlot(slot, value + 1)}
             unit={getWeightUnitLabel(unit)}
             unitTabs={
-              <WeightUnitTabs
-                value={unit}
-                onChange={(nextUnit) =>
-                  onChange({ ...weight, [`sharedWeight${slot}Unit`]: nextUnit })
-                }
-              />
+              showUnitTabs ? (
+                <WeightUnitTabs
+                  value={unit}
+                  onChange={(nextUnit) =>
+                    onChange({
+                      ...weight,
+                      [`sharedWeight${slot}Unit`]: nextUnit,
+                    })
+                  }
+                />
+              ) : undefined
             }
             value={value}
             onChange={(next) => setSlot(slot, next)}
@@ -146,6 +159,10 @@ export const ProgramDetailsPage = () => {
 
   const [seeded, setSeeded] = useState(false);
   const [pendingSwitch, setPendingSwitch] = useState(false);
+  const [replaceEnrollmentId, setReplaceEnrollmentId] = useState<string | null>(
+    null,
+  );
+  const [descriptionExpanded, setDescriptionExpanded] = useState(false);
   // Complex-set path: one shared bell pair for the whole complex.
   const [sharedWeightOneValue, setSharedWeightOneValue] = useState<
     number | null
@@ -260,9 +277,12 @@ export const ProgramDetailsPage = () => {
     (p) => p.enrollment.status === 'active',
   );
   const slotsFull = activeEnrollments.length >= MAX_ACTIVE_PROGRAMS;
-  // At the cap this program displaces the least-recently-worked one, which the
-  // confirm dialog names. Below it, enrolling just claims a free slot.
-  const displaced = slotsFull ? activeEnrollments[0] : null;
+  // At the cap one running program has to stop. The prompt pre-selects the
+  // least-recently-worked one and lets the choice move; below the cap,
+  // enrolling just claims a free slot and displaces nothing.
+  const displacedId = slotsFull
+    ? (replaceEnrollmentId ?? activeEnrollments[0]?.enrollment.id ?? null)
+    : null;
 
   // The chosen weights + auto-repeat, shared by an immediate start and a
   // queue-for-later (a queued clone bakes the same weights now).
@@ -284,7 +304,7 @@ export const ProgramDetailsPage = () => {
     enroll.mutate(
       {
         programId: id,
-        replaceUserProgramId: displaced?.enrollment.id,
+        replaceUserProgramId: displacedId ?? undefined,
         ...enrollmentConfig(),
       },
       { onSuccess: () => navigate('/') },
@@ -295,6 +315,7 @@ export const ProgramDetailsPage = () => {
   // Land on Programs, where "Up next" shows the new place in line.
   const queueForLater = () => {
     if (!id) return;
+    setPendingSwitch(false);
     enroll.mutate(
       { programId: id, queue: true, ...enrollmentConfig() },
       { onSuccess: () => navigate('/programs') },
@@ -302,11 +323,42 @@ export const ProgramDetailsPage = () => {
   };
 
   const handleStart = () => {
-    if (displaced) {
+    if (slotsFull) {
+      setReplaceEnrollmentId(
+        replaceEnrollmentId ?? activeEnrollments[0]?.enrollment.id ?? null,
+      );
       setPendingSwitch(true);
     } else {
       doEnroll();
     }
+  };
+
+  // The kg/lb switch is hoisted out of the individual bell controls: one unit
+  // for the screen, applied to every slot that carries a weight at all.
+  const displayUnit: WeightUnit =
+    (complex
+      ? sharedWeightOneUnit
+      : movementControls
+          .map((control) => movementWeights[control.movementName])
+          .find((weight) => weight?.sharedWeightOneUnit)
+          ?.sharedWeightOneUnit) ?? DEFAULT_WEIGHT_UNIT;
+
+  const retuneUnits = (weight: StartingWeight, unit: WeightUnit) => ({
+    ...weight,
+    sharedWeightOneUnit: weight.sharedWeightOneUnit === null ? null : unit,
+    sharedWeightTwoUnit: weight.sharedWeightTwoUnit === null ? null : unit,
+  });
+
+  const handleChangeUnit = (unit: WeightUnit) => {
+    handleChangeWorkingWeight(retuneUnits(workingWeight, unit));
+    setMovementWeights((current) =>
+      Object.fromEntries(
+        Object.entries(current).map(([name, weight]) => [
+          name,
+          retuneUnits(weight, unit),
+        ]),
+      ),
+    );
   };
 
   if (isLoading) {
@@ -332,7 +384,11 @@ export const ProgramDetailsPage = () => {
   // nothing rather than flashing a picker for a program you already configured.
   if (isOwnProgram) return null;
 
+
   const weeks = groupByWeek(data.sessions);
+  const movements = programMovements(data.sessions);
+  const description = data.program.description ?? '';
+  const clampable = description.length > DESCRIPTION_CLAMP_LENGTH;
 
   return (
     <Page title={data.program.title}>
@@ -344,162 +400,204 @@ export const ProgramDetailsPage = () => {
       </Link>
 
       <Card>
-        <CardContent className="flex flex-col gap-1 pt-2">
-          <p className="text-xs text-muted-foreground">
-            {data.program.authorName ? `${data.program.authorName} · ` : ''}
-            {programCadenceLabel(data.program) ?? 'No sessions yet'}
-          </p>
-          {data.program.description && (
-            <p className="text-sm text-muted-foreground">
-              {data.program.description}
+        <CardContent className="flex gap-1.5 pt-2">
+          {/* The same span monogram the catalog row carried, so the program you
+              tapped still looks like itself here. */}
+          <span
+            aria-hidden
+            className="flex h-4 w-4 shrink-0 items-center justify-center rounded-md bg-primary/10 text-sm font-semibold tabular-nums text-primary"
+          >
+            {programSpanLabel(data.program)}
+          </span>
+          <div className="flex min-w-0 flex-col gap-0.5">
+            <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+              {data.program.authorName ? `${data.program.authorName} · ` : ''}
+              {programCadenceLabel(data.program) ?? 'No sessions yet'}
             </p>
-          )}
+            {description && (
+              <>
+                <p
+                  className={cn(
+                    'text-sm text-muted-foreground',
+                    clampable && !descriptionExpanded && 'line-clamp-4',
+                  )}
+                >
+                  {description}
+                </p>
+                {clampable && (
+                  <button
+                    type="button"
+                    className="self-start text-xs font-medium text-primary"
+                    onClick={() => setDescriptionExpanded((open) => !open)}
+                  >
+                    {descriptionExpanded ? 'Show less' : 'Read more'}
+                  </button>
+                )}
+              </>
+            )}
+          </div>
         </CardContent>
       </Card>
 
       {weeks.length > 0 && (
-        <div className="flex flex-col gap-2">
-          <h2 className="text-sm font-semibold">Sessions</h2>
+        <section className="flex flex-col gap-1.5">
+          <h2 className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+            Sessions
+          </h2>
+          {movements && (
+            <p className="-mt-1 text-xs text-muted-foreground">{movements}</p>
+          )}
           {weeks.map((week) => (
             <div key={week.weekNumber} className="flex flex-col gap-0.5">
-              <span className="text-xs font-medium text-muted-foreground">
+              <span className="flex items-center gap-1 text-xs font-medium text-muted-foreground">
                 Week {week.weekNumber}
+                <span aria-hidden className="h-px flex-1 bg-border" />
               </span>
-              <Card className="divide-y">
+              <div className="flex flex-wrap gap-1">
                 {week.sessions.map((programSession) => {
-                  const { movements, workoutGoal, workoutGoalUnits } =
+                  const { workoutGoal, workoutGoalUnits } =
                     programSession.workoutOptions;
                   const goal = goalLabel(workoutGoal, workoutGoalUnits);
-                  const summary = movementsSummary(movements);
                   return (
-                    <div
+                    <span
                       key={programSession.id}
-                      className="flex flex-col gap-0.5 p-2"
+                      className="flex max-w-full items-center gap-1 rounded-md border border-border/60 px-1.5 py-1 text-xs"
                     >
-                      <div className="flex items-baseline justify-between gap-1">
-                        <span className="text-sm font-medium">
-                          Day {programSession.dayNumber} ·{' '}
-                          {programSession.title}
-                        </span>
-                        {goal && (
-                          <span className="text-xs text-muted-foreground">
-                            {goal}
-                          </span>
-                        )}
-                      </div>
-                      {summary && (
-                        <span className="text-xs text-muted-foreground">
-                          {summary}
+                      <span className="truncate font-medium">
+                        Day {programSession.dayNumber} ·{' '}
+                        {programSession.title}
+                      </span>
+                      {goal && (
+                        <span className="shrink-0 tabular-nums text-muted-foreground">
+                          {goal}
                         </span>
                       )}
-                    </div>
+                    </span>
                   );
                 })}
-              </Card>
+              </div>
             </div>
           ))}
-        </div>
+        </section>
       )}
 
-      <div className="flex flex-col gap-1">
-        <h2 className="text-sm font-semibold">Starting weight</h2>
-        <p className="text-xs text-muted-foreground">
-          Set the weight your working sessions start with. You can still adjust
-          it session by session once you&apos;re in the program.
-        </p>
-        {!seeded && <p className="text-sm text-muted-foreground">Loading…</p>}
-        {/* Complex sets share one bell pair for the whole complex, so a single
-            picker; every other program gets one control per movement. */}
-        {seeded && complex && (
-          <WeightSlots
-            weight={workingWeight}
-            onChange={handleChangeWorkingWeight}
-            namePrefix="Starting weight"
-          />
-        )}
-      </div>
-
-      {seeded &&
-        !complex &&
-        movementControls.map((control) => (
-          <div key={control.movementName} className="flex flex-col gap-1">
-            <h2 className="text-sm font-semibold">{control.movementName}</h2>
-            {control.mode === 'none' ? (
-              <p className="text-sm text-muted-foreground">
-                {WEIGHT_MODE_LABELS.none}
-              </p>
-            ) : (
-              <WeightSlots
-                weight={
-                  movementWeights[control.movementName] ?? control.modalWeight
-                }
-                onChange={(next) =>
-                  handleChangeMovementWeight(control.movementName, next)
-                }
-                namePrefix={control.movementName}
-              />
-            )}
+      <Card>
+        <CardContent className="flex min-w-0 flex-col gap-1.5 pt-2">
+          <div className="flex items-center justify-between gap-1">
+            <h2 className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+              Starting weight
+            </h2>
+            <WeightUnitTabs value={displayUnit} onChange={handleChangeUnit} />
           </div>
-        ))}
+          <p className="text-xs text-muted-foreground">
+            What your working sessions start with. You can still adjust it
+            session by session once you&apos;re in the program.
+          </p>
 
-      <div className="flex items-start justify-between gap-2">
-        <div className="flex flex-col gap-0.5">
-          <Label htmlFor="auto-repeat">Repeat automatically</Label>
-          <span id="auto-repeat-help" className="text-xs text-muted-foreground">
-            When on, finishing the last session starts the program over instead
-            of ending it. Progress by adding weight over time.
-          </span>
-        </div>
-        <Switch
-          id="auto-repeat"
-          className="mt-0.5"
-          aria-describedby="auto-repeat-help"
-          checked={autoRepeat}
-          onCheckedChange={setAutoRepeat}
-        />
+          {!seeded && <p className="text-sm text-muted-foreground">Loading…</p>}
+
+          {/* Complex sets share one bell pair for the whole complex, so a single
+              picker; every other program gets one control per movement. */}
+          {seeded && complex && (
+            <WeightSlots
+              weight={workingWeight}
+              onChange={handleChangeWorkingWeight}
+              namePrefix="Starting weight"
+              showUnitTabs={false}
+            />
+          )}
+
+          {seeded &&
+            !complex &&
+            movementControls.map((control) => (
+              <div
+                key={control.movementName}
+                className="flex flex-col gap-0.5 border-t border-border pt-1.5"
+              >
+                <h3 className="text-sm font-medium">{control.movementName}</h3>
+                {control.mode === 'none' ? (
+                  <p className="text-xs text-muted-foreground">
+                    {WEIGHT_MODE_LABELS.none}
+                  </p>
+                ) : (
+                  <WeightSlots
+                    weight={
+                      movementWeights[control.movementName] ??
+                      control.modalWeight
+                    }
+                    onChange={(next) =>
+                      handleChangeMovementWeight(control.movementName, next)
+                    }
+                    namePrefix={control.movementName}
+                    showUnitTabs={false}
+                  />
+                )}
+              </div>
+            ))}
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardContent className="flex flex-col gap-1 pt-2">
+          <h2 className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+            Program settings
+          </h2>
+          <div className="flex items-start justify-between gap-2">
+            <div className="flex flex-col gap-px">
+              <Label htmlFor="auto-repeat" size="small">
+                Repeat automatically
+              </Label>
+              <span
+                id="auto-repeat-help"
+                className="text-xs text-muted-foreground"
+              >
+                Finishing the last session starts the program over instead of
+                ending it. Progress by adding weight over time.
+              </span>
+            </div>
+            <Switch
+              id="auto-repeat"
+              className="mt-0.5"
+              aria-describedby="auto-repeat-help"
+              checked={autoRepeat}
+              onCheckedChange={setAutoRepeat}
+            />
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* One primary decision — start it. Queueing is the same commitment made
+          later, so it reads as the quiet alternative rather than a peer CTA. */}
+      <div className="flex flex-col gap-0.5">
+        <Button onClick={handleStart} disabled={enroll.isPending || !seeded}>
+          Start program
+        </Button>
+        <Button
+          variant="ghost"
+          className="text-muted-foreground"
+          onClick={queueForLater}
+          disabled={enroll.isPending || !seeded}
+        >
+          Queue for later
+        </Button>
+        <p className="text-center text-xs text-muted-foreground">
+          Queued programs start when an active program finishes.
+        </p>
       </div>
 
-      <Button onClick={handleStart} disabled={enroll.isPending || !seeded}>
-        Start program
-      </Button>
-      <Button
-        variant="secondary"
-        onClick={queueForLater}
-        disabled={enroll.isPending || !seeded}
-      >
-        Queue for later
-      </Button>
-      <p className="-mt-1 text-center text-xs text-muted-foreground">
-        Queued programs start when an active program finishes.
-      </p>
-
-      <Dialog
+      <ReplaceProgramDialog
         open={pendingSwitch}
         onOpenChange={(open) => {
           if (!open) setPendingSwitch(false);
         }}
-      >
-        <DialogContent>
-          <DialogHeader>
-            <DialogTitle>Replace a program?</DialogTitle>
-            <DialogDescription>
-              You&apos;re already running {MAX_ACTIVE_PROGRAMS} programs — the
-              most you can have at once. Starting this one stops
-              {displaced ? ` ${displaced.program.title}` : ' your oldest one'},
-              the program you&apos;ve worked least recently. Its logged workouts
-              are kept, but its place in the program is cleared.
-            </DialogDescription>
-          </DialogHeader>
-          <DialogFooter>
-            <Button variant="secondary" onClick={() => setPendingSwitch(false)}>
-              Cancel
-            </Button>
-            <Button onClick={doEnroll} disabled={enroll.isPending}>
-              Replace program
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
+        activeEnrollments={activeEnrollments}
+        replaceEnrollmentId={replaceEnrollmentId}
+        onSelectReplace={setReplaceEnrollmentId}
+        onCancel={() => setPendingSwitch(false)}
+        onQueueInstead={queueForLater}
+        onConfirm={doEnroll}
+        isPending={enroll.isPending}
+      />
     </Page>
   );
 };


### PR DESCRIPTION
## Why

The pre-enroll details page ran to a very long scroll — every movement carried its own h2 and unit tabs, the auto-repeat switch floated between the weight pickers and two equal-weight full-width CTAs, and the at-cap replace dialog was a bespoke one-off. Final surface of the programs design pass (after #206, #209, #212, #213).

## What

Leads with the catalog monogram and an author·cadence eyebrow, clamps long descriptions behind Read more, renders sessions as week-rail day chips, gathers the starting weights into one card whose kg/lb switch is hoisted to the section header (one switch retunes every movement; per-movement control unchanged), mirrors the progress page's Program settings card for auto-repeat, and demotes Queue for later to a ghost button so Start program is the page's single primary action. At the cap it now opens the shared ReplaceProgramDialog — pick which program stops, or queue instead.

`WeightSlots` gains an optional `showUnitTabs` (default true); AdjustWeightsDialog is unaffected.

## How to test

- `npm test` — 658 passing (36 details tests: enroll payloads per-movement and shared/complex, bodyweight omission, auto-repeat seeding, Start vs Queue, own-program redirect all kept; new tests for queue-instead, replacing a non-default program, and the hoisted unit switch).
- `npm run compile:ts`, `npm run lint` — clean.
- Verified live at 390×844 on the 10-week StrongFirst Snatch Test plan (the worst-case scroll).

## Gallery

Before:

<img src="https://github.com/user-attachments/assets/92415cff-38d6-447e-8d9f-0020fde83b92" width="390" />

After:

<img src="https://github.com/user-attachments/assets/15f63c2b-a682-485a-b5f4-516ccd915ff7" width="390" />

## Tradeoffs

Kept per-movement weight rows rather than collapsing to a single shared picker for non-complex programs — the density win wasn't worth losing per-movement starting weights. The hoisted unit switch assumes users don't mix kg and lb across movements in one program; each row still prints its unit, and per-row tabs remain available via `showUnitTabs` if that assumption ever breaks.
