### PR TITLE
feat(programs): AI program recommender on ProgramsPage

### DIFF
--- a/src/api/analytics.ts
+++ b/src/api/analytics.ts
@@ -24,6 +24,10 @@ export enum AnalyticsEvent {
   RecommendationAccepted = 'recommendation_accepted',
   RecommendationRegenerated = 'recommendation_regenerated',
   RecommendationPreviewShown = 'recommendation_preview_shown',
+  // AI Program Recommender.
+  ProgramRecommendationRequested = 'program_recommendation_requested',
+  ProgramRecommendationAccepted = 'program_recommendation_accepted',
+  ProgramRecommendationDismissed = 'program_recommendation_dismissed',
 }
 
 interface TrackEventParams {

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -34,6 +34,7 @@ export * from './useSetProgramStage';
 export * from './useUpdateProgramSession';
 export * from './useUpdateProgramSessionsForward';
 export * from './useRecentRepeatableWorkouts';
+export * from './useRecommendProgram';
 export * from './useRecommendSession';
 export * from './useSelectRPE';
 export * from './useSetSubscription';

--- a/src/api/useRecommendProgram.test.ts
+++ b/src/api/useRecommendProgram.test.ts
@@ -1,0 +1,93 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { HttpResponse, http } from 'msw';
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+import { ExampleProgramRecommendation } from '~/examples';
+import { server } from '~/mocks/server';
+
+import { VITE_SUPABASE_URL } from '../env';
+import {
+  RecommendProgramError,
+  useRecommendProgram,
+} from './useRecommendProgram';
+
+const FUNCTION_URL = `${VITE_SUPABASE_URL}/functions/v1/recommend-program`;
+
+const makeWrapper = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: { mutations: { retry: false } },
+  });
+  return ({ children }: { children: React.ReactNode }) =>
+    React.createElement(
+      QueryClientProvider,
+      { client: queryClient },
+      children,
+    );
+};
+
+const mutateAndSettle = async () => {
+  const { result } = renderHook(() => useRecommendProgram(), {
+    wrapper: makeWrapper(),
+  });
+  result.current.mutate();
+  await waitFor(() =>
+    expect(result.current.isSuccess || result.current.isError).toBe(true),
+  );
+  return result;
+};
+
+describe('useRecommendProgram', () => {
+  test('resolves the recommendation on success', async () => {
+    const recommendation = new ExampleProgramRecommendation();
+    server.use(
+      http.post(FUNCTION_URL, () =>
+        HttpResponse.json({ id: 'rec-1', recommendation }),
+      ),
+    );
+
+    const result = await mutateAndSettle();
+
+    expect(result.current.isSuccess).toBe(true);
+    expect(result.current.data).toEqual({
+      id: 'rec-1',
+      recommendation: { ...recommendation },
+    });
+  });
+
+  test.each([
+    ['premium_required', { error: 'premium_required', paywall_trigger: true }, 401],
+    ['no_candidates', { error: 'no_candidates' }, 422],
+    ['recommendation_failed', { error: 'recommendation_failed' }, 502],
+  ] as const)(
+    'surfaces the %s error code',
+    async (code, body, status) => {
+      server.use(
+        http.post(FUNCTION_URL, () => HttpResponse.json(body, { status })),
+      );
+
+      const result = await mutateAndSettle();
+
+      expect(result.current.isError).toBe(true);
+      const error = result.current.error;
+      expect(error).toBeInstanceOf(RecommendProgramError);
+      expect((error as RecommendProgramError).code).toBe(code);
+    },
+  );
+
+  test('falls back to the unknown code on a non-JSON error body', async () => {
+    server.use(
+      http.post(
+        FUNCTION_URL,
+        () => new HttpResponse('boom', { status: 500 }),
+      ),
+    );
+
+    const result = await mutateAndSettle();
+
+    expect(result.current.isError).toBe(true);
+    expect((result.current.error as RecommendProgramError).code).toBe(
+      'unknown',
+    );
+  });
+});

--- a/src/api/useRecommendProgram.ts
+++ b/src/api/useRecommendProgram.ts
@@ -1,0 +1,65 @@
+import { FunctionsHttpError } from '@supabase/supabase-js';
+import { useMutation } from '@tanstack/react-query';
+
+import { supabase } from '../supabaseClient';
+import type { RecommendProgramResponse } from '~/types';
+
+/** Stable codes for the failure modes the UI messages differently. */
+export type RecommendProgramErrorCode =
+  | 'premium_required'
+  | 'no_candidates'
+  | 'recommendation_failed'
+  | 'unknown';
+
+export class RecommendProgramError extends Error {
+  code: RecommendProgramErrorCode;
+  constructor(code: RecommendProgramErrorCode, message: string) {
+    super(message);
+    this.name = 'RecommendProgramError';
+    this.code = code;
+  }
+}
+
+const recommendProgram = async (): Promise<RecommendProgramResponse> => {
+  const { data, error } =
+    await supabase.functions.invoke<RecommendProgramResponse>(
+      'recommend-program',
+      { body: {} },
+    );
+
+  if (error) {
+    // supabase.functions.invoke surfaces non-2xx as a FunctionsHttpError whose
+    // body is on `.context` (a Response). Parse it to recover our error codes.
+    let code: RecommendProgramErrorCode = 'unknown';
+    if (error instanceof FunctionsHttpError) {
+      try {
+        const body = await error.context.json();
+        if (body?.paywall_trigger || body?.error === 'premium_required') {
+          code = 'premium_required';
+        } else if (body?.error === 'no_candidates') {
+          code = 'no_candidates';
+        } else if (body?.error === 'recommendation_failed') {
+          code = 'recommendation_failed';
+        }
+      } catch {
+        /* non-JSON body — leave code as 'unknown' */
+      }
+    }
+    throw new RecommendProgramError(code, error.message);
+  }
+
+  if (!data?.recommendation) {
+    throw new RecommendProgramError('unknown', 'No recommendation returned');
+  }
+
+  return data;
+};
+
+/**
+ * Calls the recommend-program Edge Function and resolves to a validated
+ * program recommendation (one program + concurrent-vs-queue mode). Premium
+ * gating is enforced server-side; the client only invokes this for premium
+ * users (free users see a preview instead).
+ */
+export const useRecommendProgram = () =>
+  useMutation({ mutationFn: recommendProgram });

--- a/src/examples/recommendation.examples.ts
+++ b/src/examples/recommendation.examples.ts
@@ -1,4 +1,4 @@
-import type { Recommendation } from '~/types';
+import type { ProgramRecommendation, Recommendation } from '~/types';
 
 /**
  * A realistic recommendation for tests, stories, and the free-user preview
@@ -38,5 +38,28 @@ export class ExampleRecommendation implements Recommendation {
     this.format = format;
     this.confidence = confidence;
     this.blocks = blocks;
+  }
+}
+
+/**
+ * A realistic program recommendation for tests and stories. Defaults model an
+ * easy strength program queued behind a running conditioning block.
+ */
+export class ExampleProgramRecommendation implements ProgramRecommendation {
+  program_id: ProgramRecommendation['program_id'];
+  mode: ProgramRecommendation['mode'];
+  rationale: ProgramRecommendation['rationale'];
+  confidence: ProgramRecommendation['confidence'];
+
+  constructor({
+    program_id = 'example-easy-strength',
+    mode = 'queue',
+    rationale = 'Your pull and carry patterns are the most undertrained, and Easy Strength hits both without adding recovery load. Your current program fills your recovery budget, so queue this to start the day it finishes.',
+    confidence = 'medium',
+  }: Partial<ProgramRecommendation> = {}) {
+    this.program_id = program_id;
+    this.mode = mode;
+    this.rationale = rationale;
+    this.confidence = confidence;
   }
 }

