### PR TITLE
fix(recommender): use calendar-day boundaries in recommend-program

### DIFF
--- a/src/api/useRecommendProgram.ts
+++ b/src/api/useRecommendProgram.ts
@@ -2,6 +2,7 @@ import { FunctionsHttpError } from '@supabase/supabase-js';
 import { useMutation } from '@tanstack/react-query';
 
 import { supabase } from '../supabaseClient';
+import { localDateString } from '~/utils/dateOnly';
 import type { RecommendProgramResponse } from '~/types';
 
 /** Stable codes for the failure modes the UI messages differently. */
@@ -21,10 +22,13 @@ export class RecommendProgramError extends Error {
 }
 
 const recommendProgram = async (): Promise<RecommendProgramResponse> => {
+  // client_today anchors the recommender's "days since last workout" and
+  // pattern-debt calculation to the user's local calendar date — the edge
+  // function runs in UTC and has no notion of the caller's timezone otherwise.
   const { data, error } =
     await supabase.functions.invoke<RecommendProgramResponse>(
       'recommend-program',
-      { body: {} },
+      { body: { client_today: localDateString() } },
     );
 
   if (error) {

--- a/supabase/functions/recommend-program/index.ts
+++ b/supabase/functions/recommend-program/index.ts
@@ -63,7 +63,8 @@ Deno.serve(async (req: Request) => {
     }
 
     // (4) Assemble inputs.
-    const inputs = await gatherInputs(admin, authClient, user.id);
+    const body = await req.json().catch(() => ({}));
+    const inputs = await gatherInputs(admin, authClient, user.id, body);
 
     if (inputs.candidates.length === 0) {
       // The user is already running or has queued every released shared

--- a/supabase/functions/recommend-program/inputs.ts
+++ b/supabase/functions/recommend-program/inputs.ts
@@ -7,6 +7,10 @@
 import type { SupabaseClient } from '@supabase/supabase-js';
 
 import {
+  daysBetweenCalendarDays,
+  parseLocalDateString,
+} from '../../../src/utils/dateOnly.ts';
+import {
   assessStackFit,
   computePatternBalance,
   type PatternAggregate,
@@ -44,7 +48,23 @@ export async function gatherInputs(
   admin: SupabaseClient,
   userClient: SupabaseClient,
   userId: string,
+  body: { client_today?: unknown } = {},
 ): Promise<RecommenderInputs> {
+  // "Today" must be the caller's local calendar date: this function runs in a
+  // Deno edge runtime with no timezone of its own, and a server-clock `Date.now()`
+  // both floats on UTC boundaries and can't distinguish "0 days elapsed" from
+  // "worked out yesterday evening" — see docs/pattern-debt-scoring-model.md.
+  const parsedClientToday =
+    typeof body.client_today === 'string'
+      ? parseLocalDateString(body.client_today)
+      : null;
+  if (parsedClientToday === null) {
+    console.warn(
+      'recommend-program: missing/invalid client_today, falling back to server clock',
+    );
+  }
+  const clientToday = parsedClientToday ?? new Date();
+
   // Live enrollments: what's running plus what's queued.
   const { data: enrollments, error: enrErr } = await admin
     .from('user_programs')
@@ -185,6 +205,7 @@ export async function gatherInputs(
   if (debtErr) throw debtErr;
   const pattern_debt = computePatternBalance(
     (debtRows ?? []) as PatternAggregate[],
+    clientToday,
   );
 
   // Recent workout history + persistent training goal.
@@ -220,9 +241,7 @@ export async function gatherInputs(
 
   const days_since_last_workout =
     logs && logs.length > 0
-      ? Math.floor(
-          (Date.now() - new Date(logs[0].completed_at).getTime()) / 86_400_000,
-        )
+      ? daysBetweenCalendarDays(new Date(logs[0].completed_at), clientToday)
       : null;
 
   const { data: profile, error: profErr } = await admin

--- a/supabase/functions/recommend-program/scoring.ts
+++ b/supabase/functions/recommend-program/scoring.ts
@@ -6,6 +6,8 @@
 // minimal local types). Keep the constants and formulas in sync with the
 // source modules and docs/pattern-debt-scoring-model.md.
 
+import { daysBetweenCalendarDays } from '../../../src/utils/dateOnly.ts';
+
 // ---------------------------------------------------------------------------
 // Pattern debt (src/utils/patternDebt.ts)
 // ---------------------------------------------------------------------------
@@ -109,11 +111,7 @@ export function computePatternBalance(
       baseline_volume_kg: null,
     };
     const daysSince = agg.last_trained_at
-      ? Math.max(
-          0,
-          (now.getTime() - new Date(agg.last_trained_at).getTime()) /
-            86_400_000,
-        )
+      ? Math.max(0, daysBetweenCalendarDays(new Date(agg.last_trained_at), now))
       : null;
     const debtScore = computeDebtScore(
       daysSince,


### PR DESCRIPTION
## What

Ports the calendar-day-boundary fix from #225 into `recommend-program`, which had the identical bug in its own separate `computePatternBalance`/`days_since_last_workout` calculation.

## Why

#225 fixed `recommend-session`'s date math (raw elapsed-ms on the edge function's UTC clock instead of local calendar-day boundaries) but explicitly scoped out `recommend-program`, which has its own copy of `computePatternBalance` in `scoring.ts` with the same bug, flagging it as a follow-up.

## How

- `supabase/functions/recommend-program/scoring.ts` — `computePatternBalance` now uses `daysBetweenCalendarDays` instead of raw elapsed ms.
- `supabase/functions/recommend-program/inputs.ts` — `gatherInputs` accepts `client_today`, parses it via `parseLocalDateString` (falling back to the server clock with a warning if missing), and uses it for both `days_since_last_workout` and the pattern-debt calculation.
- `supabase/functions/recommend-program/index.ts` — parses the request body and passes it through.
- `src/api/useRecommendProgram.ts` — client now sends `client_today: localDateString()`.

## How tested

- `npx vitest run src/api/useRecommendProgram.test.ts src/utils/dateOnly.test.ts src/utils/patternDebt.test.ts` — all pass
- `npx tsc --noEmit` and `npx eslint` on touched files — clean
- Full `npx vitest run` — 465/465 tests pass (unrelated pre-existing failures in `.stories.jsx` files from a missing `@radix-ui/react-dropdown-menu` dependency)

## Note

This branch is based on #225's branch (`claude/ai-prompts-date-accuracy-233c0a`) since it depends on the shared `src/utils/dateOnly.ts` utility that PR introduces. Merge #225 first, then this one.