### PR TITLE
feat(recommender): debt-optimal balance mode with coverage validation

### DIFF
--- a/src/api/useRecommendSession.ts
+++ b/src/api/useRecommendSession.ts
@@ -21,7 +21,12 @@ export class RecommendSessionError extends Error {
   }
 }
 
-const recommendSession = async (): Promise<RecommendSessionResponse> => {
+/** 'balance' asks for a debt-optimal session; omitted/'default' is coach's pick. */
+export type RecommendSessionMode = 'default' | 'balance';
+
+const recommendSession = async (
+  mode: RecommendSessionMode = 'default',
+): Promise<RecommendSessionResponse> => {
   // client_today anchors the recommender's "days since last workout" to the
   // user's local calendar date — the edge function runs in UTC and has no
   // notion of the caller's timezone otherwise. Daily-readiness wiring lands
@@ -29,7 +34,7 @@ const recommendSession = async (): Promise<RecommendSessionResponse> => {
   const { data, error } =
     await supabase.functions.invoke<RecommendSessionResponse>(
       'recommend-session',
-      { body: { client_today: localDateString() } },
+      { body: { client_today: localDateString(), mode } },
     );
 
   if (error) {
@@ -66,4 +71,6 @@ const recommendSession = async (): Promise<RecommendSessionResponse> => {
  * invokes this for premium users (free users see a preview modal instead).
  */
 export const useRecommendSession = () =>
-  useMutation({ mutationFn: recommendSession });
+  useMutation({
+    mutationFn: (mode?: RecommendSessionMode) => recommendSession(mode),
+  });

--- a/src/components/WeeklyBalance/WeeklyBalance.test.tsx
+++ b/src/components/WeeklyBalance/WeeklyBalance.test.tsx
@@ -125,3 +125,35 @@ describe('WeeklyBalance', () => {
     expect(screen.getByText('Hard')).toBeInTheDocument();
   });
 });
+
+describe('WeeklyBalance — Balance me out CTA', () => {
+  test('shown when a pattern is Due/Overdue and fires the callback', () => {
+    const onBalanceMe = vi.fn();
+    render(
+      <WeeklyBalance
+        balance={mixedBalance}
+        workoutCount={5}
+        onBalanceMe={onBalanceMe}
+      />,
+    );
+    const cta = screen.getByRole('button', { name: /balance me out/i });
+    fireEvent.click(cta);
+    expect(onBalanceMe).toHaveBeenCalledTimes(1);
+  });
+
+  test('hidden when every trained pattern is On track', () => {
+    render(
+      <WeeklyBalance balance={balance} workoutCount={5} onBalanceMe={vi.fn()} />,
+    );
+    expect(
+      screen.queryByRole('button', { name: /balance me out/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  test('hidden when no handler is provided', () => {
+    render(<WeeklyBalance balance={mixedBalance} workoutCount={5} />);
+    expect(
+      screen.queryByRole('button', { name: /balance me out/i }),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/src/components/WeeklyBalance/WeeklyBalance.tsx
+++ b/src/components/WeeklyBalance/WeeklyBalance.tsx
@@ -34,6 +34,8 @@ export interface WeeklyBalanceProps {
   isLoading?: boolean;
   isError?: boolean;
   onRetry?: () => void;
+  /** Shown when any pattern is Due/Overdue — jumps into the balance-focused recommender. */
+  onBalanceMe?: () => void;
 }
 
 /**
@@ -46,6 +48,7 @@ export const WeeklyBalance = ({
   isLoading = false,
   isError = false,
   onRetry,
+  onBalanceMe,
 }: WeeklyBalanceProps) => {
   const [expanded, setExpanded] = useState<Pattern | null>(null);
   // Gauges start empty and fill to their charge on mount — the panel's one
@@ -128,6 +131,18 @@ export const WeeklyBalance = ({
             }
           />
         ))}
+        {onBalanceMe &&
+          Object.values(balance.patterns).some(
+            (p) => !p.isNew && p.band !== 'green',
+          ) && (
+            <Button
+              className="mt-1 w-full"
+              variant="secondary"
+              onClick={onBalanceMe}
+            >
+              Balance me out
+            </Button>
+          )}
       </CardContent>
     </Card>
   );

--- a/src/components/WeeklyBalance/WeeklyBalanceContainer.tsx
+++ b/src/components/WeeklyBalance/WeeklyBalanceContainer.tsx
@@ -1,3 +1,5 @@
+import { useNavigate } from 'react-router-dom';
+
 import { usePatternDebt, useWorkoutLogs } from '~/api';
 
 import { WeeklyBalance } from './WeeklyBalance';
@@ -15,6 +17,7 @@ export const WeeklyBalanceContainer = () => {
     refetch,
   } = usePatternDebt();
   const { data: workoutLogs, isLoading: logsLoading } = useWorkoutLogs();
+  const navigate = useNavigate();
 
   return (
     <WeeklyBalance
@@ -23,6 +26,7 @@ export const WeeklyBalanceContainer = () => {
       isLoading={balanceLoading || logsLoading}
       isError={isError}
       onRetry={() => refetch()}
+      onBalanceMe={() => navigate('/', { state: { recommendMode: 'balance' } })}
     />
   );
 };

--- a/src/pages/StartWorkoutPage/StartWorkoutPage.tsx
+++ b/src/pages/StartWorkoutPage/StartWorkoutPage.tsx
@@ -997,6 +997,12 @@ export const StartWorkoutPage = ({
             <RecommendSessionSection
               userId={userId}
               onAccept={handleAcceptRecommendation}
+              initialMode={
+                (location.state as { recommendMode?: 'balance' } | null)
+                  ?.recommendMode === 'balance'
+                  ? 'balance'
+                  : 'default'
+              }
             />
           )}
 

--- a/src/pages/StartWorkoutPage/components/RecommendSessionSection.test.tsx
+++ b/src/pages/StartWorkoutPage/components/RecommendSessionSection.test.tsx
@@ -38,12 +38,16 @@ function makeQueryClient() {
 function renderSection(
   entitlement: EntitlementContextValue,
   onAccept = vi.fn(),
+  initialMode?: 'default' | 'balance',
 ) {
   render(
     <QueryClientProvider client={makeQueryClient()}>
       <MemoryRouter>
         <EntitlementContext.Provider value={entitlement}>
-          <RecommendSessionSection onAccept={onAccept} />
+          <RecommendSessionSection
+            onAccept={onAccept}
+            initialMode={initialMode}
+          />
         </EntitlementContext.Provider>
       </MemoryRouter>
     </QueryClientProvider>,
@@ -110,5 +114,76 @@ describe('RecommendSessionSection', () => {
     expect(
       await screen.findByText(/add a few movements to your library first/i),
     ).toBeInTheDocument();
+  });
+
+  test('Balance focus toggle sends mode=balance to the function', async () => {
+    let requestBody: Record<string, unknown> | null = null;
+    server.use(
+      http.post(FUNCTION_URL, async ({ request }) => {
+        requestBody = (await request.json()) as Record<string, unknown>;
+        return HttpResponse.json(
+          { id: 'rec-1', recommendation: new ExampleRecommendation() },
+          { status: 200 },
+        );
+      }),
+    );
+
+    renderSection(premium);
+    await userEvent.click(screen.getByRole('tab', { name: /balance focus/i }));
+    await userEvent.click(
+      screen.getByRole('button', { name: /balance me out/i }),
+    );
+
+    expect(await screen.findByText('Your AI session')).toBeInTheDocument();
+    expect(requestBody).toMatchObject({ mode: 'balance' });
+  });
+
+  test('default mode sends mode=default and keeps the original CTA label', async () => {
+    let requestBody: Record<string, unknown> | null = null;
+    server.use(
+      http.post(FUNCTION_URL, async ({ request }) => {
+        requestBody = (await request.json()) as Record<string, unknown>;
+        return HttpResponse.json(
+          { id: 'rec-1', recommendation: new ExampleRecommendation() },
+          { status: 200 },
+        );
+      }),
+    );
+
+    renderSection(premium);
+    await userEvent.click(recommendButton());
+
+    expect(await screen.findByText('Your AI session')).toBeInTheDocument();
+    expect(requestBody).toMatchObject({ mode: 'default' });
+  });
+
+  test('initialMode="balance" preselects the toggle (Weekly Balance CTA path)', () => {
+    renderSection(premium, vi.fn(), 'balance');
+    expect(
+      screen.getByRole('tab', { name: /balance focus/i }),
+    ).toHaveAttribute('aria-selected', 'true');
+    expect(
+      screen.getByRole('button', { name: /balance me out/i }),
+    ).toBeInTheDocument();
+  });
+
+  test('free user tapping Balance me out gets the preview modal, no call', async () => {
+    let calls = 0;
+    server.use(
+      http.post(FUNCTION_URL, () => {
+        calls += 1;
+        return HttpResponse.json({}, { status: 200 });
+      }),
+    );
+
+    renderSection(base, vi.fn(), 'balance');
+    await userEvent.click(
+      screen.getByRole('button', { name: /balance me out/i }),
+    );
+
+    expect(
+      await screen.findByText(/AI session recommendations/i),
+    ).toBeInTheDocument();
+    expect(calls).toBe(0);
   });
 });

--- a/src/pages/StartWorkoutPage/components/RecommendSessionSection.tsx
+++ b/src/pages/StartWorkoutPage/components/RecommendSessionSection.tsx
@@ -4,10 +4,12 @@ import { useState } from 'react';
 import {
   AnalyticsEvent,
   RecommendSessionError,
+  type RecommendSessionMode,
   trackEvent,
   useRecommendSession,
 } from '~/api';
 import { Button } from '~/components/ui/button';
+import { Tabs, TabsList, TabsTrigger } from '~/components/ui/tabs';
 import { useEntitlement } from '~/contexts';
 import type { Recommendation, RecommendSessionResponse } from '~/types';
 
@@ -19,6 +21,8 @@ interface RecommendSessionSectionProps {
   onAccept: (recommendation: Recommendation, recommendationId: string) => void;
   /** Authenticated user id, for analytics (fire-and-forget). */
   userId?: string;
+  /** Preselects the mode toggle — set to 'balance' by the Weekly Balance CTA. */
+  initialMode?: RecommendSessionMode;
 }
 
 /**
@@ -30,21 +34,23 @@ interface RecommendSessionSectionProps {
 export const RecommendSessionSection = ({
   onAccept,
   userId,
+  initialMode = 'default',
 }: RecommendSessionSectionProps) => {
   const { effectiveAccess, isLoading: entitlementLoading } = useEntitlement();
   const isPremium = !entitlementLoading && effectiveAccess === 'premium';
 
   const mutation = useRecommendSession();
+  const [mode, setMode] = useState<RecommendSessionMode>(initialMode);
   const [result, setResult] = useState<RecommendSessionResponse | null>(null);
   const [previewOpen, setPreviewOpen] = useState(false);
 
   const track = (event: AnalyticsEvent, properties = {}) => {
-    if (userId) void trackEvent({ event, userId, properties });
+    if (userId) void trackEvent({ event, userId, properties: { mode, ...properties } });
   };
 
   const fetchRecommendation = (event: AnalyticsEvent) => {
     track(event);
-    mutation.mutate(undefined, {
+    mutation.mutate(mode, {
       onSuccess: (data) => setResult(data),
       onError: (err) => {
         // A stale free-tier client could still get gated server-side; fall back
@@ -121,15 +127,28 @@ export const RecommendSessionSection = ({
           }
         />
       ) : (
-        <Button
-          className="w-full"
-          variant="secondary"
-          loading={mutation.isPending}
-          onClick={handleRecommend}
-        >
-          <SparklesIcon className="mr-1 h-2.5 w-2.5" />
-          Recommend my next session
-        </Button>
+        <>
+          <Tabs
+            value={mode}
+            onValueChange={(value) => setMode(value as RecommendSessionMode)}
+          >
+            <TabsList className="grid w-full grid-cols-2">
+              <TabsTrigger value="default">Coach&apos;s pick</TabsTrigger>
+              <TabsTrigger value="balance">Balance focus</TabsTrigger>
+            </TabsList>
+          </Tabs>
+          <Button
+            className="w-full"
+            variant="secondary"
+            loading={mutation.isPending}
+            onClick={handleRecommend}
+          >
+            <SparklesIcon className="mr-1 h-2.5 w-2.5" />
+            {mode === 'balance'
+              ? 'Balance me out'
+              : 'Recommend my next session'}
+          </Button>
+        </>
       )}
 
       {errorMessage && (

--- a/src/utils/patternDebt.test.ts
+++ b/src/utils/patternDebt.test.ts
@@ -1,4 +1,6 @@
 import {
+  BALANCE_TARGET_LIMIT,
+  type BalanceTargetPattern,
   MovementAggregate,
   OVERDUE_DAYS,
   TARGET_CADENCE_DAYS,
@@ -7,6 +9,7 @@ import {
   computeDebtScore,
   computeOverallBalance,
   computePatternBalance,
+  selectBalanceTargets,
 } from './patternDebt';
 
 const NOW = new Date('2026-06-24T12:00:00Z');
@@ -276,5 +279,74 @@ describe('computePatternBalance', () => {
       now,
     );
     expect(patterns.pull.daysSinceLastTrained).toBe(1);
+  });
+});
+
+describe('selectBalanceTargets', () => {
+  const scored = (
+    pattern: BalanceTargetPattern['pattern'],
+    debtScore: number,
+    over: Partial<BalanceTargetPattern> = {},
+  ): BalanceTargetPattern => ({
+    pattern,
+    debtScore,
+    band: debtScore >= 66 ? 'red' : debtScore >= 33 ? 'yellow' : 'green',
+    isNew: false,
+    ...over,
+  });
+
+  const allCredits = [['hinge', 'squat', 'push', 'pull', 'carry', 'rotation', 'core', 'get_up']];
+
+  test('caps at BALANCE_TARGET_LIMIT highest-debt red patterns', () => {
+    const targets = selectBalanceTargets(
+      [
+        scored('hinge', 90),
+        scored('squat', 80),
+        scored('push', 70),
+        scored('pull', 68),
+        scored('carry', 20),
+      ],
+      allCredits,
+    );
+    expect(targets).toEqual(['hinge', 'squat', 'push']);
+    expect(targets).toHaveLength(BALANCE_TARGET_LIMIT);
+  });
+
+  test('ties break on canonical PATTERNS order', () => {
+    const targets = selectBalanceTargets(
+      [scored('core', 90), scored('hinge', 90), scored('pull', 90), scored('squat', 90)],
+      allCredits,
+    );
+    expect(targets).toEqual(['hinge', 'squat', 'pull']);
+  });
+
+  test('excludes yellow and green bands', () => {
+    expect(
+      selectBalanceTargets([scored('hinge', 65), scored('squat', 30)], allCredits),
+    ).toEqual([]);
+  });
+
+  test('excludes New patterns even when red-scored', () => {
+    expect(
+      selectBalanceTargets([scored('carry', 100, { isNew: true })], allCredits),
+    ).toEqual([]);
+  });
+
+  test('excludes patterns no candidate can cover', () => {
+    const targets = selectBalanceTargets(
+      [scored('hinge', 90), scored('carry', 100)],
+      [['hinge'], null],
+    );
+    expect(targets).toEqual(['hinge']);
+  });
+
+  test('returns fewer than the cap when fewer qualify', () => {
+    expect(
+      selectBalanceTargets([scored('rotation', 70)], allCredits),
+    ).toEqual(['rotation']);
+  });
+
+  test('empty inputs yield empty targets', () => {
+    expect(selectBalanceTargets([], [])).toEqual([]);
   });
 });

--- a/src/utils/patternDebt.ts
+++ b/src/utils/patternDebt.ts
@@ -146,6 +146,43 @@ export const computeDebtScore = (
   return Math.round(100 * (W_RECENCY * recency + W_VOLUME * deficit));
 };
 
+/** Balance-mode coverage cap: the recommender targets at most this many patterns. */
+export const BALANCE_TARGET_LIMIT = 3;
+
+/** The fields target selection needs from a scored pattern (camelCase or serialized). */
+export interface BalanceTargetPattern {
+  pattern: Pattern;
+  band: DebtBand;
+  debtScore: number;
+  isNew: boolean;
+}
+
+/**
+ * Deterministic target selection for the recommender's balance mode: the
+ * highest-debt red-band patterns (non-New) that at least one candidate
+ * movement's credits can cover, capped at BALANCE_TARGET_LIMIT. Ties break on
+ * canonical PATTERNS order so results are stable.
+ */
+export const selectBalanceTargets = (
+  patterns: BalanceTargetPattern[],
+  candidateCredits: Array<readonly string[] | null>,
+  limit: number = BALANCE_TARGET_LIMIT,
+): Pattern[] => {
+  const coverable = new Set<string>();
+  for (const credits of candidateCredits) {
+    for (const credit of credits ?? []) coverable.add(credit);
+  }
+  return patterns
+    .filter((p) => p.band === 'red' && !p.isNew && coverable.has(p.pattern))
+    .sort(
+      (a, b) =>
+        b.debtScore - a.debtScore ||
+        PATTERNS.indexOf(a.pattern) - PATTERNS.indexOf(b.pattern),
+    )
+    .slice(0, limit)
+    .map((p) => p.pattern);
+};
+
 interface PatternAccumulator {
   lastTrained: Date | null;
   recentVolume: number;

--- a/supabase/functions/recommend-session/inputs.ts
+++ b/supabase/functions/recommend-session/inputs.ts
@@ -13,11 +13,14 @@ import {
 } from '../../../src/utils/dateOnly.ts';
 import {
   type MovementAggregate,
+  attributeMovement,
   computePatternBalance,
+  selectBalanceTargets,
 } from '../../../src/utils/patternDebt.ts';
 import type {
   CandidateMovement,
   PatternDebtInput,
+  RecommendMode,
   RecommenderInputs,
   WorkoutHistoryEntry,
 } from './types.ts';
@@ -93,8 +96,9 @@ export async function gatherInputs(
   admin: SupabaseClient,
   authClient: SupabaseClient,
   userId: string,
-  body: { readiness?: unknown; client_today?: unknown },
+  body: { readiness?: unknown; client_today?: unknown; mode?: unknown },
 ): Promise<RecommenderInputs> {
+  const mode: RecommendMode = body.mode === 'balance' ? 'balance' : 'default';
   const readiness =
     typeof body.readiness === 'string' && body.readiness.trim()
       ? body.readiness.trim()
@@ -115,18 +119,47 @@ export async function gatherInputs(
   }
   const clientToday = parsedClientToday ?? new Date();
 
-  // Candidate movements: the user's own library.
+  // Candidate movements: the user's own library, with catalog pattern credits
+  // joined for the prompt annotations and balance-mode coverage validation.
   const { data: userMovements, error: umErr } = await admin
     .from('user_movements')
-    .select('id, canonical_name, is_big_6')
+    .select('id, canonical_name, is_big_6, functional_movement_id')
     .eq('user_id', userId);
   if (umErr) throw umErr;
 
-  const candidates: CandidateMovement[] = (userMovements ?? []).map((m) => ({
-    user_movement_id: m.id,
-    name: m.canonical_name,
-    is_big_6: Boolean(m.is_big_6),
-  }));
+  const catalogIds = [
+    ...new Set(
+      (userMovements ?? [])
+        .map((m) => m.functional_movement_id)
+        .filter((id): id is string => id != null),
+    ),
+  ];
+  const creditsByCatalogId = new Map<string, string[]>();
+  if (catalogIds.length > 0) {
+    const { data: catalogRows, error: catErr } = await admin
+      .from('movements')
+      .select('id, pattern_credits')
+      .in('id', catalogIds);
+    if (catErr) throw catErr;
+    for (const row of catalogRows ?? []) {
+      creditsByCatalogId.set(row.id, row.pattern_credits);
+    }
+  }
+
+  const candidates: CandidateMovement[] = (userMovements ?? []).map((m) => {
+    // attributeMovement applies the shared unlinked-movement policy (get-up
+    // name fallback) and filters credits to the known coarse patterns.
+    const credited = attributeMovement(
+      creditsByCatalogId.get(m.functional_movement_id ?? '') ?? null,
+      m.canonical_name,
+    );
+    return {
+      user_movement_id: m.id,
+      name: m.canonical_name,
+      is_big_6: Boolean(m.is_big_6),
+      pattern_credits: credited.length > 0 ? credited : null,
+    };
+  });
 
   // Persistent training goal.
   const { data: profile, error: profErr } = await admin
@@ -180,7 +213,24 @@ export async function gatherInputs(
 
   const pattern_debt = await gatherPatternDebt(authClient, clientToday);
 
+  // Balance mode's deterministic targets. Degrades to [] (default behavior)
+  // when debt is unavailable or nothing red is coverable from the library.
+  const balance_targets =
+    mode === 'balance' && pattern_debt
+      ? selectBalanceTargets(
+          pattern_debt.patterns.map((p) => ({
+            pattern: p.pattern,
+            band: p.band,
+            debtScore: p.debt_score,
+            isNew: p.is_new,
+          })),
+          candidates.map((c) => c.pattern_credits),
+        )
+      : [];
+
   return {
+    mode,
+    balance_targets,
     training_goal: profile?.training_goal ?? null,
     readiness,
     days_since_last_workout,

--- a/supabase/functions/recommend-session/llm.ts
+++ b/supabase/functions/recommend-session/llm.ts
@@ -54,7 +54,13 @@ export async function generateRecommendation(
   const candidateIds = new Set(
     inputs.candidates.map((c) => c.user_movement_id),
   );
-  const system = buildSystemPrompt();
+  const coverage = {
+    targets: inputs.balance_targets,
+    creditsById: new Map(
+      inputs.candidates.map((c) => [c.user_movement_id, c.pattern_credits]),
+    ),
+  };
+  const system = buildSystemPrompt(inputs.mode);
   const messages: Message[] = [
     { role: 'user', content: buildUserPrompt(inputs) },
   ];
@@ -63,7 +69,7 @@ export async function generateRecommendation(
   for (let attempt = 0; attempt < 2; attempt++) {
     const rec = await callModel(apiKey, system, messages);
     try {
-      validateRecommendation(rec, candidateIds);
+      validateRecommendation(rec, candidateIds, coverage);
       return rec;
     } catch (err) {
       if (!(err instanceof ValidationError) || attempt === 1) throw err;

--- a/supabase/functions/recommend-session/prompt.test.ts
+++ b/supabase/functions/recommend-session/prompt.test.ts
@@ -1,0 +1,57 @@
+import { buildSystemPrompt, buildUserPrompt } from './prompt.ts';
+import type { RecommenderInputs } from './types.ts';
+
+const baseInputs = (over: Partial<RecommenderInputs> = {}): RecommenderInputs => ({
+  mode: 'default',
+  balance_targets: [],
+  training_goal: null,
+  readiness: null,
+  days_since_last_workout: null,
+  recent_history: [],
+  candidates: [
+    {
+      user_movement_id: 'tgu',
+      name: 'Turkish Get-Up',
+      is_big_6: true,
+      pattern_credits: ['get_up', 'push', 'rotation'],
+    },
+    {
+      user_movement_id: 'custom',
+      name: 'Mystery Move',
+      is_big_6: false,
+      pattern_credits: null,
+    },
+  ],
+  pattern_debt: null,
+  unlocked_weights: {},
+  ...over,
+});
+
+describe('prompt — pattern annotations and balance targets', () => {
+  test('candidates carry pays annotations; unlinked ones stay bare', () => {
+    const prompt = buildUserPrompt(baseInputs());
+    expect(prompt).toContain(
+      '- Turkish Get-Up (Big 6) · pays: get_up, push, rotation [user_movement_id: tgu]',
+    );
+    expect(prompt).toContain('- Mystery Move [user_movement_id: custom]');
+  });
+
+  test('balance targets render a mandatory section; absent when empty', () => {
+    const withTargets = buildUserPrompt(
+      baseInputs({ mode: 'balance', balance_targets: ['hinge', 'carry'] }),
+    );
+    expect(withTargets).toContain('Target patterns');
+    expect(withTargets).toContain('hinge, carry');
+    expect(buildUserPrompt(baseInputs())).not.toContain('Target patterns');
+  });
+
+  test('system prompt adds the balance rule only in balance mode', () => {
+    expect(buildSystemPrompt('balance')).toContain('BALANCE MODE');
+    expect(buildSystemPrompt('default')).not.toContain('BALANCE MODE');
+    expect(buildSystemPrompt()).not.toContain('BALANCE MODE');
+  });
+
+  test('system prompt bans the word "debt" in rationale copy', () => {
+    expect(buildSystemPrompt()).toContain('Never use');
+  });
+});

--- a/supabase/functions/recommend-session/prompt.ts
+++ b/supabase/functions/recommend-session/prompt.ts
@@ -3,10 +3,19 @@
 // Kept separate from transport (llm.ts) so prompt quality can be iterated in
 // PROD-88 without touching the API plumbing.
 
-import type { RecommenderInputs } from './types.ts';
+import type { RecommendMode, RecommenderInputs } from './types.ts';
 import { formatPatternLine } from '../_shared/patternDebtPrompt.ts';
 
-export function buildSystemPrompt(): string {
+export function buildSystemPrompt(mode: RecommendMode = 'default'): string {
+  const balanceRules =
+    mode === 'balance'
+      ? [
+          '- BALANCE MODE: the request lists "Target patterns". Your session MUST',
+          "  include, for every target pattern, at least one movement whose pays",
+          '  list covers it. Multi-pattern movements may cover several targets at',
+          '  once. Name the patterns you are catching up in the rationale.',
+        ]
+      : [];
   return [
     'You are an expert kettlebell programming coach. You know the Big 6 (swing,',
     'clean, press, snatch, squat, get-up) and common protocols (Simple & Sinister,',
@@ -25,8 +34,10 @@ export function buildSystemPrompt(): string {
     "  lifter's goal still take precedence when they conflict.",
     "- Patterns marked \"new\" have no training history yet — treat them as",
     '  neutral, not overdue; do not count them toward pattern debt.',
+    ...balanceRules,
     '- Give a short, concrete rationale a thoughtful coach would give — tie it to',
-    '  their goal, recent history, and readiness. Avoid generic filler.',
+    '  their goal, recent history, and readiness. Avoid generic filler. Never use',
+    '  the word "debt" — say a pattern is due, overdue, or needs attention.',
   ].join('\n');
 }
 
@@ -34,7 +45,11 @@ export function buildUserPrompt(inputs: RecommenderInputs): string {
   const candidateLines = inputs.candidates
     .map(
       (c) =>
-        `- ${c.name}${c.is_big_6 ? ' (Big 6)' : ''} [user_movement_id: ${c.user_movement_id}]`,
+        `- ${c.name}${c.is_big_6 ? ' (Big 6)' : ''}${
+          c.pattern_credits?.length
+            ? ` · pays: ${c.pattern_credits.join(', ')}`
+            : ''
+        } [user_movement_id: ${c.user_movement_id}]`,
     )
     .join('\n');
 
@@ -66,6 +81,13 @@ export function buildUserPrompt(inputs: RecommenderInputs): string {
       ]
     : [];
 
+  const targetSection = inputs.balance_targets.length
+    ? [
+        '',
+        `Target patterns (every one MUST be trained by at least one movement): ${inputs.balance_targets.join(', ')}`,
+      ]
+    : [];
+
   return [
     `Training goal: ${inputs.training_goal ?? '(none provided)'}`,
     `How they feel today: ${inputs.readiness ?? '(not provided)'}`,
@@ -74,6 +96,7 @@ export function buildUserPrompt(inputs: RecommenderInputs): string {
     'Recent workouts (most recent first):',
     historyLines,
     ...patternDebtSection,
+    ...targetSection,
     '',
     'Candidate movements (choose only from these):',
     candidateLines,

--- a/supabase/functions/recommend-session/types.ts
+++ b/supabase/functions/recommend-session/types.ts
@@ -12,11 +12,16 @@ import type {
   PatternRpe,
 } from '../../../src/utils/patternDebt.ts';
 
+/** How the recommender selects: default coach's pick, or balance (debt-optimal). */
+export type RecommendMode = 'default' | 'balance';
+
 /** One movement in the user's library — the candidate set the LLM may choose from. */
 export interface CandidateMovement {
   user_movement_id: string;
   name: string;
   is_big_6: boolean;
+  /** Coarse patterns this movement pays credit toward; null when unlinked with no fallback. */
+  pattern_credits: Pattern[] | null;
 }
 
 /** A compact summary of one past workout, for history context. */
@@ -55,6 +60,13 @@ export interface PatternDebtInput {
 
 /** Everything the recommender reasons over. Snapshotted into inputs JSONB. */
 export interface RecommenderInputs {
+  mode: RecommendMode;
+  /**
+   * Balance mode's deterministic targets: the highest-debt red-band patterns
+   * coverable from the candidate set (max BALANCE_TARGET_LIMIT). Always [] in
+   * default mode or when pattern debt is unavailable.
+   */
+  balance_targets: Pattern[];
   training_goal: string | null;
   readiness: string | null;
   days_since_last_workout: number | null;

--- a/supabase/functions/recommend-session/validate.test.ts
+++ b/supabase/functions/recommend-session/validate.test.ts
@@ -1,0 +1,87 @@
+import type { Recommendation } from './types.ts';
+import { ValidationError, validateRecommendation } from './validate.ts';
+
+const rec = (blocks: Array<Partial<Recommendation['blocks'][number]>>): Recommendation => ({
+  rationale: 'test',
+  duration_minutes: 20,
+  format: 'Circuit',
+  confidence: 'high',
+  blocks: blocks.map((b, i) => ({
+    user_movement_id: `um-${i}`,
+    movement_name: `Movement ${i}`,
+    weight_kg: 16,
+    rep_scheme: [5, 5, 5],
+    notes: '',
+    ...b,
+  })),
+});
+
+const idsOf = (r: Recommendation) => new Set(r.blocks.map((b) => b.user_movement_id));
+
+describe('validateRecommendation — coverage invariant', () => {
+  test('passes when block credits cover every target', () => {
+    const r = rec([{ user_movement_id: 'tgu' }, { user_movement_id: 'swing' }]);
+    expect(() =>
+      validateRecommendation(r, idsOf(r), {
+        targets: ['get_up', 'push', 'hinge'],
+        creditsById: new Map([
+          ['tgu', ['get_up', 'push', 'rotation']],
+          ['swing', ['hinge']],
+        ]),
+      }),
+    ).not.toThrow();
+  });
+
+  test('fails with a per-pattern reason for each uncovered target', () => {
+    const r = rec([{ user_movement_id: 'swing' }]);
+    try {
+      validateRecommendation(r, idsOf(r), {
+        targets: ['hinge', 'carry', 'pull'],
+        creditsById: new Map([['swing', ['hinge']]]),
+      });
+      throw new Error('expected ValidationError');
+    } catch (err) {
+      expect(err).toBeInstanceOf(ValidationError);
+      const reasons = (err as ValidationError).reasons;
+      expect(reasons).toHaveLength(2);
+      expect(reasons[0]).toContain('"carry"');
+      expect(reasons[1]).toContain('"pull"');
+    }
+  });
+
+  test('empty targets is a no-op (default mode / degraded balance mode)', () => {
+    const r = rec([{ user_movement_id: 'swing' }]);
+    expect(() =>
+      validateRecommendation(r, idsOf(r), {
+        targets: [],
+        creditsById: new Map([['swing', null]]),
+      }),
+    ).not.toThrow();
+  });
+
+  test('null credits on a chosen block cover nothing', () => {
+    const r = rec([{ user_movement_id: 'custom' }]);
+    expect(() =>
+      validateRecommendation(r, idsOf(r), {
+        targets: ['squat'],
+        creditsById: new Map([['custom', null]]),
+      }),
+    ).toThrow(ValidationError);
+  });
+
+  test('existing id/weight/reps checks still run alongside coverage', () => {
+    const r = rec([{ user_movement_id: 'rogue', weight_kg: -1 }]);
+    try {
+      validateRecommendation(r, new Set(['known']), {
+        targets: ['squat'],
+        creditsById: new Map(),
+      });
+      throw new Error('expected ValidationError');
+    } catch (err) {
+      const reasons = (err as ValidationError).reasons;
+      expect(reasons.some((x) => x.includes('not in the candidate list'))).toBe(true);
+      expect(reasons.some((x) => x.includes('non-positive weight'))).toBe(true);
+      expect(reasons.some((x) => x.includes('"squat"'))).toBe(true);
+    }
+  });
+});

--- a/supabase/functions/recommend-session/validate.ts
+++ b/supabase/functions/recommend-session/validate.ts
@@ -4,7 +4,14 @@
 // the schema can't express — movement ids must be real candidates, and reps and
 // weights must be sane. A failure here drives the single retry in llm.ts.
 
+import type { Pattern } from '../../../src/utils/patternDebt.ts';
 import type { Recommendation } from './types.ts';
+
+/** Balance-mode coverage requirement: targets plus each candidate's credits. */
+export interface CoverageRequirement {
+  targets: Pattern[];
+  creditsById: Map<string, readonly string[] | null>;
+}
 
 export class ValidationError extends Error {
   reasons: string[];
@@ -21,6 +28,7 @@ const MAX_REP = 100;
 export function validateRecommendation(
   rec: Recommendation,
   candidateIds: Set<string>,
+  coverage?: CoverageRequirement,
 ): void {
   const reasons: string[] = [];
 
@@ -51,6 +59,25 @@ export function validateRecommendation(
       )
     ) {
       reasons.push(`${where} has invalid rep counts`);
+    }
+  }
+
+  // Balance mode: the chosen movements' combined credits must cover every
+  // target pattern (the deterministic coverage invariant).
+  if (coverage && coverage.targets.length > 0) {
+    const covered = new Set<string>();
+    for (const block of rec.blocks) {
+      for (const credit of coverage.creditsById.get(block.user_movement_id) ??
+        []) {
+        covered.add(credit);
+      }
+    }
+    for (const target of coverage.targets) {
+      if (!covered.has(target)) {
+        reasons.push(
+          `the session does not train the "${target}" pattern — include at least one candidate whose pays list covers ${target}`,
+        );
+      }
     }
   }
 


### PR DESCRIPTION
## Why

Phase 1 of the pattern-debt ledger (#229) made Balance an honest, correctly-attributed score — but the recommender only *soft-nudged* the LLM toward overdue patterns, with no pattern info on candidates and no guarantee the session actually paid anything down. This is the ledger's payoff step per the CEO plan's approved X3 sequencing (`docs/designs/pattern-debt-ledger.md`, D3.6), and it feeds the premium launch path (PROD-142).

## What

`recommend-session` gains `mode: 'balance'`: code (not the LLM) picks the top-3 highest-debt red-band patterns coverable from the user's library, the prompt makes them mandatory, and the validator rejects (with one corrective retry) any session that doesn't cover them. Both modes now annotate every candidate with the patterns it pays. The client adds a "Balance me out" CTA on Weekly Balance (shown when anything is Due/Overdue) and a Coach's pick / Balance focus toggle on the recommend section.

Key pieces:
- `selectBalanceTargets` in `src/utils/patternDebt.ts` — deterministic target selection, stable tie-break, cap of 3.
- Candidate `pattern_credits` joined from the catalog via `functional_movement_id`, unlinked movements go through the shared get-up fallback (`attributeMovement`).
- Coverage invariant in `validate.ts`; `mode` + `balance_targets` snapshotted into `session_recommendations.inputs`.
- Degrades safely: debt RPC failure or zero coverable red patterns ⇒ normal recommendation, never an error. Free users hit the existing paywall preview; the server-side premium gate is unchanged.
- Rationale copy rule: user-facing text never says "debt" (X4 vocabulary decision).

## How to test

- `npm test` — 819 tests / 115 files green, 24 new: `selectBalanceTargets` (cap, ties, uncoverable, isNew), validator coverage (pass, per-pattern miss reasons, no-op on empty targets, composes with id/weight checks), prompt snapshots (pays annotations, target section, balance-only system rule), Balance CTA visibility + click, toggle sends `mode=balance`, free-user preview path.
- `npm run compile:ts` and `npm run lint` clean.
- Still open: one manual balance recommendation against local Supabase + a real Anthropic key to eyeball rationale copy.

## Gallery

All new UI (after only). Mobile 390x844, seeded local data.

**"Balance me out" CTA on Weekly Balance** (shown because Pull is Due):

![weekly-balance-cta](https://github.com/user-attachments/assets/e00729b8-aa71-40ce-8bd2-d8a9ac79f918)

**Mode toggle on the recommend section** — Balance focus (preset by the CTA) vs Coach's pick (default):

![recommend-balance-focus](https://github.com/user-attachments/assets/69d19a1c-1e8c-49a1-9cf4-153f3f267885)
![recommend-coachs-pick](https://github.com/user-attachments/assets/979902b5-8626-471e-9beb-7748593ffd99)

## Tradeoffs

- Annotate + rank + validate over hard pre-filtering: keeps the LLM's coaching judgment (fillers, session shape) while the validator makes coverage a guarantee. Hard filtering had the stronger a-priori guarantee but starves the model of sensible complements.
- Top-3 cap over "all red patterns": a lapsed user returning from a break has everything red; uncapped coverage forces bloated sessions. Multi-credit movements (TGU) often cover more than 3 anyway.