--- a/src/pages/ProgramsPage/ProgramsPage.test.tsx
+++ b/src/pages/ProgramsPage/ProgramsPage.test.tsx
@@ -63,6 +63,9 @@ vi.mock('~/api', () => ({
   useQueuedPrograms: mockUseQueuedPrograms,
   useDequeueProgram: mockUseDequeueProgram,
   useStartQueuedProgram: mockUseStartQueuedProgram,
+  // Recommender off: these tests cover the page's baseline surface; the
+  // recommendation section has its own suite.
+  useFeatureFlags: () => ({ features: { recommender: false }, isPending: false }),
   trackEvent: mockTrackEvent,
   AnalyticsEvent: { ProgramResumed: 'program_resumed' },
   MAX_ACTIVE_PROGRAMS: 3,

--- a/src/pages/ProgramsPage/ProgramsPage.tsx
+++ b/src/pages/ProgramsPage/ProgramsPage.tsx
@@ -11,6 +11,7 @@ import {
   useDeleteProgram,
   useDequeueProgram,
   useEnrollProgram,
+  useFeatureFlags,
   useProgramProgress,
   usePrograms,
   useQueuedPrograms,
@@ -31,6 +32,7 @@ import {
   CreateProgramForm,
   MyProgramCard,
   QueueTimeline,
+  RecommendProgramSection,
   ReplaceProgramDialog,
   ResumeProgramDialog,
 } from './components';
@@ -51,6 +53,7 @@ export const ProgramsPage = () => {
   const { data: queuedPrograms = [] } = useQueuedPrograms();
   const dequeue = useDequeueProgram();
   const startQueued = useStartQueuedProgram();
+  const { features } = useFeatureFlags();
 
   const [showCreate, setShowCreate] = useState(false);
   const [showArchived, setShowArchived] = useState(false);
@@ -403,6 +406,16 @@ export const ProgramsPage = () => {
             onRemove={(userProgramId) => dequeue.mutate({ userProgramId })}
           />
         </div>
+      )}
+
+      {features.recommender && (
+        <RecommendProgramSection
+          programs={programs}
+          slotsFull={slotsFull}
+          onEnrollNow={handleEnroll}
+          onQueue={(programId) => enroll.mutate({ programId, queue: true })}
+          userId={userId}
+        />
       )}
 
       {sharedPrograms.length > 0 && (

--- a/src/pages/ProgramsPage/components/RecommendProgramSection.test.tsx
+++ b/src/pages/ProgramsPage/components/RecommendProgramSection.test.tsx
@@ -1,0 +1,168 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { HttpResponse, http } from 'msw';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { MemoryRouter } from 'react-router-dom';
+
+import { EntitlementContext } from '~/contexts';
+import type { EntitlementContextValue } from '~/contexts/EntitlementContext';
+import { VITE_SUPABASE_URL } from '~/env';
+import { ExampleProgramRecommendation } from '~/examples';
+import { server } from '~/mocks/server';
+import type { Program } from '~/types';
+
+import { RecommendProgramSection } from './RecommendProgramSection';
+
+const FUNCTION_URL = `${VITE_SUPABASE_URL}/functions/v1/recommend-program`;
+
+const premiumEntitlement: EntitlementContextValue = {
+  isPremium: true,
+  isTrialing: false,
+  trialExpired: false,
+  trialDaysRemaining: null,
+  effectiveAccess: 'premium' as const,
+  isLoading: false,
+  refetch: () => {},
+};
+
+const freeEntitlement = {
+  ...premiumEntitlement,
+  isPremium: false,
+  effectiveAccess: 'free' as const,
+};
+
+const easyStrength = {
+  id: 'program-easy-strength',
+  title: 'Easy Strength',
+} as Program;
+
+const renderSection = ({
+  entitlement = premiumEntitlement,
+  slotsFull = false,
+  onEnrollNow = vi.fn(),
+  onQueue = vi.fn(),
+} = {}) => {
+  const queryClient = new QueryClient({
+    defaultOptions: { mutations: { retry: false } },
+  });
+  render(
+    <MemoryRouter>
+      <QueryClientProvider client={queryClient}>
+        <EntitlementContext.Provider value={entitlement}>
+          <RecommendProgramSection
+            programs={[easyStrength]}
+            slotsFull={slotsFull}
+            onEnrollNow={onEnrollNow}
+            onQueue={onQueue}
+            userId="user-123"
+          />
+        </EntitlementContext.Provider>
+      </QueryClientProvider>
+    </MemoryRouter>,
+  );
+  return { onEnrollNow, onQueue };
+};
+
+const respondWith = (recommendation: ExampleProgramRecommendation) =>
+  server.use(
+    http.post(FUNCTION_URL, () =>
+      HttpResponse.json({ id: 'rec-1', recommendation }),
+    ),
+  );
+
+describe('RecommendProgramSection', () => {
+  test('free users get the preview dialog, not a function call', async () => {
+    const user = userEvent.setup();
+    renderSection({ entitlement: freeEntitlement });
+
+    await user.click(
+      screen.getByRole('button', { name: /recommend a program/i }),
+    );
+
+    expect(
+      screen.getByRole('heading', { name: 'AI program recommendations' }),
+    ).toBeInTheDocument();
+  });
+
+  test('a queue-mode pick shows the card and Add to queue calls onQueue', async () => {
+    const user = userEvent.setup();
+    respondWith(
+      new ExampleProgramRecommendation({
+        program_id: easyStrength.id,
+        mode: 'queue',
+      }),
+    );
+    const { onQueue, onEnrollNow } = renderSection();
+
+    await user.click(
+      screen.getByRole('button', { name: /recommend a program/i }),
+    );
+
+    expect(
+      await screen.findByRole('heading', { name: 'Easy Strength' }),
+    ).toBeInTheDocument();
+    expect(screen.getByText('Queue for later')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Add to queue' }));
+    expect(onQueue).toHaveBeenCalledWith(easyStrength.id);
+    expect(onEnrollNow).not.toHaveBeenCalled();
+  });
+
+  test('a concurrent-mode pick starts now when a slot is free', async () => {
+    const user = userEvent.setup();
+    respondWith(
+      new ExampleProgramRecommendation({
+        program_id: easyStrength.id,
+        mode: 'concurrent',
+      }),
+    );
+    const { onQueue, onEnrollNow } = renderSection();
+
+    await user.click(
+      screen.getByRole('button', { name: /recommend a program/i }),
+    );
+    await user.click(await screen.findByRole('button', { name: 'Start now' }));
+
+    expect(onEnrollNow).toHaveBeenCalledWith(easyStrength.id);
+    expect(onQueue).not.toHaveBeenCalled();
+  });
+
+  test('a concurrent-mode pick degrades to queue once every slot is taken', async () => {
+    const user = userEvent.setup();
+    respondWith(
+      new ExampleProgramRecommendation({
+        program_id: easyStrength.id,
+        mode: 'concurrent',
+      }),
+    );
+    const { onQueue, onEnrollNow } = renderSection({ slotsFull: true });
+
+    await user.click(
+      screen.getByRole('button', { name: /recommend a program/i }),
+    );
+    await user.click(
+      await screen.findByRole('button', { name: 'Add to queue' }),
+    );
+
+    expect(onQueue).toHaveBeenCalledWith(easyStrength.id);
+    expect(onEnrollNow).not.toHaveBeenCalled();
+  });
+
+  test('no_candidates renders its friendly message', async () => {
+    const user = userEvent.setup();
+    server.use(
+      http.post(FUNCTION_URL, () =>
+        HttpResponse.json({ error: 'no_candidates' }, { status: 422 }),
+      ),
+    );
+    renderSection();
+
+    await user.click(
+      screen.getByRole('button', { name: /recommend a program/i }),
+    );
+
+    expect(
+      await screen.findByText(/already running or have queued/i),
+    ).toBeInTheDocument();
+  });
+});

--- a/src/pages/ProgramsPage/components/RecommendProgramSection.tsx
+++ b/src/pages/ProgramsPage/components/RecommendProgramSection.tsx
@@ -1,0 +1,245 @@
+import { SparklesIcon } from '@heroicons/react/24/outline';
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+import {
+  AnalyticsEvent,
+  RecommendProgramError,
+  trackEvent,
+  useRecommendProgram,
+} from '~/api';
+import { Button } from '~/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '~/components/ui/dialog';
+import { useEntitlement } from '~/contexts';
+import { ExampleProgramRecommendation } from '~/examples';
+import type { Program, RecommendProgramResponse } from '~/types';
+
+const PREVIEW = new ExampleProgramRecommendation();
+
+interface RecommendProgramSectionProps {
+  /** The full program list, for resolving the recommended id to a card. */
+  programs: Program[];
+  /** True when every parallel slot is taken — degrades "start now" to queue. */
+  slotsFull: boolean;
+  /** Start the program now (claims a slot; the page owns replace routing). */
+  onEnrollNow: (programId: string) => void;
+  /** Queue the program to start when a slot frees up. */
+  onQueue: (programId: string) => void;
+  /** Authenticated user id, for analytics (fire-and-forget). */
+  userId?: string;
+}
+
+/**
+ * "Recommend a program" entry point. Premium users get an AI pick from the
+ * shared catalog — one program, plus whether to run it alongside the current
+ * stack or queue it. Free users see a preview with an upgrade CTA — the
+ * function is never called for them.
+ */
+export const RecommendProgramSection = ({
+  programs,
+  slotsFull,
+  onEnrollNow,
+  onQueue,
+  userId,
+}: RecommendProgramSectionProps) => {
+  const { effectiveAccess, isLoading: entitlementLoading } = useEntitlement();
+  const isPremium = !entitlementLoading && effectiveAccess === 'premium';
+
+  const mutation = useRecommendProgram();
+  const [result, setResult] = useState<RecommendProgramResponse | null>(null);
+  const [previewOpen, setPreviewOpen] = useState(false);
+
+  const track = (event: AnalyticsEvent, properties = {}) => {
+    if (userId) void trackEvent({ event, userId, properties });
+  };
+
+  const fetchRecommendation = () => {
+    track(AnalyticsEvent.ProgramRecommendationRequested);
+    mutation.mutate(undefined, {
+      onSuccess: (data) => setResult(data),
+      onError: (err) => {
+        // A stale free-tier client could still get gated server-side; fall back
+        // to the preview rather than showing a raw error.
+        if (
+          err instanceof RecommendProgramError &&
+          err.code === 'premium_required'
+        ) {
+          setResult(null);
+          setPreviewOpen(true);
+        }
+      },
+    });
+  };
+
+  const handleRecommend = () => {
+    if (!isPremium) {
+      track(AnalyticsEvent.RecommendationPreviewShown, {
+        surface: 'programs',
+      });
+      setPreviewOpen(true);
+      return;
+    }
+    fetchRecommendation();
+  };
+
+  const recommendation = result?.recommendation ?? null;
+  const recommendedProgram = recommendation
+    ? (programs.find((p) => p.id === recommendation.program_id) ?? null)
+    : null;
+
+  // The server decided the mode against a snapshot; if every slot has since
+  // filled up, starting now is no longer possible, so fall back to queueing.
+  const effectiveMode =
+    recommendation?.mode === 'concurrent' && slotsFull
+      ? 'queue'
+      : recommendation?.mode;
+
+  const handleAccept = () => {
+    if (!recommendation) return;
+    track(AnalyticsEvent.ProgramRecommendationAccepted, {
+      program_id: recommendation.program_id,
+      mode: effectiveMode ?? recommendation.mode,
+    });
+    if (effectiveMode === 'queue') onQueue(recommendation.program_id);
+    else onEnrollNow(recommendation.program_id);
+    setResult(null);
+    mutation.reset();
+  };
+
+  const handleDismiss = () => {
+    if (recommendation) {
+      track(AnalyticsEvent.ProgramRecommendationDismissed, {
+        program_id: recommendation.program_id,
+      });
+    }
+    setResult(null);
+    mutation.reset();
+  };
+
+  const errorMessage = (() => {
+    if (!mutation.isError) return null;
+    const err = mutation.error;
+    if (err instanceof RecommendProgramError) {
+      if (err.code === 'premium_required') return null; // shown via preview
+      if (err.code === 'no_candidates') {
+        return "You're already running or have queued every program we'd suggest.";
+      }
+      if (err.code === 'recommendation_failed') {
+        return "Couldn't pick a program right now — try again.";
+      }
+    }
+    return 'Something went wrong — try again.';
+  })();
+
+  return (
+    <section aria-label="AI program recommendation" className="flex flex-col gap-1">
+      <h2 className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+        Recommended for you
+      </h2>
+
+      {recommendation ? (
+        <div className="flex flex-col gap-2 rounded-lg border p-2">
+          <div className="flex items-baseline justify-between gap-1">
+            <h3 className="text-sm font-semibold">
+              {recommendedProgram?.title ?? 'Recommended program'}
+            </h3>
+            <span className="shrink-0 text-xs text-muted-foreground">
+              {effectiveMode === 'queue'
+                ? 'Queue for later'
+                : 'Start alongside'}
+            </span>
+          </div>
+          <p className="text-sm text-muted-foreground">
+            {recommendation.rationale}
+          </p>
+          <div className="flex gap-1">
+            <Button className="flex-1" onClick={handleAccept}>
+              {effectiveMode === 'queue' ? 'Add to queue' : 'Start now'}
+            </Button>
+            <Button
+              className="flex-1"
+              variant="outline"
+              loading={mutation.isPending}
+              onClick={fetchRecommendation}
+            >
+              Try another
+            </Button>
+            <Button variant="ghost" onClick={handleDismiss}>
+              Dismiss
+            </Button>
+          </div>
+        </div>
+      ) : (
+        <Button
+          className="w-full"
+          variant="secondary"
+          loading={mutation.isPending}
+          onClick={handleRecommend}
+        >
+          <SparklesIcon className="mr-1 h-2.5 w-2.5" />
+          Recommend a program
+        </Button>
+      )}
+
+      {errorMessage && (
+        <p className="text-center text-xs text-destructive">{errorMessage}</p>
+      )}
+
+      <ProgramRecommendationPreviewDialog
+        open={previewOpen}
+        onOpenChange={setPreviewOpen}
+      />
+    </section>
+  );
+};
+
+/**
+ * Shown to free users who tap "Recommend a program": a real-looking example of
+ * what a recommendation delivers, plus an upgrade CTA.
+ */
+const ProgramRecommendationPreviewDialog = ({
+  open,
+  onOpenChange,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}) => {
+  const navigate = useNavigate();
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>AI program recommendations</DialogTitle>
+          <DialogDescription>
+            Premium reads your training history, movement-pattern balance, and
+            current programs, then picks your next program — like this:
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="flex flex-col gap-1 rounded-lg border p-2">
+          <div className="flex items-baseline justify-between gap-1">
+            <h3 className="text-sm font-semibold">Easy Strength</h3>
+            <span className="shrink-0 text-xs text-muted-foreground">
+              Queue for later
+            </span>
+          </div>
+          <p className="text-sm text-muted-foreground">{PREVIEW.rationale}</p>
+        </div>
+
+        <DialogFooter>
+          <Button className="w-full" onClick={() => navigate('/paywall')}>
+            See what&apos;s included
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/src/pages/ProgramsPage/components/index.ts
+++ b/src/pages/ProgramsPage/components/index.ts
@@ -6,5 +6,6 @@ export * from './CreateProgramForm';
 export * from './MyProgramCard';
 export * from './ProgramCardMenu';
 export * from './QueueTimeline';
+export * from './RecommendProgramSection';
 export * from './ReplaceProgramDialog';
 export * from './ResumeProgramDialog';

--- a/src/types/recommendation.interface.ts
+++ b/src/types/recommendation.interface.ts
@@ -33,3 +33,20 @@ export interface RecommendSessionResponse {
   id: string;
   recommendation: Recommendation;
 }
+
+/** Whether the recommended program starts now or waits for a free slot. */
+export type ProgramRecommendationMode = 'concurrent' | 'queue';
+
+/** Validated output of the `recommend-program` Edge Function. */
+export interface ProgramRecommendation {
+  program_id: string;
+  mode: ProgramRecommendationMode;
+  rationale: string;
+  confidence: RecommendationConfidence;
+}
+
+/** Success payload from `recommend-program`. */
+export interface RecommendProgramResponse {
+  id: string;
+  recommendation: ProgramRecommendation;
+}

--- a/supabase/functions/recommend-program/deno.json
+++ b/supabase/functions/recommend-program/deno.json
@@ -1,0 +1,5 @@
+{
+  "imports": {
+    "@supabase/supabase-js": "https://esm.sh/@supabase/supabase-js@2.45.0"
+  }
+}

--- a/supabase/functions/recommend-program/index.ts
+++ b/supabase/functions/recommend-program/index.ts
@@ -1,0 +1,111 @@
+// recommend-program
+//
+// Authenticated, premium-gated endpoint that recommends ONE shared program —
+// and whether to start it now alongside the current stack ("concurrent") or
+// queue it for when a current program finishes ("queue"). The user is derived
+// from the JWT (never trusted from the body). Mirrors recommend-session's
+// auth + service-role pattern. The service role is the SOLE writer of
+// program_recommendations; every attempt (success or error) is logged there
+// for analytics + prompt iteration.
+
+import { createClient } from '@supabase/supabase-js';
+
+import { corsHeaders, handleCors } from '../_shared/cors.ts';
+import { gatherInputs } from './inputs.ts';
+import { generateRecommendation, LLMError } from './llm.ts';
+import { ValidationError } from './validate.ts';
+
+function json(body: unknown, status: number): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+  });
+}
+
+Deno.serve(async (req: Request) => {
+  const preflight = handleCors(req);
+  if (preflight) return preflight;
+
+  if (req.method !== 'POST') return json({ error: 'Method not allowed' }, 405);
+
+  try {
+    const authHeader = req.headers.get('Authorization');
+    if (!authHeader) return json({ error: 'Missing authorization' }, 401);
+
+    // (1) Identity: anon client bound to the caller's JWT. Also used for the
+    // SECURITY INVOKER pattern_debt_window RPC, which scopes on auth.uid().
+    const authClient = createClient(
+      Deno.env.get('SUPABASE_URL') ?? '',
+      Deno.env.get('SUPABASE_ANON_KEY') ?? '',
+      { global: { headers: { Authorization: authHeader } } },
+    );
+    const {
+      data: { user },
+      error: userErr,
+    } = await authClient.auth.getUser();
+    if (userErr || !user) return json({ error: 'Unauthorized' }, 401);
+
+    // (2) Service-role client: premium check + RLS-bypassing reads/writes.
+    const admin = createClient(
+      Deno.env.get('SUPABASE_URL') ?? '',
+      Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') ?? '',
+    );
+
+    // (3) Gate on the single source of truth for entitlement. Free users get a
+    // paywall trigger, not a recommendation.
+    const { data: hasPremium, error: gateErr } = await admin.rpc(
+      'has_premium_access',
+      { user_id: user.id },
+    );
+    if (gateErr) throw gateErr;
+    if (!hasPremium) {
+      return json({ error: 'premium_required', paywall_trigger: true }, 401);
+    }
+
+    // (4) Assemble inputs.
+    const inputs = await gatherInputs(admin, authClient, user.id);
+
+    if (inputs.candidates.length === 0) {
+      // The user is already running or has queued every released shared
+      // program — a user-state issue, not an LLM error, so it is not logged as
+      // a generation attempt.
+      return json({ error: 'no_candidates' }, 422);
+    }
+
+    // (5) Generate (with one internal corrective retry), validate, persist.
+    try {
+      const recommendation = await generateRecommendation(inputs);
+
+      const { data: row, error: insErr } = await admin
+        .from('program_recommendations')
+        .insert({
+          user_id: user.id,
+          inputs,
+          output: recommendation,
+          status: 'generated',
+          program_id: recommendation.program_id,
+        })
+        .select('id')
+        .single();
+      if (insErr) throw insErr;
+
+      return json({ id: row.id, recommendation }, 200);
+    } catch (genErr) {
+      if (genErr instanceof LLMError || genErr instanceof ValidationError) {
+        // Log the failed attempt for prompt iteration, then surface a 502.
+        await admin.from('program_recommendations').insert({
+          user_id: user.id,
+          inputs,
+          status: 'error',
+          error: genErr.message,
+        });
+        console.error('recommend-program generation error:', genErr);
+        return json({ error: 'recommendation_failed' }, 502);
+      }
+      throw genErr;
+    }
+  } catch (err) {
+    console.error('recommend-program error:', err);
+    return json({ error: 'Internal error' }, 500);
+  }
+});

--- a/supabase/functions/recommend-program/inputs.ts
+++ b/supabase/functions/recommend-program/inputs.ts
@@ -1,0 +1,245 @@
+// recommend-program: assemble the standalone RecommenderInputs.
+//
+// The service-role client (bypasses RLS) handles the user-scoped reads; the
+// caller's JWT-bound client is needed only for `pattern_debt_window`, which is
+// SECURITY INVOKER and filters on auth.uid() internally.
+
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+import {
+  assessStackFit,
+  computePatternBalance,
+  type PatternAggregate,
+  type ProgramSystemicDemand,
+  type StackProgram,
+} from './scoring.ts';
+import type {
+  ActiveProgramSummary,
+  CandidateProgram,
+  QueuedProgramSummary,
+  RecommenderInputs,
+  WorkoutSummary,
+} from './types.ts';
+
+const HISTORY_LIMIT = 10;
+
+export const MAX_ACTIVE_PROGRAMS = 3;
+
+interface ProgramRow {
+  id: string;
+  source_program_id: string | null;
+  title: string;
+  description: string | null;
+  focus_tags: string[] | null;
+  systemic_demand: ProgramSystemicDemand | null;
+}
+
+const toStackProgram = (p: ProgramRow): StackProgram => ({
+  title: p.title,
+  focusTags: p.focus_tags ?? [],
+  systemicDemand: p.systemic_demand,
+});
+
+export async function gatherInputs(
+  admin: SupabaseClient,
+  userClient: SupabaseClient,
+  userId: string,
+): Promise<RecommenderInputs> {
+  // Live enrollments: what's running plus what's queued.
+  const { data: enrollments, error: enrErr } = await admin
+    .from('user_programs')
+    .select('id, program_id, status, queue_position')
+    .eq('user_id', userId)
+    .in('status', ['active', 'queued'])
+    .order('queue_position', { ascending: true, nullsFirst: true });
+  if (enrErr) throw enrErr;
+
+  const activeEnrollments = (enrollments ?? []).filter(
+    (e) => e.status === 'active',
+  );
+  const queuedEnrollments = (enrollments ?? []).filter(
+    (e) => e.status === 'queued',
+  );
+
+  const enrolledProgramIds = (enrollments ?? []).map((e) => e.program_id);
+  let enrolledPrograms: ProgramRow[] = [];
+  if (enrolledProgramIds.length > 0) {
+    const { data, error } = await admin
+      .from('programs')
+      .select('id, source_program_id, title, description, focus_tags, systemic_demand')
+      .in('id', enrolledProgramIds);
+    if (error) throw error;
+    enrolledPrograms = (data ?? []) as ProgramRow[];
+  }
+  const programById = new Map(enrolledPrograms.map((p) => [p.id, p]));
+
+  // Candidates: the released shared catalog, minus anything already running or
+  // queued. Enrollment clones a shared program (source_program_id back-pointer),
+  // so exclusion goes through both the clone's source and its own id.
+  const takenSharedIds = new Set(
+    enrolledPrograms.flatMap((p) =>
+      p.source_program_id ? [p.source_program_id, p.id] : [p.id],
+    ),
+  );
+  const { data: catalog, error: catErr } = await admin
+    .from('programs')
+    .select('id, source_program_id, title, description, focus_tags, systemic_demand')
+    .eq('is_public', true)
+    .not('released_at', 'is', null);
+  if (catErr) throw catErr;
+
+  const activeStack = activeEnrollments
+    .map((e) => programById.get(e.program_id))
+    .filter((p): p is ProgramRow => !!p)
+    .map(toStackProgram);
+
+  const candidatePrograms = ((catalog ?? []) as ProgramRow[]).filter(
+    (p) => !takenSharedIds.has(p.id),
+  );
+
+  // Session counts for progress and candidate length, in one query.
+  const countProgramIds = [
+    ...candidatePrograms.map((p) => p.id),
+    ...activeEnrollments.map((e) => e.program_id),
+  ];
+  const sessionCounts = new Map<string, number>();
+  if (countProgramIds.length > 0) {
+    const { data: sessionRows, error: sesErr } = await admin
+      .from('program_sessions')
+      .select('program_id')
+      .in('program_id', countProgramIds);
+    if (sesErr) throw sesErr;
+    for (const row of sessionRows ?? []) {
+      sessionCounts.set(
+        row.program_id,
+        (sessionCounts.get(row.program_id) ?? 0) + 1,
+      );
+    }
+  }
+
+  // Completions per active enrollment, for progress + last-worked.
+  const completionsByEnrollment = new Map<
+    string,
+    { count: number; lastAt: string | null }
+  >();
+  if (activeEnrollments.length > 0) {
+    const { data: completions, error: compErr } = await admin
+      .from('program_session_completions')
+      .select('user_program_id, completed_at')
+      .in('user_program_id', activeEnrollments.map((e) => e.id));
+    if (compErr) throw compErr;
+    for (const row of completions ?? []) {
+      const entry = completionsByEnrollment.get(row.user_program_id) ?? {
+        count: 0,
+        lastAt: null,
+      };
+      entry.count += 1;
+      if (entry.lastAt === null || row.completed_at > entry.lastAt) {
+        entry.lastAt = row.completed_at;
+      }
+      completionsByEnrollment.set(row.user_program_id, entry);
+    }
+  }
+
+  const active_programs: ActiveProgramSummary[] = activeEnrollments.flatMap(
+    (e) => {
+      const program = programById.get(e.program_id);
+      if (!program) return [];
+      const done = completionsByEnrollment.get(e.id);
+      return [
+        {
+          program_id: program.id,
+          title: program.title,
+          focus_tags: program.focus_tags ?? [],
+          systemic_demand: program.systemic_demand,
+          progress: `${done?.count ?? 0}/${sessionCounts.get(program.id) ?? 0}`,
+          last_worked_at: done?.lastAt ?? null,
+        },
+      ];
+    },
+  );
+
+  const queued_programs: QueuedProgramSummary[] = queuedEnrollments.flatMap(
+    (e) => {
+      const program = programById.get(e.program_id);
+      return program
+        ? [{ program_id: program.id, title: program.title }]
+        : [];
+    },
+  );
+
+  const candidates: CandidateProgram[] = candidatePrograms.map((p) => ({
+    program_id: p.id,
+    title: p.title,
+    description: p.description,
+    focus_tags: p.focus_tags ?? [],
+    systemic_demand: p.systemic_demand,
+    session_count: sessionCounts.get(p.id) ?? 0,
+    stack_fit: assessStackFit(toStackProgram(p), activeStack),
+  }));
+
+  // Pattern debt: SECURITY INVOKER RPC, so it must run as the caller.
+  const { data: debtRows, error: debtErr } = await userClient.rpc(
+    'pattern_debt_window',
+  );
+  if (debtErr) throw debtErr;
+  const pattern_debt = computePatternBalance(
+    (debtRows ?? []) as PatternAggregate[],
+  );
+
+  // Recent workout history + persistent training goal.
+  const { data: logs, error: logErr } = await admin
+    .from('workout_logs')
+    .select('id, completed_at, workout_goal, workout_goal_units, rpe')
+    .eq('user_id', userId)
+    .order('completed_at', { ascending: false })
+    .limit(HISTORY_LIMIT);
+  if (logErr) throw logErr;
+
+  const logIds = (logs ?? []).map((l) => l.id);
+  const movementsByLog = new Map<number, string[]>();
+  if (logIds.length > 0) {
+    const { data: moves, error: mvErr } = await admin
+      .from('movement_logs')
+      .select('workout_log_id, movement_name')
+      .in('workout_log_id', logIds);
+    if (mvErr) throw mvErr;
+    for (const m of moves ?? []) {
+      const list = movementsByLog.get(m.workout_log_id) ?? [];
+      list.push(m.movement_name);
+      movementsByLog.set(m.workout_log_id, list);
+    }
+  }
+
+  const recent_history: WorkoutSummary[] = (logs ?? []).map((l) => ({
+    completed_at: l.completed_at,
+    goal: `${l.workout_goal} ${l.workout_goal_units}`,
+    rpe: l.rpe ?? null,
+    movements: movementsByLog.get(l.id) ?? [],
+  }));
+
+  const days_since_last_workout =
+    logs && logs.length > 0
+      ? Math.floor(
+          (Date.now() - new Date(logs[0].completed_at).getTime()) / 86_400_000,
+        )
+      : null;
+
+  const { data: profile, error: profErr } = await admin
+    .from('profiles')
+    .select('training_goal')
+    .eq('id', userId)
+    .single();
+  if (profErr) throw profErr;
+
+  return {
+    training_goal: profile?.training_goal ?? null,
+    days_since_last_workout,
+    slots_available: MAX_ACTIVE_PROGRAMS - activeEnrollments.length,
+    active_programs,
+    queued_programs,
+    candidates,
+    pattern_debt,
+    recent_history,
+  };
+}

--- a/supabase/functions/recommend-program/llm.ts
+++ b/supabase/functions/recommend-program/llm.ts
@@ -1,0 +1,132 @@
+// recommend-program: the LLM provider boundary.
+//
+// This is the ONLY module that talks to a specific LLM provider — same
+// contract as recommend-session/llm.ts. Raw fetch to the Anthropic Messages
+// API rather than @anthropic-ai/sdk: the SDK's esm.sh type graph fails to
+// bootstrap in the Supabase edge runtime, and a single structured-outputs call
+// needs no SDK surface.
+
+import {
+  buildCorrectionPrompt,
+  buildSystemPrompt,
+  buildUserPrompt,
+} from './prompt.ts';
+import type { ProgramRecommendation, RecommenderInputs } from './types.ts';
+import { RECOMMENDATION_SCHEMA } from './types.ts';
+import { ValidationError, validateRecommendation } from './validate.ts';
+
+const API_URL = 'https://api.anthropic.com/v1/messages';
+const ANTHROPIC_VERSION = '2023-06-01';
+const MODEL = 'claude-sonnet-4-6';
+const MAX_TOKENS = 1024;
+
+/** Transport/parse-level failure (API down, bad JSON) — distinct from ValidationError. */
+export class LLMError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'LLMError';
+  }
+}
+
+interface Message {
+  role: 'user' | 'assistant';
+  content: string;
+}
+
+interface AnthropicResponse {
+  content?: Array<{ type: string; text?: string }>;
+}
+
+/**
+ * Generate a validated recommendation. Calls the model, validates the output,
+ * and retries once with a correction if validation fails. Throws LLMError on a
+ * transport/parse failure and ValidationError if the retry also fails.
+ */
+export async function generateRecommendation(
+  inputs: RecommenderInputs,
+): Promise<ProgramRecommendation> {
+  const apiKey = Deno.env.get('ANTHROPIC_API_KEY');
+  if (!apiKey) throw new LLMError('ANTHROPIC_API_KEY is not configured');
+
+  const system = buildSystemPrompt();
+  const messages: Message[] = [
+    { role: 'user', content: buildUserPrompt(inputs) },
+  ];
+
+  // First attempt, then one corrective retry on validation failure.
+  for (let attempt = 0; attempt < 2; attempt++) {
+    const rec = await callModel(apiKey, system, messages);
+    try {
+      validateRecommendation(rec, inputs);
+      return rec;
+    } catch (err) {
+      if (!(err instanceof ValidationError) || attempt === 1) throw err;
+      // Feed the failure back and let the model fix it.
+      messages.push({ role: 'assistant', content: JSON.stringify(rec) });
+      messages.push({
+        role: 'user',
+        content: buildCorrectionPrompt(err.reasons),
+      });
+    }
+  }
+
+  // Unreachable: the loop either returns or throws.
+  throw new LLMError('recommendation generation exhausted retries');
+}
+
+async function callModel(
+  apiKey: string,
+  system: string,
+  messages: Message[],
+): Promise<ProgramRecommendation> {
+  let res: Response;
+  try {
+    res = await fetch(API_URL, {
+      method: 'POST',
+      headers: {
+        'x-api-key': apiKey,
+        'anthropic-version': ANTHROPIC_VERSION,
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        model: MODEL,
+        max_tokens: MAX_TOKENS,
+        thinking: { type: 'disabled' },
+        output_config: {
+          effort: 'low',
+          format: { type: 'json_schema', schema: RECOMMENDATION_SCHEMA },
+        },
+        system,
+        messages,
+      }),
+    });
+  } catch (err) {
+    throw new LLMError(
+      `Anthropic request failed: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+
+  if (!res.ok) {
+    const detail = await res.text().catch(() => '');
+    throw new LLMError(`Anthropic API ${res.status}: ${detail.slice(0, 300)}`);
+  }
+
+  let payload: AnthropicResponse;
+  try {
+    payload = (await res.json()) as AnthropicResponse;
+  } catch {
+    throw new LLMError('Anthropic returned a non-JSON response');
+  }
+
+  const text = (payload.content ?? [])
+    .map((block) => (block.type === 'text' ? (block.text ?? '') : ''))
+    .join('')
+    .trim();
+  if (!text) throw new LLMError('model returned no text content');
+
+  try {
+    return JSON.parse(text) as ProgramRecommendation;
+  } catch {
+    throw new LLMError('model returned invalid JSON');
+  }
+}

--- a/supabase/functions/recommend-program/prompt.ts
+++ b/supabase/functions/recommend-program/prompt.ts
@@ -1,0 +1,103 @@
+// recommend-program: prompt construction.
+//
+// Kept separate from transport (llm.ts) so prompt quality can be iterated
+// without touching the API plumbing.
+
+import type { RecommenderInputs } from './types.ts';
+
+export function buildSystemPrompt(): string {
+  return [
+    'You are an expert kettlebell programming coach. You are choosing exactly',
+    'ONE training program from a candidate catalog for a lifter, and deciding',
+    'whether they should start it now alongside their current programs',
+    '(mode "concurrent") or queue it to begin when a current program finishes',
+    '(mode "queue").',
+    '',
+    'Rules:',
+    '- Choose ONLY from the candidate list, using its exact program_id. Never',
+    '  invent an id, and never pick a program that is already active or queued.',
+    '- Prefer candidates whose focus tags pay down the undertrained movement',
+    '  patterns named in the pattern-debt balance.',
+    '- Respect the precomputed stack-fit verdicts: mode "concurrent" is allowed',
+    '  only when slots_available > 0 AND that candidate\'s stack-fit verdict is',
+    '  not "conflict". Otherwise use mode "queue".',
+    '- If the lifter has no active programs, use mode "concurrent".',
+    '- Give a short, concrete rationale (2-4 sentences) a thoughtful coach would',
+    '  give — tie it to their goal, pattern balance, and current programs, and',
+    '  explain why now vs queued. Avoid generic filler.',
+  ].join('\n');
+}
+
+export function buildUserPrompt(inputs: RecommenderInputs): string {
+  const activeLines = inputs.active_programs.length
+    ? inputs.active_programs
+        .map(
+          (p) =>
+            `- ${p.title} · ${p.progress} sessions done · demand ${p.systemic_demand ?? 'unrated'} · focus ${p.focus_tags.join(', ') || '(none)'}${p.last_worked_at ? ` · last worked ${p.last_worked_at.slice(0, 10)}` : ''}`,
+        )
+        .join('\n')
+    : '- (no active programs)';
+
+  const queuedLines = inputs.queued_programs.length
+    ? inputs.queued_programs.map((p) => `- ${p.title}`).join('\n')
+    : '- (queue is empty)';
+
+  const debtLines = inputs.pattern_debt.patterns
+    .map(
+      (p) =>
+        `- ${p.pattern}: debt ${p.debt_score} (${p.band})${p.days_since_last_trained !== null ? `, last trained ${p.days_since_last_trained}d ago` : ', not trained recently'}`,
+    )
+    .join('\n');
+
+  const candidateLines = inputs.candidates
+    .map((c) => {
+      const fit = c.stack_fit
+        ? `stack fit ${c.stack_fit.verdict}${c.stack_fit.reasons.length ? ` (${c.stack_fit.reasons.join(' ')})` : ''}`
+        : 'stack fit n/a';
+      return `- ${c.title} [program_id: ${c.program_id}] · ${c.session_count} sessions · demand ${c.systemic_demand ?? 'unrated'} · focus ${c.focus_tags.join(', ') || '(none)'} · ${fit}${c.description ? `\n  ${c.description}` : ''}`;
+    })
+    .join('\n');
+
+  const historyLines = inputs.recent_history.length
+    ? inputs.recent_history
+        .map(
+          (w) =>
+            `- ${w.completed_at.slice(0, 10)} · goal ${w.goal}${w.rpe ? ` · RPE ${w.rpe}` : ''} · ${w.movements.join(', ') || '(no movements logged)'}`,
+        )
+        .join('\n')
+    : '- (no recent workouts logged)';
+
+  return [
+    `Training goal: ${inputs.training_goal ?? '(none provided)'}`,
+    `Days since last workout: ${inputs.days_since_last_workout ?? '(unknown)'}`,
+    `Open program slots: ${inputs.slots_available} of 3`,
+    '',
+    'Active programs:',
+    activeLines,
+    '',
+    'Queued programs (already chosen, do not re-pick):',
+    queuedLines,
+    '',
+    `Movement-pattern balance (overall: ${inputs.pattern_debt.overall_balance}; higher debt = more undertrained):`,
+    debtLines,
+    '',
+    'Recent workouts (most recent first):',
+    historyLines,
+    '',
+    'Candidate programs (choose exactly one, by program_id):',
+    candidateLines,
+    '',
+    'Recommend one program now, with mode "concurrent" or "queue".',
+  ].join('\n');
+}
+
+/** Appended on a retry when the first attempt failed validation. */
+export function buildCorrectionPrompt(reasons: string[]): string {
+  return [
+    'Your previous response was rejected for these reasons:',
+    ...reasons.map((r) => `- ${r}`),
+    '',
+    'Produce a corrected recommendation that uses a program_id from the',
+    'candidate list and a mode allowed by the rules.',
+  ].join('\n');
+}

--- a/supabase/functions/recommend-program/scoring.ts
+++ b/supabase/functions/recommend-program/scoring.ts
@@ -1,0 +1,230 @@
+// recommend-program: deterministic scoring copied from the app.
+//
+// SOURCE OF TRUTH: `src/utils/patternDebt.ts` and `src/utils/stackFit.ts`.
+// Those modules import `~/types`, which the Deno edge runtime cannot resolve,
+// so the pure functions this recommender needs are copied here verbatim (with
+// minimal local types). Keep the constants and formulas in sync with the
+// source modules and docs/pattern-debt-scoring-model.md.
+
+// ---------------------------------------------------------------------------
+// Pattern debt (src/utils/patternDebt.ts)
+// ---------------------------------------------------------------------------
+
+export const PATTERNS = [
+  'hinge',
+  'squat',
+  'push',
+  'pull',
+  'carry',
+  'rotation',
+  'get_up',
+] as const;
+
+export type Pattern = (typeof PATTERNS)[number];
+
+export type DebtBand = 'green' | 'yellow' | 'red';
+
+export type OverallBalance = 'balanced' | `${Pattern}-heavy`;
+
+/** One row as returned by the `pattern_debt_window` RPC. */
+export interface PatternAggregate {
+  pattern: Pattern;
+  last_trained_at: string | null;
+  set_count: number;
+  total_reps: number;
+  total_volume_kg: number;
+  baseline_volume_kg: number | null;
+}
+
+export interface PatternDebtScore {
+  pattern: Pattern;
+  days_since_last_trained: number | null;
+  debt_score: number;
+  band: DebtBand;
+}
+
+export interface PatternBalanceSummary {
+  patterns: PatternDebtScore[];
+  overall_balance: OverallBalance;
+}
+
+const TARGET_OVERDUE_DAYS = 14;
+const W_RECENCY = 0.6;
+const W_VOLUME = 0.4;
+const BAND_YELLOW = 33;
+const BAND_RED = 66;
+const BALANCE_SPREAD = 25;
+
+const clamp01 = (n: number) => Math.min(1, Math.max(0, n));
+
+const classifyBand = (debtScore: number): DebtBand => {
+  if (debtScore >= BAND_RED) return 'red';
+  if (debtScore >= BAND_YELLOW) return 'yellow';
+  return 'green';
+};
+
+const recencyComponent = (daysSince: number | null): number => {
+  if (daysSince === null) return 1;
+  return clamp01(daysSince / TARGET_OVERDUE_DAYS);
+};
+
+const volumeDeficitComponent = (
+  recentVolume: number,
+  baselineVolume: number | null,
+): number => {
+  if (baselineVolume === null || baselineVolume <= 0) {
+    return recentVolume > 0 ? 0 : 1;
+  }
+  return clamp01(1 - recentVolume / baselineVolume);
+};
+
+const computeDebtScore = (
+  daysSince: number | null,
+  recentVolume: number,
+  baselineVolume: number | null,
+): number =>
+  Math.round(
+    100 *
+      (W_RECENCY * recencyComponent(daysSince) +
+        W_VOLUME * volumeDeficitComponent(recentVolume, baselineVolume)),
+  );
+
+/**
+ * Score the seven raw aggregate rows into the compact balance summary the
+ * prompt consumes. Missing patterns are backfilled as fully idle (max debt).
+ */
+export function computePatternBalance(
+  aggregates: PatternAggregate[],
+  now: Date = new Date(),
+): PatternBalanceSummary {
+  const byPattern = new Map(aggregates.map((a) => [a.pattern, a]));
+
+  const patterns = PATTERNS.map((pattern): PatternDebtScore => {
+    const agg = byPattern.get(pattern) ?? {
+      pattern,
+      last_trained_at: null,
+      set_count: 0,
+      total_reps: 0,
+      total_volume_kg: 0,
+      baseline_volume_kg: null,
+    };
+    const daysSince = agg.last_trained_at
+      ? Math.max(
+          0,
+          (now.getTime() - new Date(agg.last_trained_at).getTime()) /
+            86_400_000,
+        )
+      : null;
+    const debtScore = computeDebtScore(
+      daysSince,
+      agg.total_volume_kg,
+      agg.baseline_volume_kg,
+    );
+    return {
+      pattern,
+      days_since_last_trained:
+        daysSince === null ? null : Math.round(daysSince),
+      debt_score: debtScore,
+      band: classifyBand(debtScore),
+    };
+  });
+
+  const scores = patterns.map((p) => p.debt_score);
+  const spread = Math.max(...scores) - Math.min(...scores);
+  const dominant = patterns.reduce((a, b) =>
+    b.debt_score < a.debt_score ? b : a,
+  );
+  const overall_balance: OverallBalance =
+    spread < BALANCE_SPREAD ? 'balanced' : `${dominant.pattern}-heavy`;
+
+  return { patterns, overall_balance };
+}
+
+// ---------------------------------------------------------------------------
+// Stack fit (src/utils/stackFit.ts)
+// ---------------------------------------------------------------------------
+
+export type ProgramSystemicDemand = 'low' | 'moderate' | 'high';
+
+export type StackVerdict = 'good' | 'caution' | 'conflict';
+
+/** The slice of a program the stack-fit model reads. */
+export interface StackProgram {
+  title: string;
+  focusTags: string[];
+  systemicDemand: ProgramSystemicDemand | null;
+}
+
+export interface StackFit {
+  verdict: StackVerdict;
+  load: number;
+  reasons: string[];
+}
+
+const DEMAND_COST: Record<ProgramSystemicDemand, number> = {
+  low: 1,
+  moderate: 2,
+  high: 3,
+};
+
+const STACK_BUDGET = 5;
+const CAUTION_LOAD = 4;
+const REDUNDANT_TAG_OVERLAP = 2;
+
+const demandCost = (program: StackProgram): number =>
+  program.systemicDemand ? DEMAND_COST[program.systemicDemand] : 0;
+
+const sharedTags = (a: StackProgram, b: StackProgram): string[] =>
+  a.focusTags.filter((tag) => b.focusTags.includes(tag));
+
+const listNames = (names: string[]): string => {
+  if (names.length <= 1) return names[0] ?? '';
+  if (names.length === 2) return `${names[0]} and ${names[1]}`;
+  return `${names.slice(0, -1).join(', ')}, and ${names[names.length - 1]}`;
+};
+
+/**
+ * Assess adding `candidate` on top of the programs already running. Returns
+ * `null` when there is nothing to say (no active programs, or an unrated
+ * candidate).
+ */
+export function assessStackFit(
+  candidate: StackProgram,
+  active: StackProgram[],
+): StackFit | null {
+  if (active.length === 0) return null;
+  if (!candidate.systemicDemand && candidate.focusTags.length === 0)
+    return null;
+
+  const load =
+    demandCost(candidate) + active.reduce((sum, p) => sum + demandCost(p), 0);
+  const reasons: string[] = [];
+
+  const fullyRated =
+    !!candidate.systemicDemand && active.every((p) => !!p.systemicDemand);
+  const overBudget = fullyRated && load > STACK_BUDGET;
+
+  if (overBudget) {
+    reasons.push(
+      `This is more hard training than most people recover from at once. ${candidate.title} is ${candidate.systemicDemand} demand on top of ${listNames(active.map((p) => p.title))}.`,
+    );
+  } else if (fullyRated && load >= CAUTION_LOAD) {
+    reasons.push(
+      `This fills your recovery budget. It works if the rest of your week is easy, but there's no room left for a third.`,
+    );
+  }
+
+  const redundant = active.filter(
+    (p) => sharedTags(candidate, p).length >= REDUNDANT_TAG_OVERLAP,
+  );
+  if (redundant.length > 0) {
+    const overlap = sharedTags(candidate, redundant[0]);
+    reasons.push(
+      `${listNames(redundant.map((p) => p.title))} already covers ${listNames(overlap)}. You'd be training the same qualities twice.`,
+    );
+  }
+
+  if (overBudget) return { verdict: 'conflict', load, reasons };
+  if (reasons.length > 0) return { verdict: 'caution', load, reasons };
+  return { verdict: 'good', load, reasons };
+}

--- a/supabase/functions/recommend-program/types.ts
+++ b/supabase/functions/recommend-program/types.ts
@@ -1,0 +1,78 @@
+// recommend-program: shared types + the structured-output JSON schema.
+//
+// RecommenderInputs is the typed snapshot fed to the LLM and persisted verbatim
+// into program_recommendations.inputs.
+
+import type { PatternBalanceSummary, StackFit } from './scoring.ts';
+
+/** One program the user is currently running. */
+export interface ActiveProgramSummary {
+  program_id: string;
+  title: string;
+  focus_tags: string[];
+  systemic_demand: string | null;
+  /** Sessions satisfied / total, e.g. "4/12". */
+  progress: string;
+  last_worked_at: string | null;
+}
+
+/** One program waiting in the queue. */
+export interface QueuedProgramSummary {
+  program_id: string;
+  title: string;
+}
+
+/** One shared-catalog program the LLM may recommend. */
+export interface CandidateProgram {
+  program_id: string;
+  title: string;
+  description: string | null;
+  focus_tags: string[];
+  systemic_demand: string | null;
+  session_count: number;
+  /** Precomputed vs the active stack; null when there is nothing to assess. */
+  stack_fit: StackFit | null;
+}
+
+/** A compact summary of one past workout, for history context. */
+export interface WorkoutSummary {
+  completed_at: string;
+  goal: string;
+  rpe: string | null;
+  movements: string[];
+}
+
+/** Everything the recommender reasons over. Snapshotted into inputs JSONB. */
+export interface RecommenderInputs {
+  training_goal: string | null;
+  days_since_last_workout: number | null;
+  slots_available: number;
+  active_programs: ActiveProgramSummary[];
+  queued_programs: QueuedProgramSummary[];
+  candidates: CandidateProgram[];
+  pattern_debt: PatternBalanceSummary;
+  recent_history: WorkoutSummary[];
+}
+
+/** The validated LLM output. Persisted into program_recommendations.output. */
+export interface ProgramRecommendation {
+  program_id: string;
+  mode: 'concurrent' | 'queue';
+  rationale: string;
+  confidence: 'high' | 'medium' | 'low';
+}
+
+// JSON schema for Anthropic structured outputs (output_config.format).
+// Structured outputs require additionalProperties:false with every property
+// required — id/mode feasibility is enforced separately in validate.ts.
+export const RECOMMENDATION_SCHEMA = {
+  type: 'object',
+  additionalProperties: false,
+  properties: {
+    program_id: { type: 'string' },
+    mode: { type: 'string', enum: ['concurrent', 'queue'] },
+    rationale: { type: 'string' },
+    confidence: { type: 'string', enum: ['high', 'medium', 'low'] },
+  },
+  required: ['program_id', 'mode', 'rationale', 'confidence'],
+} as const;

--- a/supabase/functions/recommend-program/validate.ts
+++ b/supabase/functions/recommend-program/validate.ts
@@ -1,0 +1,64 @@
+// recommend-program: validation of the LLM output.
+//
+// Structured outputs guarantee the JSON *shape*; this enforces the *semantics*
+// the schema can't express — the pick must be a real candidate and the mode
+// must be feasible given the user's slots and stack. A failure here drives the
+// single corrective retry in llm.ts.
+
+import type { ProgramRecommendation, RecommenderInputs } from './types.ts';
+
+export class ValidationError extends Error {
+  reasons: string[];
+  constructor(reasons: string[]) {
+    super(`Recommendation failed validation: ${reasons.join('; ')}`);
+    this.name = 'ValidationError';
+    this.reasons = reasons;
+  }
+}
+
+export function validateRecommendation(
+  rec: ProgramRecommendation,
+  inputs: RecommenderInputs,
+): void {
+  const reasons: string[] = [];
+
+  // Candidates already exclude active/queued programs, so this single check
+  // also rejects re-picks of anything the user is already running.
+  const candidate = inputs.candidates.find(
+    (c) => c.program_id === rec.program_id,
+  );
+  if (!candidate) {
+    reasons.push(
+      `program_id "${rec.program_id}" is not in the candidate list`,
+    );
+  }
+
+  if (rec.mode === 'concurrent') {
+    if (inputs.slots_available <= 0) {
+      reasons.push(
+        'mode "concurrent" requires an open program slot; all slots are taken — use mode "queue"',
+      );
+    }
+    if (candidate?.stack_fit?.verdict === 'conflict') {
+      reasons.push(
+        `mode "concurrent" is not allowed for ${candidate.title}: its stack-fit verdict is "conflict" — pick another candidate or use mode "queue"`,
+      );
+    }
+  }
+
+  if (
+    rec.mode === 'queue' &&
+    inputs.active_programs.length === 0 &&
+    inputs.queued_programs.length === 0
+  ) {
+    reasons.push(
+      'mode "queue" makes no sense with nothing active or queued — use mode "concurrent"',
+    );
+  }
+
+  if (rec.rationale.trim().length === 0) {
+    reasons.push('the rationale is empty');
+  }
+
+  if (reasons.length > 0) throw new ValidationError(reasons);
+}

--- a/supabase/migrations/20260804000000_create_program_recommendations_table.sql
+++ b/supabase/migrations/20260804000000_create_program_recommendations_table.sql
@@ -1,0 +1,41 @@
+-- AI Program Recommender: tracking table for the recommend-program Edge
+-- Function. Mirrors session_recommendations
+-- (20260616000000_create_session_recommendations_table.sql): the Edge Function
+-- is the SOLE writer, via the service role (which bypasses RLS); clients may
+-- only read their own rows. Every attempt (success or error) is logged for
+-- analytics and prompt iteration. A separate table from session_recommendations
+-- because the output shape (one program + enroll mode) and FK linkage
+-- (programs, not workout_logs) are disjoint.
+
+CREATE TABLE program_recommendations (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  -- Snapshot of what fed the LLM: active/queued programs, candidate catalog
+  -- with stack-fit verdicts, pattern-debt balance, recent history summary.
+  inputs JSONB NOT NULL,
+  -- Raw validated LLM output. NULL when status = 'error'.
+  output JSONB,
+  status TEXT NOT NULL DEFAULT 'generated'
+    CHECK (status IN ('generated', 'accepted', 'rejected', 'regenerated', 'error')),
+  error TEXT,
+  acted_at TIMESTAMPTZ,
+  program_id UUID REFERENCES programs(id) ON DELETE SET NULL
+);
+
+CREATE INDEX idx_program_recommendations_user_created
+  ON program_recommendations(user_id, created_at DESC);
+
+CREATE INDEX idx_program_recommendations_status
+  ON program_recommendations(status);
+
+ALTER TABLE program_recommendations ENABLE ROW LEVEL SECURITY;
+
+-- Read-own only. There is intentionally no client INSERT/UPDATE/DELETE policy:
+-- the recommend-program Edge Function writes via the service role.
+CREATE POLICY "Users can view own program_recommendations" ON program_recommendations
+  FOR SELECT USING ((SELECT auth.uid()) = user_id);
+
+REVOKE ALL ON TABLE public.program_recommendations FROM anon;
+REVOKE ALL ON TABLE public.program_recommendations FROM authenticated;
+GRANT SELECT ON TABLE public.program_recommendations TO authenticated;

--- a/types/supabase.ts
+++ b/types/supabase.ts
@@ -263,6 +263,57 @@ export type Database = {
           },
         ]
       }
