### PR TITLE
feat(programs): let the owner release/unrelease catalog programs from Browse

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -31,6 +31,7 @@ export * from './usePrograms';
 export * from './useSaveProgramSession';
 export * from './useSetProgramArchived';
 export * from './useSetProgramAutoRepeat';
+export * from './useSetProgramReleased';
 export * from './useSetProgramStage';
 export * from './useUpdateProgramSession';
 export * from './useUpdateProgramSessionsForward';

--- a/src/api/useSetProgramReleased.test.ts
+++ b/src/api/useSetProgramReleased.test.ts
@@ -1,0 +1,101 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import { HttpResponse, http } from 'msw';
+import React from 'react';
+
+import { SessionProvider, ToastContext } from '~/contexts';
+import { server } from '~/mocks/server';
+
+import { VITE_SUPABASE_URL } from '../env';
+import { PROGRAM_MUTATION_ERROR_MESSAGE } from './useProgramMutationErrorHandler';
+import { useSetProgramReleased } from './useSetProgramReleased';
+
+const RPC_URL = `${VITE_SUPABASE_URL}/rest/v1/rpc/set_program_released`;
+
+const showToast = vi.fn();
+
+const mockSession = {
+  user: {
+    id: 'user-123',
+    app_metadata: {},
+    user_metadata: {},
+    created_at: '',
+    aud: '',
+  },
+  access_token: '',
+  refresh_token: '',
+  expires_in: 10000,
+  token_type: '',
+};
+
+const makeWrapper = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return ({ children }: { children: React.ReactNode }) =>
+    React.createElement(
+      QueryClientProvider,
+      { client: queryClient },
+      React.createElement(
+        SessionProvider,
+        { value: mockSession },
+        React.createElement(
+          ToastContext.Provider,
+          { value: { showToast } },
+          children,
+        ),
+      ),
+    );
+};
+
+describe('useSetProgramReleased', () => {
+  beforeEach(() => showToast.mockClear());
+
+  it.each([true, false])(
+    'calls the RPC with the program id and released=%s',
+    async (released) => {
+      let receivedBody: {
+        p_program_id?: string;
+        p_released?: boolean;
+      } = {};
+      server.use(
+        http.post(RPC_URL, async ({ request }) => {
+          receivedBody = (await request.json()) as typeof receivedBody;
+          return new HttpResponse(null, { status: 204 });
+        }),
+      );
+
+      const { result } = renderHook(() => useSetProgramReleased(), {
+        wrapper: makeWrapper(),
+      });
+
+      await result.current.mutateAsync({ programId: 'prog-1', released });
+
+      expect(receivedBody).toEqual({
+        p_program_id: 'prog-1',
+        p_released: released,
+      });
+      expect(showToast).not.toHaveBeenCalled();
+    },
+  );
+
+  it('surfaces errors and toasts on failure', async () => {
+    server.use(
+      http.post(RPC_URL, () =>
+        HttpResponse.json({ message: 'boom' }, { status: 400 }),
+      ),
+    );
+
+    const { result } = renderHook(() => useSetProgramReleased(), {
+      wrapper: makeWrapper(),
+    });
+
+    await expect(
+      result.current.mutateAsync({ programId: 'prog-1', released: true }),
+    ).rejects.toBeTruthy();
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(showToast).toHaveBeenCalledWith(PROGRAM_MUTATION_ERROR_MESSAGE, {
+      variant: 'destructive',
+    });
+  });
+});

--- a/src/api/useSetProgramReleased.ts
+++ b/src/api/useSetProgramReleased.ts
@@ -1,0 +1,38 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { QUERIES } from '~/constants';
+
+import { supabase } from '../supabaseClient';
+import { useProgramMutationErrorHandler } from './useProgramMutationErrorHandler';
+
+export interface SetProgramReleasedInput {
+  /** The shared catalog program to release or pull back. */
+  programId: string;
+  /** `true` releases (visible to everyone); `false` pulls it back. */
+  released: boolean;
+}
+
+/**
+ * Releases or unreleases a shared catalog program by toggling
+ * `programs.released_at` through the `set_program_released` RPC. Catalog
+ * programs are system-owned (owner_id NULL), so the owner UPDATE policy can't
+ * reach them — the RPC is gated server-side to the app owner account.
+ */
+export const useSetProgramReleased = () => {
+  const queryClient = useQueryClient();
+  const onError = useProgramMutationErrorHandler();
+
+  return useMutation({
+    mutationFn: async (input: SetProgramReleasedInput): Promise<void> => {
+      const { error } = await supabase.rpc('set_program_released', {
+        p_program_id: input.programId,
+        p_released: input.released,
+      });
+      if (error) throw error;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: [QUERIES.PROGRAMS] });
+    },
+    onError,
+  });
+};

