### PR TITLE
feat(programs): let users rename their own programs

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -27,6 +27,7 @@ export * from './useEnrollProgram';
 export * from './useQueuedPrograms';
 export * from './useProgram';
 export * from './useProgramMutationErrorHandler';
+export * from './useRenameProgram';
 export * from './useResumeProgram';
 export * from './useProgramProgress';
 export * from './usePrograms';

--- a/src/api/useRenameProgram.test.ts
+++ b/src/api/useRenameProgram.test.ts
@@ -1,0 +1,98 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import { HttpResponse, http } from 'msw';
+import React from 'react';
+
+import { SessionProvider, ToastContext } from '~/contexts';
+import { server } from '~/mocks/server';
+
+import { VITE_SUPABASE_URL } from '../env';
+import { PROGRAM_MUTATION_ERROR_MESSAGE } from './useProgramMutationErrorHandler';
+import { useRenameProgram } from './useRenameProgram';
+
+const PROGRAMS_URL = `${VITE_SUPABASE_URL}/rest/v1/programs`;
+
+const showToast = vi.fn();
+
+const mockSession = {
+  user: {
+    id: 'user-123',
+    app_metadata: {},
+    user_metadata: {},
+    created_at: '',
+    aud: '',
+  },
+  access_token: '',
+  refresh_token: '',
+  expires_in: 10000,
+  token_type: '',
+};
+
+const makeWrapper = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return ({ children }: { children: React.ReactNode }) =>
+    React.createElement(
+      QueryClientProvider,
+      { client: queryClient },
+      React.createElement(
+        SessionProvider,
+        { value: mockSession },
+        React.createElement(
+          ToastContext.Provider,
+          { value: { showToast } },
+          children,
+        ),
+      ),
+    );
+};
+
+describe('useRenameProgram', () => {
+  beforeEach(() => showToast.mockClear());
+
+  it('updates the title of the targeted program, trimmed', async () => {
+    let receivedBody: { title?: string } = {};
+    let receivedUrl = '';
+    server.use(
+      http.patch(PROGRAMS_URL, async ({ request }) => {
+        receivedBody = (await request.json()) as { title?: string };
+        receivedUrl = request.url;
+        return new HttpResponse(null, { status: 204 });
+      }),
+    );
+
+    const { result } = renderHook(() => useRenameProgram(), {
+      wrapper: makeWrapper(),
+    });
+
+    await result.current.mutateAsync({
+      programId: 'prog-1',
+      title: '  Dry Fighting Weight  ',
+    });
+
+    expect(receivedUrl).toContain('id=eq.prog-1');
+    expect(receivedBody.title).toBe('Dry Fighting Weight');
+    expect(showToast).not.toHaveBeenCalled();
+  });
+
+  it('surfaces errors and toasts on failure', async () => {
+    server.use(
+      http.patch(PROGRAMS_URL, () =>
+        HttpResponse.json({ message: 'boom' }, { status: 400 }),
+      ),
+    );
+
+    const { result } = renderHook(() => useRenameProgram(), {
+      wrapper: makeWrapper(),
+    });
+
+    await expect(
+      result.current.mutateAsync({ programId: 'prog-1', title: 'New name' }),
+    ).rejects.toBeTruthy();
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(showToast).toHaveBeenCalledWith(PROGRAM_MUTATION_ERROR_MESSAGE, {
+      variant: 'destructive',
+    });
+  });
+});

