### PR TITLE
fix(programs): label the card menu action "Edit sessions"

### DIFF
--- a/src/pages/ProgramsPage/ProgramsPage.test.tsx
+++ b/src/pages/ProgramsPage/ProgramsPage.test.tsx
@@ -694,6 +694,16 @@ describe('ProgramsPage', () => {
     ).toBeInTheDocument();
   });
 
+  it('offers Edit sessions in the menu once a program has sessions', () => {
+    renderPage();
+
+    openCardMenu('My Program');
+
+    expect(
+      screen.getByRole('menuitem', { name: 'Edit sessions' }),
+    ).toBeInTheDocument();
+  });
+
   const threeActive = [1, 2, 3].map((slot) => ({
     enrollment: {
       id: `up-${slot}`,

--- a/src/pages/ProgramsPage/components/MyProgramCard.tsx
+++ b/src/pages/ProgramsPage/components/MyProgramCard.tsx
@@ -129,9 +129,9 @@ export const MyProgramCard = ({
 
   const menuActions: OverflowMenuAction[] = [
     { label: 'Rename program', onSelect: onRename },
-    ...(primary.label === 'Add sessions'
+    ...(state === 'draft'
       ? []
-      : [{ label: 'Add sessions', onSelect: onAddSessions }]),
+      : [{ label: 'Edit sessions', onSelect: onAddSessions }]),
     ...(primary.label === 'View progress'
       ? []
       : [{ label: 'View progress', onSelect: onViewProgress }]),


### PR DESCRIPTION
## Why

On the Programs page, every non-draft program card offered "Add sessions" in its kebab menu — but those programs already have sessions. The action opens the session editor, so the label misdescribed it.

## What

Renames the overflow-menu action to "Edit sessions". Draft cards keep "Add sessions" as their primary CTA, where the wording is accurate. The guard that omits the menu entry for drafts now checks `state === 'draft'` instead of comparing the primary CTA's label string, so it no longer breaks on a rename.

## How to test

`npx vitest run src/pages/ProgramsPage` (36 pass) — includes a new test asserting the menu shows "Edit sessions" for a program with sessions, alongside the existing draft test that still expects the "Add sessions" CTA. `npm run compile:ts` clean.

## Gallery

Text-only label change inside the kebab menu; screenshots pending — happy to add a before/after if you want it on the record.