### PR TITLE
feat(movements): add ab wheel rollouts and four core gaps

### DIFF
--- a/docs/movement-catalog.md
+++ b/docs/movement-catalog.md
@@ -20,11 +20,21 @@ Postgres enums — so `~/types` defines `Equipment` / `MuscleGroup` /
   whole catalog (its INSERT block is regenerated with `npm run movements:emit-sql`),
   so it is reproducible on `supabase db reset` and auto-deploys. There is **no**
   live-DB ingest path anymore.
-- **To change the catalog:** edit the CSV → `movements:check` → regenerate the
-  migration's VALUES block via `movements:emit-sql` → `supabase db reset` →
-  `gen:types`. Any new field value must already be in the app vocabularies (no
-  new enums); Explore's filter constants in `MovementsPage.tsx` mirror the CSV's
-  value set.
+- **To change the catalog:** edit the CSV → `movements:check` → add a **forward**
+  migration carrying the change → `supabase db reset` → `gen:types`. The reload
+  migration is already applied upstream and will not re-run, so never edit its
+  VALUES block; use `movements:emit-sql` only to lift correctly-quoted literals
+  for the new rows, and guard additive inserts with a
+  `WHERE NOT EXISTS (… lower("Movement") = lower(…))` check — `"Movement"` has no
+  unique index, and the guard keeps a fresh `db reset` from double-inserting.
+  `*_add_ab_wheel_core_movements.sql` is the reference shape. Any new field value
+  must already be in the app vocabularies (no new enums); Explore's filter
+  constants in `MovementsPage.tsx` mirror the CSV's value set.
+- **Implements beyond a bell:** equipment stays two classes, so anything needing
+  a bar, bench, or ab wheel is filed as `Bodyweight` with the implement named in
+  the movement (`Hanging Leg Raise`, `Decline Crunch`, `Ab Wheel Rollout`). A
+  third `Primary Equipment` value would be unreachable in the builder until
+  `movementWeightModeFilter.ts`'s `none` mode widened beyond `Bodyweight`.
 - **Renaming orphans `user_movements` FKs:** the reload relinks
   `user_movements.functional_movement_id` on exact name match, so any row whose
   `canonical_name` was renamed matches nothing and is stranded NULL (silently

--- a/scripts/data/movements.csv
+++ b/scripts/data/movements.csv
@@ -250,3 +250,10 @@ Dragon Flag,Bodyweight,1,No Arms,Abdominals,Expert,Anti-Extension,core
 L-Sit,Bodyweight,1,Double Arm,Abdominals,Expert,Anti-Extension,core
 Stomach Vacuum,Bodyweight,1,No Arms,Abdominals,Beginner,Anti-Extension,core
 Side Leg Raise,Bodyweight,1,No Arms,Adductors,Beginner,Anti-Rotation,core
+Ab Wheel Rollout,Bodyweight,1,Double Arm,Abdominals,Intermediate,Anti-Extension,core
+Standing Ab Wheel Rollout,Bodyweight,1,Double Arm,Abdominals,Expert,Anti-Extension,core
+Ab Wheel Oblique Rollout,Bodyweight,1,Double Arm,Abdominals,Intermediate,Anti-Rotation,core
+Reverse Plank,Bodyweight,1,Double Arm,Abdominals,Beginner,Anti-Extension,core
+Side Plank Hip Dip,Bodyweight,1,Single Arm,Abdominals,Intermediate,Anti-Rotation,core
+Hanging Windshield Wipers,Bodyweight,1,Double Arm,Abdominals,Expert,Rotational,rotation
+Kettlebell Plank Drag,Kettlebell,1,Single Arm,Abdominals,Intermediate,Anti-Rotation,core

--- a/supabase/migrations/20260805020000_add_ab_wheel_core_movements.sql
+++ b/supabase/migrations/20260805020000_add_ab_wheel_core_movements.sql
@@ -1,0 +1,41 @@
+-- Adds the ab wheel family plus four adjacent core gaps to the catalog.
+-- The slim-catalog reload migration is already applied upstream and will not
+-- re-run, so catalog additions land as a forward migration. Each insert is
+-- guarded on the name because `movements."Movement"` has no unique index, which
+-- keeps this safe on `supabase db reset` (where the reload runs first) and on
+-- re-application.
+INSERT INTO public.movements (
+  "Movement",
+  "Primary Equipment",
+  "# Primary Items",
+  "Single or Double Arm",
+  "Target Muscle Group",
+  "Difficulty Level",
+  "Movement Pattern #1",
+  pattern_credits
+)
+SELECT *
+FROM (
+  VALUES
+    ('Ab Wheel Rollout', 'Bodyweight', 1, 'Double Arm', 'Abdominals', 'Intermediate', 'Anti-Extension', ARRAY['core']::text[]),
+    ('Standing Ab Wheel Rollout', 'Bodyweight', 1, 'Double Arm', 'Abdominals', 'Expert', 'Anti-Extension', ARRAY['core']::text[]),
+    ('Ab Wheel Oblique Rollout', 'Bodyweight', 1, 'Double Arm', 'Abdominals', 'Intermediate', 'Anti-Rotation', ARRAY['core']::text[]),
+    ('Reverse Plank', 'Bodyweight', 1, 'Double Arm', 'Abdominals', 'Beginner', 'Anti-Extension', ARRAY['core']::text[]),
+    ('Side Plank Hip Dip', 'Bodyweight', 1, 'Single Arm', 'Abdominals', 'Intermediate', 'Anti-Rotation', ARRAY['core']::text[]),
+    ('Hanging Windshield Wipers', 'Bodyweight', 1, 'Double Arm', 'Abdominals', 'Expert', 'Rotational', ARRAY['rotation']::text[]),
+    ('Kettlebell Plank Drag', 'Kettlebell', 1, 'Single Arm', 'Abdominals', 'Intermediate', 'Anti-Rotation', ARRAY['core']::text[])
+) AS incoming (
+  movement,
+  primary_equipment,
+  primary_item_count,
+  single_or_double_arm,
+  target_muscle_group,
+  difficulty_level,
+  movement_pattern_1,
+  pattern_credits
+)
+WHERE NOT EXISTS (
+  SELECT 1
+  FROM public.movements m
+  WHERE lower(m."Movement") = lower(incoming.movement)
+);


### PR DESCRIPTION
## Why

The movement catalog had ~40 core movements but no ab wheel work at all — the strongest anti-extension progression in common home-gym use was simply missing. A few adjacent core gaps sat alongside it: no reverse plank, no side plank hip dip, no hanging windshield wipers (the hanging variant of an exercise already in the catalog), and no loaded anti-rotation drag on the kettlebell side.

## What

Adds 7 rows to the catalog (251 → 258): the ab wheel rollout family plus four core gaps.

| Movement | Equipment | Arms | Difficulty | Pattern |
| --- | --- | --- | --- | --- |
| Ab Wheel Rollout | Bodyweight | Double Arm | Intermediate | Anti-Extension |
| Standing Ab Wheel Rollout | Bodyweight | Double Arm | Expert | Anti-Extension |
| Ab Wheel Oblique Rollout | Bodyweight | Double Arm | Intermediate | Anti-Rotation |
| Reverse Plank | Bodyweight | Double Arm | Beginner | Anti-Extension |
| Side Plank Hip Dip | Bodyweight | Single Arm | Intermediate | Anti-Rotation |
| Hanging Windshield Wipers | Bodyweight | Double Arm | Expert | Rotational |
| Kettlebell Plank Drag | Kettlebell | Single Arm | Intermediate | Anti-Rotation |

Two conventions worth a reviewer's attention, both now written into `docs/movement-catalog.md`:

- **Ab wheel is filed as `Bodyweight`,** with the implement carried in the movement name. That matches existing precedent — `Hanging Leg Raise` needs a bar, `Decline Crunch` needs a bench, both are `Bodyweight`. A third `Primary Equipment` value would make these rows unreachable from *every* weight tab in the builder until `movementWeightModeFilter.ts`'s `none` mode widened beyond `Bodyweight`, on top of a CHECK-constraint migration, an `Equipment` union change, and new Explore filter constants.
- **Additions go in a forward migration,** not by regenerating the applied reload block. The docs previously said to regenerate `*_slim_movements_catalog.sql`'s VALUES block, but that migration is already applied upstream and will never re-run — regenerating it would be a no-op against staging and prod. The doc bullet is corrected here.

No app-code changes. `Equipment`, `MuscleGroup`, `DifficultyLevel`, the `MovementsPage` filter constants, and `movementWeightModeFilter.ts` already cover every value used.

## How to test

- `npm run movements:check` → `✓ 258 movements valid (120 Kettlebell, 138 Bodyweight)`
- `supabase db reset` applies cleanly; all 7 rows present with the right patterns and credits.
- **Idempotency:** re-ran the migration by hand against the already-migrated DB. Count stayed at 258 and `group by "Movement" having count(*) > 1` returned zero rows — the `NOT EXISTS` guard holds. (`movements."Movement"` has no unique index, so the guard is what keeps a fresh `db reset` — where the reload runs first — from double-inserting.)
- `npm run gen:types` → no diff, as expected for a data-only change.
- `npm test` → 662 tests pass. `src/constants/curatedWorkouts.test.ts` parses the CSV directly, so it exercises the new rows.
- **Through the app's own PostgREST paths, with a logged-in token:** the Explore filter (`Bodyweight` + `Abdominals`) returns all three ab wheel rows; the builder's `none` tab returns them via `movements_catalog`; the `1h` tab (`Kettlebell` / 1 item / `Single Arm`) returns `Kettlebell Plank Drag`.

## Gallery

No visible UI diff — this is catalog rows only, no code changed. The new movements render through the existing Movements list and builder pickers unmodified.

## Deploy notes

One additive migration, `20260805020000_add_ab_wheel_core_movements.sql`. Data-only: no schema change, so no `gen:types` needed downstream. Safe to re-run.

## Tradeoffs

Considered adding `Ab Wheel` as a third `Primary Equipment` value, which is the more honest data model — it would let users filter for "movements I can do with my wheel" and would let the equipment-ownership work (#235) gate them. Rejected for now because the weight-tab filter is currently a total function over exactly two equipment classes; a third value silently drops rows out of every builder tab, and fixing that properly means deciding what a non-bell, non-bodyweight implement *means* to the weight model. Worth revisiting if more implements arrive — the name-carries-the-implement convention scales poorly past a handful.