### PR TITLE
ci(deploy): auto-sync develop with main; move prod Supabase env to Netlify UI

### DIFF
--- a/.github/workflows/sync-develop.yaml
+++ b/.github/workflows/sync-develop.yaml
@@ -1,0 +1,23 @@
+# Mirrors main onto develop after every push to main, so the staging site
+# (dev-kettlebells, which builds develop) always deploys the latest merged code.
+# develop carries no unique work — it exists only as the staging deploy branch —
+# so a force mirror is safe and self-heals any divergence.
+
+name: Sync develop with main
+
+on:
+  push:
+    branches: ['main']
+
+permissions:
+  contents: write
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - run: git push --force origin main:develop

--- a/netlify.toml
+++ b/netlify.toml
@@ -25,13 +25,14 @@
 # VITE_SUPABASE_ANON_KEY is a public, RLS-protected key (it ships in the client
 # bundle), so it is safe to commit here.
 #
-# IMPORTANT: these two variables must NOT also be set in the Netlify UI. UI
-# environment variables override netlify.toml, so a UI value scoped to "all
-# contexts" would defeat the deploy-preview override below. Keep them here only.
-
-[context.production.environment]
-  VITE_SUPABASE_URL = "https://ynzzqpajkhqjzftiynfo.supabase.co"
-  VITE_SUPABASE_ANON_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InluenpxcGFqa2hxanpmdGl5bmZvIiwicm9sZSI6ImFub24iLCJpYXQiOjE2OTA2NjI3NjMsImV4cCI6MjAwNjIzODc2M30.xLRZaFcdp9K2HucbAkJig0GSEfyYsWOYrVOTDIrgK8g"
+# There is intentionally NO [context.production.environment] block: netlify.toml
+# applies to every site building this repo, and context blocks OVERRIDE per-site
+# UI variables. A production block with prod Supabase values hijacked the staging
+# site's production-context builds of `develop`, pointing stage.bellskill.com at
+# the prod database. Production Supabase values live as UI env vars on the
+# `bellskill` site; staging values live as UI env vars on the `dev-kettlebells`
+# site. The deploy-preview block below stays in the file because previews build
+# on both sites and must always target staging.
 
 [context.deploy-preview.environment]
   NODE_VERSION = "24"


### PR DESCRIPTION
## What

Removes the `[context.production.environment]` block from netlify.toml and adds a workflow that force-mirrors `develop` from `main` on every push to main.

## Why

netlify.toml applies to every site building this repo, and its context blocks override per-site UI env vars. The production block therefore hijacked the staging site's production-context builds of `develop`, baking the prod Supabase URL into stage.bellskill.com — the staging app was talking to the production database. Prod Supabase values now live as UI env vars on the `bellskill` Netlify site (already set and verified); staging values were already set on `dev-kettlebells`.

The sync workflow fixes the second half of the problem: `develop` had drifted ~95 PRs behind main, so staging was deploying month-old code. Mirroring on every merge keeps stage.bellskill.com current automatically.

## How tested

- Applied the netlify.toml change to `develop` directly as a hotfix; the resulting staging deploy's bundle now references `obtrxswejclgxjfyddow.supabase.co` (verified by fetching the served JS), and magic-link OTP against staging with a stage.bellskill.com redirect returns 200.
- Decoded the prod site's `VITE_SUPABASE_ANON_KEY` UI var and confirmed it targets the prod project (`ynzzqpajkhqjzftiynfo`), so prod builds keep working after the toml block is gone.
- The workflow itself runs first on merge of this PR — expect it to mirror develop (wiping the hotfix commit with the identical change from main).

## Tradeoffs

Force-push mirroring assumes `develop` never carries unique work. That's true today (deploy-only branch) and the workflow comment says so, but any future direct commit to develop will be silently discarded on the next merge to main. If `develop` has force-push protection, the first run will fail — drop the protection or switch to a merge-based sync.