### PR TITLE
feat(edge-functions): switch AI recommendations from Sonnet to Haiku

### DIFF
--- a/supabase/functions/recommend-program/llm.ts
+++ b/supabase/functions/recommend-program/llm.ts
@@ -17,7 +17,7 @@ import { ValidationError, validateRecommendation } from './validate.ts';
 
 const API_URL = 'https://api.anthropic.com/v1/messages';
 const ANTHROPIC_VERSION = '2023-06-01';
-const MODEL = 'claude-sonnet-4-6';
+const MODEL = 'claude-haiku-4-5';
 const MAX_TOKENS = 1024;
 
 /** Transport/parse-level failure (API down, bad JSON) — distinct from ValidationError. */

--- a/supabase/functions/recommend-session/llm.ts
+++ b/supabase/functions/recommend-session/llm.ts
@@ -20,7 +20,7 @@ import { ValidationError, validateRecommendation } from './validate.ts';
 
 const API_URL = 'https://api.anthropic.com/v1/messages';
 const ANTHROPIC_VERSION = '2023-06-01';
-const MODEL = 'claude-sonnet-4-6';
+const MODEL = 'claude-haiku-4-5';
 const MAX_TOKENS = 2048;
 
 /** Transport/parse-level failure (API down, bad JSON) — distinct from ValidationError. */


### PR DESCRIPTION
## Why

Reduce cost and latency on the two Anthropic-backed recommendation edge functions.

## What

Swaps `MODEL` from `claude-sonnet-4-6` to `claude-haiku-4-5` in `recommend-session/llm.ts` and `recommend-program/llm.ts` — the only two places in `supabase/functions/` that call a Claude model directly. No other logic changes.

## How to test

- `npm run compile:ts` — clean aside from two pre-existing, unrelated errors (`OverflowMenu.tsx`, missing `@radix-ui/react-dropdown-menu` types) not touched by this diff.
- No local Supabase stack was running this session, so the functions weren't invoked live. Recommend a manual smoke test of both `recommend-session` and `recommend-program` against real inputs to confirm Haiku's structured output still validates against `RECOMMENDATION_SCHEMA` before/after merging.

## Deploy notes

No migrations, flags, or env changes. Edge functions redeploy on merge.

## Tradeoffs

Haiku is cheaper/faster than Sonnet but may produce lower-quality recommendations — worth spot-checking output quality post-deploy, not just schema validity.