### PR TITLE
ci(deploy): deploy all edge functions by globbing supabase/functions

### DIFF
--- a/.github/workflows/supabase-production.yaml
+++ b/.github/workflows/supabase-production.yaml
@@ -33,10 +33,10 @@ jobs:
 
       - run: supabase link --project-ref $SUPABASE_PROJECT_ID
       - run: supabase db push
-      - run: supabase functions deploy create-checkout-session --project-ref $SUPABASE_PROJECT_ID
-      - run: supabase functions deploy stripe-webhook --project-ref $SUPABASE_PROJECT_ID
-      - run: supabase functions deploy create-portal-session --project-ref $SUPABASE_PROJECT_ID
-      - run: supabase functions deploy recommend-session --project-ref $SUPABASE_PROJECT_ID
-      - run: supabase functions deploy set-subscription --project-ref $SUPABASE_PROJECT_ID
-      - run: supabase functions deploy spotify-auth --project-ref $SUPABASE_PROJECT_ID
-      - run: supabase functions deploy spotify-player --project-ref $SUPABASE_PROJECT_ID
+      - name: Deploy edge functions
+        run: |
+          for dir in supabase/functions/*/; do
+            fn=$(basename "$dir")
+            [ "$fn" = "_shared" ] && continue
+            supabase functions deploy "$fn" --project-ref "$SUPABASE_PROJECT_ID"
+          done

--- a/.github/workflows/supabase-staging.yaml
+++ b/.github/workflows/supabase-staging.yaml
@@ -58,7 +58,9 @@ jobs:
 
       - name: Deploy edge functions
         run: |
-          for fn in create-checkout-session stripe-webhook create-portal-session recommend-session set-subscription spotify-auth spotify-player; do
+          for dir in supabase/functions/*/; do
+            fn=$(basename "$dir")
+            [ "$fn" = "_shared" ] && continue
             supabase functions deploy "$fn" --project-ref "$SUPABASE_PROJECT_ID"
           done
 


### PR DESCRIPTION
## Why

The production and staging Supabase workflows deployed edge functions from hardcoded lists. `recommend-program` was never added to either list, so it was silently skipped on every deploy — and any future function would hit the same trap.

## What

Both workflows now loop over `supabase/functions/*/` directories (skipping `_shared`), so every function directory deploys automatically.

## How to test

Verified both files parse as YAML and that the glob over `supabase/functions/` yields all eight function directories with `_shared` excluded — including `recommend-program`, which the old lists missed. Real proof lands on the first staging/production deploy after merge.

## Deploy notes

The first production run after merge will deploy `recommend-program` for the first time — confirm its secrets/env are set in the production Supabase project.