### PR TITLE
feat(movements): movement details page with personal training history

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -7,6 +7,8 @@ export * from './useFeatureFlags';
 export * from './useLinkMovementLog';
 export * from './useUnlinkMovementLog';
 export * from './useLogWorkout';
+export * from './useMovement';
+export * from './useMovementHistory';
 export * from './useMovementLogs';
 export * from './useMovements';
 export * from './usePatternDebt';

--- a/src/api/useMovement.ts
+++ b/src/api/useMovement.ts
@@ -1,0 +1,30 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { QUERIES } from '~/constants';
+import { Movement } from '~/types';
+
+import { supabase } from '../supabaseClient';
+import { mapMovementRow } from './useMovements';
+
+/** Fetch a single catalog movement by id. Resolves `null` when not found. */
+export const useMovement = (id: string) =>
+  useQuery({
+    queryKey: [QUERIES.MOVEMENT, id],
+    queryFn: () => fetchMovement(id),
+    enabled: id !== '',
+  });
+
+const fetchMovement = async (id: string): Promise<Movement | null> => {
+  const { data: movement, error } = await supabase
+    .from('movements')
+    .select('*')
+    .eq('id', id)
+    .maybeSingle();
+
+  if (error) {
+    console.error(error);
+    throw error;
+  }
+
+  return movement ? mapMovementRow(movement) : null;
+};

--- a/src/api/useMovementHistory.ts
+++ b/src/api/useMovementHistory.ts
@@ -1,0 +1,96 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { QUERIES } from '~/constants';
+import { useSession } from '~/contexts';
+import { RpeOptions, WeightUnit } from '~/types';
+
+import { supabase } from '../supabaseClient';
+
+/** One logged instance of a catalog movement, with its parent workout. */
+export interface MovementHistoryEntry {
+  movementLogId: number;
+  workoutLogId: number;
+  workoutTitle: string | null;
+  startedAt: Date;
+  rpe: RpeOptions | null;
+  /** Reps per rung, or seconds per rung when `timedRungs` is set. */
+  repScheme: number[];
+  timedRungs: boolean;
+  weightOneUnit: WeightUnit | null;
+  weightOneValue: number | null;
+  weightTwoUnit: WeightUnit | null;
+  weightTwoValue: number | null;
+}
+
+/**
+ * The signed-in user's full log history for one catalog movement, via their
+ * user_movements links. RLS scopes rows to the current user.
+ */
+export const useMovementHistory = (functionalMovementId: string) => {
+  const session = useSession();
+  const userId = session?.user?.id;
+
+  return useQuery({
+    queryKey: [QUERIES.MOVEMENT_HISTORY, userId, functionalMovementId],
+    queryFn: () => fetchMovementHistory(functionalMovementId),
+    enabled: functionalMovementId !== '' && !!userId,
+  });
+};
+
+const fetchMovementHistory = async (
+  functionalMovementId: string,
+): Promise<MovementHistoryEntry[]> => {
+  const { data: rows, error } = await supabase
+    .from('movement_logs')
+    .select(
+      `id, rep_scheme, timed_rungs, workout_log_id,
+       weight_one_unit, weight_one_value, weight_two_unit, weight_two_value,
+       user_movements!inner(functional_movement_id),
+       workout_logs!inner(started_at, title, rpe)`,
+    )
+    .eq('user_movements.functional_movement_id', functionalMovementId);
+
+  if (error) {
+    console.error(error);
+    throw error;
+  }
+
+  return mapRows(rows).sort(
+    (a, b) => b.startedAt.getTime() - a.startedAt.getTime(),
+  );
+};
+
+const mapRows = (
+  rows: {
+    id: number;
+    rep_scheme: number[];
+    timed_rungs: boolean;
+    workout_log_id: number;
+    weight_one_unit: WeightUnit | null;
+    weight_one_value: number | null;
+    weight_two_unit: WeightUnit | null;
+    weight_two_value: number | null;
+    workout_logs:
+      | { started_at: string; title: string | null; rpe: string | null }
+      | { started_at: string; title: string | null; rpe: string | null }[];
+  }[],
+): MovementHistoryEntry[] =>
+  rows.map((row) => {
+    const workoutLog = Array.isArray(row.workout_logs)
+      ? row.workout_logs[0]
+      : row.workout_logs;
+
+    return {
+      movementLogId: row.id,
+      workoutLogId: row.workout_log_id,
+      workoutTitle: workoutLog?.title ?? null,
+      startedAt: new Date(workoutLog?.started_at),
+      rpe: (workoutLog?.rpe ?? null) as RpeOptions | null,
+      repScheme: row.rep_scheme,
+      timedRungs: row.timed_rungs,
+      weightOneUnit: row.weight_one_unit,
+      weightOneValue: row.weight_one_value,
+      weightTwoUnit: row.weight_two_unit,
+      weightTwoValue: row.weight_two_value,
+    };
+  });

--- a/src/api/useMovements.ts
+++ b/src/api/useMovements.ts
@@ -2,6 +2,7 @@ import { UseQueryOptions, useQuery } from '@tanstack/react-query';
 
 import { QUERIES } from '~/constants';
 import { DifficultyLevel, Equipment, Movement, MuscleGroup } from '~/types';
+import { Supabase } from '~/types/supabase';
 
 import { supabase } from '../supabaseClient';
 
