### PR TITLE
feat(builder): derive the weight mode from the picked movement

### DIFF
--- a/src/api/useMovementSearch.ts
+++ b/src/api/useMovementSearch.ts
@@ -3,8 +3,8 @@ import { keepPreviousData, useQuery } from '@tanstack/react-query';
 import { QUERIES } from '~/constants';
 import { WeightTabValue } from '~/types';
 import {
-  applyWeightModeToCatalogQuery,
   escapeIlikePattern,
+  getWeightModeFromCatalogFields,
   tokenizeMovementSearchQuery,
 } from '~/utils';
 
@@ -13,43 +13,46 @@ import { supabase } from '../supabaseClient';
 export interface MovementSearchResult {
   id: string;
   name: string;
+  /** How the movement is held, so picking it can settle the weight mode. */
+  weightMode: WeightTabValue | null;
 }
 
 const CATALOG_SEARCH_LIMIT = 100;
 
-export const useMovementSearch = (query: string, weightMode: WeightTabValue) =>
+export const useMovementSearch = (query: string) =>
   useQuery({
-    queryKey: [QUERIES.MOVEMENTS, 'search', query, weightMode],
-    queryFn: () => searchMovements(query, weightMode),
+    queryKey: [QUERIES.MOVEMENTS, 'search', query],
+    queryFn: () => searchMovements(query),
     enabled: query.length >= 2,
     placeholderData: keepPreviousData,
   });
 
