### PR TITLE
feat(recommender): feed pattern-debt balance into session recommendations

### DIFF
--- a/supabase/functions/recommend-session/index.ts
+++ b/supabase/functions/recommend-session/index.ts
@@ -61,7 +61,7 @@ Deno.serve(async (req: Request) => {
 
     // (4) Assemble inputs.
     const body = await req.json().catch(() => ({}));
-    const inputs = await gatherInputs(admin, user.id, body);
+    const inputs = await gatherInputs(admin, authClient, user.id, body);
 
     if (inputs.candidates.length === 0) {
       // Nothing to recommend from — a user-state issue, not an LLM error, so it

--- a/supabase/functions/recommend-session/inputs.ts
+++ b/supabase/functions/recommend-session/inputs.ts
@@ -1,13 +1,20 @@
 // recommend-session (PROD-87): assemble the standalone RecommenderInputs.
 //
 // Uses the service-role client (bypasses RLS) but every query is scoped to the
-// authenticated user_id. pattern_debt / unlocked_weights are stubbed empty here
-// (PROD-75 / PROD-78).
+// authenticated user_id — except pattern debt, which goes through the caller's
+// JWT client because pattern_debt_window is SECURITY INVOKER and filters on
+// auth.uid(). unlocked_weights is still stubbed empty (PROD-78).
 
 import type { SupabaseClient } from '@supabase/supabase-js';
 
+import {
+  type Pattern,
+  type PatternAggregate,
+  computePatternBalance,
+} from '../../../src/utils/patternDebt.ts';
 import type {
   CandidateMovement,
+  PatternDebtInput,
   RecommenderInputs,
   WorkoutHistoryEntry,
 } from './types.ts';
@@ -25,8 +32,55 @@ function formatGoal(goal: number, units: string): string {
   return `${goal} ${units}`;
 }
 
+/**
+ * Fetch and score the caller's pattern-debt balance. Best-effort: any failure
+ * degrades to null so a recommendation is never blocked on it.
+ */
+async function gatherPatternDebt(
+  authClient: SupabaseClient,
+): Promise<PatternDebtInput | null> {
+  try {
+    const { data, error } = await authClient.rpc('pattern_debt_window');
+    if (error) throw error;
+
+    const aggregates: PatternAggregate[] = (data ?? []).map(
+      (row: Record<string, unknown>) => ({
+        pattern: row.pattern as Pattern,
+        last_trained_at: row.last_trained_at as string | null,
+        set_count: Number(row.set_count),
+        total_reps: Number(row.total_reps),
+        total_volume_kg: Number(row.total_volume_kg),
+        baseline_volume_kg:
+          row.baseline_volume_kg == null ? null : Number(row.baseline_volume_kg),
+        hardest_rpe: (row.hardest_rpe ?? null) as PatternAggregate['hardest_rpe'],
+      }),
+    );
+
+    const balance = computePatternBalance(aggregates);
+    return {
+      overall_balance: balance.overallBalance,
+      patterns: Object.values(balance.patterns).map((p) => ({
+        pattern: p.pattern,
+        days_since_last_trained:
+          p.daysSinceLastTrained == null
+            ? null
+            : Math.floor(p.daysSinceLastTrained),
+        recent_volume_kg: p.recentVolume,
+        baseline_volume_kg: p.baselineVolume,
+        debt_score: p.debtScore,
+        band: p.band,
+        hardest_rpe: p.hardestRpe,
+      })),
+    };
+  } catch (err) {
+    console.error('recommend-session pattern_debt fetch failed:', err);
+    return null;
+  }
+}
+
 export async function gatherInputs(
   admin: SupabaseClient,
+  authClient: SupabaseClient,
   userId: string,
   body: { readiness?: unknown },
 ): Promise<RecommenderInputs> {
@@ -100,13 +154,15 @@ export async function gatherInputs(
         )
       : null;
 
+  const pattern_debt = await gatherPatternDebt(authClient);
+
   return {
     training_goal: profile?.training_goal ?? null,
     readiness,
     days_since_last_workout,
     recent_history,
     candidates,
-    pattern_debt: [],
+    pattern_debt,
     unlocked_weights: {},
   };
 }

--- a/supabase/functions/recommend-session/prompt.ts
+++ b/supabase/functions/recommend-session/prompt.ts
@@ -3,7 +3,19 @@
 // Kept separate from transport (llm.ts) so prompt quality can be iterated in
 // PROD-88 without touching the API plumbing.
 
-import type { RecommenderInputs } from './types.ts';
+import type { PatternDebtEntry, RecommenderInputs } from './types.ts';
+
+function formatPatternLine(p: PatternDebtEntry): string {
+  const lastTrained =
+    p.days_since_last_trained == null
+      ? 'not trained recently'
+      : `last trained ${p.days_since_last_trained}d ago`;
+  const volume =
+    p.baseline_volume_kg && p.baseline_volume_kg > 0
+      ? `volume ${Math.round((p.recent_volume_kg / p.baseline_volume_kg) * 100)}% of baseline`
+      : `recent volume ${p.recent_volume_kg}kg (no baseline)`;
+  return `- ${p.pattern}: debt ${p.debt_score} (${p.band}) · ${lastTrained} · ${volume}`;
+}
 
 export function buildSystemPrompt(): string {
   return [
@@ -18,6 +30,10 @@ export function buildSystemPrompt(): string {
     '  today. When they are tired, sore, or short on time, scale volume down.',
     '- Prescribe weights in kilograms (whole or half kg) and rep schemes as a list',
     '  of positive integers (one entry per rung/set).',
+    '- When a pattern-balance section is provided, prefer movements that train',
+    '  the red- and yellow-band (highest-debt) patterns, and say so in the',
+    '  rationale when it drives your selection. Readiness, recent RPE, and the',
+    "  lifter's goal still take precedence when they conflict.",
     '- Give a short, concrete rationale a thoughtful coach would give — tie it to',
     '  their goal, recent history, and readiness. Avoid generic filler.',
   ].join('\n');
@@ -45,6 +61,17 @@ export function buildUserPrompt(inputs: RecommenderInputs): string {
         .join('\n')
     : '- (no recent workouts logged)';
 
+  const patternDebtSection = inputs.pattern_debt
+    ? [
+        '',
+        `Pattern balance (higher debt = more under-trained; overall: ${inputs.pattern_debt.overall_balance}):`,
+        ...inputs.pattern_debt.patterns
+          .slice()
+          .sort((a, b) => b.debt_score - a.debt_score)
+          .map(formatPatternLine),
+      ]
+    : [];
+
   return [
     `Training goal: ${inputs.training_goal ?? '(none provided)'}`,
     `How they feel today: ${inputs.readiness ?? '(not provided)'}`,
@@ -52,6 +79,7 @@ export function buildUserPrompt(inputs: RecommenderInputs): string {
     '',
     'Recent workouts (most recent first):',
     historyLines,
+    ...patternDebtSection,
     '',
     'Candidate movements (choose only from these):',
     candidateLines,

--- a/supabase/functions/recommend-session/types.ts
+++ b/supabase/functions/recommend-session/types.ts
@@ -1,9 +1,16 @@
 // recommend-session (PROD-87): shared types + the structured-output JSON schema.
 //
 // RecommenderInputs is the typed snapshot fed to the LLM and persisted verbatim
-// into session_recommendations.inputs. pattern_debt / unlocked_weights are present
-// but empty stubs for now (PROD-75 / PROD-78 deferred) so they can be populated
-// later without reshaping the prompt or the table.
+// into session_recommendations.inputs. unlocked_weights is still an empty stub
+// (PROD-78 deferred) so it can be populated later without reshaping the prompt
+// or the table.
+
+import type {
+  DebtBand,
+  OverallBalance,
+  Pattern,
+  PatternRpe,
+} from '../../../src/utils/patternDebt.ts';
 
 /** One movement in the user's library — the candidate set the LLM may choose from. */
 export interface CandidateMovement {
@@ -24,6 +31,26 @@ export interface WorkoutHistoryEntry {
   }>;
 }
 
+/**
+ * One pattern's scored debt, serialized (dates as ISO strings) for the inputs
+ * JSONB snapshot and the prompt. Derived from the shared scoring model
+ * (src/utils/patternDebt.ts, PROD-155).
+ */
+export interface PatternDebtEntry {
+  pattern: Pattern;
+  days_since_last_trained: number | null;
+  recent_volume_kg: number;
+  baseline_volume_kg: number | null;
+  debt_score: number;
+  band: DebtBand;
+  hardest_rpe: PatternRpe | null;
+}
+
+export interface PatternDebtInput {
+  overall_balance: OverallBalance;
+  patterns: PatternDebtEntry[];
+}
+
 /** Everything the recommender reasons over. Snapshotted into inputs JSONB. */
 export interface RecommenderInputs {
   training_goal: string | null;
@@ -31,9 +58,10 @@ export interface RecommenderInputs {
   days_since_last_workout: number | null;
   recent_history: WorkoutHistoryEntry[];
   candidates: CandidateMovement[];
-  // Reserved, populated later (PROD-75 / PROD-78). Kept in the snapshot so the
-  // prompt and the logged inputs are forward-compatible.
-  pattern_debt: never[];
+  /** Null when the pattern_debt_window RPC fails — never blocks a recommendation. */
+  pattern_debt: PatternDebtInput | null;
+  // Reserved, populated later (PROD-78). Kept in the snapshot so the prompt and
+  // the logged inputs are forward-compatible.
   unlocked_weights: Record<string, never>;
 }
 


### PR DESCRIPTION
## Why

The AI session recommender has carried an empty `pattern_debt` stub since PROD-87, while the full deterministic scoring model (PROD-155) shipped and now powers the Weekly Balance UI. The recommender should bias movement selection toward under-trained patterns instead of ignoring them.

## What

`recommend-session` now fetches the caller's `pattern_debt_window` aggregates, scores them with the shared `src/utils/patternDebt.ts` model, snapshots the result into `session_recommendations.inputs`, and renders a per-pattern balance section into the prompt with soft guidance to prefer red/yellow-band patterns (readiness, RPE, and goal still win).

## How to test

- `npm run compile:ts`, `npm run lint`, `npm test` (662 passing).
- `supabase functions serve recommend-session` — confirms the out-of-dir import of `src/utils/patternDebt.ts` bundles cleanly.
- Called the function end-to-end as the seeded local user (premium granted, movements added): the logged `inputs->pattern_debt` matches the scoring model exactly — get-up green with recent volume and `ideal` RPE, untrained patterns red at debt 100, `overall_balance: get_up-heavy`. LLM generation itself not exercised locally (no `ANTHROPIC_API_KEY` in the functions env); the failure path logs the attempt as designed.

## Deploy notes

No migrations. Requires no new env vars. Debt fetch is best-effort: RPC failure degrades to `pattern_debt: null` and never blocks a recommendation.

## Tradeoffs

- The RPC is called through the user-JWT client, not the service role — `pattern_debt_window` is `SECURITY INVOKER` and filters on `auth.uid()`, so a service-role call would return nothing. The alternative (a parameterized service-role variant of the RPC) adds surface area for no benefit here.
- Prompt uses soft prioritization rather than a hard "must include highest-debt pattern" constraint; the hard rule fights readiness/goal context and the model can already cite debt in its rationale.