### PR TITLE
fix(workout): shorten weight-mode tab labels so they fit on small phones

### DIFF
--- a/src/components/MovementAutocomplete/WeightModeTabs.stories.tsx
+++ b/src/components/MovementAutocomplete/WeightModeTabs.stories.tsx
@@ -11,10 +11,16 @@ const meta: Meta<typeof WeightModeTabs> = {
 };
 export default meta;
 
-const Interactive = ({ initial }: { initial: WeightTabValue }) => {
+const Interactive = ({
+  initial,
+  widthClassName = 'max-w-md',
+}: {
+  initial: WeightTabValue;
+  widthClassName?: string;
+}) => {
   const [value, setValue] = useState<WeightTabValue>(initial);
   return (
-    <div className="max-w-md">
+    <div className={widthClassName}>
       <WeightModeTabs value={value} onValueChange={setValue} />
     </div>
   );
@@ -24,3 +30,8 @@ export const Bodyweight: StoryObj = { render: () => <Interactive initial="none" 
 export const TwoHand: StoryObj = { render: () => <Interactive initial="2h" /> };
 export const Single: StoryObj = { render: () => <Interactive initial="1h" /> };
 export const Double: StoryObj = { render: () => <Interactive initial="double" /> };
+
+/** Approximates the MovementCard content width on a 320px-wide phone. */
+export const NarrowPhone: StoryObj = {
+  render: () => <Interactive initial="2h" widthClassName="w-[300px]" />,
+};

--- a/src/components/MovementAutocomplete/WeightModeTabs.tsx
+++ b/src/components/MovementAutocomplete/WeightModeTabs.tsx
@@ -1,7 +1,7 @@
 import { Tabs, TabsList, TabsTrigger } from '~/components/ui/tabs';
 import { cn } from '~/lib/utils';
 import { WeightTabValue } from '~/types';
-import { WEIGHT_MODE_LABELS } from '~/utils';
+import { WEIGHT_MODE_LABELS, WEIGHT_MODE_SHORT_LABELS } from '~/utils';
 
 import { KettlebellGlyph } from './KettlebellGlyph';
 
@@ -29,13 +29,14 @@ export const WeightModeTabs = ({
       {MODES.filter((mode) => !(hideNone && mode === 'none')).map((mode) => (
         <TabsTrigger
           key={mode}
+          aria-label={WEIGHT_MODE_LABELS[mode]}
           className="flex min-w-0 flex-1 flex-col gap-0.5 px-0.5 py-1"
           size="sm"
           value={mode}
         >
           <KettlebellGlyph mode={mode} />
           <span className="truncate leading-none">
-            {WEIGHT_MODE_LABELS[mode]}
+            {WEIGHT_MODE_SHORT_LABELS[mode]}
           </span>
         </TabsTrigger>
       ))}

--- a/src/utils/movementWeightModeFilter.ts
+++ b/src/utils/movementWeightModeFilter.ts
@@ -13,6 +13,14 @@ export const WEIGHT_MODE_LABELS: Record<WeightTabValue, string> = {
   double: 'Double',
 };
 
+/** Compact variants for the weight-mode tabs, which are four-across on phone widths. */
+export const WEIGHT_MODE_SHORT_LABELS: Record<WeightTabValue, string> = {
+  none: 'Body',
+  '2h': '2-Hand',
+  '1h': '1-Hand',
+  double: 'Double',
+};
+
 export const getWeightTabValue = (movement: {
   weightOneValue: MovementOptions['weightOneValue'];
   weightTwoValue: MovementOptions['weightTwoValue'];


### PR DESCRIPTION
## Why

The weight-mode tabs are four equal-width triggers in a single row. On small phones there
isn't enough width for "Bodyweight" and "Two-Hand" side by side, so the labels visually
collide — and `truncate` starts clipping. The tightest container is `MovementCard`, whose
`px-1.5` padding leaves the tabs less room than the viewport suggests.

## What

Shortened the tab labels to Body / 2-Hand / 1-Hand / Double, keeping the single-row segmented
control.

`WEIGHT_MODE_LABELS` is not tab-only — it also feeds prose and standalone labels (`Catalog
(Two-Hand)`, `No bodyweight movements for…`, `Using shared weight: …`, the summary chips, and
the plain "Bodyweight" label in `ProgramDetailsPage` / `SwapMovementDialog` /
`AdjustWeightsDialog`). Shortening it in place would have produced "No body movements for…".
So this adds a separate `WEIGHT_MODE_SHORT_LABELS` map used only by the tabs.

The full label stays as the trigger's `aria-label`, so screen readers still announce
"Bodyweight" and nothing querying tabs by accessible name changes.

## How to test

- `npx vitest run src/components/MovementAutocomplete` — 19/19 pass with no test changes, since
  the `aria-label` preserves every `getByRole('tab', { name: … })` query the suite uses.
- `npm run compile:ts` and `npm run lint` — clean.
- Storybook → `MovementAutocomplete/WeightModeTabs/NarrowPhone` (new, 300px). Measured
  `scrollWidth` vs `clientWidth` on each label span at 300px, 260px, and 240px container
  widths: no truncation at any of them, so there's headroom well below the tightest real case.

## Gallery

Both at a 300px container — roughly the `MovementCard` content width on a 320px phone.

**Before**

![before](https://github.com/user-attachments/assets/08455fd5-9a25-4436-b290-90648cfe2256)

**After**

![after](https://github.com/user-attachments/assets/694cdea3-10b0-439d-9b5f-1d34af0c8624)

## Tradeoffs

Considered a 2×2 grid instead. Rejected it: the four modes are one axis — how the bell is held
— and a segmented control reads that way at a glance. A grid breaks that mental model, doubles
the vertical height inside an already-tight card, and makes the active-state highlight look
like a selected cell rather than a position on a scale. What the grid did do well is leave room
for the original, more explicit labels; "Body" is a slightly weaker word than "Bodyweight",
which is why the full text is retained as the accessible name.