+      program_recommendations: {
+        Row: {
+          acted_at: string | null
+          created_at: string
+          error: string | null
+          id: string
+          inputs: Json
+          output: Json | null
+          program_id: string | null
+          status: string
+          user_id: string
+        }
+        Insert: {
+          acted_at?: string | null
+          created_at?: string
+          error?: string | null
+          id?: string
+          inputs: Json
+          output?: Json | null
+          program_id?: string | null
+          status?: string
+          user_id: string
+        }
+        Update: {
+          acted_at?: string | null
+          created_at?: string
+          error?: string | null
+          id?: string
+          inputs?: Json
+          output?: Json | null
+          program_id?: string | null
+          status?: string
+          user_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "program_recommendations_program_id_fkey"
+            columns: ["program_id"]
+            isOneToOne: false
+            referencedRelation: "programs"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "program_recommendations_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "user_activation"
+            referencedColumns: ["user_id"]
+          },
+        ]
+      }
       program_session_completions: {
         Row: {
           completed_at: string


### PR DESCRIPTION
## Why

The premium launch needs recommendation value beyond the next-session recommender (PROD-87). Choosing the *next program* is the harder call — it depends on pattern-debt balance, what's already running, and whether the stack can absorb more — and it's exactly the decision the categorized catalog (#207) and stack-fit model set up.

## What

A premium-gated `recommend-program` Edge Function that picks ONE released shared program — reasoning over workout history, pattern debt, active/queued programs, and precomputed stack-fit verdicts — and decides whether to start it now ("concurrent") or queue it. Surfaced as a "Recommended for you" card on ProgramsPage behind the `recommender` flag, with Start now / Add to queue actions riding the existing enroll flow. This also wires pattern debt into a recommender for the first time (the PROD-75 stub in recommend-session stays untouched).

## How to test

- `npm test` (96 files / 672 tests, incl. 5 new MSW hook tests + 5 component tests), `compile:ts`, `lint` — all green.
- Served the function against local Supabase: no auth → 401; free user → 401 `premium_required` + `paywall_trigger`; premium user → inputs assembled from real seed data (9 candidates excluding the enrolled A+A clone via `source_program_id`, `slots_available: 2`, pattern debt scored, stack-fit verdicts matching the model: Easy Strength `good`/load 3, 10k Swings `caution`/load 5) and the attempt logged to `program_recommendations`. The Anthropic call itself 401s locally (placeholder key) and correctly surfaces 502 `recommendation_failed` — first real generation happens after deploy.
- Browser-verified the flag-gated card and the free-user preview dialog on ProgramsPage.

## Gallery

| Idle (premium entry point) | Free-user preview |
|---|---|
| ![idle](https://github.com/user-attachments/assets/307aec4c-72fc-4bed-b38a-a90c231bd83f) | ![preview](https://github.com/user-attachments/assets/cad48614-d023-439d-9f27-a87dd7f9428a) |

## Deploy notes

- Migration `20260804000000_create_program_recommendations_table.sql` — **new RLS** (verbatim copy of the session_recommendations pattern: read-own SELECT, service-role sole writer) needs human sign-off per repo policy. `gen:types` already committed.
- `supabase functions deploy recommend-program` (reuses the deployed `ANTHROPIC_API_KEY` secret).
- Flip the `recommender` flag to expose the card.

## Tradeoffs

- **Separate `program_recommendations` table** over a `kind` column on `session_recommendations`: the shapes and FKs are disjoint; a shared table would make both halves nullable and every consumer filter. The shared table would have saved a migration.
- **Copied pure scorers into the function** (`scoring.ts`) instead of importing `src/utils/{patternDebt,stackFit}.ts`: those modules import `~/types`, which Deno can't resolve, and the types barrel drags in frontend-only modules. Drift risk is real but it's the same trade the pattern-debt doc already accepts between SQL and TS; a header comment names the source of truth.
- **No Deno unit tests** — matches recommend-session precedent (it ships none); validate/prompt logic is exercised indirectly and the client surface is fully tested.
