### PR TITLE
chore(config): allow Claude Browser preview tools without prompting

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -4,7 +4,10 @@
       "mcp__e7560fe6-e0dc-4e41-8b81-77e2cf92370e__get_issue",
       "Bash(npm test *)",
       "Bash(npm run compile:ts *)",
-      "Bash(npx supabase status *)"
+      "Bash(npx supabase status *)",
+      "mcp__Claude_Browser__preview_start",
+      "mcp__Claude_Browser__preview_stop",
+      "mcp__Claude_Browser__preview_logs"
     ]
   }
 }


### PR DESCRIPTION
## Why

`CLAUDE.md` tells contributors to `preview_start` the `bellskill-dev` and `bellskill-storybook` configs from `.claude/launch.json` to capture PR screenshots. Both files are committed, but there was no matching permission rule, so every preview start (and the stop/logs calls around it) prompted for approval. Shared friction, so the fix belongs in shared settings.

## What

Adds `mcp__Claude_Browser__preview_start`, `preview_stop`, and `preview_logs` to `permissions.allow` in `.claude/settings.json`.

## How to test

- `jq -e '.permissions.allow' .claude/settings.json` — valid JSON, rules present.
- Rules apply to new sessions; start a fresh session and run the `bellskill-dev` preview to confirm no prompt.

## Tradeoffs

MCP permission rules match at the tool level only — there's no argument syntax to scope the allow to just the two launch configs. So `preview_start` is also allowed for `{url: ...}` calls that open arbitrary sites in the browser pane. The alternative was allowing only `preview_stop`/`preview_logs` and leaving the prompt on `preview_start`, which keeps a gate on URL navigation but doesn't fix the actual friction. Happy to narrow it if reviewers prefer the tighter posture.
