### PR TITLE
feat(builder): collapsible sections with summaries on the workout builder

### DIFF
--- a/src/pages/StartWorkoutPage/StartWorkoutPage.collapsibleSections.test.jsx
+++ b/src/pages/StartWorkoutPage/StartWorkoutPage.collapsibleSections.test.jsx
@@ -1,0 +1,143 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+
+import {
+  DEFAULT_MOVEMENT_OPTIONS,
+  DEFAULT_WORKOUT_OPTIONS,
+  WorkoutOptionsContext,
+} from '~/contexts';
+
+import { StartWorkoutPage } from './StartWorkoutPage';
+
+// Builder sections fold to a one-line summary. They open expanded when the
+// user is building, and start collapsed when a program session arrives
+// prefilled — the user is confirming, not building.
+const { mockUseActivePrograms, mockUseFeatures } = vi.hoisted(() => ({
+  mockUseActivePrograms: vi.fn(),
+  mockUseFeatures: vi.fn(),
+}));
+vi.mock('~/api', async (importOriginal) => ({
+  ...(await importOriginal()),
+  useActivePrograms: mockUseActivePrograms,
+}));
+vi.mock('~/hooks', async (importOriginal) => ({
+  ...(await importOriginal()),
+  useFeatures: mockUseFeatures,
+}));
+
+const BASE_FEATURES = {
+  bottomNav: false,
+  complexMode: false,
+  explore: false,
+  premium: false,
+  programs: true,
+  weeklyBalance: false,
+};
+
+const programOptions = {
+  ...DEFAULT_WORKOUT_OPTIONS,
+  intervalTimer: 30,
+  movements: [
+    { ...DEFAULT_MOVEMENT_OPTIONS, movementName: 'Kettlebell Swing' },
+  ],
+};
+
+const activeProgram = {
+  enrollment: { id: 'up-1', programId: 'p-1', status: 'active' },
+  program: { id: 'p-1', title: 'Dry Fighting Weight' },
+  nextSession: {
+    session: {
+      id: 'ps-0',
+      sequenceIndex: 0,
+      weekNumber: 1,
+      dayNumber: 1,
+      title: 'Ladders 1-2-3',
+      workoutOptions: programOptions,
+    },
+    workoutOptions: programOptions,
+  },
+  progress: { completed: 0, total: 3, week: 1, day: 1 },
+  isComplete: false,
+  lastWorkedAt: null,
+};
+
+const renderPage = () =>
+  render(
+    <QueryClientProvider
+      client={
+        new QueryClient({ defaultOptions: { queries: { retry: false } } })
+      }
+    >
+      <MemoryRouter initialEntries={['/']}>
+        <WorkoutOptionsContext.Provider
+          value={[DEFAULT_WORKOUT_OPTIONS, vi.fn()]}
+        >
+          <StartWorkoutPage />
+        </WorkoutOptionsContext.Provider>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+
+describe('StartWorkoutPage — collapsible builder sections', () => {
+  beforeEach(() => {
+    mockUseFeatures.mockReturnValue(BASE_FEATURES);
+  });
+
+  test('build-custom opens with sections expanded, and Goal collapses to a summary', () => {
+    mockUseActivePrograms.mockReturnValue({ data: [], isError: false });
+
+    renderPage();
+    fireEvent.click(screen.getByRole('button', { name: 'Build a workout' }));
+
+    expect(screen.getByRole('tab', { name: 'Volume' })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Collapse Goal' }));
+
+    expect(screen.queryByRole('tab', { name: 'Volume' })).toBeNull();
+    expect(screen.getByText('10 minutes')).toBeInTheDocument();
+
+    fireEvent.click(
+      screen.getAllByRole('button', { name: 'Expand Goal' })[0],
+    );
+    expect(screen.getByRole('tab', { name: 'Volume' })).toBeInTheDocument();
+  });
+
+  test('re-enabling a toggled-off section shows it expanded', () => {
+    mockUseActivePrograms.mockReturnValue({ data: [], isError: false });
+
+    renderPage();
+    fireEvent.click(screen.getByRole('button', { name: 'Build a workout' }));
+
+    fireEvent.click(screen.getByRole('button', { name: 'Interval, off' }));
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Collapse Interval Timer' }),
+    );
+    // Toggle off, then back on — it should come back expanded, not collapsed.
+    fireEvent.click(screen.getByRole('button', { name: 'Interval, on' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Interval, off' }));
+
+    expect(
+      screen.getByRole('button', { name: 'Collapse Interval Timer' }),
+    ).toBeInTheDocument();
+  });
+
+  test('starting the next program session opens everything collapsed', () => {
+    mockUseActivePrograms.mockReturnValue({
+      data: [activeProgram],
+      isError: false,
+    });
+
+    renderPage();
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Start next workout' }),
+    );
+
+    expect(screen.queryByRole('tab', { name: 'Volume' })).toBeNull();
+    expect(screen.getByText('10 minutes')).toBeInTheDocument();
+    expect(screen.getByText('30 sec')).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Expand Kettlebell Swing' }),
+    ).toBeInTheDocument();
+  });
+});

--- a/src/pages/StartWorkoutPage/StartWorkoutPage.tsx
+++ b/src/pages/StartWorkoutPage/StartWorkoutPage.tsx
@@ -37,6 +37,7 @@ import {
   WorkoutOptions,
 } from '~/types';
 import {
+  WEIGHT_MODE_LABELS,
   applySharedWeights,
   getWeightRange,
   getWeightTabValue,
@@ -87,6 +88,15 @@ const INCREMENT_DURATION: number = 1; // minutes
 const INCREMENT_INTERVAL_TIMER: number = 5; // seconds
 const INCREMENT_REST_TIMER: number = 5; // seconds
 const TIMER_BOUNDS = { min: 5, max: 300 }; // seconds
+
+type BuilderSectionId = 'goal' | 'notes' | 'interval' | 'rest' | 'sharedWeight';
+const ALL_BUILDER_SECTIONS: BuilderSectionId[] = [
+  'goal',
+  'notes',
+  'interval',
+  'rest',
+  'sharedWeight',
+];
 const DEFAULT_VOLUME: number = 1000; // kg
 const DEFAULT_MINUTES: number = 10; // minutes
 const DEFAULT_ROUNDS: number = 10; // rounds
@@ -351,6 +361,9 @@ export const StartWorkoutPage = ({
   const [collapsedMovements, setCollapsedMovements] = useState<Set<number>>(
     () => new Set(),
   );
+  const [collapsedSections, setCollapsedSections] = useState<
+    Set<BuilderSectionId>
+  >(() => new Set());
   const [title, setTitle] = useState<string | null>(workoutOptions.title);
   const [preWorkoutNotes, setPreWorkoutNotes] = useState<string | null>(
     workoutOptions.preWorkoutNotes,
@@ -382,6 +395,8 @@ export const StartWorkoutPage = ({
   // can review/edit before starting. Defined ahead of the gate so the nav-start
   // effect below can reuse it without a temporal-dead-zone hazard.
   const loadIntoBuilder = (options: Omit<WorkoutOptions, 'startedAt'>) => {
+    setCollapsedSections(new Set());
+    setCollapsedMovements(new Set());
     setMovements(options.movements);
     setWorkoutGoal(options.workoutGoal);
     setWorkoutGoalUnits(options.workoutGoalUnits);
@@ -407,6 +422,12 @@ export const StartWorkoutPage = ({
     programTitle: string,
   ) => {
     loadIntoBuilder(session.workoutOptions);
+    // Program options arrive prefilled, so fold everything down to summaries —
+    // the user is confirming, not building.
+    setCollapsedSections(new Set(ALL_BUILDER_SECTIONS));
+    setCollapsedMovements(
+      new Set(session.workoutOptions.movements.map((_, index) => index)),
+    );
     setTitle(composeProgramSessionTitle(programTitle, session));
     setStartSource('program');
     setStartSourceProps({
@@ -492,11 +513,28 @@ export const StartWorkoutPage = ({
     setPreWorkoutNotes(notesRef.current?.value ?? '');
   };
 
+  const handleToggleSection = (id: BuilderSectionId) =>
+    setCollapsedSections((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+
+  const expandSection = (id: BuilderSectionId) =>
+    setCollapsedSections((prev) => {
+      if (!prev.has(id)) return prev;
+      const next = new Set(prev);
+      next.delete(id);
+      return next;
+    });
+
   const handleToggleNotes = () => {
     if (preWorkoutNotes !== null) {
       setPreWorkoutNotes(null);
     } else {
       setPreWorkoutNotes('');
+      expandSection('notes');
     }
   };
 
@@ -505,6 +543,7 @@ export const StartWorkoutPage = ({
       setIntervalTimer(0);
     } else {
       handleIncrementInterval();
+      expandSection('interval');
     }
   };
 
@@ -513,6 +552,7 @@ export const StartWorkoutPage = ({
       setRestTimer(0);
     } else {
       handleIncrementRest();
+      expandSection('rest');
     }
   };
 
@@ -520,6 +560,7 @@ export const StartWorkoutPage = ({
   // movement before the next. They describe opposite arrangements, so turning
   // either on clears the other.
   const handleToggleComplex = () => {
+    if (!complexSet) expandSection('sharedWeight');
     setComplexSet((prev) => !prev);
     setStraightSets(false);
   };
@@ -885,6 +926,20 @@ export const StartWorkoutPage = ({
     .filter((load): load is SummaryLoad => (load.value ?? 0) > 0)
     .map((load) => ({ value: load.value as number, unit: load.unit }));
 
+  const goalSummary = `${workoutGoal} ${
+    workoutGoalUnits === 'kilograms' ? 'kg' : workoutGoalUnits
+  }`;
+  const sharedWeightSummary = [
+    WEIGHT_MODE_LABELS[sharedWeightTabValue],
+    sharedWeightOneValue !== null &&
+      `${sharedWeightOneValue} ${getWeightUnitLabel(sharedWeightOneUnit)}`,
+    sharedWeightTwoValue !== null &&
+      sharedWeightTwoValue > 0 &&
+      `${sharedWeightTwoValue} ${getWeightUnitLabel(sharedWeightTwoUnit)}`,
+  ]
+    .filter(Boolean)
+    .join(' · ');
+
   // Held below every hook so the pending→resolved gate transition can't change
   // the hook count between renders (Rules of Hooks / React #310). The mode above
   // is still derived from a forced `showBrowse` until the gate settles, so
@@ -981,6 +1036,10 @@ export const StartWorkoutPage = ({
           <Card>
             <Section
               title="Goal"
+              collapsible
+              collapsed={collapsedSections.has('goal')}
+              onToggle={() => handleToggleSection('goal')}
+              summary={goalSummary}
               actions={
                 <Tabs
                   value={workoutGoalUnits}
@@ -1085,7 +1144,13 @@ export const StartWorkoutPage = ({
 
           {preWorkoutNotes !== null && (
             <Card>
-              <Section title="Pre-workout notes">
+              <Section
+                title="Pre-workout notes"
+                collapsible
+                collapsed={collapsedSections.has('notes')}
+                onToggle={() => handleToggleSection('notes')}
+                summary={preWorkoutNotes || 'No notes'}
+              >
                 <Textarea
                   autoFocus
                   className="w-full"
@@ -1101,7 +1166,13 @@ export const StartWorkoutPage = ({
 
           {intervalTimer > 0 && (
             <Card>
-              <Section title="Interval Timer">
+              <Section
+                title="Interval Timer"
+                collapsible
+                collapsed={collapsedSections.has('interval')}
+                onToggle={() => handleToggleSection('interval')}
+                summary={`${intervalTimer} sec`}
+              >
                 <ModifyCountButtons
                   {...TIMER_BOUNDS}
                   step={INCREMENT_INTERVAL_TIMER}
@@ -1117,7 +1188,13 @@ export const StartWorkoutPage = ({
 
           {restTimer > 0 && (
             <Card>
-              <Section title="Rest Timer">
+              <Section
+                title="Rest Timer"
+                collapsible
+                collapsed={collapsedSections.has('rest')}
+                onToggle={() => handleToggleSection('rest')}
+                summary={`${restTimer} sec`}
+              >
                 <ModifyCountButtons
                   {...TIMER_BOUNDS}
                   step={INCREMENT_REST_TIMER}
@@ -1133,7 +1210,13 @@ export const StartWorkoutPage = ({
 
           {features.complexMode && complexSet && (
             <Card>
-              <Section title="Shared Weight">
+              <Section
+                title="Shared Weight"
+                collapsible
+                collapsed={collapsedSections.has('sharedWeight')}
+                onToggle={() => handleToggleSection('sharedWeight')}
+                summary={sharedWeightSummary}
+              >
                 <p className="text-xs text-muted-foreground">
                   Complete all movements before setting the weight down.
                 </p>

--- a/src/pages/StartWorkoutPage/components/Section.test.tsx
+++ b/src/pages/StartWorkoutPage/components/Section.test.tsx
@@ -1,0 +1,71 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+
+import { Section } from './Section';
+
+describe('Section', () => {
+  test('renders title, actions, and children when not collapsible', () => {
+    render(
+      <Section title="Goal" actions={<button>action</button>}>
+        <div>content</div>
+      </Section>,
+    );
+
+    expect(screen.getByText('Goal')).toBeInTheDocument();
+    expect(screen.getByText('action')).toBeInTheDocument();
+    expect(screen.getByText('content')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Collapse Goal' })).toBeNull();
+  });
+
+  test('expanded collapsible shows children and a collapse button', () => {
+    render(
+      <Section title="Goal" collapsible collapsed={false} onToggle={vi.fn()}>
+        <div>content</div>
+      </Section>,
+    );
+
+    expect(screen.getByText('content')).toBeInTheDocument();
+    const toggle = screen.getByRole('button', { name: 'Collapse Goal' });
+    expect(toggle).toHaveAttribute('aria-expanded', 'true');
+  });
+
+  test('collapsed hides children and actions, shows summary', () => {
+    render(
+      <Section
+        title="Goal"
+        collapsible
+        collapsed
+        onToggle={vi.fn()}
+        summary="10 minutes"
+        actions={<button>action</button>}
+      >
+        <div>content</div>
+      </Section>,
+    );
+
+    expect(screen.queryByText('content')).toBeNull();
+    expect(screen.queryByText('action')).toBeNull();
+    expect(screen.getByText('10 minutes')).toBeInTheDocument();
+  });
+
+  test('both the chevron and the header button fire onToggle', () => {
+    const onToggle = vi.fn();
+    render(
+      <Section
+        title="Goal"
+        collapsible
+        collapsed
+        onToggle={onToggle}
+        summary="10 minutes"
+      >
+        <div>content</div>
+      </Section>,
+    );
+
+    const [header, chevron] = screen.getAllByRole('button', {
+      name: 'Expand Goal',
+    });
+    fireEvent.click(header);
+    fireEvent.click(chevron);
+    expect(onToggle).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/pages/StartWorkoutPage/components/Section.tsx
+++ b/src/pages/StartWorkoutPage/components/Section.tsx
@@ -1,25 +1,74 @@
+import { ChevronDownIcon, ChevronUpIcon } from '@heroicons/react/24/outline';
 import { ReactNode } from 'react';
 
+import { Button } from '~/components/ui/button';
 import { CardContent, CardHeader, CardTitle } from '~/components/ui/card';
 
 export const Section = ({
   actions = null,
   children,
   title,
+  collapsible = false,
+  collapsed = false,
+  onToggle,
+  summary,
 }: {
   actions?: ReactNode;
   children: ReactNode;
   title?: string;
+  collapsible?: boolean;
+  collapsed?: boolean;
+  onToggle?: () => void;
+  summary?: ReactNode;
 }) => {
+  const showCollapsed = collapsible && collapsed;
+
   return (
     <>
       <CardHeader>
         <div className="flex w-full items-center justify-between gap-x-1">
-          <CardTitle className="text-sm font-medium">{title}</CardTitle>
-          {actions}
+          {showCollapsed ? (
+            <button
+              type="button"
+              onClick={onToggle}
+              className="min-w-0 flex-1 text-left"
+              aria-expanded={false}
+              aria-label={`Expand ${title}`}
+            >
+              <CardTitle className="text-sm font-medium">{title}</CardTitle>
+              {summary != null && (
+                <div className="mt-0.5 truncate text-xs text-muted-foreground">
+                  {summary}
+                </div>
+              )}
+            </button>
+          ) : (
+            <>
+              <CardTitle className="text-sm font-medium">{title}</CardTitle>
+              {actions}
+            </>
+          )}
+          {collapsible && (
+            <Button
+              variant="ghost"
+              size="icon"
+              className="shrink-0"
+              aria-label={collapsed ? `Expand ${title}` : `Collapse ${title}`}
+              aria-expanded={!collapsed}
+              onClick={onToggle}
+            >
+              {collapsed ? (
+                <ChevronDownIcon className="h-2.5 w-2.5" />
+              ) : (
+                <ChevronUpIcon className="h-2.5 w-2.5" />
+              )}
+            </Button>
+          )}
         </div>
       </CardHeader>
-      <CardContent className="flex flex-col gap-y-2">{children}</CardContent>
+      {!showCollapsed && (
+        <CardContent className="flex flex-col gap-y-2">{children}</CardContent>
+      )}
     </>
   );
 };


### PR DESCRIPTION
## Why

Continuing a program session drops you into the full builder even though every option arrives prefilled — a long expanded form when all you really want is to confirm and start. Movements already collapse to summary chips; the rest of the sections had no way to fold.

## What

Every builder section (Goal, Pre-workout notes, Interval, Rest, Shared Weight) is now collapsible with a one-line summary of its settings, and starting a program's next session opens with every section and movement card pre-collapsed.

## How to test

- `npx vitest run src/pages/StartWorkoutPage` — 102 tests, including new `Section.test.tsx` and `StartWorkoutPage.collapsibleSections.test.jsx` (default-expanded builder, collapse/expand round-trip, re-enabled toggles come back expanded, program start opens collapsed). `hooksOrder`/`pendingGate` still pass — the new state hook sits above the gate.
- `npm run compile:ts` and `npm run lint` clean.
- Manually against local Supabase: built a custom workout (sections expanded, each folds to a summary), enrolled in Easy Strength and hit "Start next workout" (everything collapsed, expands and starts fine).

## Gallery

| Before — program session opens fully expanded | After — program session opens collapsed | After — Goal expanded again | After — build custom still opens expanded |
|---|---|---|---|
| ![before](https://github.com/user-attachments/assets/23e11552-5524-458c-9063-d3c70e52ce70) | ![after collapsed](https://github.com/user-attachments/assets/5c34d81e-d49b-42c7-8e77-fbab87fbc355) | ![after goal expanded](https://github.com/user-attachments/assets/84356e7b-7e67-4794-91bf-e2e49de3fe0a) | ![after custom](https://github.com/user-attachments/assets/f636184e-4b17-44c7-b554-61304c0b395f) |

## Tradeoffs

Hand-rolled the collapse in the shared `Section` shell (mirroring `MovementCard`) instead of adding `@radix-ui/react-collapsible` — the Radix primitive would give free animation, but the app already has this pattern and no other accordion needs.