--- a/src/pages/ProgramsPage/ProgramsPage.test.tsx
+++ b/src/pages/ProgramsPage/ProgramsPage.test.tsx
@@ -14,6 +14,7 @@ const {
   mockUseCancelProgram,
   mockUseDeleteProgram,
   mockUseSetProgramArchived,
+  mockUseSetProgramReleased,
   mockUseQueuedPrograms,
   mockUseDequeueProgram,
   mockUseStartQueuedProgram,
@@ -24,6 +25,7 @@ const {
   cancelMutate,
   deleteMutate,
   setArchivedMutate,
+  setReleasedMutate,
   dequeueMutate,
   startQueuedMutate,
 } = vi.hoisted(() => ({
@@ -36,6 +38,7 @@ const {
   mockUseCancelProgram: vi.fn(),
   mockUseDeleteProgram: vi.fn(),
   mockUseSetProgramArchived: vi.fn(),
+  mockUseSetProgramReleased: vi.fn(),
   mockUseQueuedPrograms: vi.fn(),
   mockUseDequeueProgram: vi.fn(),
   mockUseStartQueuedProgram: vi.fn(),
@@ -46,6 +49,7 @@ const {
   cancelMutate: vi.fn(),
   deleteMutate: vi.fn(),
   setArchivedMutate: vi.fn(),
+  setReleasedMutate: vi.fn(),
   dequeueMutate: vi.fn(),
   startQueuedMutate: vi.fn(),
 }));
@@ -60,6 +64,7 @@ vi.mock('~/api', () => ({
   useCancelProgram: mockUseCancelProgram,
   useDeleteProgram: mockUseDeleteProgram,
   useSetProgramArchived: mockUseSetProgramArchived,
+  useSetProgramReleased: mockUseSetProgramReleased,
   useQueuedPrograms: mockUseQueuedPrograms,
   useDequeueProgram: mockUseDequeueProgram,
   useStartQueuedProgram: mockUseStartQueuedProgram,
@@ -182,6 +187,7 @@ describe('ProgramsPage', () => {
     cancelMutate.mockReset();
     deleteMutate.mockReset();
     setArchivedMutate.mockReset();
+    setReleasedMutate.mockReset();
     mockTrackEvent.mockReset();
     mockUsePrograms.mockReturnValue({
       data: [dfw, myProgram],
@@ -218,6 +224,10 @@ describe('ProgramsPage', () => {
     });
     mockUseSetProgramArchived.mockReturnValue({
       mutate: setArchivedMutate,
+      isPending: false,
+    });
+    mockUseSetProgramReleased.mockReturnValue({
+      mutate: setReleasedMutate,
       isPending: false,
     });
     dequeueMutate.mockReset();
@@ -373,7 +383,7 @@ describe('ProgramsPage', () => {
     expect(screen.getByText('Repeats')).toBeInTheDocument();
   });
 
-  it('badges released shared programs for the owner account only', () => {
+  it('shows the owner a release toggle reflecting each shared program state', () => {
     mockSessionEmail = 'daniel_bowers@icloud.com';
     mockUsePrograms.mockReturnValue({
       data: [
@@ -385,17 +395,43 @@ describe('ProgramsPage', () => {
 
     renderPage();
 
-    // Chip on the released program only.
-    expect(screen.getAllByText('Released')).toHaveLength(1);
     expect(screen.getByLabelText('View Dry Fighting Weight')).toHaveTextContent(
-      'Released',
+      'Unrelease',
     );
     expect(
       screen.getByLabelText('View Armor Building Complex'),
-    ).not.toHaveTextContent('Released');
+    ).toHaveTextContent('Release');
   });
 
-  it('never shows the released badge to a non-owner', () => {
+  it('releases and unreleases from the toggle without navigating', () => {
+    mockSessionEmail = 'daniel_bowers@icloud.com';
+    mockUsePrograms.mockReturnValue({
+      data: [
+        { ...dfw, releasedAt: '2026-07-28T12:00:00Z' },
+        { ...armor, releasedAt: null },
+      ],
+      isLoading: false,
+    });
+
+    renderPage();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Unrelease' }));
+    expect(setReleasedMutate).toHaveBeenCalledWith({
+      programId: dfw.id,
+      released: false,
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Release' }));
+    expect(setReleasedMutate).toHaveBeenCalledWith({
+      programId: armor.id,
+      released: true,
+    });
+
+    // Still on the programs page — the row link didn't navigate.
+    expect(screen.getByText('Browse programs')).toBeInTheDocument();
+  });
+
+  it('never shows the release toggle to a non-owner', () => {
     mockUsePrograms.mockReturnValue({
       data: [{ ...dfw, releasedAt: '2026-07-28T12:00:00Z' }],
       isLoading: false,
@@ -403,7 +439,9 @@ describe('ProgramsPage', () => {
 
     renderPage();
 
-    expect(screen.queryByText('Released')).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: /release/i }),
+    ).not.toBeInTheDocument();
   });
 
   it('enrolls in your own program directly, with no starting-weight prompt', () => {

--- a/src/pages/ProgramsPage/components/BrowseProgramsList.tsx
+++ b/src/pages/ProgramsPage/components/BrowseProgramsList.tsx
@@ -1,6 +1,7 @@
 import { ChevronRightIcon } from '@heroicons/react/24/outline';
 import { Link } from 'react-router-dom';
 
+import { useSetProgramReleased } from '~/api';
 import { ProgramTags } from '~/components';
 import { Card } from '~/components/ui/card';
 import { Program } from '~/types';
@@ -10,7 +11,7 @@ import { programSpanLabel } from '../utils';
 
 export interface BrowseProgramsListProps {
   programs: Program[];
-  /** Owner-only: surfaces the release state of a shared program. */
+  /** Owner-only: shows a release/unrelease toggle on each shared program. */
   showReleasedBadge: boolean;
 }
 
@@ -22,46 +23,62 @@ export interface BrowseProgramsListProps {
 export const BrowseProgramsList = ({
   programs,
   showReleasedBadge,
-}: BrowseProgramsListProps) => (
-  <Card className="divide-y overflow-hidden">
-    {programs.map((program) => (
-      <Link
-        key={program.id}
-        to={`/programs/${program.id}/details`}
-        aria-label={`View ${program.title}`}
-        className="flex items-center gap-1.5 p-2 transition-colors hover:bg-secondary"
-      >
-        <span
-          aria-hidden
-          className="flex h-4 w-4 shrink-0 items-center justify-center rounded-md bg-primary/10 text-sm font-semibold tabular-nums text-primary"
+}: BrowseProgramsListProps) => {
+  const setReleased = useSetProgramReleased();
+
+  return (
+    <Card className="divide-y overflow-hidden">
+      {programs.map((program) => (
+        <Link
+          key={program.id}
+          to={`/programs/${program.id}/details`}
+          aria-label={`View ${program.title}`}
+          className="flex items-center gap-1.5 p-2 transition-colors hover:bg-secondary"
         >
-          {programSpanLabel(program)}
-        </span>
-        <div className="min-w-0 flex-1">
-          <p className="flex items-center gap-1 truncate text-sm font-semibold leading-tight">
-            {program.title}
-            {program.defaultAutoRepeat && (
-              <span className="rounded bg-secondary px-0.5 text-xs font-normal text-muted-foreground">
-                Repeats
-              </span>
-            )}
-            {showReleasedBadge && program.releasedAt && (
-              <span className="rounded bg-secondary px-0.5 text-xs font-normal text-muted-foreground">
-                Released
-              </span>
-            )}
-          </p>
-          <p className="truncate text-xs text-muted-foreground">
-            {program.authorName ? `${program.authorName} · ` : ''}
-            {programCadenceLabel(program) ?? 'No sessions yet'}
-          </p>
-          <ProgramTags tags={program.focusTags} className="mt-0.5" />
-        </div>
-        <ChevronRightIcon
-          aria-hidden
-          className="h-2 w-2 shrink-0 text-muted-foreground"
-        />
-      </Link>
-    ))}
-  </Card>
-);
+          <span
+            aria-hidden
+            className="flex h-4 w-4 shrink-0 items-center justify-center rounded-md bg-primary/10 text-sm font-semibold tabular-nums text-primary"
+          >
+            {programSpanLabel(program)}
+          </span>
+          <div className="min-w-0 flex-1">
+            <p className="flex items-center gap-1 truncate text-sm font-semibold leading-tight">
+              {program.title}
+              {program.defaultAutoRepeat && (
+                <span className="rounded bg-secondary px-0.5 text-xs font-normal text-muted-foreground">
+                  Repeats
+                </span>
+              )}
+              {showReleasedBadge && (
+                <button
+                  type="button"
+                  disabled={setReleased.isPending}
+                  onClick={(event) => {
+                    event.preventDefault();
+                    event.stopPropagation();
+                    setReleased.mutate({
+                      programId: program.id,
+                      released: !program.releasedAt,
+                    });
+                  }}
+                  className="rounded bg-secondary px-0.5 text-xs font-normal text-muted-foreground hover:text-foreground disabled:opacity-50"
+                >
+                  {program.releasedAt ? 'Unrelease' : 'Release'}
+                </button>
+              )}
+            </p>
+            <p className="truncate text-xs text-muted-foreground">
+              {program.authorName ? `${program.authorName} · ` : ''}
+              {programCadenceLabel(program) ?? 'No sessions yet'}
+            </p>
+            <ProgramTags tags={program.focusTags} className="mt-0.5" />
+          </div>
+          <ChevronRightIcon
+            aria-hidden
+            className="h-2 w-2 shrink-0 text-muted-foreground"
+          />
+        </Link>
+      ))}
+    </Card>
+  );
+};

--- a/src/pages/ProgramsPage/components/BrowseProgramsSection.tsx
+++ b/src/pages/ProgramsPage/components/BrowseProgramsSection.tsx
@@ -9,7 +9,7 @@ export interface BrowseProgramsSectionProps {
   programs: Program[];
   open: boolean;
   onOpenChange: (open: boolean) => void;
-  /** Owner-only: surfaces the release state of a shared program. */
+  /** Owner-only: shows a release/unrelease toggle on each shared program. */
   showReleasedBadge: boolean;
 }
 

--- a/supabase/migrations/20260804140000_add_set_program_released_rpc.sql
+++ b/supabase/migrations/20260804140000_add_set_program_released_rpc.sql
@@ -1,0 +1,28 @@
+-- Owner-only release toggle for shared catalog programs (follow-up to
+-- PROD-246's release gate). Seeded public programs have owner_id NULL, so the
+-- "Users can update own programs" policy can't flip released_at from the app;
+-- releasing has required raw SQL. This RPC lets the app owner release or pull
+-- back a catalog program from the UI.
+--
+-- The email gate mirrors the owner exemption in the PROD-246 SELECT policy
+-- (and OWNER_EMAILS in src/config/features.ts): it controls catalog
+-- visibility only, not a privilege boundary. The function touches nothing but
+-- released_at on public programs.
+CREATE OR REPLACE FUNCTION public.set_program_released(
+  p_program_id uuid,
+  p_released boolean
+)
+  RETURNS void
+  LANGUAGE sql
+  SECURITY DEFINER
+  SET search_path = ''
+AS $$
+  UPDATE public.programs
+  SET released_at = CASE WHEN p_released THEN now() END
+  WHERE id = p_program_id
+    AND is_public
+    AND (SELECT auth.jwt() ->> 'email') = 'daniel_bowers@icloud.com';
+$$;
+
+REVOKE EXECUTE ON FUNCTION public.set_program_released(uuid, boolean) FROM anon, public;
+GRANT EXECUTE ON FUNCTION public.set_program_released(uuid, boolean) TO authenticated;

--- a/types/supabase.ts
+++ b/types/supabase.ts
@@ -974,6 +974,10 @@ export type Database = {
         Args: { p_replace_user_program_id?: string; p_user_program_id: string }
         Returns: string
       }
+      set_program_released: {
+        Args: { p_program_id: string; p_released: boolean }
+        Returns: undefined
+      }
       set_program_stage: {
         Args: { p_stage_index: number; p_user_program_id: string }
         Returns: number


### PR DESCRIPTION
## Why

The "Recommend a program" button returned *"You're already running or have queued every program we'd suggest."* despite Browse showing 10 plans. Root cause: the recommender only considers public programs with `released_at` set, and prod had exactly one released — A+A Plan A, the one already active — so the candidate pool was empty and the edge function short-circuited before ever calling the LLM. Releasing the rest required raw SQL, because seeded catalog rows are system-owned (`owner_id NULL`) and out of reach of the owner UPDATE policy.

## What

An owner-only Release/Unrelease toggle on each Browse row, backed by a `set_program_released` RPC gated to the app owner email — the same pattern as the PROD-246 SELECT exemption. The toggle replaces the static "Released" badge.

## How to test

- `npm test` — 762 passing, including new `useSetProgramReleased` hook tests and ProgramsPage tests: owner sees state-reflecting labels, clicks mutate without navigating the row link, non-owner never sees the toggle.
- Migration applied to local DB; `compile:ts` and `lint` clean.

## Gallery

<!-- Owner toggle screenshot pending — headless auth capture was blocked this session; drag-drop one in. -->

## Deploy notes

- New migration `supabase/migrations/20260804140000_add_set_program_released_rpc.sql` (SECURITY DEFINER — review the email gate).
- `types/supabase.ts` was hand-updated in the generated format because `npm run gen:types` was blocked; rerun it to confirm it matches.
- The one-time bulk release of the 9 catalog programs was applied directly in prod (rollback SQL noted in the session plan file).