### PR TITLE
test(programs): fill the unit-layer gaps in program coverage

### DIFF
--- a/docs/program-user-flows.md
+++ b/docs/program-user-flows.md
@@ -64,7 +64,7 @@ test coverage.
 - **Entry point:** finishing a workout started from a program card (any of flows 1–5).
 - **Key files:** `src/api/useLogWorkout.ts` — reads `useProgramSession()` (from `ProgramSessionContext`) and on success calls `completeProgramSession` (`src/api/useCompleteProgramSession.ts`), which invokes the `complete_program_session` RPC. Skip path: `handleSkipProgram` in `StartWorkoutPage.tsx` (writes a skipped completion, no `workout_logs` row). Auto-repeat restart and queue promotion are implemented **inside the SQL function itself**, not in client code — `useLogWorkout.ts` only forwards the call and contains no auto-repeat/queue branching.
 - **Traceability:**
-  - **No unit-layer coverage of the completion hand-off**: `src/api/useLogWorkout.test.ts` has no program-related mocks or assertions — the `useLogWorkout` → `completeProgramSession` wiring is untested at the unit level.
+  - Unit: `useLogWorkout.test.ts` (completion-wiring describe block: RPC payload with the real log id, context clear, `ACTIVE_PROGRAM` invalidation, non-program no-op, RPC-failure isolation, full `ProgramSessionProvider` round-trip), `useCompleteProgramSession.test.ts` (skip payload + invalidation semantics), `ProgramSessionContext.test.tsx`, `StartWorkoutPage.parallelPrograms.test.jsx` (start stashes the selected program's session in context).
   - e2e: `e2e/program-next-workout.spec.ts` (advance, skip, terminal completion, idempotent duplicate completion), `e2e/program-queue.spec.ts` (auto-repeat vs queue promotion, FIFO queue), `e2e/program-parallel.spec.ts`.
 
 ## 7. Lifecycle
@@ -78,4 +78,4 @@ test coverage.
 
 ## Notes on gaps found while verifying
 
-- No unit test exists for: `useProgram.ts`, `useResumeProgram.ts`, `useAdjustProgramWeights.ts`, `useUpdateProgramSessionsForward.ts`, `AdjustWeightsDialog.tsx` (standalone), and — most notably — the `useLogWorkout` → `completeProgramSession` wiring. These are covered only by the e2e suite listed above (or, for the RPC-only logic, not covered at the unit layer at all since the logic lives in SQL).
+- The gaps originally listed here (`useProgram.ts`, `useResumeProgram.ts`, `useAdjustProgramWeights.ts`, `useUpdateProgramSessionsForward.ts`, standalone `AdjustWeightsDialog.tsx`, `program.ts` mappers, `programCadenceLabel.ts`, and the `useLogWorkout` → `completeProgramSession` wiring) now have colocated unit tests. Auto-repeat restart and queue promotion remain SQL-only logic inside `complete_program_session`, exercised by the e2e suite rather than unit tests.

--- a/src/api/program.test.ts
+++ b/src/api/program.test.ts
@@ -1,0 +1,196 @@
+import {
+  mapProgramRow,
+  mapProgramSessionCompletionRow,
+  mapProgramSessionRow,
+  mapUserProgramRow,
+} from './program';
+
+describe('mapProgramRow', () => {
+  it('maps a raw programs row to camelCase, including stages', () => {
+    const stages = [{ label: 'Base', repeatWeeks: 2 }];
+    const row = {
+      id: 'prog-1',
+      owner_id: 'user-123',
+      source_program_id: 'prog-source',
+      slug: 'dry-fighting-weight',
+      title: 'Dry Fighting Weight',
+      description: 'A classic.',
+      author_name: 'Pavel',
+      num_weeks: 2,
+      days_per_week: 3,
+      is_public: true,
+      created_at: '2026-01-01T00:00:00Z',
+      archived_at: null,
+      default_auto_repeat: false,
+      released_at: '2026-01-01T00:00:00Z',
+      stages,
+    } as never;
+
+    expect(mapProgramRow(row)).toEqual({
+      id: 'prog-1',
+      ownerId: 'user-123',
+      sourceProgramId: 'prog-source',
+      slug: 'dry-fighting-weight',
+      title: 'Dry Fighting Weight',
+      description: 'A classic.',
+      authorName: 'Pavel',
+      numWeeks: 2,
+      daysPerWeek: 3,
+      isPublic: true,
+      createdAt: '2026-01-01T00:00:00Z',
+      archivedAt: null,
+      defaultAutoRepeat: false,
+      releasedAt: '2026-01-01T00:00:00Z',
+      stages,
+    });
+  });
+
+  it('passes through a null stages column', () => {
+    const row = {
+      id: 'prog-1',
+      owner_id: 'user-123',
+      source_program_id: null,
+      slug: null,
+      title: 'Simple & Sinister',
+      description: null,
+      author_name: null,
+      num_weeks: null,
+      days_per_week: null,
+      is_public: false,
+      created_at: '2026-01-01T00:00:00Z',
+      archived_at: null,
+      default_auto_repeat: true,
+      released_at: null,
+      stages: null,
+    } as never;
+
+    expect(mapProgramRow(row).stages).toBeNull();
+  });
+});
+
+describe('mapProgramSessionRow', () => {
+  it('maps a raw program_sessions row to camelCase and passes workoutOptions through verbatim', () => {
+    const workoutOptions = {
+      complexSet: false,
+      movements: [{ movementName: 'Kettlebell Swing' }],
+    };
+    const row = {
+      id: 'ps-1',
+      program_id: 'prog-1',
+      sequence_index: 0,
+      week_number: 1,
+      day_number: 1,
+      title: 'Week 1 Day 1',
+      workout_options: workoutOptions,
+      notes: 'Go easy on the swings.',
+      weight_label: 'Deload weeks',
+    } as never;
+
+    expect(mapProgramSessionRow(row)).toEqual({
+      id: 'ps-1',
+      programId: 'prog-1',
+      sequenceIndex: 0,
+      weekNumber: 1,
+      dayNumber: 1,
+      title: 'Week 1 Day 1',
+      workoutOptions,
+      notes: 'Go easy on the swings.',
+      weightLabel: 'Deload weeks',
+    });
+  });
+});
+
+describe('mapProgramSessionCompletionRow', () => {
+  it('maps a raw program_session_completions row to camelCase', () => {
+    const row = {
+      id: 'comp-1',
+      user_program_id: 'up-1',
+      program_session_id: 'ps-1',
+      user_id: 'user-123',
+      workout_log_id: 42,
+      status: 'done',
+      completed_at: '2026-07-01T00:00:00Z',
+    } as never;
+
+    expect(mapProgramSessionCompletionRow(row)).toEqual({
+      id: 'comp-1',
+      userProgramId: 'up-1',
+      programSessionId: 'ps-1',
+      userId: 'user-123',
+      workoutLogId: 42,
+      status: 'done',
+      completedAt: '2026-07-01T00:00:00Z',
+    });
+  });
+
+  it('maps a skipped completion with no linked workout log', () => {
+    const row = {
+      id: 'comp-2',
+      user_program_id: 'up-1',
+      program_session_id: 'ps-2',
+      user_id: 'user-123',
+      workout_log_id: null,
+      status: 'skipped',
+      completed_at: '2026-07-02T00:00:00Z',
+    } as never;
+
+    expect(mapProgramSessionCompletionRow(row)).toMatchObject({
+      workoutLogId: null,
+      status: 'skipped',
+    });
+  });
+});
+
+describe('mapUserProgramRow', () => {
+  it('maps a raw user_programs row to camelCase, defaulting a null config to {}', () => {
+    const row = {
+      id: 'up-1',
+      user_id: 'user-123',
+      program_id: 'prog-1',
+      status: 'active',
+      config: null,
+      started_at: '2026-07-01T00:00:00Z',
+      completed_at: null,
+      active_slot: 1,
+      auto_repeat: false,
+      cycles_completed: 0,
+      queue_position: null,
+      current_stage_index: 0,
+    } as never;
+
+    expect(mapUserProgramRow(row)).toEqual({
+      id: 'up-1',
+      userId: 'user-123',
+      programId: 'prog-1',
+      status: 'active',
+      config: {},
+      startedAt: '2026-07-01T00:00:00Z',
+      completedAt: null,
+      activeSlot: 1,
+      autoRepeat: false,
+      cyclesCompleted: 0,
+      queuePosition: null,
+      currentStageIndex: 0,
+    });
+  });
+
+  it('passes through a populated config', () => {
+    const row = {
+      id: 'up-1',
+      user_id: 'user-123',
+      program_id: 'prog-1',
+      status: 'queued',
+      config: { someKey: 'someValue' },
+      started_at: null,
+      completed_at: null,
+      active_slot: null,
+      auto_repeat: true,
+      cycles_completed: 2,
+      queue_position: 3,
+      current_stage_index: null,
+    } as never;
+
+    expect(mapUserProgramRow(row).config).toEqual({ someKey: 'someValue' });
+    expect(mapUserProgramRow(row).queuePosition).toBe(3);
+  });
+});

--- a/src/api/useAdjustProgramWeights.test.ts
+++ b/src/api/useAdjustProgramWeights.test.ts
@@ -1,0 +1,199 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import { HttpResponse, http } from 'msw';
+import React from 'react';
+
+import { SessionProvider, ToastContext } from '~/contexts';
+import { server } from '~/mocks/server';
+
+import { VITE_SUPABASE_URL } from '../env';
+import { useAdjustProgramWeights } from './useAdjustProgramWeights';
+import { PROGRAM_MUTATION_ERROR_MESSAGE } from './useProgramMutationErrorHandler';
+
+const RPC_URL = `${VITE_SUPABASE_URL}/rest/v1/rpc/adjust_program_weights`;
+
+const showToast = vi.fn();
+
+const mockSession = {
+  user: {
+    id: 'user-123',
+    app_metadata: {},
+    user_metadata: {},
+    created_at: '',
+    aud: '',
+  },
+  access_token: '',
+  refresh_token: '',
+  expires_in: 10000,
+  token_type: '',
+};
+
+const makeWrapper = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return ({ children }: { children: React.ReactNode }) =>
+    React.createElement(
+      QueryClientProvider,
+      { client: queryClient },
+      React.createElement(
+        SessionProvider,
+        { value: mockSession },
+        React.createElement(
+          ToastContext.Provider,
+          { value: { showToast } },
+          children,
+        ),
+      ),
+    );
+};
+
+describe('useAdjustProgramWeights', () => {
+  beforeEach(() => showToast.mockClear());
+
+  it('passes shared bell weights for a complex-set program', async () => {
+    let receivedBody: unknown;
+    server.use(
+      http.post(RPC_URL, async ({ request }) => {
+        receivedBody = await request.json();
+        return HttpResponse.json(4);
+      }),
+    );
+
+    const { result } = renderHook(() => useAdjustProgramWeights(), {
+      wrapper: makeWrapper(),
+    });
+
+    const updatedCount = await result.current.mutateAsync({
+      userProgramId: 'up-1',
+      sharedWeightOneValue: 20,
+      sharedWeightOneUnit: 'kilograms',
+      sharedWeightTwoValue: 16,
+      sharedWeightTwoUnit: 'kilograms',
+    });
+
+    expect(updatedCount).toBe(4);
+    expect(receivedBody).toEqual({
+      p_user_program_id: 'up-1',
+      p_shared_weight_one_value: 20,
+      p_shared_weight_one_unit: 'kilograms',
+      p_shared_weight_two_value: 16,
+      p_shared_weight_two_unit: 'kilograms',
+    });
+  });
+
+  it('omits null weight fields from the body', async () => {
+    let receivedBody: unknown;
+    server.use(
+      http.post(RPC_URL, async ({ request }) => {
+        receivedBody = await request.json();
+        return HttpResponse.json(2);
+      }),
+    );
+
+    const { result } = renderHook(() => useAdjustProgramWeights(), {
+      wrapper: makeWrapper(),
+    });
+
+    await result.current.mutateAsync({
+      userProgramId: 'up-1',
+      sharedWeightOneValue: 24,
+      sharedWeightOneUnit: 'pounds',
+      sharedWeightTwoValue: null,
+      sharedWeightTwoUnit: null,
+    });
+
+    expect(receivedBody).toEqual({
+      p_user_program_id: 'up-1',
+      p_shared_weight_one_value: 24,
+      p_shared_weight_one_unit: 'pounds',
+    });
+  });
+
+  it('passes per-movement weights as p_movement_weights', async () => {
+    let receivedBody: unknown;
+    server.use(
+      http.post(RPC_URL, async ({ request }) => {
+        receivedBody = await request.json();
+        return HttpResponse.json(3);
+      }),
+    );
+
+    const { result } = renderHook(() => useAdjustProgramWeights(), {
+      wrapper: makeWrapper(),
+    });
+
+    const movementWeights = [
+      {
+        movementName: 'Kettlebell Swing',
+        weightOneValue: 28,
+        weightOneUnit: 'kilograms' as const,
+        weightTwoValue: null,
+        weightTwoUnit: null,
+      },
+    ];
+
+    await result.current.mutateAsync({
+      userProgramId: 'up-1',
+      movementWeights,
+    });
+
+    expect(receivedBody).toEqual({
+      p_user_program_id: 'up-1',
+      p_movement_weights: movementWeights,
+    });
+  });
+
+  it('omits p_movement_weights when the array is empty', async () => {
+    let receivedBody: unknown;
+    server.use(
+      http.post(RPC_URL, async ({ request }) => {
+        receivedBody = await request.json();
+        return HttpResponse.json(0);
+      }),
+    );
+
+    const { result } = renderHook(() => useAdjustProgramWeights(), {
+      wrapper: makeWrapper(),
+    });
+
+    await result.current.mutateAsync({
+      userProgramId: 'up-1',
+      movementWeights: [],
+    });
+
+    expect(receivedBody).toEqual({ p_user_program_id: 'up-1' });
+  });
+
+  it('surfaces RPC errors', async () => {
+    server.use(
+      http.post(RPC_URL, () =>
+        HttpResponse.json({ message: 'boom' }, { status: 400 }),
+      ),
+    );
+
+    const { result } = renderHook(() => useAdjustProgramWeights(), {
+      wrapper: makeWrapper(),
+    });
+
+    await expect(
+      result.current.mutateAsync({ userProgramId: 'up-1' }),
+    ).rejects.toBeTruthy();
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(showToast).toHaveBeenCalledWith(PROGRAM_MUTATION_ERROR_MESSAGE, {
+      variant: 'destructive',
+    });
+  });
+
+  it('does not toast on the happy path', async () => {
+    server.use(http.post(RPC_URL, () => HttpResponse.json(1)));
+
+    const { result } = renderHook(() => useAdjustProgramWeights(), {
+      wrapper: makeWrapper(),
+    });
+
+    await result.current.mutateAsync({ userProgramId: 'up-1' });
+
+    expect(showToast).not.toHaveBeenCalled();
+  });
+});

