### PR TITLE
fix(recommender): drop unsupported effort param for Haiku

### DIFF
--- a/supabase/functions/recommend-program/llm.ts
+++ b/supabase/functions/recommend-program/llm.ts
@@ -92,8 +92,8 @@ async function callModel(
         model: MODEL,
         max_tokens: MAX_TOKENS,
         thinking: { type: 'disabled' },
+        // Haiku rejects `effort`; Sonnet accepts it. Omit so both models work.
         output_config: {
-          effort: 'low',
           format: { type: 'json_schema', schema: RECOMMENDATION_SCHEMA },
         },
         system,

--- a/supabase/functions/recommend-session/llm.ts
+++ b/supabase/functions/recommend-session/llm.ts
@@ -98,8 +98,8 @@ async function callModel(
         model: MODEL,
         max_tokens: MAX_TOKENS,
         thinking: { type: 'disabled' },
+        // Haiku rejects `effort`; Sonnet accepts it. Omit so both models work.
         output_config: {
-          effort: 'low',
           format: { type: 'json_schema', schema: RECOMMENDATION_SCHEMA },
         },
         system,


### PR DESCRIPTION
## Why

After switching both AI recommenders to `claude-haiku-4-5`, Anthropic started rejecting every request with `This model does not support the effort parameter.`, which surfaced as 502 `recommendation_failed` in prod for both `recommend-session` and `recommend-program`.

## What

Omit `output_config.effort` from the Anthropic Messages API payload in both recommender edge functions. Structured JSON schema output is unchanged.

## How to test

1. Merge/deploy the edge functions (or invoke against a project with this code).
2. As a premium user, trigger session recommend and program recommend.
3. Confirm both return 200 with a recommendation (not 502 `recommendation_failed`).
4. Optionally check `session_recommendations` / `program_recommendations` for a new `status = 'generated'` row rather than `error` mentioning `effort`.

## Deploy notes

Merging to `main` redeploys edge functions via the production Supabase workflow (`supabase/**` path). No migrations, flags, or env changes.


Made with [Cursor](https://cursor.com)