### PR TITLE
feat(movements): mobile card list, pattern column/filter, rename tab to Movements

### DIFF
--- a/src/api/useMovements.ts
+++ b/src/api/useMovements.ts
@@ -9,6 +9,7 @@ interface MovementFilters {
   difficultyLevel?: DifficultyLevel;
   equipment?: Equipment;
   movementName?: string;
+  movementPattern?: string;
   muscleGroup?: MuscleGroup;
 }
 
@@ -40,6 +41,11 @@ export const useMovements = (
     ...queryOptions,
   });
 
+// PostgREST stops parsing unquoted identifiers at `#`, so columns like
+// "Movement Pattern #1" must be double-quoted in order/filter params.
+const quoteSpecialColumn = (column: string) =>
+  column.includes('#') ? `"${column}"` : column;
+
 const fetchMovements = async ({
   page = 1,
   limit = 25,
@@ -51,7 +57,9 @@ const fetchMovements = async ({
   const to = from + limit - 1;
 
   let query = supabase.from('movements').select('*', { count: 'exact' });
-  query = query.order(orderBy, { ascending: order === 'ASC' });
+  query = query.order(quoteSpecialColumn(orderBy), {
+    ascending: order === 'ASC',
+  });
 
   if (where?.difficultyLevel) {
     query = query.eq('Difficulty Level', where.difficultyLevel);
@@ -61,6 +69,9 @@ const fetchMovements = async ({
   }
   if (where?.movementName) {
     query = query.ilike('Movement', `%${where.movementName}%`);
+  }
+  if (where?.movementPattern) {
+    query = query.filter('"Movement Pattern #1"', 'eq', where.movementPattern);
   }
   if (where?.muscleGroup) {
     query = query.eq('Target Muscle Group', where.muscleGroup);

--- a/src/components/BottomNav/BottomNav.test.tsx
+++ b/src/components/BottomNav/BottomNav.test.tsx
@@ -92,7 +92,7 @@ describe('BottomNav', () => {
   });
 
   test('More sheet rows carry their resolved row classes', () => {
-    // AI wins the promoted slot, so Explore is the one that overflows.
+    // AI wins the promoted slot, so Movements is the one that overflows.
     mockedUseFeatures.mockReturnValue(
       featuresWith({ premium: true, explore: true }),
     );
@@ -102,7 +102,7 @@ describe('BottomNav', () => {
     // Regression: routing these through `DialogClose asChild` forwarded
     // NavLink's function className to the anchor as a stringified arrow, so the
     // rows rendered with no styling at all.
-    for (const name of [/Account/, /Explore/]) {
+    for (const name of [/Account/, /Movements/]) {
       expect(screen.getByRole('link', { name })).toHaveClass(
         'flex',
         'items-center',
@@ -123,10 +123,10 @@ describe('BottomNav', () => {
       featuresWith({ premium: true, explore: true }),
     );
     renderNav();
-    // AI is promoted into the bar; Explore overflows into More.
+    // AI is promoted into the bar; Movements overflows into More.
     expect(screen.getByRole('link', { name: 'AI' })).toBeInTheDocument();
     fireEvent.click(screen.getByRole('button', { name: 'More' }));
-    expect(screen.getByRole('link', { name: /Explore/ })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /Movements/ })).toBeInTheDocument();
   });
 
   test('hides while a text input is focused (mobile keyboard)', () => {

--- a/src/components/BottomNav/buildTabs.test.ts
+++ b/src/components/BottomNav/buildTabs.test.ts
@@ -45,12 +45,12 @@ describe('buildTabs', () => {
     expect(tabs[2]).toMatchObject({ label: 'AI', to: '/recommendations' });
   });
 
-  test('promotes Explore when only explore is enabled', () => {
+  test('promotes Movements when only explore is enabled', () => {
     const { tabs } = buildTabs({ ...allOff, explore: true });
     expect(tabs.map((t) => t.key)).toEqual(['home', 'history', 'explore']);
   });
 
-  test('AI wins the promoted slot over Explore', () => {
+  test('AI wins the promoted slot over Movements', () => {
     const features = {
       ...allOff,
       premium: true,

--- a/src/components/BottomNav/buildTabs.ts
+++ b/src/components/BottomNav/buildTabs.ts
@@ -18,7 +18,7 @@ export interface BuiltTabs {
  *   1. Home        (always)
  *   2. Programs    (reserved; `programs` flag)
  *   3. History     (always)
- *   4. one promoted feature, AI → Explore (first enabled wins)
+ *   4. one promoted feature, AI → Movements (first enabled wins)
  *   5. More        (always; rendered by the component, not part of `tabs`)
  *
  * Pure and side-effect free so every flag combination is cheap to unit-test.

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -88,7 +88,7 @@ export const Header = () => {
               asChild
               className={navigationMenuTriggerStyle()}
             >
-              <NavLink to="/movements">Explore</NavLink>
+              <NavLink to="/movements">Movements</NavLink>
             </NavigationMenuLink>
           </NavigationMenuItem>
         )}

--- a/src/components/ui/data-table.tsx
+++ b/src/components/ui/data-table.tsx
@@ -60,8 +60,6 @@ export function DataTable<TData, TValue>({
     rowCount,
   });
 
-  const totalPages = Math.ceil(rowCount / pageSize);
-
   const handleHeaderClick = (columnId: string) => {
     if (!onSort) return;
     onSort(columnId);
@@ -135,52 +133,95 @@ export function DataTable<TData, TValue>({
         </TableBody>
       </Table>
 
-      <div className="flex items-center justify-between py-4">
-        <div className="text-sm text-muted-foreground">
-          Page {currentPage} of {totalPages} • {rowCount} total items
-        </div>
-        <div className="flex items-center space-x-2">
-          {onClickFirstPage && (
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={onClickFirstPage}
-              disabled={!hasPreviousPage || isLoading}
-            >
-              First
-            </Button>
-          )}
-          {onClickPreviousPage && (
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={onClickPreviousPage}
-              disabled={!hasPreviousPage || isLoading}
-            >
-              Previous
-            </Button>
-          )}
-          {onClickNextPage && (
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={onClickNextPage}
-              disabled={!hasNextPage || isLoading}
-            >
-              Next
-            </Button>
-          )}
-          {onClickLastPage && (
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={onClickLastPage}
-              disabled={!hasNextPage || isLoading}
-            >
-              Last
-            </Button>
-          )}
-        </div>
+      <DataTablePagination
+        currentPage={currentPage}
+        hasNextPage={hasNextPage}
+        hasPreviousPage={hasPreviousPage}
+        isLoading={isLoading}
+        onClickFirstPage={onClickFirstPage}
+        onClickLastPage={onClickLastPage}
+        onClickNextPage={onClickNextPage}
+        onClickPreviousPage={onClickPreviousPage}
+        pageSize={pageSize}
+        rowCount={rowCount}
+      />
+    </div>
+  );
+}
+
+interface DataTablePaginationProps {
+  currentPage: number;
+  hasNextPage?: boolean;
+  hasPreviousPage?: boolean;
+  isLoading?: boolean;
+  onClickFirstPage?: () => void;
+  onClickLastPage?: () => void;
+  onClickNextPage?: () => void;
+  onClickPreviousPage?: () => void;
+  pageSize: number;
+  rowCount: number;
+}
+
+export function DataTablePagination({
+  currentPage,
+  hasNextPage,
+  hasPreviousPage,
+  isLoading = false,
+  onClickFirstPage,
+  onClickLastPage,
+  onClickNextPage,
+  onClickPreviousPage,
+  pageSize,
+  rowCount,
+}: DataTablePaginationProps) {
+  const totalPages = Math.ceil(rowCount / pageSize);
+
+  return (
+    <div className="flex items-center justify-between py-4">
+      <div className="text-sm text-muted-foreground">
+        Page {currentPage} of {totalPages} • {rowCount} total items
+      </div>
+      <div className="flex items-center space-x-2">
+        {onClickFirstPage && (
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={onClickFirstPage}
+            disabled={!hasPreviousPage || isLoading}
+          >
+            First
+          </Button>
+        )}
+        {onClickPreviousPage && (
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={onClickPreviousPage}
+            disabled={!hasPreviousPage || isLoading}
+          >
+            Previous
+          </Button>
+        )}
+        {onClickNextPage && (
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={onClickNextPage}
+            disabled={!hasNextPage || isLoading}
+          >
+            Next
+          </Button>
+        )}
+        {onClickLastPage && (
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={onClickLastPage}
+            disabled={!hasNextPage || isLoading}
+          >
+            Last
+          </Button>
+        )}
       </div>
     </div>
   );

--- a/src/lib/navItems.ts
+++ b/src/lib/navItems.ts
@@ -57,7 +57,7 @@ export const NAV_ITEMS: NavItem[] = [
   },
   {
     key: 'explore',
-    label: 'Explore',
+    label: 'Movements',
     to: '/movements',
     icon: MagnifyingGlassIcon,
     activeIcon: MagnifyingGlassSolidIcon,

--- a/src/pages/MovementsPage/MovementsPage.test.tsx
+++ b/src/pages/MovementsPage/MovementsPage.test.tsx
@@ -1,0 +1,122 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { HttpResponse, http } from 'msw';
+import { MemoryRouter } from 'react-router-dom';
+import { QueryParamProvider } from 'use-query-params';
+import { ReactRouter6Adapter } from 'use-query-params/adapters/react-router-6';
+
+import { VITE_SUPABASE_URL } from '~/env';
+import { server } from '~/mocks/server';
+
+import { MovementsPage } from './MovementsPage';
+
+const MOVEMENT_ROWS = [
+  {
+    id: 1,
+    'Difficulty Level': 'Beginner',
+    Movement: 'Kettlebell Swing',
+    'Movement Pattern #1': 'Hip Hinge',
+    'Primary Equipment': 'Kettlebell',
+    '# Primary Items': 1,
+    'Single or Double Arm': null,
+    'Target Muscle Group': 'Glutes',
+  },
+  {
+    id: 2,
+    'Difficulty Level': 'Intermediate',
+    Movement: 'Goblet Squat',
+    'Movement Pattern #1': 'Knee Dominant',
+    'Primary Equipment': 'Kettlebell',
+    '# Primary Items': 1,
+    'Single or Double Arm': null,
+    'Target Muscle Group': 'Quadriceps',
+  },
+];
+
+const requestUrls: URL[] = [];
+
+const renderPage = () => {
+  requestUrls.length = 0;
+  server.use(
+    http.get(`${VITE_SUPABASE_URL}/rest/v1/movements`, ({ request }) => {
+      const url = new URL(request.url);
+      requestUrls.push(url);
+      const pattern = url.searchParams.get('"Movement Pattern #1"');
+      const rows = pattern
+        ? MOVEMENT_ROWS.filter(
+            (row) => `eq.${row['Movement Pattern #1']}` === pattern,
+          )
+        : MOVEMENT_ROWS;
+      return HttpResponse.json(rows, {
+        headers: { 'content-range': `0-${rows.length - 1}/${rows.length}` },
+      });
+    }),
+  );
+
+  return render(
+    <MemoryRouter>
+      <QueryParamProvider adapter={ReactRouter6Adapter}>
+        <QueryClientProvider client={new QueryClient()}>
+          <MovementsPage />
+        </QueryClientProvider>
+      </QueryParamProvider>
+    </MemoryRouter>,
+  );
+};
+
+describe('movements page', () => {
+  test('renders movements in both the table and the mobile list', async () => {
+    renderPage();
+    expect(await screen.findAllByText('Kettlebell Swing')).toHaveLength(2);
+    expect(screen.getAllByText('Goblet Squat')).toHaveLength(2);
+  });
+
+  test('shows the movement pattern', async () => {
+    renderPage();
+    expect(await screen.findAllByText('Hip Hinge')).toHaveLength(2);
+  });
+
+  test('filters by movement pattern', async () => {
+    const user = userEvent.setup();
+    renderPage();
+    await screen.findAllByText('Kettlebell Swing');
+
+    const patternTrigger = screen
+      .getAllByText('Pattern')
+      .map((element) => element.closest('button'))
+      .find(Boolean);
+    await user.click(patternTrigger!);
+    await user.click(screen.getByRole('option', { name: 'Hip Hinge' }));
+
+    await waitFor(() =>
+      expect(
+        requestUrls.at(-1)?.searchParams.get('"Movement Pattern #1"'),
+      ).toBe('eq.Hip Hinge'),
+    );
+    await waitFor(() =>
+      expect(screen.queryAllByText('Goblet Squat')).toHaveLength(0),
+    );
+  });
+
+  test('reset filters clears the pattern filter', async () => {
+    const user = userEvent.setup();
+    renderPage();
+    await screen.findAllByText('Kettlebell Swing');
+
+    const patternTrigger = screen
+      .getAllByText('Pattern')
+      .map((element) => element.closest('button'))
+      .find(Boolean);
+    await user.click(patternTrigger!);
+    await user.click(screen.getByRole('option', { name: 'Hip Hinge' }));
+    await user.click(await screen.findByRole('button', { name: 'Reset Filters' }));
+
+    await waitFor(() =>
+      expect(
+        requestUrls.at(-1)?.searchParams.get('"Movement Pattern #1"'),
+      ).toBeNull(),
+    );
+    expect(await screen.findAllByText('Goblet Squat')).toHaveLength(2);
+  });
+});

--- a/src/pages/MovementsPage/MovementsPage.tsx
+++ b/src/pages/MovementsPage/MovementsPage.tsx
@@ -8,9 +8,10 @@ import {
 } from 'use-query-params';
 
 import { useMovements } from '~/api';
-import { Page } from '~/components';
+import { Loading, Page } from '~/components';
 import { Button } from '~/components/ui/button';
-import { DataTable } from '~/components/ui/data-table';
+import { Card } from '~/components/ui/card';
+import { DataTable, DataTablePagination } from '~/components/ui/data-table';
 import { Input } from '~/components/ui/input';
 import {
   Select,
@@ -22,12 +23,15 @@ import {
 import { useDebouncedCallback } from '~/hooks/useDebouncedCallback';
 import { DifficultyLevel, Equipment, Movement, MuscleGroup } from '~/types';
 
+import { MovementRow } from './components';
+
 export const MovementsPage = () => {
   const [queryParams, setQueryParams] = useQueryParams({
     page: withDefault(NumberParam, 1),
     muscleGroup: withDefault(StringParam, undefined),
     equipment: withDefault(StringParam, undefined),
     difficultyLevel: withDefault(StringParam, undefined),
+    movementPattern: withDefault(StringParam, undefined),
     orderBy: withDefault(StringParam, 'Movement'),
     order: withDefault(StringParam, 'ASC'),
     search: withDefault(StringParam, undefined),
@@ -39,6 +43,7 @@ export const MovementsPage = () => {
     queryParams.muscleGroup !== undefined ||
     queryParams.equipment !== undefined ||
     queryParams.difficultyLevel !== undefined ||
+    queryParams.movementPattern !== undefined ||
     queryParams.search !== undefined ||
     queryParams.orderBy !== 'Movement' ||
     queryParams.order !== 'ASC';
@@ -56,6 +61,7 @@ export const MovementsPage = () => {
       difficultyLevel: queryParams.difficultyLevel as DifficultyLevel,
       equipment: queryParams.equipment as Equipment,
       movementName: queryParams.search,
+      movementPattern: queryParams.movementPattern,
       muscleGroup: queryParams.muscleGroup as MuscleGroup,
     },
   });
@@ -86,6 +92,9 @@ export const MovementsPage = () => {
   const handleFilterByDifficulty = (value: string | undefined) => {
     setQueryParams({ difficultyLevel: value, page: undefined });
   };
+  const handleFilterByPattern = (value: string | undefined) => {
+    setQueryParams({ movementPattern: value, page: undefined });
+  };
   const handleSearch = useCallback(
     (value: string) => {
       setSearchInput(value);
@@ -108,6 +117,7 @@ export const MovementsPage = () => {
     setQueryParams({
       difficultyLevel: undefined,
       equipment: undefined,
+      movementPattern: undefined,
       muscleGroup: undefined,
       order: undefined,
       orderBy: undefined,
@@ -119,8 +129,9 @@ export const MovementsPage = () => {
 
   return (
     <Page title="Movements" width="full">
-      <div className="mb-2 flex items-center gap-2">
+      <div className="mb-2 grid grid-cols-2 gap-1 md:flex md:items-center md:gap-2">
         <Input
+          className="col-span-2 md:col-auto"
           onChange={(e) => handleSearch(e.target.value)}
           placeholder="Search movements..."
           value={searchInput}
@@ -180,30 +191,84 @@ export const MovementsPage = () => {
           </SelectContent>
         </Select>
 
+        <Select
+          value={queryParams.movementPattern || ''}
+          onValueChange={handleFilterByPattern}
+          showReset={!!queryParams.movementPattern}
+          onReset={() => handleFilterByPattern(undefined)}
+        >
+          <SelectTrigger>
+            <SelectValue placeholder="Pattern" />
+          </SelectTrigger>
+          <SelectContent>
+            {MOVEMENT_PATTERNS.map((pattern) => (
+              <SelectItem key={pattern} value={pattern}>
+                {pattern}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+
         {hasActiveFilters && (
-          <Button variant="ghost" onClick={handleResetFilters}>
+          <Button
+            className="col-span-2 md:col-auto"
+            variant="ghost"
+            onClick={handleResetFilters}
+          >
             Reset Filters
           </Button>
         )}
       </div>
 
-      <DataTable
-        columns={COLUMNS}
-        currentPage={queryParams.page}
-        data={movements}
-        hasNextPage={hasNextPage}
-        hasPreviousPage={hasPreviousPage}
-        isLoading={isLoading}
-        onClickFirstPage={handleClickFirstPage}
-        onClickLastPage={handleClickLastPage}
-        onClickNextPage={handleClickNextPage}
-        onClickPreviousPage={handleClickPreviousPage}
-        onSort={handleSort}
-        order={queryParams.order as 'ASC' | 'DESC'}
-        orderBy={queryParams.orderBy}
-        pageSize={PAGE_SIZE}
-        rowCount={rowCount}
-      />
+      <div className="hidden md:block">
+        <DataTable
+          columns={COLUMNS}
+          currentPage={queryParams.page}
+          data={movements}
+          hasNextPage={hasNextPage}
+          hasPreviousPage={hasPreviousPage}
+          isLoading={isLoading}
+          onClickFirstPage={handleClickFirstPage}
+          onClickLastPage={handleClickLastPage}
+          onClickNextPage={handleClickNextPage}
+          onClickPreviousPage={handleClickPreviousPage}
+          onSort={handleSort}
+          order={queryParams.order as 'ASC' | 'DESC'}
+          orderBy={queryParams.orderBy}
+          pageSize={PAGE_SIZE}
+          rowCount={rowCount}
+        />
+      </div>
+
+      <div className="md:hidden">
+        {isLoading ? (
+          <div className="flex justify-center py-3">
+            <Loading />
+          </div>
+        ) : movements.length === 0 ? (
+          <div className="py-3 text-center text-muted-foreground">
+            No results.
+          </div>
+        ) : (
+          <Card>
+            <div className="divide-y">
+              {movements.map((movement) => (
+                <MovementRow key={movement.id} movement={movement} />
+              ))}
+            </div>
+          </Card>
+        )}
+        <DataTablePagination
+          currentPage={queryParams.page}
+          hasNextPage={hasNextPage}
+          hasPreviousPage={hasPreviousPage}
+          isLoading={isLoading}
+          onClickNextPage={handleClickNextPage}
+          onClickPreviousPage={handleClickPreviousPage}
+          pageSize={PAGE_SIZE}
+          rowCount={rowCount}
+        />
+      </div>
     </Page>
   );
 };
@@ -213,6 +278,11 @@ const COLUMNS: ColumnDef<Movement>[] = [
     header: 'Movement',
     accessorKey: 'movementName',
     id: 'Movement',
+  },
+  {
+    header: 'Pattern',
+    accessorKey: 'movementPattern1',
+    id: 'Movement Pattern #1',
   },
   {
     header: 'Target Muscle Group',
@@ -257,3 +327,17 @@ const DIFFICULTY_LEVELS: DifficultyLevel[] = [
 ];
 
 const EQUIPMENT_TYPES: Equipment[] = ['Bodyweight', 'Kettlebell'];
+
+const MOVEMENT_PATTERNS: string[] = [
+  'Anti-Extension',
+  'Anti-Rotation',
+  'Hip Extension',
+  'Hip Hinge',
+  'Horizontal Pull',
+  'Horizontal Push',
+  'Knee Dominant',
+  'Loaded Carry',
+  'Rotational',
+  'Vertical Pull',
+  'Vertical Push',
+];

--- a/src/pages/MovementsPage/components/MovementRow.tsx
+++ b/src/pages/MovementsPage/components/MovementRow.tsx
@@ -1,0 +1,30 @@
+import { Badge } from '~/components/ui/badge';
+import { Movement } from '~/types';
+
+interface Props {
+  movement: Movement;
+}
+
+export const MovementRow = ({ movement }: Props) => {
+  const badges = [
+    movement.movementPattern1,
+    movement.primaryEquipment,
+    movement.difficultyLevel,
+    movement.targetMuscleGroup,
+  ].filter((badge): badge is string => badge !== null);
+
+  return (
+    <div className="flex flex-col gap-0.5 p-1">
+      <div className="font-medium">{movement.movementName}</div>
+      {badges.length > 0 && (
+        <div className="flex flex-wrap gap-0.5">
+          {badges.map((badge) => (
+            <Badge key={badge} variant="secondary">
+              {badge}
+            </Badge>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};

--- a/src/pages/MovementsPage/components/index.ts
+++ b/src/pages/MovementsPage/components/index.ts
@@ -1,0 +1,1 @@
+export * from './MovementRow';


### PR DESCRIPTION
## What

Rebuilds the Movements page (formerly Explore) for mobile with a card list, adds a movement-pattern column and filter, and renames the tab label to "Movements".

## Why

The page was a desktop-only table — four columns plus a single-row filter bar overflowed badly on phones, which is where the app actually gets used. The catalog already carries `Movement Pattern #1` for every movement but never surfaced it, even though pattern is the most useful lens for browsing.

## How

- Desktop keeps the sortable `DataTable` (`hidden md:block`, now with a Pattern column); mobile gets a `md:hidden` card list of name + badge rows, matching the History page's card pattern.
- Filter bar becomes a 2×2 grid on mobile (full-width search and reset) and stays a single row on `md+`; a fourth Pattern select filters on the 11 catalog values.
- Pagination footer extracted from `DataTable` as `DataTablePagination` so both views share the same URL `page` state.
- Fixed a latent PostgREST bug this surfaced: unquoted identifiers stop parsing at `#`, so both `order` and filter params on `"Movement Pattern #1"` returned 400. `useMovements` now double-quotes columns containing `#`.
- Renamed only the visible label Explore → Movements; the `explore` flag key, `VITE_FEATURE_EXPLORE`, nav key, and `/movements` route are unchanged.

## How tested

- New `MovementsPage.test.tsx`: both views render, pattern column shows, pattern filter issues the quoted request param and narrows results, reset clears it.
- Full suite: 114 files / 800 tests pass; `compile:ts` and `lint` clean.
- Live against local Supabase: pattern filter returns correct counts (e.g. Loaded Carry → 9), sorting by Pattern works, no console/network errors; checked at 1280px and 375px.

## Gallery

### Mobile (before → after)

<img src="https://github.com/user-attachments/assets/fc618171-1244-4bdf-bf82-b9f1a1dede43" width="45%" /> <img src="https://github.com/user-attachments/assets/d6023e66-7f17-46c7-92ab-c2efc8a138f4" width="45%" />

### Desktop (before → after)

![desktop before](https://github.com/user-attachments/assets/5085ab66-30e4-4492-8bfa-7bf2bdc33b95)
![desktop after](https://github.com/user-attachments/assets/25a1da2d-ea54-40a0-82f4-a4fc7e228095)

## Tradeoffs

- The mobile list has no sort control — default Movement A→Z applies. A sort sheet felt like more UI than the page needs; easy to add later if browsing habits demand it.
- Kept First/Prev/Next/Last pagination on mobile rather than "Load More" so the two views share one URL `page` state and never desync on resize.