--- a/src/api/useRenameProgram.ts
+++ b/src/api/useRenameProgram.ts
@@ -1,0 +1,41 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { QUERIES } from '~/constants';
+
+import { supabase } from '../supabaseClient';
+import { useProgramMutationErrorHandler } from './useProgramMutationErrorHandler';
+
+export interface RenameProgramInput {
+  /** The owned program to rename. */
+  programId: string;
+  title: string;
+}
+
+/**
+ * Renames an owned program. Shared/system programs have a null `owner_id`, so
+ * the existing "Users can update own programs" policy already limits this to
+ * the user's own copy — no extra ownership check is needed here.
+ */
+export const useRenameProgram = () => {
+  const queryClient = useQueryClient();
+  const onError = useProgramMutationErrorHandler();
+
+  return useMutation({
+    mutationFn: async (input: RenameProgramInput): Promise<void> => {
+      const { error } = await supabase
+        .from('programs')
+        .update({ title: input.title.trim() })
+        .eq('id', input.programId);
+      if (error) throw error;
+    },
+    onSuccess: (_data, variables) => {
+      queryClient.invalidateQueries({
+        queryKey: [QUERIES.PROGRAM, variables.programId],
+      });
+      queryClient.invalidateQueries({ queryKey: [QUERIES.PROGRAMS] });
+      queryClient.invalidateQueries({ queryKey: [QUERIES.ACTIVE_PROGRAM] });
+      queryClient.invalidateQueries({ queryKey: [QUERIES.PROGRAM_PROGRESS] });
+    },
+    onError,
+  });
+};

