### PR TITLE
feat(workout): tag custom movements in the movement picker

### DIFF
--- a/src/components/MovementAutocomplete/MovementAutocomplete.stories.tsx
+++ b/src/components/MovementAutocomplete/MovementAutocomplete.stories.tsx
@@ -3,6 +3,7 @@ import { HttpResponse, http } from 'msw';
 import { useState } from 'react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
+import { SessionProvider } from '~/contexts';
 import { VITE_SUPABASE_URL } from '~/env';
 import { WeightTabValue } from '~/types';
 
@@ -37,13 +38,37 @@ const mockRecentMovements = [
   {
     id: 'um-2',
     canonical_name: 'Kettlebell Swing',
-    functional_movement_id: null,
+    functional_movement_id: 'mov-swing',
     created_at: '2026-05-19T10:00:00Z',
     user_id: 'user-1',
     is_big_6: false,
     skill_tree_enabled: false,
   },
 ];
+
+const mockRecentCatalogRows = [
+  {
+    id: 'mov-swing',
+    Movement: 'Kettlebell Swing',
+    'Primary Equipment': 'Kettlebell',
+    '# Primary Items': 1,
+    'Single or Double Arm': 'Double Arm',
+  },
+];
+
+const mockSession = {
+  user: {
+    id: 'user-1',
+    app_metadata: {},
+    user_metadata: {},
+    created_at: '',
+    aud: '',
+  },
+  access_token: '',
+  refresh_token: '',
+  expires_in: 10000,
+  token_type: '',
+};
 
 const makeQueryClient = () =>
   new QueryClient({
@@ -79,9 +104,11 @@ export default {
   decorators: [
     (Story) => (
       <QueryClientProvider client={makeQueryClient()}>
-        <div className="max-w-sm p-4">
-          <Story />
-        </div>
+        <SessionProvider value={mockSession}>
+          <div className="max-w-sm p-4">
+            <Story />
+          </div>
+        </SessionProvider>
       </QueryClientProvider>
     ),
   ],
@@ -108,7 +135,12 @@ export const WithRecentMovements: Story = {
     msw: {
       handlers: [
         http.get(MOVEMENTS_CATALOG_URL, () => HttpResponse.json([])),
-        http.get(MOVEMENTS_URL, () => HttpResponse.json([])),
+        http.get(MOVEMENTS_URL, ({ request }) => {
+          const url = new URL(request.url);
+          if (url.searchParams.get('id')?.startsWith('in.'))
+            return HttpResponse.json(mockRecentCatalogRows);
+          return HttpResponse.json([]);
+        }),
         http.get(USER_MOVEMENTS_URL, () =>
           HttpResponse.json(mockRecentMovements),
         ),

--- a/src/components/MovementAutocomplete/MovementAutocomplete.test.tsx
+++ b/src/components/MovementAutocomplete/MovementAutocomplete.test.tsx
@@ -345,6 +345,60 @@ describe('MovementAutocomplete', () => {
     });
   });
 
+  test('shows a Custom badge only for recent movements not linked to the catalog', async () => {
+    server.use(
+      http.get(MOVEMENTS_URL, ({ request }) => {
+        const url = new URL(request.url);
+        if (url.searchParams.get('id')?.startsWith('in.')) {
+          return HttpResponse.json([toMovementsTableRow(twoHandedCatalogMovement)]);
+        }
+        return HttpResponse.json([]);
+      }),
+      http.get(USER_MOVEMENTS_URL, () =>
+        HttpResponse.json([
+          {
+            id: 'um-1',
+            canonical_name: 'My Custom Move',
+            functional_movement_id: null,
+            created_at: '2026-05-20T10:00:00Z',
+            user_id: 'user-123',
+            is_big_6: false,
+            skill_tree_enabled: false,
+          },
+          {
+            id: 'um-2',
+            canonical_name: 'Kettlebell Swing',
+            functional_movement_id: 'mov-2h',
+            created_at: '2026-05-19T10:00:00Z',
+            user_id: 'user-123',
+            is_big_6: false,
+            skill_tree_enabled: false,
+          },
+        ]),
+      ),
+    );
+
+    renderAutocomplete({ weightMode: '2h' });
+
+    const input = screen.getByRole('textbox', { name: 'Movement Input' });
+    await userEvent.click(input);
+
+    await waitFor(() => {
+      expect(screen.getByText('My Custom Move')).toBeInTheDocument();
+      expect(screen.getByText('Kettlebell Swing')).toBeInTheDocument();
+    });
+
+    expect(screen.getByText('Custom')).toBeInTheDocument();
+
+    const swingItem = screen.getByText('Kettlebell Swing').closest('li');
+    expect(swingItem).not.toBeNull();
+    expect(
+      swingItem && Array.from(swingItem.querySelectorAll('span')).some(
+        (el) => el.textContent === 'Custom',
+      ),
+    ).toBe(false);
+  });
+
   test('selecting a recent movement calls onChange with the name', async () => {
     server.use(
       http.get(USER_MOVEMENTS_URL, () =>

--- a/src/components/MovementAutocomplete/MovementAutocomplete.tsx
+++ b/src/components/MovementAutocomplete/MovementAutocomplete.tsx
@@ -3,6 +3,7 @@ import { useEffect, useRef, useState } from 'react';
 import { useCreateUserMovement } from '~/api/useCreateUserMovement';
 import { useMovementSearch } from '~/api/useMovementSearch';
 import { useUserMovementFrequency } from '~/api/useUserMovementFrequency';
+import { Badge } from '~/components/ui/badge';
 import { cn } from '~/lib/utils';
 import { WeightTabValue } from '~/types';
 import {
@@ -249,7 +250,14 @@ export const MovementAutocomplete = ({
                     );
                   }}
                 >
-                  {movement.canonicalName}
+                  <span className="flex items-center justify-between gap-2">
+                    <span>{movement.canonicalName}</span>
+                    {movement.functionalMovementId == null && (
+                      <Badge variant="secondary" className="text-[10px]">
+                        Custom
+                      </Badge>
+                    )}
+                  </span>
                 </li>
               ))}
             </>


### PR DESCRIPTION
## Why

Recent movements in the builder's autocomplete render identically whether they're linked to a catalog entry or freely typed via "Use '…' as custom movement." Nothing tells you which of your recents are custom — and custom ones behave differently, since they carry no catalog metadata to drive weight-mode filtering or any future catalog-derived features.

## What

Adds a "Custom" badge to recent-list entries whose `functional_movement_id` is null. Catalog-section results are always catalog-linked, so they're untouched.

## How to test

- `npm test` — 1013 tests pass across 129 files, including a new case in `MovementAutocomplete.test.tsx` asserting the badge renders for the unlinked recent and not for the catalog-linked one.
- Storybook: `npm run storybook` → **MovementAutocomplete / WithRecentMovements**, click the input. "Clean and Press" (custom) shows the badge; "Kettlebell Swing" (catalog-linked) doesn't.

That story was silently broken before this PR — the recents query is session-gated and the story had no `SessionProvider`, so it never rendered any recents at all. Fixed here, with the fixture seeded as a custom/catalog mix so the story actually demonstrates the distinction.

## Gallery

**Before** — no way to tell the two apart

![before](https://github.com/user-attachments/assets/86b3bf6a-a1d5-4026-ac1c-5b6a9acd9466)

**After** — custom entries are tagged

![after](https://github.com/user-attachments/assets/dd482c65-2b23-47fa-bdc9-0410f23d1f7f)

## Tradeoffs

Tagged only the custom side rather than badging both. Badging catalog entries too would be more explicit, but it puts a chip on nearly every row and turns a quiet signal into visual noise — custom is the exception worth flagging.

Derived "custom" from `functional_movement_id == null` rather than adding an `is_custom` column. It's the same fact the write path already encodes (`handleCustomEntry` persists a null link), so a column would be denormalized state that could drift once linking custom movements to catalog entries lands.

## Follow-up

Surface a user's custom movements in the explore-movements table so they can be linked to catalog entries in bulk.
