### PR TITLE
chore(db): drop legacy pattern_debt_window RPC (hold until clients cycle)

### DIFF
--- a/supabase/migrations/20260804160000_drop_pattern_debt_window.sql
+++ b/supabase/migrations/20260804160000_drop_pattern_debt_window.sql
@@ -1,0 +1,9 @@
+-- Pattern-debt ledger Phase 1 cleanup (T8): drop the legacy 7-pattern RPC.
+--
+-- All shipped callers (PWA bundle index-87a09062+, recommend-session,
+-- recommend-program) migrated to pattern_debt_movements in PR #229. This was
+-- deliberately deferred so service-worker-cached PWA bundles could keep
+-- calling the old function during rollout. Merge only after stale clients
+-- have cycled (a few days after #229 reached production).
+
+DROP FUNCTION IF EXISTS public.pattern_debt_window(int, int);

--- a/types/supabase.ts
+++ b/types/supabase.ts
@@ -972,18 +972,6 @@ export type Database = {
           total_volume_kg: number
         }[]
       }
-      pattern_debt_window: {
-        Args: { p_baseline_days?: number; p_window_days?: number }
-        Returns: {
-          baseline_volume_kg: number
-          hardest_rpe: Database["public"]["Enums"]["RPE"]
-          last_trained_at: string
-          pattern: string
-          set_count: number
-          total_reps: number
-          total_volume_kg: number
-        }[]
-      }
       reorder_program_sessions: {
         Args: { p_ordered_ids: string[]; p_program_id: string }
         Returns: undefined


### PR DESCRIPTION
## What
Drops the legacy `pattern_debt_window` RPC — the T8 cleanup from the pattern-debt ledger plan.

## Why
#229 moved every caller (PWA, recommend-session, recommend-program) to `pattern_debt_movements`. The old function was kept live only so service-worker-cached PWA bundles wouldn't break mid-rollout.

## How tested
`supabase db reset` applies cleanly with the drop; the pattern-debt e2e spec (new RPC) still passes 2/2 afterward.

## ⚠️ Hold merge
Merge **a few days after #229's deploy** (2026-08-03), once stale PWA bundles have cycled. Merging early breaks any tab still running the pre-#229 bundle.