--- a/src/pages/ProgramsPage/ProgramsPage.test.tsx
+++ b/src/pages/ProgramsPage/ProgramsPage.test.tsx
@@ -14,6 +14,7 @@ const {
   mockUseCancelProgram,
   mockUseDeleteProgram,
   mockUseSetProgramArchived,
+  mockUseRenameProgram,
   mockUseSetProgramReleased,
   mockUseQueuedPrograms,
   mockUseDequeueProgram,
@@ -25,6 +26,7 @@ const {
   cancelMutate,
   deleteMutate,
   setArchivedMutate,
+  renameMutate,
   setReleasedMutate,
   dequeueMutate,
   startQueuedMutate,
@@ -38,6 +40,7 @@ const {
   mockUseCancelProgram: vi.fn(),
   mockUseDeleteProgram: vi.fn(),
   mockUseSetProgramArchived: vi.fn(),
+  mockUseRenameProgram: vi.fn(),
   mockUseSetProgramReleased: vi.fn(),
   mockUseQueuedPrograms: vi.fn(),
   mockUseDequeueProgram: vi.fn(),
@@ -49,6 +52,7 @@ const {
   cancelMutate: vi.fn(),
   deleteMutate: vi.fn(),
   setArchivedMutate: vi.fn(),
+  renameMutate: vi.fn(),
   setReleasedMutate: vi.fn(),
   dequeueMutate: vi.fn(),
   startQueuedMutate: vi.fn(),
@@ -64,6 +68,7 @@ vi.mock('~/api', () => ({
   useCancelProgram: mockUseCancelProgram,
   useDeleteProgram: mockUseDeleteProgram,
   useSetProgramArchived: mockUseSetProgramArchived,
+  useRenameProgram: mockUseRenameProgram,
   useSetProgramReleased: mockUseSetProgramReleased,
   useQueuedPrograms: mockUseQueuedPrograms,
   useDequeueProgram: mockUseDequeueProgram,
@@ -224,6 +229,10 @@ describe('ProgramsPage', () => {
     });
     mockUseSetProgramArchived.mockReturnValue({
       mutate: setArchivedMutate,
+      isPending: false,
+    });
+    mockUseRenameProgram.mockReturnValue({
+      mutate: renameMutate,
       isPending: false,
     });
     mockUseSetProgramReleased.mockReturnValue({

--- a/src/pages/ProgramsPage/ProgramsPage.tsx
+++ b/src/pages/ProgramsPage/ProgramsPage.tsx
@@ -15,6 +15,7 @@ import {
   useProgramProgress,
   usePrograms,
   useQueuedPrograms,
+  useRenameProgram,
   useResumeProgram,
   useSetProgramArchived,
   useStartQueuedProgram,
@@ -32,6 +33,7 @@ import {
   MyProgramCard,
   QueueTimeline,
   RecommendProgramSection,
+  RenameProgramDialog,
   ReplaceProgramDialog,
   ResumeProgramDialog,
 } from './components';
@@ -49,6 +51,7 @@ export const ProgramsPage = () => {
   const cancelProgram = useCancelProgram();
   const deleteProgram = useDeleteProgram();
   const setArchived = useSetProgramArchived();
+  const renameProgram = useRenameProgram();
   const { data: queuedPrograms = [] } = useQueuedPrograms();
   const dequeue = useDequeueProgram();
   const startQueued = useStartQueuedProgram();
@@ -65,6 +68,8 @@ export const ProgramsPage = () => {
   // Several programs can be active at once, so this holds which one.
   const [pendingCancelId, setPendingCancelId] = useState<string | null>(null);
   const [title, setTitle] = useState('');
+  // Own program being renamed.
+  const [renameTargetId, setRenameTargetId] = useState<string | null>(null);
 
   // Program the user is trying to start with every parallel slot taken, plus
   // the active enrollment they picked to drop for it.
@@ -193,6 +198,17 @@ export const ProgramsPage = () => {
 
   const resumeDialogProgram =
     programs.find((p) => p.id === resumeTarget?.programId) ?? null;
+
+  const renameTargetProgram =
+    programs.find((p) => p.id === renameTargetId) ?? null;
+
+  const confirmRename = (newTitle: string) => {
+    if (!renameTargetId) return;
+    renameProgram.mutate(
+      { programId: renameTargetId, title: newTitle },
+      { onSuccess: () => setRenameTargetId(null) },
+    );
+  };
 
   // A resume needs a free slot too. At the cap the least-recently-worked
   // program is the one it displaces — named in the dialog so the choice is
@@ -341,6 +357,7 @@ export const ProgramsPage = () => {
           onQueueForLater={() =>
             enroll.mutate({ programId: program.id, queue: true })
           }
+          onRename={() => setRenameTargetId(program.id)}
           onCancel={() =>
             setPendingCancelId(enrollmentFor(program)?.enrollment.id ?? null)
           }
@@ -379,6 +396,7 @@ export const ProgramsPage = () => {
                     archived: false,
                   })
                 }
+                onRename={() => setRenameTargetId(program.id)}
                 onDelete={() => setPendingDeleteId(program.id)}
               />
             ))}
@@ -424,6 +442,16 @@ export const ProgramsPage = () => {
           showReleasedBadge={isOwner(session)}
         />
       )}
+
+      <RenameProgramDialog
+        open={renameTargetProgram !== null}
+        onOpenChange={(open) => {
+          if (!open) setRenameTargetId(null);
+        }}
+        currentTitle={renameTargetProgram?.title ?? ''}
+        onSubmit={confirmRename}
+        isPending={renameProgram.isPending}
+      />
 
       <ReplaceProgramDialog
         open={pendingSwitchId !== null}

--- a/src/pages/ProgramsPage/components/ArchivedProgramCard.tsx
+++ b/src/pages/ProgramsPage/components/ArchivedProgramCard.tsx
@@ -10,6 +10,7 @@ export interface ArchivedProgramCardProps {
   program: Program;
   pending: { archive: boolean; delete: boolean };
   onRestore: () => void;
+  onRename: () => void;
   onDelete: () => void;
 }
 
@@ -23,6 +24,7 @@ export const ArchivedProgramCard = ({
   program,
   pending,
   onRestore,
+  onRename,
   onDelete,
 }: ArchivedProgramCardProps) => (
   <Card className="flex flex-col gap-2 p-2 opacity-90">
@@ -51,6 +53,7 @@ export const ArchivedProgramCard = ({
       <OverflowMenu
         menuLabel={program.title}
         actions={[
+          { label: 'Rename program', onSelect: onRename },
           {
             label: 'Delete program',
             onSelect: onDelete,

--- a/src/pages/ProgramsPage/components/MyProgramCard.stories.tsx
+++ b/src/pages/ProgramsPage/components/MyProgramCard.stories.tsx
@@ -52,6 +52,7 @@ const meta = {
     onAddSessions: () => {},
     onViewProgress: () => {},
     onQueueForLater: () => {},
+    onRename: () => {},
     onCancel: () => {},
     onArchive: () => {},
     onDelete: () => {},

--- a/src/pages/ProgramsPage/components/MyProgramCard.tsx
+++ b/src/pages/ProgramsPage/components/MyProgramCard.tsx
@@ -30,6 +30,7 @@ export interface MyProgramCardProps {
   onAddSessions: () => void;
   onViewProgress: () => void;
   onQueueForLater: () => void;
+  onRename: () => void;
   onCancel: () => void;
   onArchive: () => void;
   onDelete: () => void;
@@ -103,6 +104,7 @@ export const MyProgramCard = ({
   onAddSessions,
   onViewProgress,
   onQueueForLater,
+  onRename,
   onCancel,
   onArchive,
   onDelete,
@@ -126,6 +128,7 @@ export const MyProgramCard = ({
         : { label: 'View progress', onClick: onViewProgress, disabled: false };
 
   const menuActions: OverflowMenuAction[] = [
+    { label: 'Rename program', onSelect: onRename },
     ...(primary.label === 'Add sessions'
       ? []
       : [{ label: 'Add sessions', onSelect: onAddSessions }]),

--- a/src/pages/ProgramsPage/components/RenameProgramDialog.test.tsx
+++ b/src/pages/ProgramsPage/components/RenameProgramDialog.test.tsx
@@ -1,0 +1,49 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { vi } from 'vitest';
+
+import { RenameProgramDialog } from './RenameProgramDialog';
+
+const setup = (
+  props: Partial<Parameters<typeof RenameProgramDialog>[0]> = {},
+) => {
+  const onSubmit = vi.fn();
+  render(
+    <RenameProgramDialog
+      open
+      onOpenChange={() => {}}
+      currentTitle="Dry Fighting Weight"
+      onSubmit={onSubmit}
+      isPending={false}
+      {...props}
+    />,
+  );
+  return { onSubmit };
+};
+
+describe('RenameProgramDialog', () => {
+  it('seeds the input with the current title', () => {
+    setup();
+    expect(screen.getByLabelText('Title')).toHaveValue('Dry Fighting Weight');
+  });
+
+  it('disables save while the title is unchanged', () => {
+    setup();
+    expect(screen.getByRole('button', { name: 'Save' })).toBeDisabled();
+  });
+
+  it('disables save when the title is emptied', async () => {
+    setup();
+    await userEvent.clear(screen.getByLabelText('Title'));
+    expect(screen.getByRole('button', { name: 'Save' })).toBeDisabled();
+  });
+
+  it('submits the trimmed title', async () => {
+    const { onSubmit } = setup();
+    const input = screen.getByLabelText('Title');
+    await userEvent.clear(input);
+    await userEvent.type(input, '  Rite of Passage  ');
+    await userEvent.click(screen.getByRole('button', { name: 'Save' }));
+    expect(onSubmit).toHaveBeenCalledWith('Rite of Passage');
+  });
+});

--- a/src/pages/ProgramsPage/components/RenameProgramDialog.tsx
+++ b/src/pages/ProgramsPage/components/RenameProgramDialog.tsx
@@ -1,0 +1,75 @@
+import { useState } from 'react';
+
+import { Button } from '~/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '~/components/ui/dialog';
+import { Input } from '~/components/ui/input';
+import { Label } from '~/components/ui/label';
+
+export interface RenameProgramDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  currentTitle: string;
+  onSubmit: (title: string) => void;
+  isPending: boolean;
+}
+
+const RenameProgramForm = ({
+  currentTitle,
+  onOpenChange,
+  onSubmit,
+  isPending,
+}: Omit<RenameProgramDialogProps, 'open'>) => {
+  const [title, setTitle] = useState(currentTitle);
+  const trimmed = title.trim();
+
+  return (
+    <>
+      <DialogHeader>
+        <DialogTitle>Rename program</DialogTitle>
+      </DialogHeader>
+
+      <div className="flex flex-col gap-0.5">
+        <Label htmlFor="rename-program-title">Title</Label>
+        <Input
+          id="rename-program-title"
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+          placeholder="e.g. Dry Fighting Weight"
+        />
+      </div>
+
+      <DialogFooter>
+        <Button variant="secondary" onClick={() => onOpenChange(false)}>
+          Cancel
+        </Button>
+        <Button
+          onClick={() => onSubmit(trimmed)}
+          disabled={
+            trimmed.length === 0 || trimmed === currentTitle.trim() || isPending
+          }
+        >
+          {isPending ? 'Saving…' : 'Save'}
+        </Button>
+      </DialogFooter>
+    </>
+  );
+};
+
+/**
+ * Renames an owned program. The form is remounted on each open (`open &&`) so
+ * the input re-seeds from the current title instead of keeping a stale draft.
+ */
+export const RenameProgramDialog = ({
+  open,
+  ...props
+}: RenameProgramDialogProps) => (
+  <Dialog open={open} onOpenChange={props.onOpenChange}>
+    <DialogContent>{open && <RenameProgramForm {...props} />}</DialogContent>
+  </Dialog>
+);

--- a/src/pages/ProgramsPage/components/index.ts
+++ b/src/pages/ProgramsPage/components/index.ts
@@ -5,5 +5,6 @@ export * from './CreateProgramForm';
 export * from './MyProgramCard';
 export * from './QueueTimeline';
 export * from './RecommendProgramSection';
+export * from './RenameProgramDialog';
 export * from './ReplaceProgramDialog';
 export * from './ResumeProgramDialog';


### PR DESCRIPTION
## Why

A program's title was set once, at creation, and never again. Typo it and you live with it; enroll in a shared program — which clones it into an owned copy — and you're stuck with whatever it was called. There was no way to fix either.

## What

Adds a "Rename program" action to the overflow menu on owned program cards (live and archived), opening a small dialog seeded with the current title. Backed by `useRenameProgram`, a plain owner UPDATE on `programs.title`.

Shared/system programs have a null `owner_id`, so the existing "Users can update own programs" policy already scopes renaming to the user's own copy — no schema or policy change here.

## How to test

- `npm test` — 1018 tests pass, including `src/api/useRenameProgram.test.ts` (update payload is trimmed and id-scoped; error path toasts) and `RenameProgramDialog.test.tsx` (seeded value; Save disabled while empty or unchanged; submits trimmed).
- `npm run compile:ts` and `npm run lint` clean.
- Manually against local Supabase: created a program, renamed it from the card menu. `PATCH /rest/v1/programs?id=eq.… → 204`, dialog closed, card re-rendered with the new title after the invalidated queries refetched.

## Gallery

New UI, so after only.

| Menu action | Dialog | Renamed card |
|---|---|---|
| ![Rename program in the card overflow menu](https://github.com/user-attachments/assets/ca77f9aa-7f06-4ed9-8de0-367454de5cee) | ![Rename dialog seeded with the current title, Save disabled](https://github.com/user-attachments/assets/352b7c9e-9d4b-464d-b42a-81198dbce6e6) | ![Card showing the corrected title](https://github.com/user-attachments/assets/bccf1159-4b52-4166-946d-3ad58870215b) |

## Tradeoffs

Went with a dialog rather than an inline blur-to-save title (the pattern `CompletedWorkoutPage` uses for notes). Inline is fewer taps and would have avoided a new component, but the title doubles as the card's link to the program, so making it an input either breaks navigation or hides the edit affordance behind a long-press. The dialog also gives somewhere to put the empty/unchanged guard.

Rename only lives on the Programs page cards. The program detail route redirects owned programs away, so the cards and the session builder are the real owned-title surfaces; adding it to the builder header can follow if it's wanted there.