--- a/src/api/useCompleteProgramSession.test.ts
+++ b/src/api/useCompleteProgramSession.test.ts
@@ -3,6 +3,7 @@ import { HttpResponse, http } from 'msw';
 import React from 'react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
+import { QUERIES } from '~/constants';
 import { SessionProvider } from '~/contexts';
 import { server } from '~/mocks/server';
 
@@ -25,17 +26,20 @@ const mockSession = {
   token_type: '',
 };
 
-const makeWrapper = () => {
-  const queryClient = new QueryClient({
+const makeQueryClient = () =>
+  new QueryClient({
     defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
   });
-  return ({ children }: { children: React.ReactNode }) =>
+
+const wrapperFor = (queryClient: QueryClient) =>
+  ({ children }: { children: React.ReactNode }) =>
     React.createElement(
       QueryClientProvider,
       { client: queryClient },
       React.createElement(SessionProvider, { value: mockSession }, children),
     );
-};
+
+const makeWrapper = () => wrapperFor(makeQueryClient());
 
 describe('useCompleteProgramSession', () => {
   it('completes a session with its workout_log_id and resolves the program-complete flag', async () => {
@@ -93,6 +97,54 @@ describe('useCompleteProgramSession', () => {
     });
     // No workout_log_id sent for a skip — the RPC's NULL default applies.
     expect(receivedBody?.p_workout_log_id).toBeUndefined();
+  });
+
+  it('invalidates the active-program query after a successful skip', async () => {
+    server.use(http.post(RPC_URL, () => HttpResponse.json(false)));
+
+    const queryClient = makeQueryClient();
+    const invalidateQueries = vi.spyOn(queryClient, 'invalidateQueries');
+
+    const { result } = renderHook(() => useCompleteProgramSession(), {
+      wrapper: wrapperFor(queryClient),
+    });
+
+    await result.current.mutateAsync({
+      userProgramId: 'up-1',
+      programSessionId: 'ps-9',
+      status: 'skipped',
+    });
+
+    await waitFor(() =>
+      expect(invalidateQueries).toHaveBeenCalledWith({
+        queryKey: [QUERIES.ACTIVE_PROGRAM],
+      }),
+    );
+  });
+
+  it('leaves the active-program query alone when the RPC fails', async () => {
+    server.use(
+      http.post(RPC_URL, () =>
+        HttpResponse.json({ message: 'boom' }, { status: 400 }),
+      ),
+    );
+
+    const queryClient = makeQueryClient();
+    const invalidateQueries = vi.spyOn(queryClient, 'invalidateQueries');
+
+    const { result } = renderHook(() => useCompleteProgramSession(), {
+      wrapper: wrapperFor(queryClient),
+    });
+
+    await expect(
+      result.current.mutateAsync({
+        userProgramId: 'up-1',
+        programSessionId: 'ps-9',
+        status: 'skipped',
+      }),
+    ).rejects.toBeTruthy();
+
+    expect(invalidateQueries).not.toHaveBeenCalled();
   });
 
   it('surfaces RPC errors', async () => {

--- a/src/api/useLogWorkout.test.ts
+++ b/src/api/useLogWorkout.test.ts
@@ -6,9 +6,14 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import {
   DEFAULT_MOVEMENT_OPTIONS,
   DEFAULT_WORKOUT_OPTIONS,
+  PendingProgramSession,
+  ProgramSessionContext,
+  ProgramSessionProvider,
   SessionProvider,
   WorkoutOptionsContext,
+  useProgramSession,
 } from '~/contexts';
+import { QUERIES } from '~/constants';
 import { VITE_SUPABASE_URL } from '../env';
 import { server } from '~/mocks/server';
 
@@ -151,6 +156,250 @@ describe('useLogWorkout — complex_set persistence', () => {
 
     expect(capturedBody).not.toBeNull();
     expect(capturedBody!.completed_sides).toBe(logWorkoutInput.completedSides);
+  });
+});
+
+describe('useLogWorkout — program session completion wiring (Slice 3)', () => {
+  const COMPLETE_RPC_URL = `${VITE_SUPABASE_URL}/rest/v1/rpc/complete_program_session`;
+
+  function makeProgramWrapper(programSession: PendingProgramSession | null) {
+    const workoutOptions = {
+      ...DEFAULT_WORKOUT_OPTIONS,
+      movements: [defaultMovement],
+    };
+
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+
+    const setProgramSession = vi.fn();
+
+    const wrapper = ({ children }: { children: React.ReactNode }) =>
+      React.createElement(
+        QueryClientProvider,
+        { client: queryClient },
+        React.createElement(
+          SessionProvider,
+          { value: mockSession },
+          React.createElement(
+            WorkoutOptionsContext.Provider,
+            { value: [workoutOptions, () => {}] },
+            React.createElement(
+              ProgramSessionContext.Provider,
+              { value: [programSession, setProgramSession] },
+              children,
+            ),
+          ),
+        ),
+      );
+
+    return { wrapper, setProgramSession, queryClient };
+  }
+
+  beforeEach(() => {
+    server.use(
+      http.get(USER_MOVEMENTS_URL, () => HttpResponse.json([])),
+      http.post(MOVEMENT_LOGS_URL, () => HttpResponse.json([])),
+      http.post(WORKOUT_LOGS_URL, () => HttpResponse.json([{ id: 77 }])),
+    );
+  });
+
+  test('advances the pending program session with the new workout log id', async () => {
+    let rpcBody: Record<string, unknown> | null = null;
+
+    server.use(
+      http.post(COMPLETE_RPC_URL, async ({ request }) => {
+        rpcBody = (await request.json()) as Record<string, unknown>;
+        return HttpResponse.json(false);
+      }),
+    );
+
+    const { wrapper } = makeProgramWrapper({
+      userProgramId: 'up-1',
+      programSessionId: 'ps-9',
+    });
+
+    const { result } = renderHook(() => useLogWorkout(), { wrapper });
+
+    act(() => {
+      result.current.mutate(logWorkoutInput);
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    await waitFor(() => expect(rpcBody).not.toBeNull());
+
+    expect(rpcBody).toEqual({
+      p_user_program_id: 'up-1',
+      p_program_session_id: 'ps-9',
+      p_workout_log_id: 77,
+      p_status: 'completed',
+    });
+  });
+
+  test('clears the pending session so a later non-program log cannot re-attach', async () => {
+    server.use(http.post(COMPLETE_RPC_URL, () => HttpResponse.json(false)));
+
+    const { wrapper, setProgramSession } = makeProgramWrapper({
+      userProgramId: 'up-1',
+      programSessionId: 'ps-9',
+    });
+
+    const { result } = renderHook(() => useLogWorkout(), { wrapper });
+
+    act(() => {
+      result.current.mutate(logWorkoutInput);
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(setProgramSession).toHaveBeenCalledWith(null);
+  });
+
+  test('invalidates the active-program query after the RPC resolves', async () => {
+    server.use(http.post(COMPLETE_RPC_URL, () => HttpResponse.json(false)));
+
+    const { wrapper, queryClient } = makeProgramWrapper({
+      userProgramId: 'up-1',
+      programSessionId: 'ps-9',
+    });
+    const invalidateQueries = vi.spyOn(queryClient, 'invalidateQueries');
+
+    const { result } = renderHook(() => useLogWorkout(), { wrapper });
+
+    act(() => {
+      result.current.mutate(logWorkoutInput);
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    await waitFor(() =>
+      expect(invalidateQueries).toHaveBeenCalledWith({
+        queryKey: [QUERIES.ACTIVE_PROGRAM],
+      }),
+    );
+  });
+
+  test('does not call the RPC for a non-program workout', async () => {
+    const rpc = vi.fn(() => HttpResponse.json(false));
+    server.use(http.post(COMPLETE_RPC_URL, rpc));
+
+    const { wrapper, setProgramSession } = makeProgramWrapper(null);
+
+    const { result } = renderHook(() => useLogWorkout(), { wrapper });
+
+    act(() => {
+      result.current.mutate(logWorkoutInput);
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    // Give the fire-and-forget path a tick to prove it never fires.
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+
+    expect(rpc).not.toHaveBeenCalled();
+    expect(setProgramSession).not.toHaveBeenCalled();
+  });
+
+  test('an RPC failure does not fail the workout log', async () => {
+    const consoleError = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
+
+    server.use(
+      http.post(COMPLETE_RPC_URL, () =>
+        HttpResponse.json({ message: 'boom' }, { status: 400 }),
+      ),
+    );
+
+    const { wrapper } = makeProgramWrapper({
+      userProgramId: 'up-1',
+      programSessionId: 'ps-9',
+    });
+
+    const { result } = renderHook(() => useLogWorkout(), { wrapper });
+
+    act(() => {
+      result.current.mutate(logWorkoutInput);
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    await waitFor(() =>
+      expect(consoleError).toHaveBeenCalledWith(
+        'Failed to advance program session',
+        expect.anything(),
+      ),
+    );
+    expect(result.current.isError).toBe(false);
+
+    consoleError.mockRestore();
+  });
+
+  test('the real provider hands the pending session through start → log → clear', async () => {
+    let rpcBody: Record<string, unknown> | null = null;
+    server.use(
+      http.post(COMPLETE_RPC_URL, async ({ request }) => {
+        rpcBody = (await request.json()) as Record<string, unknown>;
+        return HttpResponse.json(false);
+      }),
+    );
+
+    const workoutOptions = {
+      ...DEFAULT_WORKOUT_OPTIONS,
+      movements: [defaultMovement],
+    };
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+
+    const wrapper = ({ children }: { children: React.ReactNode }) =>
+      React.createElement(
+        QueryClientProvider,
+        { client: queryClient },
+        React.createElement(
+          SessionProvider,
+          { value: mockSession },
+          React.createElement(
+            WorkoutOptionsContext.Provider,
+            { value: [workoutOptions, () => {}] },
+            React.createElement(ProgramSessionProvider, null, children),
+          ),
+        ),
+      );
+
+    const { result } = renderHook(
+      () => ({
+        log: useLogWorkout(),
+        programSession: useProgramSession(),
+      }),
+      { wrapper },
+    );
+
+    // The provider starts empty (every non-program start leaves it null).
+    expect(result.current.programSession[0]).toBeNull();
+
+    act(() => {
+      result.current.programSession[1]({
+        userProgramId: 'up-7',
+        programSessionId: 'ps-2',
+      });
+    });
+    expect(result.current.programSession[0]).toEqual({
+      userProgramId: 'up-7',
+      programSessionId: 'ps-2',
+    });
+
+    act(() => {
+      result.current.log.mutate(logWorkoutInput);
+    });
+
+    await waitFor(() => expect(result.current.log.isSuccess).toBe(true));
+    await waitFor(() => expect(rpcBody).not.toBeNull());
+
+    expect(rpcBody).toMatchObject({
+      p_user_program_id: 'up-7',
+      p_program_session_id: 'ps-2',
+      p_workout_log_id: 77,
+    });
+    await waitFor(() => expect(result.current.programSession[0]).toBeNull());
   });
 });
 

--- a/src/api/useProgram.test.ts
+++ b/src/api/useProgram.test.ts
@@ -1,0 +1,125 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import { HttpResponse, http } from 'msw';
+import React from 'react';
+
+import { SessionProvider } from '~/contexts';
+import { server } from '~/mocks/server';
+
+import { VITE_SUPABASE_URL } from '../env';
+import { useProgram } from './useProgram';
+
+const PROGRAMS_URL = `${VITE_SUPABASE_URL}/rest/v1/programs`;
+const SESSIONS_URL = `${VITE_SUPABASE_URL}/rest/v1/program_sessions`;
+
+const mockSession = {
+  user: {
+    id: 'user-123',
+    app_metadata: {},
+    user_metadata: {},
+    created_at: '',
+    aud: '',
+  },
+  access_token: '',
+  refresh_token: '',
+  expires_in: 10000,
+  token_type: '',
+};
+
+const makeWrapper = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return ({ children }: { children: React.ReactNode }) =>
+    React.createElement(
+      QueryClientProvider,
+      { client: queryClient },
+      React.createElement(SessionProvider, { value: mockSession }, children),
+    );
+};
+
+const programRow = {
+  id: 'prog-1',
+  owner_id: 'user-123',
+  source_program_id: null,
+  slug: 'dry-fighting-weight',
+  title: 'Dry Fighting Weight',
+  description: 'A classic.',
+  author_name: 'Pavel',
+  num_weeks: 2,
+  days_per_week: 3,
+  is_public: true,
+  created_at: '2026-01-01T00:00:00Z',
+  archived_at: null,
+  default_auto_repeat: false,
+  released_at: '2026-01-01T00:00:00Z',
+  stages: null,
+};
+
+const sessionRow = (seq: number) => ({
+  id: `ps-${seq}`,
+  program_id: 'prog-1',
+  sequence_index: seq,
+  week_number: Math.floor(seq / 3) + 1,
+  day_number: (seq % 3) + 1,
+  title: `Session ${seq}`,
+  workout_options: { movements: [] },
+  notes: null,
+  weight_label: null,
+});
+
+describe('useProgram', () => {
+  it('is disabled when no programId is given', () => {
+    const { result } = renderHook(() => useProgram(undefined), {
+      wrapper: makeWrapper(),
+    });
+
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(result.current.data).toBeUndefined();
+  });
+
+  it('fetches the program and its sessions, mapped to camelCase and ordered by sequenceIndex', async () => {
+    server.use(
+      http.get(PROGRAMS_URL, () => HttpResponse.json(programRow)),
+      http.get(SESSIONS_URL, () =>
+        HttpResponse.json([sessionRow(1), sessionRow(0)]),
+      ),
+    );
+
+    const { result } = renderHook(() => useProgram('prog-1'), {
+      wrapper: makeWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data?.program).toMatchObject({
+      id: 'prog-1',
+      ownerId: 'user-123',
+      title: 'Dry Fighting Weight',
+      numWeeks: 2,
+      daysPerWeek: 3,
+    });
+    expect(result.current.data?.sessions).toHaveLength(2);
+    // Supabase's `.order(...)` request param does the sequencing server-side;
+    // the query just passes the ordered rows through the mapper unchanged.
+    expect(result.current.data?.sessions.map((s) => s.id)).toEqual([
+      'ps-1',
+      'ps-0',
+    ]);
+  });
+
+  it('surfaces an error when the program fetch fails', async () => {
+    server.use(
+      http.get(PROGRAMS_URL, () =>
+        HttpResponse.json({ message: 'not found' }, { status: 404 }),
+      ),
+      http.get(SESSIONS_URL, () => HttpResponse.json([])),
+    );
+
+    const { result } = renderHook(() => useProgram('missing'), {
+      wrapper: makeWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+  });
+});

--- a/src/api/useResumeProgram.test.ts
+++ b/src/api/useResumeProgram.test.ts
@@ -1,0 +1,151 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import { HttpResponse, http } from 'msw';
+import React from 'react';
+
+import { SessionProvider, ToastContext } from '~/contexts';
+import { server } from '~/mocks/server';
+
+import { VITE_SUPABASE_URL } from '../env';
+import { PROGRAM_MUTATION_ERROR_MESSAGE } from './useProgramMutationErrorHandler';
+import { useResumeProgram } from './useResumeProgram';
+
+const RPC_URL = `${VITE_SUPABASE_URL}/rest/v1/rpc/resume_program`;
+
+const showToast = vi.fn();
+
+const mockSession = {
+  user: {
+    id: 'user-123',
+    app_metadata: {},
+    user_metadata: {},
+    created_at: '',
+    aud: '',
+  },
+  access_token: '',
+  refresh_token: '',
+  expires_in: 10000,
+  token_type: '',
+};
+
+const makeWrapper = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return ({ children }: { children: React.ReactNode }) =>
+    React.createElement(
+      QueryClientProvider,
+      { client: queryClient },
+      React.createElement(
+        SessionProvider,
+        { value: mockSession },
+        React.createElement(
+          ToastContext.Provider,
+          { value: { showToast } },
+          children,
+        ),
+      ),
+    );
+};
+
+describe('useResumeProgram', () => {
+  beforeEach(() => showToast.mockClear());
+
+  it('calls resume_program with just the enrollment id when no slot swap is needed', async () => {
+    let receivedBody: unknown;
+    server.use(
+      http.post(RPC_URL, async ({ request }) => {
+        receivedBody = await request.json();
+        return HttpResponse.json('up-resumed');
+      }),
+    );
+
+    const { result } = renderHook(() => useResumeProgram(), {
+      wrapper: makeWrapper(),
+    });
+
+    const resumed = await result.current.mutateAsync({
+      userProgramId: 'up-1',
+    });
+
+    expect(resumed).toBe('up-resumed');
+    expect(receivedBody).toEqual({ p_user_program_id: 'up-1' });
+  });
+
+  it('passes p_replace_user_program_id when replacing a full slot', async () => {
+    let receivedBody: unknown;
+    server.use(
+      http.post(RPC_URL, async ({ request }) => {
+        receivedBody = await request.json();
+        return HttpResponse.json('up-resumed');
+      }),
+    );
+
+    const { result } = renderHook(() => useResumeProgram(), {
+      wrapper: makeWrapper(),
+    });
+
+    await result.current.mutateAsync({
+      userProgramId: 'up-1',
+      replaceUserProgramId: 'up-2',
+    });
+
+    expect(receivedBody).toEqual({
+      p_user_program_id: 'up-1',
+      p_replace_user_program_id: 'up-2',
+    });
+  });
+
+  it('omits p_replace_user_program_id when it is null', async () => {
+    let receivedBody: unknown;
+    server.use(
+      http.post(RPC_URL, async ({ request }) => {
+        receivedBody = await request.json();
+        return HttpResponse.json('up-resumed');
+      }),
+    );
+
+    const { result } = renderHook(() => useResumeProgram(), {
+      wrapper: makeWrapper(),
+    });
+
+    await result.current.mutateAsync({
+      userProgramId: 'up-1',
+      replaceUserProgramId: null,
+    });
+
+    expect(receivedBody).toEqual({ p_user_program_id: 'up-1' });
+  });
+
+  it('surfaces RPC errors', async () => {
+    server.use(
+      http.post(RPC_URL, () =>
+        HttpResponse.json({ message: 'boom' }, { status: 400 }),
+      ),
+    );
+
+    const { result } = renderHook(() => useResumeProgram(), {
+      wrapper: makeWrapper(),
+    });
+
+    await expect(
+      result.current.mutateAsync({ userProgramId: 'up-1' }),
+    ).rejects.toBeTruthy();
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(showToast).toHaveBeenCalledWith(PROGRAM_MUTATION_ERROR_MESSAGE, {
+      variant: 'destructive',
+    });
+  });
+
+  it('does not toast on the happy path', async () => {
+    server.use(http.post(RPC_URL, () => HttpResponse.json('up-resumed')));
+
+    const { result } = renderHook(() => useResumeProgram(), {
+      wrapper: makeWrapper(),
+    });
+
+    await result.current.mutateAsync({ userProgramId: 'up-1' });
+
+    expect(showToast).not.toHaveBeenCalled();
+  });
+});

--- a/src/api/useUpdateProgramSessionsForward.test.ts
+++ b/src/api/useUpdateProgramSessionsForward.test.ts
@@ -1,0 +1,201 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import { HttpResponse, http } from 'msw';
+import React from 'react';
+
+import { SessionProvider, ToastContext } from '~/contexts';
+import { server } from '~/mocks/server';
+import { WorkoutOptions } from '~/types';
+
+import { VITE_SUPABASE_URL } from '../env';
+import { PROGRAM_MUTATION_ERROR_MESSAGE } from './useProgramMutationErrorHandler';
+import { useUpdateProgramSessionsForward } from './useUpdateProgramSessionsForward';
+
+const SESSIONS_URL = `${VITE_SUPABASE_URL}/rest/v1/program_sessions`;
+const RPC_URL = `${VITE_SUPABASE_URL}/rest/v1/rpc/update_program_sessions_forward`;
+
+const showToast = vi.fn();
+
+const mockSession = {
+  user: {
+    id: 'user-123',
+    app_metadata: {},
+    user_metadata: {},
+    created_at: '',
+    aud: '',
+  },
+  access_token: '',
+  refresh_token: '',
+  expires_in: 10000,
+  token_type: '',
+};
+
+const makeWrapper = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return ({ children }: { children: React.ReactNode }) =>
+    React.createElement(
+      QueryClientProvider,
+      { client: queryClient },
+      React.createElement(
+        SessionProvider,
+        { value: mockSession },
+        React.createElement(
+          ToastContext.Provider,
+          { value: { showToast } },
+          children,
+        ),
+      ),
+    );
+};
+
+const workoutOptions: Omit<WorkoutOptions, 'startedAt'> = {
+  complexSet: false,
+  intervalTimer: 0,
+  movements: [
+    {
+      movementName: 'Kettlebell Swing',
+      repScheme: [10],
+      weightOneValue: 24,
+      weightOneUnit: 'kilograms',
+      weightTwoValue: null,
+      weightTwoUnit: null,
+    },
+  ],
+  restTimer: 0,
+  sharedWeightOneUnit: null,
+  sharedWeightOneValue: null,
+  sharedWeightTwoUnit: null,
+  sharedWeightTwoValue: null,
+  title: null,
+  preWorkoutNotes: null,
+  workoutGoal: 30,
+  workoutGoalUnits: 'minutes',
+};
+
+describe('useUpdateProgramSessionsForward', () => {
+  beforeEach(() => showToast.mockClear());
+
+  it('rewrites the session in full, then forwards only its prescription via RPC', async () => {
+    let patchBody: unknown;
+    let patchUrl = '';
+    let rpcBody: unknown;
+    server.use(
+      http.patch(SESSIONS_URL, async ({ request }) => {
+        patchBody = await request.json();
+        patchUrl = request.url;
+        return new HttpResponse(null, { status: 204 });
+      }),
+      http.post(RPC_URL, async ({ request }) => {
+        rpcBody = await request.json();
+        return HttpResponse.json(5);
+      }),
+    );
+
+    const { result } = renderHook(() => useUpdateProgramSessionsForward(), {
+      wrapper: makeWrapper(),
+    });
+
+    const updatedCount = await result.current.mutateAsync({
+      sessionId: 'ps-1',
+      programId: 'prog-1',
+      title: 'Week 2 Day 1',
+      workoutOptions,
+    });
+
+    expect(updatedCount).toBe(5);
+
+    expect(patchUrl).toContain('id=eq.ps-1');
+    expect(patchBody).toEqual({
+      title: 'Week 2 Day 1',
+      workout_options: workoutOptions,
+    });
+
+    expect(rpcBody).toEqual({
+      p_session_id: 'ps-1',
+      p_forward_options: {
+        movements: workoutOptions.movements,
+        sharedWeightOneValue: workoutOptions.sharedWeightOneValue,
+        sharedWeightOneUnit: workoutOptions.sharedWeightOneUnit,
+        sharedWeightTwoValue: workoutOptions.sharedWeightTwoValue,
+        sharedWeightTwoUnit: workoutOptions.sharedWeightTwoUnit,
+        complexSet: workoutOptions.complexSet,
+      },
+    });
+  });
+
+  it('does not call the RPC when the session update itself fails', async () => {
+    let rpcCalled = false;
+    server.use(
+      http.patch(SESSIONS_URL, () =>
+        HttpResponse.json({ message: 'boom' }, { status: 400 }),
+      ),
+      http.post(RPC_URL, () => {
+        rpcCalled = true;
+        return HttpResponse.json(5);
+      }),
+    );
+
+    const { result } = renderHook(() => useUpdateProgramSessionsForward(), {
+      wrapper: makeWrapper(),
+    });
+
+    await expect(
+      result.current.mutateAsync({
+        sessionId: 'ps-1',
+        programId: 'prog-1',
+        title: 'Week 2 Day 1',
+        workoutOptions,
+      }),
+    ).rejects.toBeTruthy();
+
+    expect(rpcCalled).toBe(false);
+  });
+
+  it('surfaces RPC errors', async () => {
+    server.use(
+      http.patch(SESSIONS_URL, () => new HttpResponse(null, { status: 204 })),
+      http.post(RPC_URL, () =>
+        HttpResponse.json({ message: 'boom' }, { status: 400 }),
+      ),
+    );
+
+    const { result } = renderHook(() => useUpdateProgramSessionsForward(), {
+      wrapper: makeWrapper(),
+    });
+
+    await expect(
+      result.current.mutateAsync({
+        sessionId: 'ps-1',
+        programId: 'prog-1',
+        title: 'Week 2 Day 1',
+        workoutOptions,
+      }),
+    ).rejects.toBeTruthy();
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(showToast).toHaveBeenCalledWith(PROGRAM_MUTATION_ERROR_MESSAGE, {
+      variant: 'destructive',
+    });
+  });
+
+  it('does not toast on the happy path', async () => {
+    server.use(
+      http.patch(SESSIONS_URL, () => new HttpResponse(null, { status: 204 })),
+      http.post(RPC_URL, () => HttpResponse.json(1)),
+    );
+
+    const { result } = renderHook(() => useUpdateProgramSessionsForward(), {
+      wrapper: makeWrapper(),
+    });
+
+    await result.current.mutateAsync({
+      sessionId: 'ps-1',
+      programId: 'prog-1',
+      title: 'Week 2 Day 1',
+      workoutOptions,
+    });
+
+    expect(showToast).not.toHaveBeenCalled();
+  });
+});

--- a/src/contexts/ProgramSessionContext.test.tsx
+++ b/src/contexts/ProgramSessionContext.test.tsx
@@ -1,0 +1,40 @@
+import { act, renderHook } from '@testing-library/react';
+
+import {
+  ProgramSessionProvider,
+  useProgramSession,
+} from './ProgramSessionContext';
+
+describe('ProgramSessionContext', () => {
+  it('degrades to a null session and a no-op setter outside the provider', () => {
+    const { result } = renderHook(() => useProgramSession());
+
+    expect(result.current[0]).toBeNull();
+    act(() => {
+      result.current[1]({ userProgramId: 'up-1', programSessionId: 'ps-1' });
+    });
+    expect(result.current[0]).toBeNull();
+  });
+
+  it('holds the pending session a program start stashes, until it is cleared', () => {
+    const { result } = renderHook(() => useProgramSession(), {
+      wrapper: ProgramSessionProvider,
+    });
+
+    expect(result.current[0]).toBeNull();
+
+    act(() => {
+      result.current[1]({ userProgramId: 'up-1', programSessionId: 'ps-1' });
+    });
+    expect(result.current[0]).toEqual({
+      userProgramId: 'up-1',
+      programSessionId: 'ps-1',
+    });
+
+    // A subsequent non-program start passes null, clearing the stale session.
+    act(() => {
+      result.current[1](null);
+    });
+    expect(result.current[0]).toBeNull();
+  });
+});

--- a/src/pages/ProgramProgressPage/components/AdjustWeightsDialog.test.tsx
+++ b/src/pages/ProgramProgressPage/components/AdjustWeightsDialog.test.tsx
@@ -1,0 +1,228 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { vi } from 'vitest';
+
+import { ProgramSession } from '~/types';
+
+import { AdjustWeightsDialog } from './AdjustWeightsDialog';
+
+const { mockAdjustMutate, mockShowToast } = vi.hoisted(() => ({
+  mockAdjustMutate: vi.fn(),
+  mockShowToast: vi.fn(),
+}));
+
+vi.mock('~/api', () => ({
+  useAdjustProgramWeights: () => ({
+    mutate: mockAdjustMutate,
+    isPending: false,
+  }),
+}));
+
+vi.mock('~/contexts', () => ({
+  useToast: () => ({ showToast: mockShowToast }),
+}));
+
+const bareOptions = {
+  complexSet: false,
+  intervalTimer: 0,
+  restTimer: 0,
+  sharedWeightOneUnit: null,
+  sharedWeightOneValue: null,
+  sharedWeightTwoUnit: null,
+  sharedWeightTwoValue: null,
+  title: null,
+  preWorkoutNotes: null,
+  workoutGoal: 30,
+  workoutGoalUnits: 'minutes' as const,
+};
+
+const session = (
+  id: string,
+  overrides: Partial<ProgramSession['workoutOptions']>,
+): ProgramSession => ({
+  id,
+  programId: 'prog-1',
+  sequenceIndex: 0,
+  weekNumber: 1,
+  dayNumber: 1,
+  title: 'Session',
+  notes: null,
+  weightLabel: null,
+  workoutOptions: { ...bareOptions, movements: [], ...overrides },
+});
+
+const perMovementSessions: ProgramSession[] = [
+  session('ps-1', {
+    movements: [
+      {
+        movementName: 'Kettlebell Swing',
+        repScheme: [10],
+        weightOneValue: 24,
+        weightOneUnit: 'kilograms',
+        weightTwoValue: null,
+        weightTwoUnit: null,
+      },
+      {
+        movementName: 'Pull-Up',
+        repScheme: [5],
+        weightOneValue: null,
+        weightOneUnit: null,
+        weightTwoValue: null,
+        weightTwoUnit: null,
+      },
+    ],
+  }),
+];
+
+const complexSessions: ProgramSession[] = [
+  session('ps-1', {
+    complexSet: true,
+    sharedWeightOneValue: 20,
+    sharedWeightOneUnit: 'kilograms',
+    sharedWeightTwoValue: null,
+    sharedWeightTwoUnit: null,
+    movements: [
+      {
+        movementName: 'Clean',
+        repScheme: [5],
+        weightOneValue: null,
+        weightOneUnit: null,
+        weightTwoValue: null,
+        weightTwoUnit: null,
+      },
+    ],
+  }),
+];
+
+describe('AdjustWeightsDialog', () => {
+  beforeEach(() => {
+    mockAdjustMutate.mockReset();
+    mockShowToast.mockReset();
+  });
+
+  it('renders one editable control per movement and labels the bodyweight one', () => {
+    render(
+      <AdjustWeightsDialog
+        open
+        onOpenChange={vi.fn()}
+        userProgramId="up-1"
+        sessions={perMovementSessions}
+      />,
+    );
+
+    expect(
+      screen.getByRole('heading', { name: 'Adjust weights' }),
+    ).toBeInTheDocument();
+    expect(screen.getByText('Kettlebell Swing')).toBeInTheDocument();
+    expect(screen.getByText('Pull-Up')).toBeInTheDocument();
+    expect(screen.getByText('Bodyweight')).toBeInTheDocument();
+  });
+
+  it('submits the adjusted per-movement weight and closes on success', async () => {
+    const user = userEvent.setup();
+    const onOpenChange = vi.fn();
+    mockAdjustMutate.mockImplementation((_args, { onSuccess }) =>
+      onSuccess(2),
+    );
+
+    render(
+      <AdjustWeightsDialog
+        open
+        onOpenChange={onOpenChange}
+        userProgramId="up-1"
+        sessions={perMovementSessions}
+      />,
+    );
+
+    await user.click(
+      screen.getByRole('button', {
+        name: '+ kg — Kettlebell Swing',
+      }),
+    );
+    await user.click(screen.getByRole('button', { name: 'Update weights' }));
+
+    expect(mockAdjustMutate).toHaveBeenCalledWith(
+      {
+        userProgramId: 'up-1',
+        movementWeights: [
+          expect.objectContaining({
+            movementName: 'Kettlebell Swing',
+            weightOneValue: 25,
+            weightOneUnit: 'kilograms',
+          }),
+        ],
+      },
+      expect.anything(),
+    );
+    expect(mockShowToast).toHaveBeenCalledWith(
+      'Weights updated for 2 upcoming sessions',
+    );
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it('submits a single shared weight for a complex-set program', async () => {
+    const user = userEvent.setup();
+    mockAdjustMutate.mockImplementation((_args, { onSuccess }) =>
+      onSuccess(1),
+    );
+
+    render(
+      <AdjustWeightsDialog
+        open
+        onOpenChange={vi.fn()}
+        userProgramId="up-1"
+        sessions={complexSessions}
+      />,
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Update weights' }));
+
+    expect(mockAdjustMutate).toHaveBeenCalledWith(
+      {
+        userProgramId: 'up-1',
+        sharedWeightOneValue: 20,
+        sharedWeightOneUnit: 'kilograms',
+        sharedWeightTwoValue: null,
+        sharedWeightTwoUnit: null,
+      },
+      expect.anything(),
+    );
+    expect(mockShowToast).toHaveBeenCalledWith(
+      'Weights updated for 1 upcoming session',
+    );
+  });
+
+  it('closes without submitting when Cancel is clicked', async () => {
+    const user = userEvent.setup();
+    const onOpenChange = vi.fn();
+
+    render(
+      <AdjustWeightsDialog
+        open
+        onOpenChange={onOpenChange}
+        userProgramId="up-1"
+        sessions={perMovementSessions}
+      />,
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Cancel' }));
+
+    expect(mockAdjustMutate).not.toHaveBeenCalled();
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it('renders nothing when closed', () => {
+    render(
+      <AdjustWeightsDialog
+        open={false}
+        onOpenChange={vi.fn()}
+        userProgramId="up-1"
+        sessions={perMovementSessions}
+      />,
+    );
+
+    expect(
+      screen.queryByRole('heading', { name: 'Adjust weights' }),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/src/pages/StartWorkoutPage/StartWorkoutPage.parallelPrograms.test.jsx
+++ b/src/pages/StartWorkoutPage/StartWorkoutPage.parallelPrograms.test.jsx
@@ -2,7 +2,13 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { act, fireEvent, render, screen } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 
-import { DEFAULT_WORKOUT_OPTIONS, WorkoutOptionsContext } from '~/contexts';
+import {
+  DEFAULT_MOVEMENT_OPTIONS,
+  DEFAULT_WORKOUT_OPTIONS,
+  ProgramSessionProvider,
+  WorkoutOptionsContext,
+  useProgramSession,
+} from '~/contexts';
 
 import { StartWorkoutPage } from './StartWorkoutPage';
 
@@ -74,6 +80,45 @@ const renderPage = () =>
       </MemoryRouter>
     </QueryClientProvider>,
   );
+
+// Reads whatever pending program session the page stashed, so the start path can
+// be asserted at the seam `useLogWorkout` later reads from.
+const PendingSessionProbe = () => {
+  const [programSession] = useProgramSession();
+  return (
+    <div data-testid="pending-session">
+      {programSession
+        ? `${programSession.userProgramId}/${programSession.programSessionId}`
+        : 'none'}
+    </div>
+  );
+};
+
+const renderPageWithProgramSession = () => {
+  const workoutOptions = {
+    ...DEFAULT_WORKOUT_OPTIONS,
+    movements: [
+      { ...DEFAULT_MOVEMENT_OPTIONS, movementName: 'Kettlebell Swing' },
+    ],
+  };
+
+  return render(
+    <QueryClientProvider
+      client={
+        new QueryClient({ defaultOptions: { queries: { retry: false } } })
+      }
+    >
+      <MemoryRouter initialEntries={['/']}>
+        <ProgramSessionProvider>
+          <WorkoutOptionsContext.Provider value={[workoutOptions, vi.fn()]}>
+            <StartWorkoutPage />
+            <PendingSessionProbe />
+          </WorkoutOptionsContext.Provider>
+        </ProgramSessionProvider>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+};
 
 describe('StartWorkoutPage parallel programs', () => {
   beforeEach(() => {
@@ -148,5 +193,48 @@ describe('StartWorkoutPage parallel programs', () => {
       programSessionId: 'up-2-ps-0',
       status: 'skipped',
     });
+  });
+
+  // The completion half of the wiring: starting a program session stashes it in
+  // ProgramSessionContext, which is exactly what `useLogWorkout` reads on success
+  // to write the `complete_program_session` row (asserted in useLogWorkout.test).
+  test('stashes the selected program session when its workout is started', () => {
+    const withMovements = (program) => ({
+      ...program,
+      nextSession: {
+        ...program.nextSession,
+        session: {
+          ...program.nextSession.session,
+          workoutOptions: {
+            ...DEFAULT_WORKOUT_OPTIONS,
+            movements: [
+              { ...DEFAULT_MOVEMENT_OPTIONS, movementName: 'Kettlebell Swing' },
+            ],
+          },
+        },
+      },
+    });
+
+    mockUseActivePrograms.mockReturnValue({
+      data: [
+        withMovements(activeProgram('up-1', 'Easy Strength', 'Day 1')),
+        withMovements(
+          activeProgram('up-2', 'Dry Fighting Weight', 'Ladders 1-2-3'),
+        ),
+      ],
+      isError: false,
+    });
+
+    renderPageWithProgramSession();
+
+    expect(screen.getByTestId('pending-session')).toHaveTextContent('none');
+
+    fireEvent.click(screen.getByRole('tab', { name: /Dry Fighting Weight/ }));
+    fireEvent.click(screen.getByRole('button', { name: 'Start next workout' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Start workout' }));
+
+    expect(screen.getByTestId('pending-session')).toHaveTextContent(
+      'up-2/up-2-ps-0',
+    );
   });
 });

--- a/src/utils/programCadenceLabel.test.ts
+++ b/src/utils/programCadenceLabel.test.ts
@@ -1,0 +1,64 @@
+import { Program } from '~/types';
+
+import { programCadenceLabel } from './programCadenceLabel';
+
+const baseProgram: Program = {
+  id: 'prog-1',
+  ownerId: 'user-123',
+  sourceProgramId: null,
+  slug: 'dry-fighting-weight',
+  title: 'Dry Fighting Weight',
+  description: null,
+  authorName: null,
+  numWeeks: 2,
+  daysPerWeek: 3,
+  isPublic: true,
+  createdAt: '2026-01-01T00:00:00Z',
+  archivedAt: null,
+  defaultAutoRepeat: false,
+  releasedAt: '2026-01-01T00:00:00Z',
+  stages: null,
+};
+
+describe('programCadenceLabel', () => {
+  it('reads "Repeating workout" for a default-auto-repeat program, regardless of week/day counts', () => {
+    expect(
+      programCadenceLabel({
+        ...baseProgram,
+        defaultAutoRepeat: true,
+        numWeeks: 1,
+        daysPerWeek: 1,
+      }),
+    ).toBe('Repeating workout');
+  });
+
+  it('pluralizes "weeks" even for a single-week program', () => {
+    expect(
+      programCadenceLabel({ ...baseProgram, numWeeks: 1, daysPerWeek: 3 }),
+    ).toBe('1 weeks · 3/week');
+  });
+
+  it('shows the derived weeks/days-per-week cadence for a multi-week program', () => {
+    expect(
+      programCadenceLabel({ ...baseProgram, numWeeks: 4, daysPerWeek: 5 }),
+    ).toBe('4 weeks · 5/week');
+  });
+
+  it('returns null when numWeeks is not yet derived', () => {
+    expect(
+      programCadenceLabel({ ...baseProgram, numWeeks: null, daysPerWeek: 3 }),
+    ).toBeNull();
+  });
+
+  it('returns null when daysPerWeek is not yet derived', () => {
+    expect(
+      programCadenceLabel({ ...baseProgram, numWeeks: 2, daysPerWeek: null }),
+    ).toBeNull();
+  });
+
+  it('returns null when neither cadence field has been derived', () => {
+    expect(
+      programCadenceLabel({ ...baseProgram, numWeeks: null, daysPerWeek: null }),
+    ).toBeNull();
+  });
+});


### PR DESCRIPTION
## Why

The flow audit in #202 found that several program modules were covered only by the e2e suite — most notably the `useLogWorkout` → `complete_program_session` wiring that advances a program when you finish a workout. Final phase of the programs audit (docs #202, design #206/#209/#212/#213/#214).

## What

Adds colocated unit tests for every gap the audit flagged: `useAdjustProgramWeights`, `useResumeProgram`, `useUpdateProgramSessionsForward`, `useProgram`, the `program.ts` row mappers, a standalone `AdjustWeightsDialog` test, `programCadenceLabel`, `ProgramSessionContext`, and the completion wiring (RPC payload with the real log id, context clear, cache invalidation, non-program no-op, RPC-failure isolation, and a full provider round-trip). Updates the flow doc's traceability section to match. Tests only — no production source changed.

## How to test

- `npm test` — 100 files, 705 passing (was 658).
- `npm run compile:ts`, `npm run lint` — clean.

## Tradeoffs

Auto-repeat restart and queue promotion live inside the `complete_program_session` SQL function, so they stay e2e-covered rather than unit-tested; the client tests pin the payload seam instead. Completion-after-finishing can't be driven from StartWorkoutPage at the unit layer (the log fires post-navigation), so the provider round-trip test covers that seam at the hook level.