-const searchMovements = async (
-  query: string,
-  weightMode: WeightTabValue,
-): Promise<MovementSearchResult[]> => {
+const searchMovements = async (query: string): Promise<MovementSearchResult[]> => {
   const tokens = tokenizeMovementSearchQuery(query);
   if (tokens.length === 0) return [];
 
-  let movementsQuery = supabase.from('movements_catalog').select('id, name');
+  let movementsQuery = supabase
+    .from('movements_catalog')
+    .select(
+      'id, name, primary_equipment, primary_item_count, single_or_double_arm',
+    );
 
   for (const token of tokens) {
     movementsQuery = movementsQuery.ilike('name', `%${escapeIlikePattern(token)}%`);
   }
 
-  movementsQuery = applyWeightModeToCatalogQuery(movementsQuery, weightMode);
-
   const { data, error } = await movementsQuery.limit(CATALOG_SEARCH_LIMIT);
 
   if (error) throw error;
   return (data ?? [])
-    .filter(
-      (movement): movement is { id: string; name: string } =>
-        movement.id !== null && movement.name !== null,
-    )
+    .filter((movement) => movement.id !== null && movement.name !== null)
     .map((movement) => ({
-      id: movement.id,
-      name: movement.name,
+      id: movement.id!,
+      name: movement.name!,
+      weightMode: getWeightModeFromCatalogFields({
+        primaryEquipment: movement.primary_equipment,
+        primaryItemCount: movement.primary_item_count,
+        singleOrDoubleArm: movement.single_or_double_arm,
+      }),
     }));
 };

--- a/src/components/MovementAutocomplete/MovementAutocomplete.stories.tsx
+++ b/src/components/MovementAutocomplete/MovementAutocomplete.stories.tsx
@@ -79,6 +79,7 @@ const MovementAutocompleteDemo = ({
   initialValue = '',
   initialWeightMode = '2h' as WeightTabValue,
   showWeightModeTabs = true,
+  weightModeLocked = false,
   weightModeHint = null as string | null,
   weightSummary = null as string | null,
 }) => {
@@ -93,6 +94,7 @@ const MovementAutocompleteDemo = ({
       weightMode={weightMode}
       onWeightModeChange={setWeightMode}
       showWeightModeTabs={showWeightModeTabs}
+      weightModeLocked={weightModeLocked}
       weightModeHint={weightModeHint}
       weightSummary={weightSummary}
     />
@@ -164,9 +166,14 @@ export const WithCatalogResults: Story = {
   },
 };
 
-export const BodyweightMode: Story = {
+/** The picked movement is in the catalog, so its mode is shown, not chosen. */
+export const LockedWeightMode: Story = {
   render: () => (
-    <MovementAutocompleteDemo initialValue="Push" initialWeightMode="none" />
+    <MovementAutocompleteDemo
+      initialValue="One-Arm Kettlebell Swing"
+      initialWeightMode="1h"
+      weightModeLocked
+    />
   ),
   parameters: {
     msw: {

--- a/src/components/MovementAutocomplete/MovementAutocomplete.test.tsx
+++ b/src/components/MovementAutocomplete/MovementAutocomplete.test.tsx
@@ -152,18 +152,11 @@ describe('MovementAutocomplete', () => {
     expect(onWeightModeChange).toHaveBeenCalledWith('1h');
   });
 
-  test('renders the tabs as a read-only indicator when the mode is locked', async () => {
-    const onWeightModeChange = vi.fn();
-    renderAutocomplete({ weightModeLocked: true, onWeightModeChange });
+  test('reads the mode out instead of offering tabs when it is locked', () => {
+    renderAutocomplete({ weightModeLocked: true });
 
-    expect(screen.getByRole('tab', { name: 'Single' })).toBeDisabled();
-    expect(screen.getByRole('tab', { name: 'Two-Hand' })).toHaveAttribute(
-      'data-state',
-      'active',
-    );
-
-    await userEvent.click(screen.getByRole('tab', { name: 'Single' }));
-    expect(onWeightModeChange).not.toHaveBeenCalled();
+    expect(screen.queryByRole('tab')).not.toBeInTheDocument();
+    expect(screen.getByText('Two-Hand')).toBeInTheDocument();
   });
 
   test('keeps dropdown open while focus moves to the weight-mode tabs', async () => {

--- a/src/components/MovementAutocomplete/MovementAutocomplete.test.tsx
+++ b/src/components/MovementAutocomplete/MovementAutocomplete.test.tsx
@@ -84,6 +84,7 @@ interface RenderOptions {
   showWeightModeTabs?: boolean;
   weightSummary?: string | null;
   weightModeHint?: string | null;
+  weightModeLocked?: boolean;
   deferUserMovementWrite?: boolean;
   onMovementPick?: ReturnType<typeof vi.fn>;
 }
@@ -97,6 +98,7 @@ function renderAutocomplete({
   showWeightModeTabs = true,
   weightSummary = null,
   weightModeHint = null,
+  weightModeLocked = false,
   deferUserMovementWrite = false,
   onMovementPick,
 }: RenderOptions = {}) {
@@ -110,6 +112,7 @@ function renderAutocomplete({
       showWeightModeTabs={showWeightModeTabs}
       weightSummary={weightSummary}
       weightModeHint={weightModeHint}
+      weightModeLocked={weightModeLocked}
       deferUserMovementWrite={deferUserMovementWrite}
       onMovementPick={onMovementPick}
     />,
@@ -149,6 +152,20 @@ describe('MovementAutocomplete', () => {
     expect(onWeightModeChange).toHaveBeenCalledWith('1h');
   });
 
+  test('renders the tabs as a read-only indicator when the mode is locked', async () => {
+    const onWeightModeChange = vi.fn();
+    renderAutocomplete({ weightModeLocked: true, onWeightModeChange });
+
+    expect(screen.getByRole('tab', { name: 'Single' })).toBeDisabled();
+    expect(screen.getByRole('tab', { name: 'Two-Hand' })).toHaveAttribute(
+      'data-state',
+      'active',
+    );
+
+    await userEvent.click(screen.getByRole('tab', { name: 'Single' }));
+    expect(onWeightModeChange).not.toHaveBeenCalled();
+  });
+
   test('keeps dropdown open while focus moves to the weight-mode tabs', async () => {
     renderAutocomplete();
 
@@ -157,8 +174,8 @@ describe('MovementAutocomplete', () => {
     await userEvent.type(input, 'Swing');
     expect(screen.getByRole('listbox')).toBeInTheDocument();
 
-    // The tabs filter the dropdown's catalog results, so moving focus onto
-    // them must not dismiss the results being filtered.
+    // The tabs sit below the results, so reaching for them must not dismiss
+    // the list they sit under.
     await userEvent.tab();
     expect(screen.getByRole('tab', { name: 'Two-Hand' })).toHaveFocus();
     expect(screen.getByRole('listbox')).toBeInTheDocument();
@@ -271,7 +288,7 @@ describe('MovementAutocomplete', () => {
     expect(screen.queryByText('Clean and Press')).not.toBeInTheDocument();
   });
 
-  test('filters recent movements by weight mode when catalog metadata exists', async () => {
+  test('shows recent movements whose mode differs from the selected tab', async () => {
     server.use(
       http.get(MOVEMENTS_URL, ({ request }) => {
         const url = new URL(request.url);
@@ -315,7 +332,7 @@ describe('MovementAutocomplete', () => {
     await waitFor(() => {
       expect(screen.getByText('Kettlebell Swing')).toBeInTheDocument();
     });
-    expect(screen.queryByText('Kettlebell Clean')).not.toBeInTheDocument();
+    expect(screen.getByText('Kettlebell Clean')).toBeInTheDocument();
   });
 
   test('shows custom recent movements regardless of weight mode', async () => {
@@ -488,7 +505,7 @@ describe('MovementAutocomplete', () => {
 
     await waitFor(() => {
       expect(screen.getByText('Kettlebell Snatch')).toBeInTheDocument();
-      expect(screen.getByText('Catalog (Two-Hand)')).toBeInTheDocument();
+      expect(screen.getByText('Catalog')).toBeInTheDocument();
     });
 
     await userEvent.click(screen.getByText('Kettlebell Snatch'));
@@ -530,7 +547,11 @@ describe('MovementAutocomplete', () => {
 
     await userEvent.click(screen.getByText('Kettlebell Snatch'));
 
-    expect(onMovementPick).toHaveBeenCalledWith('Kettlebell Snatch', 'mov-1');
+    expect(onMovementPick).toHaveBeenCalledWith(
+      'Kettlebell Snatch',
+      'mov-1',
+      '2h',
+    );
     expect(capturedInsert).toBeNull();
   });
 
@@ -542,7 +563,7 @@ describe('MovementAutocomplete', () => {
 
     await waitFor(() => {
       expect(
-        screen.getByText(/No two-hand movements for.*Swing.*try another mode/i),
+        screen.getByText(/No movements match .*Swing/i),
       ).toBeInTheDocument();
     });
   });

--- a/src/components/MovementAutocomplete/MovementAutocomplete.tsx
+++ b/src/components/MovementAutocomplete/MovementAutocomplete.tsx
@@ -13,6 +13,7 @@ import {
   tokenizeMovementSearchQuery,
 } from '~/utils';
 
+import { WeightModeIndicator } from './WeightModeIndicator';
 import { WeightModeTabs } from './WeightModeTabs';
 
 export interface MovementAutocompleteProps {
@@ -22,7 +23,7 @@ export interface MovementAutocompleteProps {
   onWeightModeChange: (mode: WeightTabValue) => void;
   weightSummary?: string | null;
   showWeightModeTabs?: boolean;
-  /** The movement's mode comes from the catalog — show it, don't let it be fought. */
+  /** The catalog settled this movement's mode — read it out instead of offering a choice. */
   weightModeLocked?: boolean;
   weightModeHint?: string | null;
   className?: string;
@@ -217,14 +218,16 @@ export const MovementAutocomplete = ({
         <p className="mt-1 text-xs text-muted-foreground">{weightSummary}</p>
       )}
 
-      {showWeightModeTabs && (
-        <WeightModeTabs
-          value={weightMode}
-          onValueChange={handleWeightModeChange}
-          disabled={weightModeLocked}
-          className="mt-1"
-        />
-      )}
+      {showWeightModeTabs &&
+        (weightModeLocked ? (
+          <WeightModeIndicator mode={weightMode} className="mt-1" />
+        ) : (
+          <WeightModeTabs
+            value={weightMode}
+            onValueChange={handleWeightModeChange}
+            className="mt-1"
+          />
+        ))}
 
       {weightModeHint && (
         <p className="mt-1 text-xs text-muted-foreground">{weightModeHint}</p>

--- a/src/components/MovementAutocomplete/MovementAutocomplete.tsx
+++ b/src/components/MovementAutocomplete/MovementAutocomplete.tsx
@@ -7,10 +7,9 @@ import { Badge } from '~/components/ui/badge';
 import { cn } from '~/lib/utils';
 import { WeightTabValue } from '~/types';
 import {
-  WEIGHT_MODE_LABELS,
+  getWeightModeFromCatalogFields,
   movementNameMatchesSearchTokens,
   rankMovements,
-  recentMovementMatchesWeightMode,
   tokenizeMovementSearchQuery,
 } from '~/utils';
 
@@ -23,10 +22,16 @@ export interface MovementAutocompleteProps {
   onWeightModeChange: (mode: WeightTabValue) => void;
   weightSummary?: string | null;
   showWeightModeTabs?: boolean;
+  /** The movement's mode comes from the catalog — show it, don't let it be fought. */
+  weightModeLocked?: boolean;
   weightModeHint?: string | null;
   className?: string;
   deferUserMovementWrite?: boolean;
-  onMovementPick?: (name: string, functionalMovementId?: string | null) => void;
+  onMovementPick?: (
+    name: string,
+    functionalMovementId?: string | null,
+    weightMode?: WeightTabValue | null,
+  ) => void;
 }
 
 export const MovementAutocomplete = ({
@@ -36,6 +41,7 @@ export const MovementAutocomplete = ({
   onWeightModeChange,
   weightSummary = null,
   showWeightModeTabs = true,
+  weightModeLocked = false,
   weightModeHint = null,
   className,
   deferUserMovementWrite = false,
@@ -61,25 +67,21 @@ export const MovementAutocomplete = ({
     data: catalogResults = [],
     isFetching: isCatalogFetching,
     isLoading: isCatalogLoading,
-  } = useMovementSearch(debouncedSearchQuery, weightMode);
+  } = useMovementSearch(debouncedSearchQuery);
   const createUserMovement = useCreateUserMovement();
 
   const frequentNames = new Set(
     frequentMovements.map((m) => m.canonicalName.toLowerCase()),
   );
 
-  const weightModeFilteredRecent = frequentMovements.filter((m) =>
-    recentMovementMatchesWeightMode(m.catalogWeightFields, weightMode),
-  );
-
   const searchTokens = tokenizeMovementSearchQuery(inputValue);
 
   const filteredRecentMatches =
     inputValue.length >= 1
-      ? weightModeFilteredRecent.filter((m) =>
+      ? frequentMovements.filter((m) =>
           movementNameMatchesSearchTokens(m.canonicalName, searchTokens),
         )
-      : weightModeFilteredRecent.slice(0, 8);
+      : frequentMovements.slice(0, 8);
 
   const filteredRecent =
     inputValue.length >= 1
@@ -118,8 +120,6 @@ export const MovementAutocomplete = ({
   const hasOptions =
     filteredRecent.length > 0 || rankedCatalog.length > 0 || showCatalogEmpty;
 
-  const catalogSectionLabel = `Catalog (${WEIGHT_MODE_LABELS[weightMode]})`;
-
   useEffect(() => {
     const handleClickOutside = (e: MouseEvent) => {
       if (
@@ -136,9 +136,10 @@ export const MovementAutocomplete = ({
   const persistUserMovement = (
     name: string,
     functionalMovementId?: string | null,
+    pickedWeightMode?: WeightTabValue | null,
   ) => {
     if (deferUserMovementWrite) {
-      onMovementPick?.(name, functionalMovementId);
+      onMovementPick?.(name, functionalMovementId, pickedWeightMode);
       return;
     }
     createUserMovement.mutate({ canonicalName: name, functionalMovementId });
@@ -156,11 +157,15 @@ export const MovementAutocomplete = ({
     setIsOpen(true);
   };
 
-  const handleSelect = (name: string, functionalMovementId?: string | null) => {
+  const handleSelect = (
+    name: string,
+    functionalMovementId?: string | null,
+    pickedWeightMode?: WeightTabValue | null,
+  ) => {
     setInputValue(name);
     onChange(name);
     setIsOpen(false);
-    persistUserMovement(name, functionalMovementId);
+    persistUserMovement(name, functionalMovementId, pickedWeightMode);
   };
 
   const handleCustomEntry = () => {
@@ -169,9 +174,8 @@ export const MovementAutocomplete = ({
     persistUserMovement(inputValue, null);
   };
 
-  // The tabs double as the dropdown's mode filter, so the whole picker is one
-  // focus scope: moving focus to the tabs keeps the dropdown open (refiltered
-  // live); leaving the picker entirely closes it. Attached to the container —
+  // The picker is one focus scope: moving focus to the tabs keeps the dropdown
+  // open; leaving the picker entirely closes it. Attached to the container —
   // React's onBlur bubbles — so it also fires when focus leaves from the tabs.
   const handleContainerBlur = () => {
     window.setTimeout(() => {
@@ -184,10 +188,9 @@ export const MovementAutocomplete = ({
   const showDropdown = isOpen && (hasOptions || showCustomEntry);
   const showSummaryChip = value.length > 0 && weightSummary && !isOpen;
 
-  // The name comes first — you pick the exercise before you pick the grip.
+  // The name comes first — the movement determines the grip, not the reverse.
   // The open dropdown is anchored to the bottom of the whole picker so the
-  // weight-mode tabs stay visible and clickable while browsing results (they
-  // filter the catalog list).
+  // weight-mode tabs stay visible while browsing results.
   return (
     <div
       ref={containerRef}
@@ -218,6 +221,7 @@ export const MovementAutocomplete = ({
         <WeightModeTabs
           value={weightMode}
           onValueChange={handleWeightModeChange}
+          disabled={weightModeLocked}
           className="mt-1"
         />
       )}
@@ -247,6 +251,9 @@ export const MovementAutocomplete = ({
                     handleSelect(
                       movement.canonicalName,
                       movement.functionalMovementId,
+                      getWeightModeFromCatalogFields(
+                        movement.catalogWeightFields,
+                      ),
                     );
                   }}
                 >
@@ -266,7 +273,7 @@ export const MovementAutocomplete = ({
           {rankedCatalog.length > 0 && (
             <>
               <li className="px-2 py-0.5 text-xs font-medium text-muted-foreground">
-                {catalogSectionLabel}
+                Catalog
               </li>
               {rankedCatalog.map((movement) => (
                 <li
@@ -276,7 +283,11 @@ export const MovementAutocomplete = ({
                   className="cursor-pointer px-2 py-1 text-sm hover:bg-accent hover:text-accent-foreground"
                   onMouseDown={(e) => {
                     e.preventDefault();
-                    handleSelect(movement.name, movement.id);
+                    handleSelect(
+                      movement.name,
+                      movement.id,
+                      movement.weightMode,
+                    );
                   }}
                 >
                   {movement.name}
@@ -287,9 +298,7 @@ export const MovementAutocomplete = ({
 
           {showCatalogEmpty && (
             <li className="px-2 py-1 text-sm text-muted-foreground">
-              No {WEIGHT_MODE_LABELS[weightMode].toLowerCase()} movements for
-              &ldquo;
-              {inputValue}&rdquo; — try another mode
+              No movements match &ldquo;{inputValue}&rdquo;
             </li>
           )}
 

--- a/src/components/MovementAutocomplete/WeightModeIndicator.stories.tsx
+++ b/src/components/MovementAutocomplete/WeightModeIndicator.stories.tsx
@@ -1,0 +1,14 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { WeightModeIndicator } from './WeightModeIndicator';
+
+const meta: Meta<typeof WeightModeIndicator> = {
+  title: 'MovementAutocomplete/WeightModeIndicator',
+  component: WeightModeIndicator,
+};
+export default meta;
+
+export const Bodyweight: StoryObj = { args: { mode: 'none' } };
+export const TwoHand: StoryObj = { args: { mode: '2h' } };
+export const Single: StoryObj = { args: { mode: '1h' } };
+export const Double: StoryObj = { args: { mode: 'double' } };

--- a/src/components/MovementAutocomplete/WeightModeIndicator.tsx
+++ b/src/components/MovementAutocomplete/WeightModeIndicator.tsx
@@ -1,0 +1,29 @@
+import { cn } from '~/lib/utils';
+import { WeightTabValue } from '~/types';
+import { WEIGHT_MODE_LABELS } from '~/utils';
+
+import { KettlebellGlyph } from './KettlebellGlyph';
+
+/**
+ * The weight mode as a fact rather than a choice — for movements whose grip the
+ * catalog already settled, and for the shared bell, which is decided once for
+ * the whole workout. Wears the same chip as the collapsed card's summary so a
+ * read-only value never looks like a control you've been locked out of.
+ */
+export const WeightModeIndicator = ({
+  mode,
+  className,
+}: {
+  mode: WeightTabValue;
+  className?: string;
+}) => (
+  <span
+    className={cn(
+      'inline-flex items-center gap-0.5 rounded-full bg-muted/70 px-1 py-0.5 text-xs font-medium',
+      className,
+    )}
+  >
+    <KettlebellGlyph mode={mode} />
+    {WEIGHT_MODE_LABELS[mode]}
+  </span>
+);

--- a/src/components/MovementAutocomplete/WeightModeTabs.stories.tsx
+++ b/src/components/MovementAutocomplete/WeightModeTabs.stories.tsx
@@ -35,12 +35,3 @@ export const Double: StoryObj = { render: () => <Interactive initial="double" />
 export const NarrowPhone: StoryObj = {
   render: () => <Interactive initial="2h" widthClassName="w-[300px]" />,
 };
-
-/** Read-only: the catalog already settled how this movement is held. */
-export const Locked: StoryObj = {
-  render: () => (
-    <div className="max-w-md">
-      <WeightModeTabs value="1h" onValueChange={() => {}} disabled />
-    </div>
-  ),
-};

--- a/src/components/MovementAutocomplete/WeightModeTabs.stories.tsx
+++ b/src/components/MovementAutocomplete/WeightModeTabs.stories.tsx
@@ -35,3 +35,12 @@ export const Double: StoryObj = { render: () => <Interactive initial="double" />
 export const NarrowPhone: StoryObj = {
   render: () => <Interactive initial="2h" widthClassName="w-[300px]" />,
 };
+
+/** Read-only: the catalog already settled how this movement is held. */
+export const Locked: StoryObj = {
+  render: () => (
+    <div className="max-w-md">
+      <WeightModeTabs value="1h" onValueChange={() => {}} disabled />
+    </div>
+  ),
+};

--- a/src/components/MovementAutocomplete/WeightModeTabs.tsx
+++ b/src/components/MovementAutocomplete/WeightModeTabs.tsx
@@ -10,6 +10,8 @@ interface WeightModeTabsProps {
   onValueChange: (value: WeightTabValue) => void;
   className?: string;
   hideNone?: boolean;
+  /** Render as a read-only indicator of a mode determined elsewhere. */
+  disabled?: boolean;
 }
 
 const MODES: WeightTabValue[] = ['none', '2h', '1h', 'double'];
@@ -19,6 +21,7 @@ export const WeightModeTabs = ({
   onValueChange,
   className,
   hideNone = false,
+  disabled = false,
 }: WeightModeTabsProps) => (
   <Tabs
     value={value}
@@ -30,9 +33,13 @@ export const WeightModeTabs = ({
         <TabsTrigger
           key={mode}
           aria-label={WEIGHT_MODE_LABELS[mode]}
-          className="flex min-w-0 flex-1 flex-col gap-0.5 px-0.5 py-1"
+          className={cn(
+            'flex min-w-0 flex-1 flex-col gap-0.5 px-0.5 py-1',
+            disabled && 'data-[state=active]:opacity-100',
+          )}
           size="sm"
           value={mode}
+          disabled={disabled}
         >
           <KettlebellGlyph mode={mode} />
           <span className="truncate leading-none">

--- a/src/components/MovementAutocomplete/WeightModeTabs.tsx
+++ b/src/components/MovementAutocomplete/WeightModeTabs.tsx
@@ -10,8 +10,6 @@ interface WeightModeTabsProps {
   onValueChange: (value: WeightTabValue) => void;
   className?: string;
   hideNone?: boolean;
-  /** Render as a read-only indicator of a mode determined elsewhere. */
-  disabled?: boolean;
 }
 
 const MODES: WeightTabValue[] = ['none', '2h', '1h', 'double'];
@@ -21,7 +19,6 @@ export const WeightModeTabs = ({
   onValueChange,
   className,
   hideNone = false,
-  disabled = false,
 }: WeightModeTabsProps) => (
   <Tabs
     value={value}
@@ -33,13 +30,9 @@ export const WeightModeTabs = ({
         <TabsTrigger
           key={mode}
           aria-label={WEIGHT_MODE_LABELS[mode]}
-          className={cn(
-            'flex min-w-0 flex-1 flex-col gap-0.5 px-0.5 py-1',
-            disabled && 'data-[state=active]:opacity-100',
-          )}
+          className="flex min-w-0 flex-1 flex-col gap-0.5 px-0.5 py-1"
           size="sm"
           value={mode}
-          disabled={disabled}
         >
           <KettlebellGlyph mode={mode} />
           <span className="truncate leading-none">

--- a/src/components/MovementAutocomplete/index.ts
+++ b/src/components/MovementAutocomplete/index.ts
@@ -1,2 +1,3 @@
 export * from './MovementAutocomplete';
 export * from './WeightModeTabs';
+export * from './WeightModeIndicator';

--- a/src/pages/CompletedWorkoutPage/components/LinkMovementDialog.test.tsx
+++ b/src/pages/CompletedWorkoutPage/components/LinkMovementDialog.test.tsx
@@ -126,9 +126,6 @@ describe('LinkMovementDialog', () => {
 
     expect(screen.getByRole('dialog')).toBeInTheDocument();
     expect(screen.getByText(/Currently: My Custom Swing/)).toBeInTheDocument();
-    expect(
-      screen.getByText(/Catalog filtered to Two-Hand/),
-    ).toBeInTheDocument();
   });
 
   test('confirm is enabled with typed input and persists link on confirm', async () => {

--- a/src/pages/CompletedWorkoutPage/components/LinkMovementDialog.tsx
+++ b/src/pages/CompletedWorkoutPage/components/LinkMovementDialog.tsx
@@ -13,7 +13,7 @@ import {
   DialogTrigger,
 } from '~/components/ui/dialog';
 import { MovementLog, WeightTabValue } from '~/types';
-import { WEIGHT_MODE_LABELS, getWeightTabValue } from '~/utils';
+import { getWeightTabValue } from '~/utils';
 
 import type { SharedWeights } from '../utils/resolveSharedWeights';
 
@@ -131,7 +131,6 @@ export const LinkMovementDialog = ({
           weightMode={weightMode}
           onWeightModeChange={() => {}}
           showWeightModeTabs={false}
-          weightModeHint={`Catalog filtered to ${WEIGHT_MODE_LABELS[weightMode]}`}
           deferUserMovementWrite
           onMovementPick={handleMovementPick}
         />

--- a/src/pages/ProgramProgressPage/components/SwapMovementDialog.tsx
+++ b/src/pages/ProgramProgressPage/components/SwapMovementDialog.tsx
@@ -132,6 +132,10 @@ export const SwapMovementDialog = ({
   const [newName, setNewName] = useState('');
   // null until touched — seeded from whichever old movement is selected.
   const [mode, setMode] = useState<WeightTabValue | null>(null);
+  // The catalog settles how the replacement is held, so picking one locks the
+  // mode; a name we have no catalog row for stays hand-picked.
+  const [pickedWeightMode, setPickedWeightMode] =
+    useState<WeightTabValue | null>(null);
   const [weight, setWeight] = useState<StartingWeight | null>(null);
 
   const effectiveMode = mode ?? oldControl?.mode ?? '2h';
@@ -151,11 +155,26 @@ export const SwapMovementDialog = ({
     setSelectedOldName(name);
     setMode(null);
     setWeight(null);
+    setPickedWeightMode(null);
   };
 
   const handleModeChange = (nextMode: WeightTabValue) => {
     setMode(nextMode);
     setWeight(adaptWeightToMode(effectiveWeight, nextMode));
+  };
+
+  const handleMovementPick = (
+    _name: string,
+    _functionalMovementId?: string | null,
+    weightMode?: WeightTabValue | null,
+  ) => {
+    setPickedWeightMode(weightMode ?? null);
+    if (weightMode) handleModeChange(weightMode);
+  };
+
+  const handleChangeNewName = (name: string) => {
+    setNewName(name);
+    setPickedWeightMode(null);
   };
 
   const takenNames = useMemo(
@@ -243,10 +262,12 @@ export const SwapMovementDialog = ({
             </span>
             <MovementAutocomplete
               value={newName}
-              onChange={setNewName}
+              onChange={handleChangeNewName}
               weightMode={effectiveMode}
               onWeightModeChange={handleModeChange}
+              weightModeLocked={pickedWeightMode !== null}
               deferUserMovementWrite
+              onMovementPick={handleMovementPick}
             />
             {isDuplicate && (
               <p className="text-xs text-destructive">

--- a/src/pages/StartWorkoutPage/StartWorkoutPage.movementWeightMode.test.jsx
+++ b/src/pages/StartWorkoutPage/StartWorkoutPage.movementWeightMode.test.jsx
@@ -109,6 +109,12 @@ const enterBuildMode = async () => {
 };
 
 const tab = (name) => screen.getByRole('tab', { name });
+// A catalog-linked movement reads its mode out as a chip; only a custom one
+// still gets the tablist.
+const readOutMode = () =>
+  screen.queryByRole('tab', { name: 'Bodyweight' })
+    ? null
+    : screen.getByText(/^(Bodyweight|Two-Hand|Single|Double)$/).textContent;
 
 describe('builder weight mode follows the picked movement', () => {
   beforeEach(() => {
@@ -124,8 +130,7 @@ describe('builder weight mode follows the picked movement', () => {
 
     await userEvent.type(await enterBuildMode(), 'Kettlebell Swing');
 
-    await waitFor(() => expect(tab('Two-Hand')).toBeDisabled());
-    expect(tab('Two-Hand')).toHaveAttribute('data-state', 'active');
+    await waitFor(() => expect(readOutMode()).toBe('Two-Hand'));
   });
 
   test('a single-arm movement selects Single', async () => {
@@ -133,8 +138,7 @@ describe('builder weight mode follows the picked movement', () => {
 
     await userEvent.type(await enterBuildMode(), 'One-Arm Kettlebell Swing');
 
-    await waitFor(() => expect(tab('Single')).toHaveAttribute('data-state', 'active'));
-    expect(tab('Single')).toBeDisabled();
+    await waitFor(() => expect(readOutMode()).toBe('Single'));
   });
 
   test('a double movement selects Double and mirrors the load', async () => {
@@ -142,9 +146,7 @@ describe('builder weight mode follows the picked movement', () => {
 
     await userEvent.type(await enterBuildMode(), 'Double Kettlebell Swing');
 
-    await waitFor(() =>
-      expect(tab('Double')).toHaveAttribute('data-state', 'active'),
-    );
+    await waitFor(() => expect(readOutMode()).toBe('Double'));
     expect(screen.getAllByRole('button', { name: '+ kg' })).toHaveLength(2);
     expect(screen.getAllByDisplayValue('16')).toHaveLength(2);
   });
@@ -171,9 +173,7 @@ describe('builder weight mode follows the picked movement', () => {
     await userEvent.clear(input);
     await userEvent.type(input, 'Double Kettlebell Swing');
 
-    await waitFor(() =>
-      expect(tab('Double')).toHaveAttribute('data-state', 'active'),
-    );
+    await waitFor(() => expect(readOutMode()).toBe('Double'));
     expect(screen.getAllByDisplayValue('17')).toHaveLength(2);
   });
 });

--- a/src/pages/StartWorkoutPage/StartWorkoutPage.movementWeightMode.test.jsx
+++ b/src/pages/StartWorkoutPage/StartWorkoutPage.movementWeightMode.test.jsx
@@ -1,0 +1,179 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { HttpResponse, http } from 'msw';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { MemoryRouter } from 'react-router-dom';
+
+import {
+  DEFAULT_WORKOUT_OPTIONS,
+  EntitlementContext,
+  SessionProvider,
+  WorkoutOptionsContext,
+} from '~/contexts';
+import { VITE_SUPABASE_URL } from '~/env';
+import { server } from '~/mocks/server';
+
+import { StartWorkoutPage } from './StartWorkoutPage';
+
+const { mockUseFeatureFlags } = vi.hoisted(() => ({
+  mockUseFeatureFlags: vi.fn(),
+}));
+vi.mock('~/api', async (importOriginal) => ({
+  ...(await importOriginal()),
+  useFeatureFlags: mockUseFeatureFlags,
+}));
+mockUseFeatureFlags.mockReturnValue({
+  features: {
+    launchpadShell: false,
+    curatedFirstWorkout: false,
+    repeatPrevious: false,
+    recommender: false,
+  },
+  isPending: false,
+});
+
+const freeEntitlement = {
+  isPremium: false,
+  isTrialing: false,
+  trialExpired: false,
+  trialDaysRemaining: null,
+  effectiveAccess: 'free',
+  isLoading: false,
+  refetch: () => {},
+};
+
+const mockSession = {
+  user: {
+    id: 'user-123',
+    app_metadata: {},
+    user_metadata: {},
+    created_at: '',
+    aud: '',
+  },
+  access_token: '',
+  refresh_token: '',
+  expires_in: 10000,
+  token_type: '',
+};
+
+const catalogRow = (id, name, itemCount, arm) => ({
+  id,
+  Movement: name,
+  'Primary Equipment': 'Kettlebell',
+  '# Primary Items': itemCount,
+  'Single or Double Arm': arm,
+  'Target Muscle Group': 'Hamstrings',
+  'Difficulty Level': 'Beginner',
+  'Movement Pattern #1': 'Hip Hinge',
+  'Pattern Credits': 'hinge',
+});
+
+const CATALOG = [
+  catalogRow('mov-2h', 'Kettlebell Swing', 1, 'Double Arm'),
+  catalogRow('mov-1h', 'One-Arm Kettlebell Swing', 1, 'Single Arm'),
+  catalogRow('mov-dbl', 'Double Kettlebell Swing', 2, 'Double Arm'),
+];
+
+const renderPage = () =>
+  render(
+    <QueryClientProvider
+      client={
+        new QueryClient({
+          defaultOptions: {
+            queries: { retry: false },
+            mutations: { retry: false },
+          },
+        })
+      }
+    >
+      <MemoryRouter>
+        <SessionProvider value={mockSession}>
+          <EntitlementContext.Provider value={freeEntitlement}>
+            <WorkoutOptionsContext.Provider
+              value={[DEFAULT_WORKOUT_OPTIONS, vi.fn()]}
+            >
+              <StartWorkoutPage />
+            </WorkoutOptionsContext.Provider>
+          </EntitlementContext.Provider>
+        </SessionProvider>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+
+// The hub is the default surface; the builder is behind "Build a workout".
+const enterBuildMode = async () => {
+  await userEvent.click(
+    await screen.findByRole('button', { name: /build a workout/i }),
+  );
+  return screen.getByLabelText('Movement Input');
+};
+
+const tab = (name) => screen.getByRole('tab', { name });
+
+describe('builder weight mode follows the picked movement', () => {
+  beforeEach(() => {
+    server.use(
+      http.get(`${VITE_SUPABASE_URL}/rest/v1/movements`, () =>
+        HttpResponse.json(CATALOG),
+      ),
+    );
+  });
+
+  test('a two-hand movement selects Two-Hand and locks the tabs', async () => {
+    renderPage();
+
+    await userEvent.type(await enterBuildMode(), 'Kettlebell Swing');
+
+    await waitFor(() => expect(tab('Two-Hand')).toBeDisabled());
+    expect(tab('Two-Hand')).toHaveAttribute('data-state', 'active');
+  });
+
+  test('a single-arm movement selects Single', async () => {
+    renderPage();
+
+    await userEvent.type(await enterBuildMode(), 'One-Arm Kettlebell Swing');
+
+    await waitFor(() => expect(tab('Single')).toHaveAttribute('data-state', 'active'));
+    expect(tab('Single')).toBeDisabled();
+  });
+
+  test('a double movement selects Double and mirrors the load', async () => {
+    renderPage();
+
+    await userEvent.type(await enterBuildMode(), 'Double Kettlebell Swing');
+
+    await waitFor(() =>
+      expect(tab('Double')).toHaveAttribute('data-state', 'active'),
+    );
+    expect(screen.getAllByRole('button', { name: '+ kg' })).toHaveLength(2);
+    expect(screen.getAllByDisplayValue('16')).toHaveLength(2);
+  });
+
+  test('a movement the catalog does not know leaves the tabs editable', async () => {
+    renderPage();
+
+    await userEvent.type(await enterBuildMode(), 'My Homemade Carry');
+
+    expect(tab('Single')).toBeEnabled();
+
+    await userEvent.click(tab('Single'));
+    expect(tab('Single')).toHaveAttribute('data-state', 'active');
+  });
+
+  test('carries the load already dialled in over into the derived mode', async () => {
+    renderPage();
+
+    const input = await enterBuildMode();
+    await userEvent.type(input, 'My Homemade Carry');
+    await userEvent.click(screen.getByRole('button', { name: '+ kg' }));
+    expect(screen.getAllByDisplayValue('17')).toHaveLength(1);
+
+    await userEvent.clear(input);
+    await userEvent.type(input, 'Double Kettlebell Swing');
+
+    await waitFor(() =>
+      expect(tab('Double')).toHaveAttribute('data-state', 'active'),
+    );
+    expect(screen.getAllByDisplayValue('17')).toHaveLength(2);
+  });
+});

--- a/src/pages/StartWorkoutPage/StartWorkoutPage.test.jsx
+++ b/src/pages/StartWorkoutPage/StartWorkoutPage.test.jsx
@@ -867,23 +867,27 @@ describe('Complex Mode', () => {
 
   test('movement card shows the shared weight, not its own, while Complex is on', async () => {
     await userEvent.type(screen.getByLabelText('Movement Input'), 'Clean');
-    // The suggestion list hides the weight summary while it's open.
+    // The suggestion list covers the card's controls while it's open.
     const closeSuggestions = () =>
       userEvent.click(screen.getByRole('heading', { name: 'Movements' }));
     await closeSuggestions();
-    const ownWeight = `${DEFAULT_MOVEMENT_OPTIONS.weightOneValue} kg (2h)`;
-    expect(screen.getByText(ownWeight)).toBeInTheDocument();
+    const ownWeight = String(DEFAULT_MOVEMENT_OPTIONS.weightOneValue);
+    expect(screen.getByDisplayValue(ownWeight)).toBeInTheDocument();
 
+    // Complex takes the movement's own Load away and states the shared bell.
     await selectMode('Complex');
-    await userEvent.click(screen.getByLabelText('+ kg'));
+    expect(screen.getByText(`Shared bell · ${ownWeight} kg`)).toBeInTheDocument();
 
-    const sharedWeight = screen.getByText(/kg \(2h\)/).textContent;
-    expect(sharedWeight).not.toBe(ownWeight);
+    await userEvent.click(screen.getByLabelText('+ kg'));
+    expect(screen.getByText(/^Shared bell · /).textContent).not.toBe(
+      `Shared bell · ${ownWeight} kg`,
+    );
 
     await selectMode('Circuit');
     await toggleSharedBell();
 
-    expect(screen.getByText(ownWeight)).toBeInTheDocument();
+    expect(screen.getByDisplayValue(ownWeight)).toBeInTheDocument();
+    expect(screen.queryByText(/Shared bell · /)).not.toBeInTheDocument();
   });
 
   test('complex mode is preserved when adding movements', async () => {

--- a/src/pages/StartWorkoutPage/StartWorkoutPage.tsx
+++ b/src/pages/StartWorkoutPage/StartWorkoutPage.tsx
@@ -35,6 +35,7 @@ import {
   MovementOptions,
   ProgramSession,
   Recommendation,
+  WeightTabValue,
   WeightUnit,
   WorkoutGoalUnits,
   WorkoutMode,
@@ -43,6 +44,8 @@ import {
 import {
   WEIGHT_MODE_LABELS,
   applySharedWeights,
+  applyWeightMode,
+  getWeightModeFromCatalogFields,
   getWeightRange,
   getWeightTabValue,
   getWeightUnitLabel,
@@ -81,8 +84,8 @@ import {
   recommendationToWorkoutOptions,
 } from './utils/recommendationToMovements';
 
-// One page comfortably covers the whole ~250-row catalog, so the recommender
-// can infer each movement's loading mode without paginating.
+// One page comfortably covers the whole ~250-row catalog, so weight-mode
+// inference never has to paginate.
 const MOVEMENT_CATALOG_PAGE_SIZE: number = 500;
 
 const DEFAULT_INTERVAL_TIMER: number = 30; // seconds
@@ -93,6 +96,10 @@ const DEFAULT_WEIGHT_UNIT: WeightUnit =
   DEFAULT_MOVEMENT_OPTIONS.weightOneUnit ?? 'kilograms';
 const DEFAULT_WEIGHT_VALUE: number =
   DEFAULT_MOVEMENT_OPTIONS.weightOneValue ?? 16;
+const WEIGHT_MODE_DEFAULTS = {
+  value: DEFAULT_WEIGHT_VALUE,
+  unit: DEFAULT_WEIGHT_UNIT,
+};
 
 const INCREMENT_DURATION: number = 1; // minutes
 const INCREMENT_INTERVAL_TIMER: number = 5; // seconds
@@ -250,23 +257,6 @@ export const StartWorkoutPage = ({
   );
   const slotsFull = activeEnrollments.length >= MAX_ACTIVE_PROGRAMS;
 
-  // The recommender prescribes a single weight per movement; the catalog's
-  // primary-item count + arm split tell us whether that load means two-hand,
-  // single, or two-bell so an accepted recommendation opens in the right mode
-  // (PROD-238). Only fetched when the recommender surface is actually shown.
-  const movementCatalogQuery = useMovements(
-    { limit: MOVEMENT_CATALOG_PAGE_SIZE },
-    { enabled: showRecommender },
-  );
-  const recommendationCatalog = useMemo<RecommendationCatalog>(
-    () =>
-      buildRecommendationCatalog(
-        movementCatalogQuery.data?.movements ?? [],
-        movementCatalogQuery.data?.hasNextPage,
-      ),
-    [movementCatalogQuery.data],
-  );
-
   // Browse mode shows recommendations plus a Build-custom button; the builder
   // opens directly when there's nothing to browse or when history's "Repeat"
   // navigates here with `editWorkout`.
@@ -282,6 +272,26 @@ export const StartWorkoutPage = ({
   // against, so it's excluded from the gate.
   const [builderOverride, setBuilderOverride] = useState<boolean | null>(null);
   const showBuilder = builderOverride ?? (editWorkout || !showBrowse);
+
+  // The catalog's primary-item count + arm split settle each movement's loading
+  // mode: the recommender maps a prescribed weight into the right slots
+  // (PROD-238), and the builder derives the mode from whatever movement you
+  // pick. Fetched only when one of those surfaces is actually shown.
+  const movementCatalogQuery = useMovements(
+    { limit: MOVEMENT_CATALOG_PAGE_SIZE },
+    { enabled: showRecommender || showBuilder },
+  );
+  const movementCatalog = useMemo<RecommendationCatalog>(
+    () =>
+      buildRecommendationCatalog(
+        movementCatalogQuery.data?.movements ?? [],
+        movementCatalogQuery.data?.hasNextPage,
+      ),
+    [movementCatalogQuery.data],
+  );
+  const getCatalogWeightMode = (movementName: string) =>
+    getWeightModeFromCatalogFields(movementCatalog.get(movementName));
+
   const gatesPending = !programSaveMode && programGatePending && !editWorkout;
   // Where the (eventual) start originated, carried through any edits the user
   // makes in the builder so `workout_started` stays attributed to the surface.
@@ -611,11 +621,22 @@ export const StartWorkoutPage = ({
     });
   };
 
-  const handleChangeMovementName = (index: number, value: string) =>
+  // The catalog knows how a movement is held, so naming one settles its loading
+  // mode too — applied in the same update so the name and its weights can never
+  // disagree. A movement we have no catalog row for keeps whatever mode it had.
+  const handleChangeMovementName = (
+    index: number,
+    value: string,
+    weightMode: WeightTabValue | null,
+  ) =>
     setMovements((prev) =>
-      prev.map((movement, i) =>
-        i === index ? { ...movement, movementName: value } : movement,
-      ),
+      prev.map((movement, i) => {
+        if (i !== index) return movement;
+        const renamed = { ...movement, movementName: value };
+        return weightMode
+          ? applyWeightMode(renamed, weightMode, WEIGHT_MODE_DEFAULTS)
+          : renamed;
+      }),
     );
 
   const handleClickRemoveMovement = (index: number) => {
@@ -641,19 +662,21 @@ export const StartWorkoutPage = ({
       return next;
     });
 
-  const handleChangeSharedWeightTab = (value: string) => {
-    setSharedWeightOneValue(
-      value === 'none' ? null : sharedWeightOneValue || DEFAULT_WEIGHT_VALUE,
+  const handleChangeSharedWeightTab = (value: WeightTabValue) => {
+    const next = applyWeightMode(
+      {
+        weightOneUnit: sharedWeightOneUnit,
+        weightOneValue: sharedWeightOneValue,
+        weightTwoUnit: sharedWeightTwoUnit,
+        weightTwoValue: sharedWeightTwoValue,
+      },
+      value,
+      WEIGHT_MODE_DEFAULTS,
     );
-    setSharedWeightOneUnit(value === 'none' ? null : DEFAULT_WEIGHT_UNIT);
-    setSharedWeightTwoValue(
-      value === 'double'
-        ? sharedWeightTwoValue || DEFAULT_WEIGHT_VALUE
-        : value === '1h'
-          ? 0
-          : null,
-    );
-    setSharedWeightTwoUnit(value === 'double' ? DEFAULT_WEIGHT_UNIT : null);
+    setSharedWeightOneValue(next.weightOneValue);
+    setSharedWeightOneUnit(next.weightOneUnit);
+    setSharedWeightTwoValue(next.weightTwoValue);
+    setSharedWeightTwoUnit(next.weightTwoUnit);
   };
 
   const handleChangeSharedWeightOneValue = (value: number) =>
@@ -668,25 +691,11 @@ export const StartWorkoutPage = ({
   const handleChangeSharedWeightTwoUnit = (value: WeightUnit) =>
     setSharedWeightTwoUnit(value);
 
-  const handleChangeWeightTab = (index: number, value: string) => {
+  const handleChangeWeightTab = (index: number, value: WeightTabValue) => {
     setMovements((prev) =>
       prev.map((movement, i) =>
         i === index
-          ? {
-              ...movement,
-              weightOneValue:
-                value === 'none'
-                  ? null
-                  : movement.weightOneValue || DEFAULT_WEIGHT_VALUE,
-              weightOneUnit: value === 'none' ? null : DEFAULT_WEIGHT_UNIT,
-              weightTwoValue:
-                value === 'double'
-                  ? movement.weightTwoValue || DEFAULT_WEIGHT_VALUE
-                  : value === '1h'
-                    ? 0
-                    : null,
-              weightTwoUnit: value === 'double' ? DEFAULT_WEIGHT_UNIT : null,
-            }
+          ? applyWeightMode(movement, value, WEIGHT_MODE_DEFAULTS)
           : movement,
       ),
     );
@@ -835,7 +844,7 @@ export const StartWorkoutPage = ({
     recommendationId: string,
   ) => {
     loadIntoBuilder(
-      recommendationToWorkoutOptions(recommendation, recommendationCatalog),
+      recommendationToWorkoutOptions(recommendation, movementCatalog),
     );
     setStartSource('recommender');
     setStartSourceProps({ recommendation_id: recommendationId });
@@ -1192,7 +1201,14 @@ export const StartWorkoutPage = ({
               onToggleExpanded={() => handleToggleMovementExpanded(index)}
               onRemove={() => handleClickRemoveMovement(index)}
               hasError={erroredMovementIndexes.has(index)}
-              onChangeName={(name) => handleChangeMovementName(index, name)}
+              catalogWeightMode={getCatalogWeightMode(movement.movementName)}
+              onChangeName={(name) =>
+                handleChangeMovementName(
+                  index,
+                  name,
+                  sharedBellActive ? null : getCatalogWeightMode(name),
+                )
+              }
               onChangeWeightTab={(mode) =>
                 sharedBellActive
                   ? handleChangeSharedWeightTab(mode)

--- a/src/pages/StartWorkoutPage/components/MovementCard.test.tsx
+++ b/src/pages/StartWorkoutPage/components/MovementCard.test.tsx
@@ -91,17 +91,18 @@ describe('MovementCard weight display', () => {
     );
   });
 
-  test('shows the movement own weight when not a complex set', () => {
+  test('edits the movement own load when not a complex set', () => {
     renderCard();
 
-    expect(screen.getByText('16 kg (2h)')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('16')).toBeInTheDocument();
+    expect(screen.queryByText(/Shared bell/)).not.toBeInTheDocument();
   });
 
   test('shows the shared weight instead of the movement own when complex', () => {
     renderCard({ sharedBell: true });
 
-    expect(screen.getByText('24 kg (2h)')).toBeInTheDocument();
-    expect(screen.queryByText('16 kg (2h)')).not.toBeInTheDocument();
+    expect(screen.getByText('Shared bell · 24 kg')).toBeInTheDocument();
+    expect(screen.queryByDisplayValue('16')).not.toBeInTheDocument();
   });
 
   test('collapsed chips track the shared weight when complex', () => {
@@ -113,15 +114,22 @@ describe('MovementCard weight display', () => {
 
   test('turning the shared bell off restores the movement own weight', () => {
     const { rerender } = renderCard({ sharedBell: true });
-    expect(screen.getByText('24 kg (2h)')).toBeInTheDocument();
+    expect(screen.getByText('Shared bell · 24 kg')).toBeInTheDocument();
 
     rerender(<MovementCard {...baseProps} sharedBell={false} />);
 
-    expect(screen.getByText('16 kg (2h)')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('16')).toBeInTheDocument();
+    expect(screen.queryByText(/Shared bell/)).not.toBeInTheDocument();
+  });
+
+  test('does not repeat the mode and load above the controls that set them', () => {
+    renderCard();
+
+    expect(screen.queryByText('16 kg (2h)')).not.toBeInTheDocument();
   });
 });
 
-describe('MovementCard weight mode tabs', () => {
+describe('MovementCard weight mode control', () => {
   beforeEach(() => {
     server.use(
       http.get(`${VITE_SUPABASE_URL}/rest/v1/movements_catalog`, () =>
@@ -136,33 +144,37 @@ describe('MovementCard weight mode tabs', () => {
     );
   });
 
-  test('locks the tabs for a movement the catalog knows', () => {
+  test('reads the mode out for a movement the catalog knows', () => {
     renderCard({ catalogWeightMode: '2h' });
 
-    expect(screen.getByRole('tab', { name: 'Single' })).toBeDisabled();
+    expect(screen.queryByRole('tab', { name: 'Single' })).not.toBeInTheDocument();
+    expect(screen.getByText('Two-Hand')).toBeInTheDocument();
   });
 
-  test('leaves the tabs editable for a custom movement', () => {
+  test('offers the tabs for a custom movement', () => {
     renderCard({ catalogWeightMode: null });
 
     expect(screen.getByRole('tab', { name: 'Single' })).toBeEnabled();
+  });
+
+  test('reads the mode out under a shared bell', () => {
+    renderCard({ sharedBell: true, catalogWeightMode: null });
+
+    expect(screen.queryByRole('tab', { name: 'Single' })).not.toBeInTheDocument();
+    expect(screen.getByText('Two-Hand')).toBeInTheDocument();
   });
 
   test('names the mismatch when the shared bell overrides the catalog', () => {
     renderCard({ sharedBell: true, catalogWeightMode: '1h' });
 
     expect(
-      screen.getByText(
-        'Using shared weight: Two-Hand (this movement is usually Single)',
-      ),
+      screen.getByText('Shared bell · 24 kg · usually Single'),
     ).toBeInTheDocument();
   });
 
   test('states the shared weight plainly when it matches the catalog', () => {
     renderCard({ sharedBell: true, catalogWeightMode: '2h' });
 
-    expect(
-      screen.getByText('Using shared weight: Two-Hand'),
-    ).toBeInTheDocument();
+    expect(screen.getByText('Shared bell · 24 kg')).toBeInTheDocument();
   });
 });

--- a/src/pages/StartWorkoutPage/components/MovementCard.test.tsx
+++ b/src/pages/StartWorkoutPage/components/MovementCard.test.tsx
@@ -120,3 +120,49 @@ describe('MovementCard weight display', () => {
     expect(screen.getByText('16 kg (2h)')).toBeInTheDocument();
   });
 });
+
+describe('MovementCard weight mode tabs', () => {
+  beforeEach(() => {
+    server.use(
+      http.get(`${VITE_SUPABASE_URL}/rest/v1/movements_catalog`, () =>
+        HttpResponse.json([]),
+      ),
+      http.get(`${VITE_SUPABASE_URL}/rest/v1/movements`, () =>
+        HttpResponse.json([]),
+      ),
+      http.get(`${VITE_SUPABASE_URL}/rest/v1/user_movements`, () =>
+        HttpResponse.json([]),
+      ),
+    );
+  });
+
+  test('locks the tabs for a movement the catalog knows', () => {
+    renderCard({ catalogWeightMode: '2h' });
+
+    expect(screen.getByRole('tab', { name: 'Single' })).toBeDisabled();
+  });
+
+  test('leaves the tabs editable for a custom movement', () => {
+    renderCard({ catalogWeightMode: null });
+
+    expect(screen.getByRole('tab', { name: 'Single' })).toBeEnabled();
+  });
+
+  test('names the mismatch when the shared bell overrides the catalog', () => {
+    renderCard({ sharedBell: true, catalogWeightMode: '1h' });
+
+    expect(
+      screen.getByText(
+        'Using shared weight: Two-Hand (this movement is usually Single)',
+      ),
+    ).toBeInTheDocument();
+  });
+
+  test('states the shared weight plainly when it matches the catalog', () => {
+    renderCard({ sharedBell: true, catalogWeightMode: '2h' });
+
+    expect(
+      screen.getByText('Using shared weight: Two-Hand'),
+    ).toBeInTheDocument();
+  });
+});

--- a/src/pages/StartWorkoutPage/components/MovementCard.tsx
+++ b/src/pages/StartWorkoutPage/components/MovementCard.tsx
@@ -45,6 +45,8 @@ export interface MovementCardProps {
   hasError?: boolean;
   /** Straight sets reads the rep scheme as a list of sets, not a ladder. */
   repSchemeUnitNoun?: 'rung' | 'set';
+  /** The mode the catalog dictates for this movement; null when it has no row. */
+  catalogWeightMode?: WeightTabValue | null;
   onToggleExpanded: () => void;
   onRemove: () => void;
   onChangeName: (name: string) => void;
@@ -69,6 +71,7 @@ export const MovementCard = ({
   intervalActive,
   hasError = false,
   repSchemeUnitNoun = 'rung',
+  catalogWeightMode = null,
   onToggleExpanded,
   onRemove,
   onChangeName,
@@ -99,6 +102,14 @@ export const MovementCard = ({
     : null;
   const showLoad = !sharedBell && weightTabValue !== 'none';
 
+  // One movement's metadata shouldn't reshape a workout-level decision, so the
+  // shared bell wins outright — the hint just names the discrepancy.
+  const sharedWeightHint = sharedBell
+    ? catalogWeightMode && catalogWeightMode !== sharedWeightTabValue
+      ? `Using shared weight: ${WEIGHT_MODE_LABELS[sharedWeightTabValue]} (this movement is usually ${WEIGHT_MODE_LABELS[catalogWeightMode]})`
+      : `Using shared weight: ${WEIGHT_MODE_LABELS[sharedWeightTabValue]}`
+    : null;
+
   return (
     <Card
       className={cn('overflow-hidden', hasError && 'border-destructive')}
@@ -120,11 +131,7 @@ export const MovementCard = ({
               weightMode={activeWeightMode}
               onWeightModeChange={onChangeWeightTab}
               showWeightModeTabs={false}
-              weightModeHint={
-                sharedBell
-                  ? `Using shared weight: ${WEIGHT_MODE_LABELS[sharedWeightTabValue]}`
-                  : null
-              }
+              weightModeHint={sharedWeightHint}
               weightSummary={weightSummary}
             />
           ) : (
@@ -187,6 +194,7 @@ export const MovementCard = ({
               <WeightModeTabs
                 value={activeWeightMode}
                 onValueChange={onChangeWeightTab}
+                disabled={catalogWeightMode !== null}
               />
             </div>
           )}

--- a/src/pages/StartWorkoutPage/components/MovementCard.tsx
+++ b/src/pages/StartWorkoutPage/components/MovementCard.tsx
@@ -7,7 +7,6 @@ import {
 import { Button } from '~/components/ui/button';
 import { Card } from '~/components/ui/card';
 import { cn } from '~/lib/utils';
-import { getWeightsDisplayValue } from '~/pages/CompletedWorkoutPage/utils/displayValues';
 import {
   MovementOptions,
   WeightTabValue,
@@ -22,11 +21,14 @@ import {
   resolveMovementWeights,
 } from '~/utils';
 
+import { loadSummary } from '../utils/loadSummary';
+
 import { FieldLabel } from './FieldLabel';
 import { LadderRepScheme } from './LadderRepScheme';
 import { ModifyCountButtons } from './ModifyCountButtons';
 import { MovementAutocomplete } from './MovementAutocomplete';
 import { MovementSummaryChips } from './MovementSummaryChips';
+import { WeightModeIndicator } from './WeightModeIndicator';
 import { WeightModeTabs } from './WeightModeTabs';
 import { WeightUnitTabs } from './WeightUnitTabs';
 
@@ -92,22 +94,26 @@ export const MovementCard = ({
     sharedBell,
     ...sharedWeights,
   });
-  const weightSummary = named
-    ? getWeightsDisplayValue(
-        displayedMovement.weightOneValue,
-        displayedMovement.weightOneUnit,
-        displayedMovement.weightTwoValue,
-        displayedMovement.weightTwoUnit,
-      )
-    : null;
   const showLoad = !sharedBell && weightTabValue !== 'none';
 
-  // One movement's metadata shouldn't reshape a workout-level decision, so the
-  // shared bell wins outright — the hint just names the discrepancy.
+  // The mode is a fact, not a choice, when the catalog settled it or the shared
+  // bell overrode it — either way there is nothing here to pick.
+  const weightModeReadOnly = sharedBell || catalogWeightMode !== null;
+
+  // Expanded, the Weight and Load rows below already state the mode and the
+  // load, so a summary line would only repeat them. Under a shared bell both
+  // rows are gone, so this is the one place the movement's load appears — and
+  // the mode indicator carries the mode, leaving the deviation to name itself.
   const sharedWeightHint = sharedBell
-    ? catalogWeightMode && catalogWeightMode !== sharedWeightTabValue
-      ? `Using shared weight: ${WEIGHT_MODE_LABELS[sharedWeightTabValue]} (this movement is usually ${WEIGHT_MODE_LABELS[catalogWeightMode]})`
-      : `Using shared weight: ${WEIGHT_MODE_LABELS[sharedWeightTabValue]}`
+    ? [
+        'Shared bell',
+        named ? loadSummary(displayedMovement) : null,
+        catalogWeightMode && catalogWeightMode !== sharedWeightTabValue
+          ? `usually ${WEIGHT_MODE_LABELS[catalogWeightMode]}`
+          : null,
+      ]
+        .filter(Boolean)
+        .join(' · ')
     : null;
 
   return (
@@ -132,7 +138,6 @@ export const MovementCard = ({
               onWeightModeChange={onChangeWeightTab}
               showWeightModeTabs={false}
               weightModeHint={sharedWeightHint}
-              weightSummary={weightSummary}
             />
           ) : (
             <button
@@ -188,13 +193,17 @@ export const MovementCard = ({
         <div className="flex flex-col gap-1.5 px-1.5 pb-1.5">
           <div className="h-px bg-border" />
 
-          {!sharedBell && (
+          {weightModeReadOnly ? (
+            <div className="flex items-center gap-1">
+              <FieldLabel>Weight</FieldLabel>
+              <WeightModeIndicator mode={activeWeightMode} />
+            </div>
+          ) : (
             <div>
               <FieldLabel className="mb-0.5">Weight</FieldLabel>
               <WeightModeTabs
                 value={activeWeightMode}
                 onValueChange={onChangeWeightTab}
-                disabled={catalogWeightMode !== null}
               />
             </div>
           )}

--- a/src/pages/StartWorkoutPage/components/MovementSummaryChips.tsx
+++ b/src/pages/StartWorkoutPage/components/MovementSummaryChips.tsx
@@ -4,24 +4,9 @@ import {
   formatRungDuration,
   getBellColor,
   getWeightTabValue,
-  getWeightUnitLabel,
 } from '~/utils';
 
-const loadSummary = (movement: MovementOptions): string | null => {
-  const { weightOneValue, weightOneUnit, weightTwoValue, weightTwoUnit } =
-    movement;
-  if (!weightOneValue) return null;
-  const one = `${weightOneValue} ${getWeightUnitLabel(weightOneUnit)}`;
-
-  // Two bells: "16 kg ×2" when matched, otherwise spell both out.
-  if (weightTwoValue && weightTwoValue > 0) {
-    const two = `${weightTwoValue} ${getWeightUnitLabel(weightTwoUnit)}`;
-    return weightOneValue === weightTwoValue && weightOneUnit === weightTwoUnit
-      ? `${one} ×2`
-      : `${one} + ${two}`;
-  }
-  return one;
-};
+import { loadSummary } from '../utils/loadSummary';
 
 const repSummary = (movement: MovementOptions): string => {
   const { repScheme, timedRungs } = movement;

--- a/src/pages/StartWorkoutPage/components/WeightModeIndicator.tsx
+++ b/src/pages/StartWorkoutPage/components/WeightModeIndicator.tsx
@@ -1,0 +1,1 @@
+export { WeightModeIndicator } from '~/components/MovementAutocomplete';

--- a/src/pages/StartWorkoutPage/components/index.ts
+++ b/src/pages/StartWorkoutPage/components/index.ts
@@ -26,3 +26,4 @@ export * from './Section';
 export * from './WeightModeTabs';
 export * from './WeightUnitTabs';
 export * from './WorkoutSummaryBar';
+export * from './WeightModeIndicator';

--- a/src/pages/StartWorkoutPage/utils/loadSummary.ts
+++ b/src/pages/StartWorkoutPage/utils/loadSummary.ts
@@ -1,0 +1,19 @@
+import { MovementOptions } from '~/types';
+import { getWeightUnitLabel } from '~/utils';
+
+/** The load alone — no grip marker, for pairing with a weight-mode indicator. */
+export const loadSummary = (movement: MovementOptions): string | null => {
+  const { weightOneValue, weightOneUnit, weightTwoValue, weightTwoUnit } =
+    movement;
+  if (!weightOneValue) return null;
+  const one = `${weightOneValue} ${getWeightUnitLabel(weightOneUnit)}`;
+
+  // Two bells: "16 kg ×2" when matched, otherwise spell both out.
+  if (weightTwoValue && weightTwoValue > 0) {
+    const two = `${weightTwoValue} ${getWeightUnitLabel(weightTwoUnit)}`;
+    return weightOneValue === weightTwoValue && weightOneUnit === weightTwoUnit
+      ? `${one} ×2`
+      : `${one} + ${two}`;
+  }
+  return one;
+};

--- a/src/utils/applyWeightMode.test.ts
+++ b/src/utils/applyWeightMode.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from 'vitest';
+
+import { WeightSlots, applyWeightMode } from './applyWeightMode';
+
+const DEFAULTS = { value: 16, unit: 'kilograms' as const };
+
+const slots = (overrides: Partial<WeightSlots> = {}): WeightSlots => ({
+  weightOneUnit: null,
+  weightOneValue: null,
+  weightTwoUnit: null,
+  weightTwoValue: null,
+  ...overrides,
+});
+
+describe('applyWeightMode', () => {
+  it('clears both slots for bodyweight', () => {
+    const result = applyWeightMode(
+      slots({ weightOneUnit: 'kilograms', weightOneValue: 24 }),
+      'none',
+      DEFAULTS,
+    );
+
+    expect(result).toEqual(slots());
+  });
+
+  it('leaves the second slot null for two-hand', () => {
+    const result = applyWeightMode(slots(), '2h', DEFAULTS);
+
+    expect(result.weightOneValue).toBe(16);
+    expect(result.weightOneUnit).toBe('kilograms');
+    expect(result.weightTwoValue).toBeNull();
+    expect(result.weightTwoUnit).toBeNull();
+  });
+
+  it('zeroes the second slot for single-arm', () => {
+    const result = applyWeightMode(slots(), '1h', DEFAULTS);
+
+    expect(result.weightTwoValue).toBe(0);
+    expect(result.weightTwoUnit).toBeNull();
+  });
+
+  it('mirrors the first slot into the second for double', () => {
+    const result = applyWeightMode(
+      slots({ weightOneUnit: 'pounds', weightOneValue: 35 }),
+      'double',
+      DEFAULTS,
+    );
+
+    expect(result).toEqual({
+      weightOneUnit: 'pounds',
+      weightOneValue: 35,
+      weightTwoUnit: 'pounds',
+      weightTwoValue: 35,
+    });
+  });
+
+  it('carries over an existing weight rather than resetting it', () => {
+    const result = applyWeightMode(
+      slots({ weightOneUnit: 'pounds', weightOneValue: 53 }),
+      '1h',
+      DEFAULTS,
+    );
+
+    expect(result.weightOneValue).toBe(53);
+    expect(result.weightOneUnit).toBe('pounds');
+  });
+
+  it('keeps a distinct second weight when switching into double', () => {
+    const result = applyWeightMode(
+      slots({
+        weightOneUnit: 'kilograms',
+        weightOneValue: 24,
+        weightTwoUnit: 'kilograms',
+        weightTwoValue: 20,
+      }),
+      'double',
+      DEFAULTS,
+    );
+
+    expect(result.weightTwoValue).toBe(20);
+  });
+
+  it('preserves unrelated fields on the movement', () => {
+    const result = applyWeightMode(
+      { ...slots(), movementName: 'Kettlebell Swing', repScheme: [5] },
+      '2h',
+      DEFAULTS,
+    );
+
+    expect(result.movementName).toBe('Kettlebell Swing');
+    expect(result.repScheme).toEqual([5]);
+  });
+});

--- a/src/utils/applyWeightMode.ts
+++ b/src/utils/applyWeightMode.ts
@@ -1,0 +1,62 @@
+import { WeightTabValue, WeightUnit } from '~/types';
+
+export interface WeightSlots {
+  weightOneUnit: WeightUnit | null;
+  weightOneValue: number | null;
+  weightTwoUnit: WeightUnit | null;
+  weightTwoValue: number | null;
+}
+
+export interface WeightModeDefaults {
+  value: number;
+  unit: WeightUnit;
+}
+
+/** Re-encode the carried-over weight into the mode's null-pattern:
+ *  'none' = both null, '2h' = two null, '1h' = two 0, 'double' = both loaded. */
+export const applyWeightMode = <T extends WeightSlots>(
+  current: T,
+  mode: WeightTabValue,
+  defaults: WeightModeDefaults,
+): T => {
+  if (mode === 'none') {
+    return {
+      ...current,
+      weightOneUnit: null,
+      weightOneValue: null,
+      weightTwoUnit: null,
+      weightTwoValue: null,
+    };
+  }
+
+  const unit = current.weightOneUnit ?? defaults.unit;
+  const one = current.weightOneValue || defaults.value;
+
+  if (mode === '2h') {
+    return {
+      ...current,
+      weightOneUnit: unit,
+      weightOneValue: one,
+      weightTwoUnit: null,
+      weightTwoValue: null,
+    };
+  }
+
+  if (mode === '1h') {
+    return {
+      ...current,
+      weightOneUnit: unit,
+      weightOneValue: one,
+      weightTwoUnit: null,
+      weightTwoValue: 0,
+    };
+  }
+
+  return {
+    ...current,
+    weightOneUnit: unit,
+    weightOneValue: one,
+    weightTwoUnit: unit,
+    weightTwoValue: current.weightTwoValue || one,
+  };
+};

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,4 +1,5 @@
 export * from './applySharedWeights';
+export * from './applyWeightMode';
 export * from './bellColors';
 export * from './equipment';
 export * from './formatRungDuration';

--- a/src/utils/movementWeightModeFilter.test.ts
+++ b/src/utils/movementWeightModeFilter.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, test } from 'vitest';
 
 import {
+  getWeightModeFromCatalogFields,
   getWeightTabValue,
   movementMatchesWeightMode,
-  recentMovementMatchesWeightMode,
   type MovementWeightModeFields,
 } from './movementWeightModeFilter';
 
@@ -144,26 +144,54 @@ describe('movementMatchesWeightMode', () => {
   });
 });
 
-describe('recentMovementMatchesWeightMode', () => {
-  test('includes movements without catalog metadata', () => {
-    expect(recentMovementMatchesWeightMode(null, '2h')).toBe(true);
+describe('getWeightModeFromCatalogFields', () => {
+  test('derives each weight mode from the catalog fields', () => {
+    expect(
+      getWeightModeFromCatalogFields(row({ primaryEquipment: 'Bodyweight' })),
+    ).toBe('none');
+    expect(
+      getWeightModeFromCatalogFields(
+        row({
+          primaryEquipment: 'Kettlebell',
+          primaryItemCount: 1,
+          singleOrDoubleArm: 'Double Arm',
+        }),
+      ),
+    ).toBe('2h');
+    expect(
+      getWeightModeFromCatalogFields(
+        row({
+          primaryEquipment: 'Kettlebell',
+          primaryItemCount: 1,
+          singleOrDoubleArm: 'Single Arm',
+        }),
+      ),
+    ).toBe('1h');
+    expect(
+      getWeightModeFromCatalogFields(
+        row({
+          primaryEquipment: 'Kettlebell',
+          primaryItemCount: 2,
+          singleOrDoubleArm: 'Double Arm',
+        }),
+      ),
+    ).toBe('double');
   });
 
-  test('filters linked catalog movements by weight mode', () => {
-    const twoHanded = row({
-      primaryEquipment: 'Kettlebell',
-      primaryItemCount: 1,
-      singleOrDoubleArm: 'Double Arm',
-    });
-    const singleArm = row({
-      primaryEquipment: 'Kettlebell',
-      primaryItemCount: 1,
-      singleOrDoubleArm: 'Single Arm',
-    });
+  test('returns null without catalog metadata', () => {
+    expect(getWeightModeFromCatalogFields(null)).toBeNull();
+    expect(getWeightModeFromCatalogFields(undefined)).toBeNull();
+  });
 
-    expect(recentMovementMatchesWeightMode(twoHanded, '2h')).toBe(true);
-    expect(recentMovementMatchesWeightMode(twoHanded, '1h')).toBe(false);
-    expect(recentMovementMatchesWeightMode(singleArm, '1h')).toBe(true);
-    expect(recentMovementMatchesWeightMode(singleArm, '2h')).toBe(false);
+  test('returns null for a row that maps to no mode', () => {
+    expect(
+      getWeightModeFromCatalogFields(
+        row({
+          primaryEquipment: 'Barbell',
+          primaryItemCount: 1,
+          singleOrDoubleArm: 'Double Arm',
+        }),
+      ),
+    ).toBeNull();
   });
 });

--- a/src/utils/movementWeightModeFilter.test.ts
+++ b/src/utils/movementWeightModeFilter.test.ts
@@ -183,6 +183,21 @@ describe('getWeightModeFromCatalogFields', () => {
     expect(getWeightModeFromCatalogFields(undefined)).toBeNull();
   });
 
+  // Bodyweight rows still carry an arm split (Side Plank Hip Dip is
+  // Bodyweight/Single Arm), so equipment has to win or they'd derive 1h and
+  // pick up a phantom bell.
+  test('reads a single-arm bodyweight row as bodyweight, not single', () => {
+    expect(
+      getWeightModeFromCatalogFields(
+        row({
+          primaryEquipment: 'Bodyweight',
+          primaryItemCount: 1,
+          singleOrDoubleArm: 'Single Arm',
+        }),
+      ),
+    ).toBe('none');
+  });
+
   test('returns null for a row that maps to no mode', () => {
     expect(
       getWeightModeFromCatalogFields(

--- a/src/utils/movementWeightModeFilter.ts
+++ b/src/utils/movementWeightModeFilter.ts
@@ -61,34 +61,10 @@ export const movementMatchesWeightMode = (
   }
 };
 
-export const recentMovementMatchesWeightMode = (
-  catalogWeightFields: MovementWeightModeFields | null,
-  mode: WeightTabValue,
-): boolean => {
-  if (!catalogWeightFields) return true;
-  return movementMatchesWeightMode(catalogWeightFields, mode);
-};
-
-export const applyWeightModeToCatalogQuery = (query: any, mode: WeightTabValue) => {
-  switch (mode) {
-    case 'none':
-      return query.eq('primary_equipment', 'Bodyweight');
-    case '2h':
-      return query
-        .eq('primary_equipment', 'Kettlebell')
-        .eq('primary_item_count', 1)
-        .eq('single_or_double_arm', 'Double Arm');
-    case '1h':
-      return query
-        .eq('primary_equipment', 'Kettlebell')
-        .eq('primary_item_count', 1)
-        .eq('single_or_double_arm', 'Single Arm');
-    case 'double':
-      return query
-        .eq('primary_equipment', 'Kettlebell')
-        .eq('primary_item_count', 2)
-        .eq('single_or_double_arm', 'Double Arm');
-    default:
-      return query;
-  }
+export const getWeightModeFromCatalogFields = (
+  fields: MovementWeightModeFields | null | undefined,
+): WeightTabValue | null => {
+  if (!fields) return null;
+  const modes: WeightTabValue[] = ['none', '2h', '1h', 'double'];
+  return modes.find((mode) => movementMatchesWeightMode(fields, mode)) ?? null;
 };


### PR DESCRIPTION
## Why

In the custom workout builder, picking a movement was a three-way tug-of-war between the text you type, the autocomplete results, and the weight-mode tab. The tab *filtered* the dropdown — but it renders **below** the input, so a movement could silently vanish from the results for a reason the user hadn't looked at yet. Typing `swing` in the default Two-Hand mode returned exactly one row; `One-Arm Kettlebell Swing` and `Double Kettlebell Swing` were hidden.

The filtering was never necessary. Every catalog row maps to exactly one mode via `(primary_equipment, primary_item_count, single_or_double_arm)`, so the mode is a *consequence* of the movement, not an input to finding it. This inverts the relationship.

## What

Three parts:

1. **The dropdown stops filtering.** `applyWeightModeToCatalogQuery` and `recentMovementMatchesWeightMode` are deleted; catalog search and the "Recent" list now match on typed text alone.
2. **The movement picks the mode.** New `getWeightModeFromCatalogFields` derives the mode from a catalog row. `StartWorkoutPage` already loaded the full catalog for the recommender (PROD-238) — that query moved below `showBuilder` so it serves both surfaces, and naming a movement applies its mode in the *same* `setMovements` update, so name and weights can never disagree. Existing weights carry over.
3. **The mode is read out rather than picked** for catalog-linked movements — a chip, not a disabled tablist. The tabs stay for custom movements, where there's nothing to derive from.

Along the way, the mode-to-weight-slot encoding existed in three places (`handleChangeWeightTab`, `handleChangeSharedWeightTab`, and `SwapMovementDialog`'s `adaptWeightToMode`). The two builder copies now share a new `applyWeightMode` util.

The shared bell still wins over a picked movement's mode — one movement's metadata shouldn't reshape a workout-level decision — and the hint names the discrepancy: *"Using shared weight: Two-Hand (this movement is usually Single)"*.

## How to test

```
npm test && npm run compile:ts && npm run lint
```

1029 tests pass. New coverage: `applyWeightMode.test.ts` (null patterns, carry-over, fallback), `getWeightModeFromCatalogFields` (all four modes plus an unmapped row), `StartWorkoutPage.movementWeightMode.test.jsx` (auto-select per mode, custom movement stays editable, load carries over), and `MovementCard.test.tsx` (locked vs editable tabs, mismatch hint). The two `MovementAutocomplete` tests that asserted filtering now assert the opposite.

Also driven manually against local Supabase (`npm run start:server`, `npm run dev`):

- Typing `swing` lists `Kettlebell Swing`, `One-Arm Kettlebell Swing`, `Double Kettlebell Swing`, and `Alternating Kettlebell Swing` together.
- Picking `One-Arm Kettlebell Swing` → tabs jump to **Single**, disabled; the 16 kg load carries over.
- Picking `Double Kettlebell Swing` → tabs jump to **Double**, second bell populated at 16 kg.
- Entering a name not in the catalog → tabs stay enabled and clickable.
- Shared bell on with a mismatched movement → shared weights untouched, hint shows the discrepancy.
- No console errors.

## Gallery

**Dropdown — typing `swing`.** Before, the Two-Hand tab hid three of the four matches. After, all four are listed under one `Catalog` heading.

| Before | After |
|--------|-------|
| <img width="390" src="https://github.com/user-attachments/assets/b02155a4-3766-447a-9bea-711ad977cba3" /> | <img width="390" src="https://github.com/user-attachments/assets/af8ba498-a2ea-4dc1-a79a-fe3bf7e65336" /> |

**Weight mode after picking.** Before, the tab you'd already set dictated what you could find, and a `16 kg (2h)` line restated the Weight and Load rows directly beneath it. After, picking `One-Arm Kettlebell Swing` reads the mode out as a chip and drops the duplicate line — which also lifts Load above the fold.

| Before | After |
|--------|-------|
| <img width="390" src="https://github.com/user-attachments/assets/3e0cbc40-ecb6-41b1-aa45-ae052eb4bfc1" /> | <img width="390" src="https://github.com/user-attachments/assets/11becf4b-bf40-4276-a5f5-781fd4e51c18" /> |

## Tradeoffs

**Where the mode comes from.** The builder resolves it by name against the already-loaded catalog map rather than threading it through `onMovementPick`. Adding a catalog-link field to `MovementOptions` would have been more direct and would survive a rename, but it ripples into every producer (curated workouts, program sessions, repeat-workout, the recommender) and into persistence. The name lookup needs no schema change and also covers movements loaded from a saved session or a repeat — not just fresh picks. The cost is that a user-renamed movement loses its catalog link, which is the same behaviour as before.

`SwapMovementDialog` can't use that map (it has no page-level catalog), so it does get the mode via a third argument on `onMovementPick`, which is why `useMovementSearch` now selects the three weight-mode columns.

**A disabled control vs. a read-out.** The first cut dimmed the four tabs. That kept the mode in a familiar place, but a dimmed tablist reads as "you've been locked out" rather than "this is settled," and the dim state was barely distinguishable from the live one. The chip gives up the spatial consistency in exchange for saying the true thing, and it reuses the collapsed card's existing chip vocabulary rather than inventing a third idiom.

**`adaptWeightToMode` stays.** It's now the only remaining copy of the encoding. It keys off `sharedWeight*` and sets a unit on the second slot for `1h` where the builder sets null; folding it in would change what the swap RPC writes, which didn't belong in this change.