@@ -45,6 +46,22 @@ export const useMovements = (
 // "Movement Pattern #1" must be double-quoted in order/filter params.
 const quoteSpecialColumn = (column: string) =>
   column.includes('#') ? `"${column}"` : column;
+
+type MovementRow = Supabase['public']['Tables']['movements']['Row'];
+
+export const mapMovementRow = (movement: MovementRow): Movement => ({
+  id: movement['id'],
+  difficultyLevel: movement['Difficulty Level'] as DifficultyLevel | null,
+  movementName: movement['Movement'],
+  movementPattern1: movement['Movement Pattern #1'],
+  patternCredits: movement['pattern_credits'] ?? [],
+  primaryEquipment: movement['Primary Equipment'] as Equipment | null,
+  primaryItemCount: movement['# Primary Items'],
+  singleOrDoubleArm: movement[
+    'Single or Double Arm'
+  ] as Movement['singleOrDoubleArm'],
+  targetMuscleGroup: movement['Target Muscle Group'] as MuscleGroup | null,
+});
 
 const fetchMovements = async ({
   page = 1,
@@ -101,24 +118,6 @@ const fetchMovements = async ({
     count: totalCount,
     hasNextPage,
     hasPreviousPage,
-    movements:
-      movements.map(
-        (movement): Movement => ({
-          id: movement['id'],
-          difficultyLevel: movement[
-            'Difficulty Level'
-          ] as DifficultyLevel | null,
-          movementName: movement['Movement'],
-          movementPattern1: movement['Movement Pattern #1'],
-          primaryEquipment: movement['Primary Equipment'] as Equipment | null,
-          primaryItemCount: movement['# Primary Items'],
-          singleOrDoubleArm: movement[
-            'Single or Double Arm'
-          ] as Movement['singleOrDoubleArm'],
-          targetMuscleGroup: movement[
-            'Target Muscle Group'
-          ] as MuscleGroup | null,
-        }),
-      ) ?? [],
+    movements: movements.map(mapMovementRow) ?? [],
   };
 };

--- a/src/app/routes.tsx
+++ b/src/app/routes.tsx
@@ -8,6 +8,7 @@ import {
   CheckoutSuccessPage,
   CompletedWorkoutPage,
   HistoryPage,
+  MovementDetailsPage,
   MovementsPage,
   NotFoundPage,
   PaywallPage,
@@ -69,7 +70,10 @@ export const createRoutes = (flags: Features = features): RouteObject[] => [
         ? [{ path: 'spotify/callback', element: <SpotifyCallbackPage /> }]
         : []),
       ...(flags.explore
-        ? [{ path: 'movements', element: <MovementsPage /> }]
+        ? [
+            { path: 'movements', element: <MovementsPage /> },
+            { path: 'movements/:id', element: <MovementDetailsPage /> },
+          ]
         : []),
       ...(flags.premium
         ? [{ path: 'recommendations', element: <RecommendationsPage /> }]

--- a/src/components/ui/data-table.tsx
+++ b/src/components/ui/data-table.tsx
@@ -28,6 +28,7 @@ interface DataTableProps<TData, TValue> {
   onClickLastPage?: () => void;
   onClickNextPage?: () => void;
   onClickPreviousPage?: () => void;
+  onRowClick?: (row: TData) => void;
   onSort?: (columnId: string) => void;
   order?: 'ASC' | 'DESC';
   orderBy?: string;
@@ -46,6 +47,7 @@ export function DataTable<TData, TValue>({
   onClickLastPage,
   onClickNextPage,
   onClickPreviousPage,
+  onRowClick,
   onSort,
   order,
   orderBy,
@@ -115,6 +117,15 @@ export function DataTable<TData, TValue>({
               <TableRow
                 key={row.id}
                 data-state={row.getIsSelected() && 'selected'}
+                className={onRowClick ? 'cursor-pointer' : undefined}
+                tabIndex={onRowClick ? 0 : undefined}
+                onClick={onRowClick && (() => onRowClick(row.original))}
+                onKeyDown={
+                  onRowClick &&
+                  ((event) => {
+                    if (event.key === 'Enter') onRowClick(row.original);
+                  })
+                }
               >
                 {row.getVisibleCells().map((cell) => (
                   <TableCell key={cell.id}>

--- a/src/constants/queries.enum.ts
+++ b/src/constants/queries.enum.ts
@@ -2,6 +2,8 @@ export enum QUERIES {
   ACTIVE_PROGRAM = 'activeProgram',
   ENTITLEMENT = 'entitlement',
   FEATURE_FLAGS = 'featureFlags',
+  MOVEMENT = 'movement',
+  MOVEMENT_HISTORY = 'movementHistory',
   MOVEMENT_LOGS = 'movementLogs',
   MOVEMENTS = 'movements',
   PATTERN_DEBT = 'patternDebt',

--- a/src/pages/CompletedWorkoutPage/components/WorkoutHistoryItem.stories.tsx
+++ b/src/pages/CompletedWorkoutPage/components/WorkoutHistoryItem.stories.tsx
@@ -1,5 +1,6 @@
 import { Meta, StoryObj } from '@storybook/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { MemoryRouter } from 'react-router-dom';
 
 import { SessionProvider } from '~/contexts';
 
@@ -66,13 +67,15 @@ const meta = {
   },
   decorators: [
     (Story) => (
-      <QueryClientProvider client={queryClient}>
-        <SessionProvider value={mockSession}>
-          <div className="max-w-sm">
-            <Story />
-          </div>
-        </SessionProvider>
-      </QueryClientProvider>
+      <MemoryRouter>
+        <QueryClientProvider client={queryClient}>
+          <SessionProvider value={mockSession}>
+            <div className="max-w-sm">
+              <Story />
+            </div>
+          </SessionProvider>
+        </QueryClientProvider>
+      </MemoryRouter>
     ),
   ],
 } satisfies Meta<WorkoutHistoryItemProps>;

--- a/src/pages/CompletedWorkoutPage/components/WorkoutHistoryItem.tsx
+++ b/src/pages/CompletedWorkoutPage/components/WorkoutHistoryItem.tsx
@@ -1,5 +1,8 @@
+import { Link } from 'react-router-dom';
+
 import { Loading } from '~/components';
 import { Badge } from '~/components/ui/badge';
+import { useFeatures } from '~/hooks/useFeatures';
 import {
   Card,
   CardContent,
@@ -56,6 +59,7 @@ export const WorkoutHistoryItem = ({
   workoutGoalUnits,
   workoutLogId,
 }: WorkoutHistoryItemProps) => {
+  const { explore } = useFeatures();
   const displayDate = getDisplayDate(completedAt);
   const timeRange = getTimeRange(startedAt, completedAt);
   const isComplexSet = complexSet === true;
@@ -143,7 +147,16 @@ export const WorkoutHistoryItem = ({
                 <div className="flex min-w-0 flex-col gap-0.5">
                   <CardDescription>Movement #{index + 1}</CardDescription>
                   <div className="flex flex-col gap-0.5">
-                    <div>{movement.movementName}</div>
+                    {explore && movement.functionalMovementId !== null ? (
+                      <Link
+                        to={`/movements/${movement.functionalMovementId}`}
+                        className="underline-offset-4 hover:underline"
+                      >
+                        {movement.movementName}
+                      </Link>
+                    ) : (
+                      <div>{movement.movementName}</div>
+                    )}
                     <div className="flex gap-1">
                       {movement.functionalMovementId !== null ? (
                         <CatalogedBadge

--- a/src/pages/MovementDetailsPage/MovementDetailsPage.test.tsx
+++ b/src/pages/MovementDetailsPage/MovementDetailsPage.test.tsx
@@ -1,0 +1,141 @@
+import { Session } from '@supabase/supabase-js';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen } from '@testing-library/react';
+import { HttpResponse, http } from 'msw';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+
+import { SessionProvider } from '~/contexts';
+import { VITE_SUPABASE_URL } from '~/env';
+import { server } from '~/mocks/server';
+
+import { MovementDetailsPage } from './MovementDetailsPage';
+
+const MOVEMENT_ROW = {
+  id: 'movement-1',
+  'Difficulty Level': 'Intermediate',
+  Movement: 'Kettlebell Front Squat',
+  'Movement Pattern #1': 'Knee Dominant',
+  pattern_credits: ['Squat'],
+  'Primary Equipment': 'Kettlebell',
+  '# Primary Items': 1,
+  'Single or Double Arm': 'Double Arm',
+  'Target Muscle Group': 'Quadriceps',
+};
+
+const HISTORY_ROWS = [
+  {
+    id: 11,
+    rep_scheme: [5, 5, 5],
+    timed_rungs: false,
+    workout_log_id: 101,
+    weight_one_unit: 'kilograms',
+    weight_one_value: 24,
+    weight_two_unit: null,
+    weight_two_value: null,
+    user_movements: { functional_movement_id: 'movement-1' },
+    workout_logs: {
+      started_at: '2026-07-30T10:00:00Z',
+      title: 'Leg Day',
+      rpe: null,
+    },
+  },
+  {
+    id: 12,
+    rep_scheme: [1, 2, 3],
+    timed_rungs: false,
+    workout_log_id: 102,
+    weight_one_unit: 'kilograms',
+    weight_one_value: 20,
+    weight_two_unit: null,
+    weight_two_value: null,
+    user_movements: { functional_movement_id: 'movement-1' },
+    workout_logs: {
+      started_at: '2026-07-24T10:00:00Z',
+      title: null,
+      rpe: null,
+    },
+  },
+];
+
+const mockSession = { user: { id: 'user-1' } } as Session;
+
+const renderPage = ({
+  movement = MOVEMENT_ROW as object | null,
+  history = HISTORY_ROWS,
+}: {
+  movement?: object | null;
+  history?: typeof HISTORY_ROWS;
+} = {}) => {
+  server.use(
+    http.get(`${VITE_SUPABASE_URL}/rest/v1/movements`, () =>
+      movement ? HttpResponse.json(movement) : HttpResponse.json(null),
+    ),
+    http.get(`${VITE_SUPABASE_URL}/rest/v1/movement_logs`, () =>
+      HttpResponse.json(history),
+    ),
+  );
+
+  return render(
+    <MemoryRouter initialEntries={['/movements/movement-1']}>
+      <SessionProvider value={mockSession}>
+        <QueryClientProvider client={new QueryClient()}>
+          <Routes>
+            <Route
+              path="/movements/:id"
+              element={<MovementDetailsPage />}
+            />
+          </Routes>
+        </QueryClientProvider>
+      </SessionProvider>
+    </MemoryRouter>,
+  );
+};
+
+describe('MovementDetailsPage', () => {
+  it('shows catalog details and badges', async () => {
+    renderPage();
+
+    expect(
+      await screen.findByText('Kettlebell Front Squat'),
+    ).toBeInTheDocument();
+    expect(screen.getByText('Movement pattern')).toBeInTheDocument();
+    expect(screen.getAllByText('Knee Dominant').length).toBeGreaterThan(0);
+    expect(screen.getByText('Squat')).toBeInTheDocument();
+    expect(screen.getByText('Target muscle group')).toBeInTheDocument();
+  });
+
+  it('shows personal stats and recent logs linking to history', async () => {
+    renderPage();
+
+    expect(await screen.findByText('Sessions')).toBeInTheDocument();
+    expect(screen.getByText('2')).toBeInTheDocument();
+    expect(screen.getByText('Heaviest bell')).toBeInTheDocument();
+    expect(screen.getByText('24 kg')).toBeInTheDocument();
+    expect(screen.getByText('Total reps')).toBeInTheDocument();
+    expect(screen.getByText('21')).toBeInTheDocument();
+
+    const logLink = screen.getByRole('link', { name: /Leg Day/ });
+    expect(logLink).toHaveAttribute('href', '/history/101');
+  });
+
+  it('shows an empty state with a start-workout CTA when never trained', async () => {
+    renderPage({ history: [] });
+
+    expect(
+      await screen.findByText("You haven't trained this yet"),
+    ).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Start a workout' })).toHaveAttribute(
+      'href',
+      '/',
+    );
+  });
+
+  it('shows a not-found message for an unknown movement', async () => {
+    renderPage({ movement: null });
+
+    expect(await screen.findByText('Movement not found')).toBeInTheDocument();
+    expect(
+      screen.getByRole('link', { name: 'Browse movements' }),
+    ).toHaveAttribute('href', '/movements');
+  });
+});

--- a/src/pages/MovementDetailsPage/MovementDetailsPage.tsx
+++ b/src/pages/MovementDetailsPage/MovementDetailsPage.tsx
@@ -1,0 +1,162 @@
+import { ArrowLeftIcon } from '@heroicons/react/24/outline';
+import { Link, useNavigate, useParams } from 'react-router-dom';
+
+import { useMovement, useMovementHistory } from '~/api';
+import { Loading, Page } from '~/components';
+import { Badge } from '~/components/ui/badge';
+import { Button } from '~/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '~/components/ui/card';
+
+import { HistoryList } from './components/HistoryList';
+import { StatGrid } from './components/StatGrid';
+import { getLastTrainedLabel } from './utils/stats';
+
+export const MovementDetailsPage = () => {
+  const { id = '' } = useParams<{ id: string }>();
+  const navigate = useNavigate();
+
+  const { data: movement, isLoading: movementLoading } = useMovement(id);
+  const { data: history = [], isLoading: historyLoading } =
+    useMovementHistory(id);
+
+  if (movementLoading) {
+    return (
+      <Page>
+        <div className="flex justify-center py-3">
+          <Loading />
+        </div>
+      </Page>
+    );
+  }
+
+  if (!movement) {
+    return (
+      <Page title="Movement not found">
+        <p className="text-muted-foreground">
+          This movement isn&apos;t in the catalog. It may have been removed.
+        </p>
+        <Button asChild variant="outline">
+          <Link to="/movements">Browse movements</Link>
+        </Button>
+      </Page>
+    );
+  }
+
+  const badges = [
+    movement.movementPattern1,
+    movement.primaryEquipment,
+    movement.difficultyLevel,
+    movement.targetMuscleGroup,
+    movement.singleOrDoubleArm,
+  ].filter((badge): badge is string => badge !== null);
+
+  const lastTrainedLabel = getLastTrainedLabel(history);
+
+  return (
+    <Page>
+      <div>
+        <button
+          onClick={() => navigate(-1)}
+          aria-label="Go back"
+          className="mb-1 flex items-center gap-0.5 text-sm text-muted-foreground hover:text-foreground"
+        >
+          <ArrowLeftIcon className="h-2 w-2" />
+          Back
+        </button>
+        <div className="text-xl font-semibold">{movement.movementName}</div>
+        {badges.length > 0 && (
+          <div className="mt-0.5 flex flex-wrap gap-0.5">
+            {badges.map((badge) => (
+              <Badge key={badge} variant="secondary">
+                {badge}
+              </Badge>
+            ))}
+          </div>
+        )}
+        {lastTrainedLabel && (
+          <div className="mt-1 text-sm text-muted-foreground">
+            Last trained {lastTrainedLabel}
+          </div>
+        )}
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-sm">Catalog details</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <dl>
+            <DetailRow label="Movement pattern" value={movement.movementPattern1} />
+            <DetailRow label="Primary equipment" value={movement.primaryEquipment} />
+            <DetailRow
+              label="Target muscle group"
+              value={movement.targetMuscleGroup}
+            />
+            <DetailRow label="Difficulty" value={movement.difficultyLevel} />
+            <DetailRow label="Arms" value={movement.singleOrDoubleArm} />
+            <DetailRow
+              label="Bells"
+              value={
+                movement.primaryItemCount !== null
+                  ? String(movement.primaryItemCount)
+                  : null
+              }
+            />
+            {movement.patternCredits.length > 0 && (
+              <div className="flex items-center justify-between gap-1 py-0.5 text-sm">
+                <dt className="text-muted-foreground">Pattern credits</dt>
+                <dd className="flex flex-wrap justify-end gap-0.5">
+                  {movement.patternCredits.map((pattern) => (
+                    <Badge key={pattern} variant="outline">
+                      {pattern}
+                    </Badge>
+                  ))}
+                </dd>
+              </div>
+            )}
+          </dl>
+        </CardContent>
+      </Card>
+
+      {historyLoading ? (
+        <div className="flex justify-center py-3">
+          <Loading />
+        </div>
+      ) : history.length === 0 ? (
+        <Card>
+          <CardContent className="flex flex-col items-center gap-1 py-3 text-center">
+            <div className="font-medium">You haven&apos;t trained this yet</div>
+            <p className="text-sm text-muted-foreground">
+              Log a workout with this movement and your history will show up
+              here.
+            </p>
+            <Button asChild>
+              <Link to="/">Start a workout</Link>
+            </Button>
+          </CardContent>
+        </Card>
+      ) : (
+        <>
+          <StatGrid history={history} />
+          <HistoryList history={history} />
+        </>
+      )}
+    </Page>
+  );
+};
+
+const DetailRow = ({
+  label,
+  value,
+}: {
+  label: string;
+  value: string | null;
+}) => {
+  if (value === null) return null;
+  return (
+    <div className="flex items-center justify-between gap-1 py-0.5 text-sm">
+      <dt className="text-muted-foreground">{label}</dt>
+      <dd className="font-medium">{value}</dd>
+    </div>
+  );
+};

--- a/src/pages/MovementDetailsPage/components/HistoryList.tsx
+++ b/src/pages/MovementDetailsPage/components/HistoryList.tsx
@@ -1,0 +1,64 @@
+import { Link } from 'react-router-dom';
+
+import { MovementHistoryEntry } from '~/api';
+import { Card, CardHeader, CardTitle } from '~/components/ui/card';
+
+import {
+  getRepSchemeDisplayValue,
+  getWeightsDisplayValue,
+} from '../../CompletedWorkoutPage/utils';
+import { getRowDateLabel } from '../../HistoryPage/utils';
+
+const RECENT_LOG_COUNT = 10;
+
+export const HistoryList = ({
+  history,
+}: {
+  history: MovementHistoryEntry[];
+}) => (
+  <Card>
+    <CardHeader>
+      <CardTitle className="text-sm">Recent logs</CardTitle>
+    </CardHeader>
+    <div className="divide-y">
+      {history.slice(0, RECENT_LOG_COUNT).map((entry) => (
+        <Link
+          key={entry.movementLogId}
+          to={`/history/${entry.workoutLogId}`}
+          className="flex min-h-[44px] items-center gap-1 px-2 py-1 hover:bg-accent hover:text-accent-foreground"
+        >
+          <div className="min-w-0 flex-1">
+            <div className="truncate text-sm font-medium">
+              {entry.workoutTitle?.trim() || getRowDateLabel(entry.startedAt)}
+            </div>
+            <div className="truncate text-xs text-muted-foreground">
+              {getRowDateLabel(entry.startedAt)} ·{' '}
+              {getRepSchemeDisplayValue(
+                entry.repScheme,
+                [entry.weightOneValue, entry.weightTwoValue],
+                entry.timedRungs,
+              )}{' '}
+              @{' '}
+              {getWeightsDisplayValue(
+                entry.weightOneValue,
+                entry.weightOneUnit,
+                entry.weightTwoValue,
+                entry.weightTwoUnit,
+              )}
+            </div>
+          </div>
+        </Link>
+      ))}
+    </div>
+    {history.length > RECENT_LOG_COUNT && (
+      <div className="p-1 text-center">
+        <Link
+          to="/history"
+          className="text-sm font-medium underline-offset-4 hover:underline"
+        >
+          View all history
+        </Link>
+      </div>
+    )}
+  </Card>
+);

--- a/src/pages/MovementDetailsPage/components/StatGrid.tsx
+++ b/src/pages/MovementDetailsPage/components/StatGrid.tsx
@@ -1,0 +1,55 @@
+import { MovementHistoryEntry } from '~/api';
+import { WeightUnit } from '~/types';
+import { getWeightUnitLabel } from '~/utils';
+
+import { computeMovementStats, getLastTrainedLabel } from '../utils/stats';
+
+export const StatGrid = ({
+  history,
+}: {
+  history: MovementHistoryEntry[];
+}) => {
+  const stats = computeMovementStats(history);
+  const lastTrainedLabel = getLastTrainedLabel(history);
+
+  const heaviest =
+    stats.heaviestWeightValue !== null
+      ? `${stats.heaviestWeightValue} ${getWeightUnitLabel(
+          stats.heaviestWeightUnit as WeightUnit,
+        )}`
+      : 'bw';
+
+  return (
+    <div className="grid grid-cols-2 overflow-hidden rounded-lg border">
+      <Stat label="Sessions" value={String(stats.sessionCount)} />
+      <Stat label="Heaviest bell" value={heaviest} className="border-l" />
+      <Stat
+        label="Total reps"
+        value={stats.totalReps.toLocaleString()}
+        className="border-t"
+      />
+      <Stat
+        label="Last trained"
+        value={lastTrainedLabel ?? '—'}
+        className="border-l border-t"
+      />
+    </div>
+  );
+};
+
+const Stat = ({
+  label,
+  value,
+  className = '',
+}: {
+  label: string;
+  value: string;
+  className?: string;
+}) => (
+  <div className={`flex flex-col items-center gap-0.5 p-1.5 ${className}`}>
+    <div className="text-lg font-semibold tabular-nums">{value}</div>
+    <div className="text-xs uppercase tracking-wide text-muted-foreground">
+      {label}
+    </div>
+  </div>
+);

--- a/src/pages/MovementDetailsPage/index.ts
+++ b/src/pages/MovementDetailsPage/index.ts
@@ -1,0 +1,1 @@
+export * from './MovementDetailsPage';

--- a/src/pages/MovementDetailsPage/utils/stats.test.ts
+++ b/src/pages/MovementDetailsPage/utils/stats.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, test } from 'vitest';
+
+import { MovementHistoryEntry } from '~/api';
+
+import { computeMovementStats, getLastTrainedLabel } from './stats';
+
+const entry = (
+  fields: Partial<MovementHistoryEntry>,
+): MovementHistoryEntry => ({
+  movementLogId: 1,
+  workoutLogId: 1,
+  workoutTitle: null,
+  startedAt: new Date('2026-07-30T10:00:00Z'),
+  rpe: null,
+  repScheme: [5, 5, 5],
+  timedRungs: false,
+  weightOneUnit: 'kilograms',
+  weightOneValue: 16,
+  weightTwoUnit: null,
+  weightTwoValue: null,
+  ...fields,
+});
+
+describe('computeMovementStats', () => {
+  test('counts distinct workouts as sessions', () => {
+    const stats = computeMovementStats([
+      entry({ movementLogId: 1, workoutLogId: 1 }),
+      entry({ movementLogId: 2, workoutLogId: 1 }),
+      entry({ movementLogId: 3, workoutLogId: 2 }),
+    ]);
+    expect(stats.sessionCount).toBe(2);
+  });
+
+  test('sums reps but skips timed rungs', () => {
+    const stats = computeMovementStats([
+      entry({ repScheme: [1, 2, 3] }),
+      entry({ movementLogId: 2, repScheme: [30, 30], timedRungs: true }),
+    ]);
+    expect(stats.totalReps).toBe(6);
+  });
+
+  test('finds the heaviest bell across units', () => {
+    const stats = computeMovementStats([
+      entry({ weightOneValue: 24, weightOneUnit: 'kilograms' }),
+      entry({
+        movementLogId: 2,
+        weightOneValue: 70,
+        weightOneUnit: 'pounds',
+      }),
+    ]);
+    // 70 lb ≈ 31.8 kg, heavier than 24 kg
+    expect(stats.heaviestWeightValue).toBe(70);
+    expect(stats.heaviestWeightUnit).toBe('pounds');
+  });
+
+  test('ignores null and zero weights', () => {
+    const stats = computeMovementStats([
+      entry({ weightOneValue: null, weightTwoValue: 0 }),
+    ]);
+    expect(stats.heaviestWeightValue).toBeNull();
+  });
+
+  test('returns the most recent startedAt as lastTrainedAt', () => {
+    const stats = computeMovementStats([
+      entry({ startedAt: new Date('2026-07-01T10:00:00Z') }),
+      entry({ movementLogId: 2, startedAt: new Date('2026-07-30T10:00:00Z') }),
+    ]);
+    expect(stats.lastTrainedAt).toEqual(new Date('2026-07-30T10:00:00Z'));
+  });
+});
+
+describe('getLastTrainedLabel', () => {
+  test('returns null for empty history', () => {
+    expect(getLastTrainedLabel([])).toBeNull();
+  });
+
+  test('labels today and yesterday', () => {
+    expect(getLastTrainedLabel([entry({ startedAt: new Date() })])).toBe(
+      'today',
+    );
+    const yesterday = new Date();
+    yesterday.setDate(yesterday.getDate() - 1);
+    expect(getLastTrainedLabel([entry({ startedAt: yesterday })])).toBe(
+      'yesterday',
+    );
+  });
+
+  test('labels older sessions in days', () => {
+    const fiveDaysAgo = new Date();
+    fiveDaysAgo.setDate(fiveDaysAgo.getDate() - 5);
+    expect(getLastTrainedLabel([entry({ startedAt: fiveDaysAgo })])).toBe(
+      '5 days ago',
+    );
+  });
+});

--- a/src/pages/MovementDetailsPage/utils/stats.ts
+++ b/src/pages/MovementDetailsPage/utils/stats.ts
@@ -1,0 +1,79 @@
+import { DateTime } from 'luxon';
+
+import { MovementHistoryEntry } from '~/api';
+
+const KG_PER_POUND = 0.45359237;
+
+const toKg = (value: number, unit: string | null) =>
+  unit === 'pounds' ? value * KG_PER_POUND : value;
+
+export interface MovementStats {
+  sessionCount: number;
+  totalReps: number;
+  /** Heaviest single bell across all logs, in its logged unit. */
+  heaviestWeightValue: number | null;
+  heaviestWeightUnit: string | null;
+  lastTrainedAt: Date | null;
+}
+
+export const computeMovementStats = (
+  history: MovementHistoryEntry[],
+): MovementStats => {
+  const sessionCount = new Set(history.map((entry) => entry.workoutLogId)).size;
+
+  const totalReps = history.reduce(
+    (reps, entry) =>
+      entry.timedRungs
+        ? reps
+        : reps + entry.repScheme.reduce((sum, rung) => sum + rung, 0),
+    0,
+  );
+
+  let heaviestWeightValue: number | null = null;
+  let heaviestWeightUnit: string | null = null;
+  let heaviestKg = 0;
+  for (const entry of history) {
+    for (const [value, unit] of [
+      [entry.weightOneValue, entry.weightOneUnit],
+      [entry.weightTwoValue, entry.weightTwoUnit],
+    ] as const) {
+      if (value === null || value <= 0) continue;
+      const kg = toKg(value, unit);
+      if (kg > heaviestKg) {
+        heaviestKg = kg;
+        heaviestWeightValue = value;
+        heaviestWeightUnit = unit;
+      }
+    }
+  }
+
+  const lastTrainedAt = history.reduce<Date | null>(
+    (latest, entry) =>
+      latest === null || entry.startedAt > latest ? entry.startedAt : latest,
+    null,
+  );
+
+  return {
+    sessionCount,
+    totalReps,
+    heaviestWeightValue,
+    heaviestWeightUnit,
+    lastTrainedAt,
+  };
+};
+
+export const getLastTrainedLabel = (
+  history: MovementHistoryEntry[],
+): string | null => {
+  const { lastTrainedAt } = computeMovementStats(history);
+  if (lastTrainedAt === null) return null;
+
+  const days = Math.floor(
+    DateTime.now()
+      .startOf('day')
+      .diff(DateTime.fromJSDate(lastTrainedAt).startOf('day'), 'days').days,
+  );
+  if (days <= 0) return 'today';
+  if (days === 1) return 'yesterday';
+  return `${days} days ago`;
+};

--- a/src/pages/MovementsPage/MovementsPage.test.tsx
+++ b/src/pages/MovementsPage/MovementsPage.test.tsx
@@ -2,7 +2,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { HttpResponse, http } from 'msw';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter, Route, Routes, useParams } from 'react-router-dom';
 import { QueryParamProvider } from 'use-query-params';
 import { ReactRouter6Adapter } from 'use-query-params/adapters/react-router-6';
 
@@ -36,6 +36,11 @@ const MOVEMENT_ROWS = [
 
 const requestUrls: URL[] = [];
 
+const DetailsProbe = () => {
+  const { id } = useParams();
+  return <div>movement details {id}</div>;
+};
+
 const renderPage = () => {
   requestUrls.length = 0;
   server.use(
@@ -58,7 +63,13 @@ const renderPage = () => {
     <MemoryRouter>
       <QueryParamProvider adapter={ReactRouter6Adapter}>
         <QueryClientProvider client={new QueryClient()}>
-          <MovementsPage />
+          <Routes>
+            <Route path="/" element={<MovementsPage />} />
+            <Route
+              path="/movements/:id"
+              element={<DetailsProbe />}
+            />
+          </Routes>
         </QueryClientProvider>
       </QueryParamProvider>
     </MemoryRouter>,
@@ -97,6 +108,23 @@ describe('movements page', () => {
     await waitFor(() =>
       expect(screen.queryAllByText('Goblet Squat')).toHaveLength(0),
     );
+  });
+
+  test('clicking a table row navigates to the movement details page', async () => {
+    const user = userEvent.setup();
+    renderPage();
+
+    const [tableCell] = await screen.findAllByText('Kettlebell Swing');
+    await user.click(tableCell.closest('tr')!);
+
+    expect(await screen.findByText('movement details 1')).toBeInTheDocument();
+  });
+
+  test('mobile rows link to the movement details page', async () => {
+    renderPage();
+
+    const [, mobileRow] = await screen.findAllByText('Kettlebell Swing');
+    expect(mobileRow.closest('a')).toHaveAttribute('href', '/movements/1');
   });
 
   test('reset filters clears the pattern filter', async () => {

--- a/src/pages/MovementsPage/MovementsPage.tsx
+++ b/src/pages/MovementsPage/MovementsPage.tsx
@@ -1,5 +1,6 @@
 import { ColumnDef } from '@tanstack/react-table';
 import { useCallback, useState } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
 import {
   NumberParam,
   StringParam,
@@ -26,6 +27,7 @@ import { DifficultyLevel, Equipment, Movement, MuscleGroup } from '~/types';
 import { MovementRow } from './components';
 
 export const MovementsPage = () => {
+  const navigate = useNavigate();
   const [queryParams, setQueryParams] = useQueryParams({
     page: withDefault(NumberParam, 1),
     muscleGroup: withDefault(StringParam, undefined),
@@ -232,6 +234,7 @@ export const MovementsPage = () => {
           onClickLastPage={handleClickLastPage}
           onClickNextPage={handleClickNextPage}
           onClickPreviousPage={handleClickPreviousPage}
+          onRowClick={(movement) => navigate(`/movements/${movement.id}`)}
           onSort={handleSort}
           order={queryParams.order as 'ASC' | 'DESC'}
           orderBy={queryParams.orderBy}
@@ -253,7 +256,9 @@ export const MovementsPage = () => {
           <Card>
             <div className="divide-y">
               {movements.map((movement) => (
-                <MovementRow key={movement.id} movement={movement} />
+                <Link key={movement.id} to={`/movements/${movement.id}`}>
+                  <MovementRow movement={movement} />
+                </Link>
               ))}
             </div>
           </Card>

--- a/src/pages/MovementsPage/components/MovementRow.tsx
+++ b/src/pages/MovementsPage/components/MovementRow.tsx
@@ -1,3 +1,5 @@
+import { ChevronRightIcon } from '@heroicons/react/24/outline';
+
 import { Badge } from '~/components/ui/badge';
 import { Movement } from '~/types';
 
@@ -14,17 +16,20 @@ export const MovementRow = ({ movement }: Props) => {
   ].filter((badge): badge is string => badge !== null);
 
   return (
-    <div className="flex flex-col gap-0.5 p-1">
-      <div className="font-medium">{movement.movementName}</div>
-      {badges.length > 0 && (
-        <div className="flex flex-wrap gap-0.5">
-          {badges.map((badge) => (
-            <Badge key={badge} variant="secondary">
-              {badge}
-            </Badge>
-          ))}
-        </div>
-      )}
+    <div className="flex items-center gap-1 p-1 hover:bg-accent hover:text-accent-foreground">
+      <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+        <div className="font-medium">{movement.movementName}</div>
+        {badges.length > 0 && (
+          <div className="flex flex-wrap gap-0.5">
+            {badges.map((badge) => (
+              <Badge key={badge} variant="secondary">
+                {badge}
+              </Badge>
+            ))}
+          </div>
+        )}
+      </div>
+      <ChevronRightIcon className="h-2 w-2 shrink-0 text-muted-foreground" />
     </div>
   );
 };

--- a/src/pages/StartWorkoutPage/utils/recommendationToMovements.test.ts
+++ b/src/pages/StartWorkoutPage/utils/recommendationToMovements.test.ts
@@ -19,6 +19,7 @@ const catalogRow = (fields: Partial<Movement>): Movement => ({
   targetMuscleGroup: null,
   difficultyLevel: null,
   movementPattern1: null,
+  patternCredits: [],
   ...fields,
 });
 

--- a/src/pages/index.ts
+++ b/src/pages/index.ts
@@ -4,6 +4,7 @@ export * from './CheckoutCancelPage';
 export * from './CheckoutSuccessPage';
 export * from './CompletedWorkoutPage';
 export * from './HistoryPage';
+export * from './MovementDetailsPage';
 export * from './MovementsPage';
 export * from './NotFoundPage';
 export * from './PaywallPage';

--- a/src/types/movement.interface.ts
+++ b/src/types/movement.interface.ts
@@ -16,4 +16,5 @@ export interface Movement {
   targetMuscleGroup: MuscleGroup | null;
   difficultyLevel: DifficultyLevel | null;
   movementPattern1: string | null;
+  patternCredits: string[];
 }


### PR DESCRIPTION
## Why

The Movements tab lists the catalog but rows are dead ends — no way to drill into a movement, see its full catalog facts, or see your own history with it. Completed workout logs likewise name movements without linking anywhere.

## What

Adds a `movements/:id` details page (explore flag) showing everything the catalog knows about a movement plus your personal history — sessions, heaviest bell, total reps, last trained, and recent logs linking back to `/history/:id`. Reachable from the movements table (desktop rows and mobile card list) and from cataloged movement names on completed workout logs.

## How to test

- `npm test` — 814 passing, including new tests for the page states (loading / not found / never trained / populated), the history hook's stats math (distinct sessions, timed-rung skipping, lb→kg comparison for heaviest bell), table row navigation, and the workout-log link.
- `npm run compile:ts` and `npm run lint` clean.
- Manually against local Supabase: clicked a table row and a mobile card row into the page, opened a completed workout and clicked the linked movement name, verified the never-trained empty state and stat numbers against seeded logs.

## Gallery

Movement details (mobile):

![details-mobile](https://github.com/user-attachments/assets/ccf45bc3-e15c-42d7-9537-c6472a877d25)

Movement details (desktop):

![details-desktop](https://github.com/user-attachments/assets/60e6395d-3c2c-4bd6-beb0-acc185b1f8cb)

Never-trained empty state:

![details-empty](https://github.com/user-attachments/assets/27949f3a-5a50-4cae-bdb9-166f7a5a1536)

Movements list rows now tappable (chevron):

![movements-list](https://github.com/user-attachments/assets/74845c06-3c0a-4c3d-9ebe-f2b2022f92e0)

Completed workout log — cataloged movement names link to details:

![workout-log-link](https://github.com/user-attachments/assets/4c84251f-6dca-4920-8f51-cd8b9be5fc40)

## Tradeoffs

- Stats are computed client-side from the raw history rows rather than reusing the `pattern_debt_movements` RPC — the RPC is windowed (14/84 days) and shaped for pattern scoring, not all-time per-movement stats.
- No volume stat in v1: per-movement volume needs the shared-weight/complex-set resolution logic, so the grid shows total reps instead; a trend sparkline is a clean follow-up.
- Recent logs sort client-side by `started_at` (the workout embed) since `workout_log_id` isn't chronological.
