### PR TITLE
fix(recommender): use calendar-day boundaries for days-since-workout

### DIFF
--- a/src/api/useRecommendSession.ts
+++ b/src/api/useRecommendSession.ts
@@ -2,6 +2,7 @@ import { FunctionsHttpError } from '@supabase/supabase-js';
 import { useMutation } from '@tanstack/react-query';
 
 import { supabase } from '../supabaseClient';
+import { localDateString } from '~/utils/dateOnly';
 import type { RecommendSessionResponse } from '~/types';
 
 /** Stable codes for the failure modes the UI messages differently. */
@@ -21,11 +22,14 @@ export class RecommendSessionError extends Error {
 }
 
 const recommendSession = async (): Promise<RecommendSessionResponse> => {
-  // Body is empty for now; daily-readiness wiring lands in PROD-151.
+  // client_today anchors the recommender's "days since last workout" to the
+  // user's local calendar date — the edge function runs in UTC and has no
+  // notion of the caller's timezone otherwise. Daily-readiness wiring lands
+  // in PROD-151.
   const { data, error } =
     await supabase.functions.invoke<RecommendSessionResponse>(
       'recommend-session',
-      { body: {} },
+      { body: { client_today: localDateString() } },
     );
 
   if (error) {

--- a/src/pages/StartWorkoutPage/components/HubHeader.test.tsx
+++ b/src/pages/StartWorkoutPage/components/HubHeader.test.tsx
@@ -1,0 +1,30 @@
+import { render, screen } from '@testing-library/react';
+
+import { HubHeader } from './HubHeader';
+
+describe('HubHeader', () => {
+  test('no workout yet', () => {
+    render(<HubHeader lastWorkoutAt={null} />);
+    expect(screen.getByText("Let's get your first workout in.")).toBeVisible();
+  });
+
+  test('trained earlier today', () => {
+    const now = new Date(2026, 5, 24, 9, 0, 0);
+    render(<HubHeader lastWorkoutAt={new Date(2026, 5, 24, 6, 0, 0)} now={now} />);
+    expect(screen.getByText('You already trained today. Nice.')).toBeVisible();
+  });
+
+  test('trained yesterday evening, less than 24h ago, still reads as yesterday', () => {
+    const now = new Date(2026, 5, 24, 8, 0, 0);
+    const lastWorkoutAt = new Date(2026, 5, 23, 20, 0, 0);
+    render(<HubHeader lastWorkoutAt={lastWorkoutAt} now={now} />);
+    expect(screen.getByText('Last trained yesterday.')).toBeVisible();
+  });
+
+  test('trained several days ago', () => {
+    const now = new Date(2026, 5, 24, 9, 0, 0);
+    const lastWorkoutAt = new Date(2026, 5, 20, 9, 0, 0);
+    render(<HubHeader lastWorkoutAt={lastWorkoutAt} now={now} />);
+    expect(screen.getByText('Last trained 4 days ago.')).toBeVisible();
+  });
+});

--- a/src/pages/StartWorkoutPage/components/HubHeader.tsx
+++ b/src/pages/StartWorkoutPage/components/HubHeader.tsx
@@ -1,3 +1,5 @@
+import { daysBetweenCalendarDays } from '~/utils/dateOnly';
+
 export interface HubHeaderProps {
   /** Most recent workout date, or null for a user who hasn't trained yet. */
   lastWorkoutAt: Date | null;
@@ -11,23 +13,15 @@ const greetingForHour = (hour: number): string => {
   return 'Good evening';
 };
 
-const MS_PER_DAY = 24 * 60 * 60 * 1000;
-
 const lastTrainedLabel = (lastWorkoutAt: Date | null, now: Date): string => {
   if (!lastWorkoutAt) return "Let's get your first workout in.";
 
-  const days = Math.floor(
-    (startOfDay(now).getTime() - startOfDay(lastWorkoutAt).getTime()) /
-      MS_PER_DAY,
-  );
+  const days = daysBetweenCalendarDays(lastWorkoutAt, now);
 
   if (days <= 0) return 'You already trained today. Nice.';
   if (days === 1) return 'Last trained yesterday.';
   return `Last trained ${days} days ago.`;
 };
-
-const startOfDay = (date: Date): Date =>
-  new Date(date.getFullYear(), date.getMonth(), date.getDate());
 
 /**
  * The hub's identity strip: a time-of-day greeting over a quiet "last trained"

--- a/src/utils/dateOnly.test.ts
+++ b/src/utils/dateOnly.test.ts
@@ -1,0 +1,61 @@
+import {
+  daysBetweenCalendarDays,
+  localDateString,
+  parseLocalDateString,
+  startOfDay,
+} from './dateOnly';
+
+describe('startOfDay', () => {
+  test('zeroes out the time of day', () => {
+    expect(startOfDay(new Date(2026, 5, 24, 23, 59, 59))).toEqual(
+      new Date(2026, 5, 24, 0, 0, 0),
+    );
+  });
+});
+
+describe('daysBetweenCalendarDays', () => {
+  test('same calendar day, regardless of time of day, is 0', () => {
+    const morning = new Date(2026, 5, 24, 6, 0, 0);
+    const night = new Date(2026, 5, 24, 23, 0, 0);
+    expect(daysBetweenCalendarDays(morning, night)).toBe(0);
+  });
+
+  test('logged yesterday evening, now this morning -> 1 (not 0)', () => {
+    // Only ~14 hours elapsed, but a calendar midnight has passed — this is the
+    // exact case the raw elapsed-ms computation used to misreport as "today".
+    const loggedYesterdayEvening = new Date(2026, 5, 23, 19, 0, 0);
+    const thisMorning = new Date(2026, 5, 24, 9, 0, 0);
+    expect(daysBetweenCalendarDays(loggedYesterdayEvening, thisMorning)).toBe(1);
+  });
+
+  test('just before midnight vs just after midnight is still 1 day apart', () => {
+    const before = new Date(2026, 5, 23, 23, 59, 59);
+    const after = new Date(2026, 5, 24, 0, 0, 1);
+    expect(daysBetweenCalendarDays(before, after)).toBe(1);
+  });
+
+  test('multi-day gap', () => {
+    const from = new Date(2026, 5, 20, 12, 0, 0);
+    const to = new Date(2026, 5, 24, 8, 0, 0);
+    expect(daysBetweenCalendarDays(from, to)).toBe(4);
+  });
+
+  test('to before from is negative', () => {
+    const from = new Date(2026, 5, 24);
+    const to = new Date(2026, 5, 22);
+    expect(daysBetweenCalendarDays(from, to)).toBe(-2);
+  });
+});
+
+describe('localDateString / parseLocalDateString', () => {
+  test('round-trips a local date', () => {
+    const date = new Date(2026, 5, 4, 15, 30);
+    expect(localDateString(date)).toBe('2026-06-04');
+    expect(parseLocalDateString('2026-06-04')).toEqual(new Date(2026, 5, 4));
+  });
+
+  test('parseLocalDateString rejects malformed input', () => {
+    expect(parseLocalDateString('not-a-date')).toBeNull();
+    expect(parseLocalDateString('2026-13-40')).toBeNull();
+  });
+});

--- a/src/utils/dateOnly.ts
+++ b/src/utils/dateOnly.ts
@@ -1,0 +1,39 @@
+// Calendar-day (not elapsed-time) date math. "Days ago" should mean "how many
+// local midnights have passed," not "how many 24-hour periods" — the latter
+// misreports a workout from yesterday evening as "today" for anyone checking
+// before that same time of day has re-elapsed.
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+export const startOfDay = (date: Date): Date =>
+  new Date(date.getFullYear(), date.getMonth(), date.getDate());
+
+/** Whole calendar days between two dates' local midnights. `to` may precede `from`. */
+export const daysBetweenCalendarDays = (from: Date, to: Date): number =>
+  Math.floor((startOfDay(to).getTime() - startOfDay(from).getTime()) / MS_PER_DAY);
+
+/** Today's date as `YYYY-MM-DD` in the local timezone (not UTC — see `Date.toISOString`). */
+export const localDateString = (date: Date = new Date()): string => {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+};
+
+/** Parses a `YYYY-MM-DD` string as a local calendar date (midnight local time). */
+export const parseLocalDateString = (value: string): Date | null => {
+  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(value);
+  if (!match) return null;
+  const [, y, m, d] = match;
+  const year = Number(y);
+  const month = Number(m);
+  const day = Number(d);
+  const date = new Date(year, month - 1, day);
+  // Date rolls over out-of-range fields (e.g. month 13) instead of erroring —
+  // reject anything that didn't round-trip to the fields we parsed.
+  const roundTrips =
+    date.getFullYear() === year &&
+    date.getMonth() === month - 1 &&
+    date.getDate() === day;
+  return roundTrips ? date : null;
+};

--- a/src/utils/patternDebt.test.ts
+++ b/src/utils/patternDebt.test.ts
@@ -117,4 +117,15 @@ describe('computePatternBalance', () => {
     // Backfilled (untrained) patterns carry no rating.
     expect(patterns.carry.hardestRpe).toBeNull();
   });
+
+  test('days-since is a calendar-day count, not raw elapsed hours', () => {
+    // Trained yesterday evening; "now" is this morning, less than 24h later.
+    const now = new Date(2026, 5, 24, 8, 0, 0);
+    const trainedYesterdayEvening = new Date(2026, 5, 23, 20, 0, 0).toISOString();
+    const { patterns } = computePatternBalance(
+      [agg({ pattern: 'pull', last_trained_at: trainedYesterdayEvening })],
+      now,
+    );
+    expect(patterns.pull.daysSinceLastTrained).toBe(1);
+  });
 });

--- a/src/utils/patternDebt.ts
+++ b/src/utils/patternDebt.ts
@@ -5,7 +5,7 @@
 // Pure + deterministic so it can be unit-tested here and reused verbatim by the
 // recommender edge function. See docs/pattern-debt-scoring-model.md.
 
-import { daysBetweenCalendarDays } from './dateOnly';
+import { daysBetweenCalendarDays } from './dateOnly.ts';
 
 export const PATTERNS = [
   'hinge',

--- a/src/utils/patternDebt.ts
+++ b/src/utils/patternDebt.ts
@@ -5,6 +5,8 @@
 // Pure + deterministic so it can be unit-tested here and reused verbatim by the
 // recommender edge function. See docs/pattern-debt-scoring-model.md.
 
+import { daysBetweenCalendarDays } from './dateOnly';
+
 export const PATTERNS = [
   'hinge',
   'squat',
@@ -100,13 +102,10 @@ export const computeDebtScore = (
   return Math.round(100 * (W_RECENCY * recency + W_VOLUME * deficit));
 };
 
-const daysBetween = (from: Date, to: Date): number =>
-  (to.getTime() - from.getTime()) / (1000 * 60 * 60 * 24);
-
 const scorePattern = (agg: PatternAggregate, now: Date): PatternDebt => {
   const lastTrained = agg.last_trained_at ? new Date(agg.last_trained_at) : null;
   const daysSinceLastTrained = lastTrained
-    ? Math.max(0, daysBetween(lastTrained, now))
+    ? Math.max(0, daysBetweenCalendarDays(lastTrained, now))
     : null;
   const debtScore = computeDebtScore(
     daysSinceLastTrained,

--- a/supabase/functions/recommend-session/inputs.ts
+++ b/supabase/functions/recommend-session/inputs.ts
@@ -8,6 +8,10 @@
 import type { SupabaseClient } from '@supabase/supabase-js';
 
 import {
+  daysBetweenCalendarDays,
+  parseLocalDateString,
+} from '../../../src/utils/dateOnly.ts';
+import {
   type Pattern,
   type PatternAggregate,
   computePatternBalance,
@@ -38,6 +42,7 @@ function formatGoal(goal: number, units: string): string {
  */
 async function gatherPatternDebt(
   authClient: SupabaseClient,
+  today: Date,
 ): Promise<PatternDebtInput | null> {
   try {
     const { data, error } = await authClient.rpc('pattern_debt_window');
@@ -56,7 +61,7 @@ async function gatherPatternDebt(
       }),
     );
 
-    const balance = computePatternBalance(aggregates);
+    const balance = computePatternBalance(aggregates, today);
     return {
       overall_balance: balance.overallBalance,
       patterns: Object.values(balance.patterns).map((p) => ({
@@ -82,12 +87,27 @@ export async function gatherInputs(
   admin: SupabaseClient,
   authClient: SupabaseClient,
   userId: string,
-  body: { readiness?: unknown },
+  body: { readiness?: unknown; client_today?: unknown },
 ): Promise<RecommenderInputs> {
   const readiness =
     typeof body.readiness === 'string' && body.readiness.trim()
       ? body.readiness.trim()
       : null;
+
+  // "Today" must be the caller's local calendar date: this function runs in a
+  // Deno edge runtime with no timezone of its own, and a server-clock `Date.now()`
+  // both floats on UTC boundaries and can't distinguish "0 days elapsed" from
+  // "worked out yesterday evening" — see docs/pattern-debt-scoring-model.md.
+  const parsedClientToday =
+    typeof body.client_today === 'string'
+      ? parseLocalDateString(body.client_today)
+      : null;
+  if (parsedClientToday === null) {
+    console.warn(
+      'recommend-session: missing/invalid client_today, falling back to server clock',
+    );
+  }
+  const clientToday = parsedClientToday ?? new Date();
 
   // Candidate movements: the user's own library.
   const { data: userMovements, error: umErr } = await admin
@@ -149,12 +169,10 @@ export async function gatherInputs(
 
   const days_since_last_workout =
     logs && logs.length > 0
-      ? Math.floor(
-          (Date.now() - new Date(logs[0].completed_at).getTime()) / 86_400_000,
-        )
+      ? daysBetweenCalendarDays(new Date(logs[0].completed_at), clientToday)
       : null;
 
-  const pattern_debt = await gatherPatternDebt(authClient);
+  const pattern_debt = await gatherPatternDebt(authClient, clientToday);
 
   return {
     training_goal: profile?.training_goal ?? null,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,6 +14,7 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,
+    "allowImportingTsExtensions": true,
     "jsx": "react-jsx",
     "paths": {
       "~/*": ["./src/*"]


### PR DESCRIPTION
## Why

The AI session recommender was telling users they'd already worked out today when the home page correctly said they'd last trained yesterday. Root cause: `recommend-session`'s `days_since_last_workout` was computed as raw elapsed hours (`Math.floor((Date.now() - completed_at) / 86_400_000)`) on the edge function's server-side UTC clock, instead of local calendar-day boundaries. A workout logged yesterday evening and checked this morning has under 24h elapsed, so it floored to `0` ("today") — while the home page (`HubHeader`), which already diffs local calendar midnights, correctly said "yesterday." The same UTC-clock/`new Date()` default fed into `computePatternBalance`'s `daysSinceLastTrained`.

## What

- Extracted `HubHeader`'s correct calendar-day-diff logic into a shared `src/utils/dateOnly.ts` (`daysBetweenCalendarDays`, `startOfDay`, `localDateString`, `parseLocalDateString`), and reused it in `patternDebt.ts`'s `daysSinceLastTrained`.
- The client now sends its local date (`client_today`) with the `recommend-session` request; the edge function uses it (falling back to the server clock with a warning if missing) to anchor "today" to the user's timezone instead of the function's own UTC clock, for both `days_since_last_workout` and the pattern-debt calculation.

## How to test

- `npm test` — 771 tests pass, including new coverage of the exact "logged yesterday evening, checked this morning" case in `dateOnly.test.ts`, `patternDebt.test.ts`, and a new `HubHeader.test.tsx` (previously untested).
- `npx tsc --noEmit` and `npx eslint` on all touched files — clean.

## Deploy notes

None — no schema/migration changes, no new env vars or flags.

## Tradeoffs

Found the identical bug in `recommend-program`'s edge function (its own separate `computePatternBalance` in `scoring.ts`), but left it out of this PR to keep the change scoped; flagged as a follow-up task instead.