### PR TITLE
feat(account): export training data as JSON for AI assistants

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -3,6 +3,7 @@ export * from './useCreateCheckoutSession';
 export * from './useCreatePortalSession';
 export * from './useDeleteWorkoutLog';
 export * from './useEntitlement';
+export * from './useExportTrainingData';
 export * from './useFeatureFlags';
 export * from './useLinkMovementLog';
 export * from './useLinkUserMovement';

--- a/src/api/useExportTrainingData.test.ts
+++ b/src/api/useExportTrainingData.test.ts
@@ -1,0 +1,92 @@
+import { HttpResponse, http } from 'msw';
+
+import { server } from '~/mocks/server';
+
+import { VITE_SUPABASE_URL } from '../env';
+import { buildTrainingExport } from './useExportTrainingData';
+
+const base = `${VITE_SUPABASE_URL}/rest/v1`;
+
+const workoutLog = { id: 1, user_id: 'user-123', movements: ['Clean'] };
+const movementLog = { id: 10, workout_log_id: 1, movement_name: 'Clean' };
+
+const useHandlers = () => {
+  server.use(
+    http.get(`${base}/profiles`, ({ request }) => {
+      const select = new URL(request.url).searchParams.get('select');
+      expect(select).toBe('username,training_goal');
+      return HttpResponse.json({ username: 'luke', training_goal: 'strength' });
+    }),
+    http.get(`${base}/workout_logs`, () => HttpResponse.json([workoutLog])),
+    http.get(`${base}/movement_logs`, () => HttpResponse.json([movementLog])),
+    http.get(`${base}/user_movements`, () =>
+      HttpResponse.json([{ id: 5, canonical_name: 'Clean' }]),
+    ),
+    http.get(`${base}/user_equipment`, () =>
+      HttpResponse.json([{ id: 7, kind: 'kettlebell', weight: 24 }]),
+    ),
+    http.get(`${base}/user_programs`, () =>
+      HttpResponse.json([{ id: 'up-1', program_id: 'p-1' }]),
+    ),
+    http.get(`${base}/programs`, () =>
+      HttpResponse.json([{ id: 'p-1', title: 'DFW' }]),
+    ),
+    http.get(`${base}/program_sessions`, () =>
+      HttpResponse.json([{ id: 'ps-1', program_id: 'p-1' }]),
+    ),
+    http.get(`${base}/program_session_completions`, () =>
+      HttpResponse.json([{ id: 'c-1', user_program_id: 'up-1' }]),
+    ),
+    http.post(`${base}/rpc/pattern_debt_movements`, () =>
+      HttpResponse.json([{ movement_name: 'Clean', total_reps: 100 }]),
+    ),
+  );
+};
+
+describe('buildTrainingExport', () => {
+  test('assembles every training section with agent-facing metadata', async () => {
+    useHandlers();
+
+    const result = await buildTrainingExport('user-123');
+
+    expect(result.meta.app).toBe('Bellskill');
+    expect(result.meta.export_version).toBe(1);
+    expect(result.meta.exported_at).toBeTruthy();
+    expect(result.meta.schema.workout_logs).toContain('rep_scheme');
+    expect(result.profile).toEqual({
+      username: 'luke',
+      training_goal: 'strength',
+    });
+    expect(result.workout_logs).toEqual([workoutLog]);
+    expect(result.movement_logs).toEqual([movementLog]);
+    expect(result.user_movements).toHaveLength(1);
+    expect(result.user_equipment).toHaveLength(1);
+    expect(result.programs).toEqual({
+      enrollments: [{ id: 'up-1', program_id: 'p-1' }],
+      programs: [{ id: 'p-1', title: 'DFW' }],
+      sessions: [{ id: 'ps-1', program_id: 'p-1' }],
+      completions: [{ id: 'c-1', user_program_id: 'up-1' }],
+    });
+    expect(result.pattern_debt).toEqual([
+      { movement_name: 'Clean', total_reps: 100 },
+    ]);
+
+    const serialized = JSON.stringify(result);
+    expect(serialized).not.toContain('stripe');
+    expect(serialized).not.toContain('spotify');
+  });
+
+  test('exports pattern_debt as null when the RPC fails', async () => {
+    useHandlers();
+    server.use(
+      http.post(`${base}/rpc/pattern_debt_movements`, () =>
+        HttpResponse.json({ message: 'nope' }, { status: 500 }),
+      ),
+    );
+
+    const result = await buildTrainingExport('user-123');
+
+    expect(result.pattern_debt).toBeNull();
+    expect(result.workout_logs).toEqual([workoutLog]);
+  });
+});

--- a/src/api/useExportTrainingData.ts
+++ b/src/api/useExportTrainingData.ts
@@ -1,0 +1,163 @@
+import { useMutation } from '@tanstack/react-query';
+
+import { useSession } from '~/contexts';
+import { downloadJson } from '~/utils';
+
+import { supabase } from '../supabaseClient';
+
+const EXPORT_VERSION = 1;
+const PAGE_SIZE = 1000;
+
+const EXPORT_SCHEMA = {
+  description:
+    'Complete training history exported from Bellskill, a kettlebell workout-tracking app. All weights carry their own unit field (kg or lb). Timestamps are ISO 8601.',
+  workout_logs:
+    'One row per completed workout session. `rep_scheme` is the planned ladder — rep counts per rung, e.g. [1,2,3]; a rung is one element. `movements` lists movement names done as a circuit (or as straight sets when `straight_sets` is true). `complex_set` means movements were done back-to-back without setting the bell down. `workout_goal` + `workout_goal_units` describe the target (time in minutes, rounds, or volume). `completed_volume` is total weight moved.',
+  movement_logs:
+    'One row per movement within a workout (`workout_log_id` links to workout_logs). `completed_rep_scheme` holds actual reps per set. `timed_rungs` means rungs were seconds of work rather than reps. Two weight slots support double-bell work: weight_one and weight_two.',
+  user_movements:
+    'The user\'s personal movement library; `functional_movement_id` links to a shared movement catalog when matched.',
+  user_equipment: 'Kettlebells and other equipment the user owns.',
+  programs:
+    'Structured multi-week training programs. `enrollments` are the user\'s runs through a program with per-enrollment progress; `sessions` are the prescribed workouts per program (week_number/day_number); `completions` record which sessions were done or skipped.',
+  pattern_debt:
+    'Recent per-movement training aggregates used to spot under-trained movement patterns; null if unavailable.',
+} as const;
+
+const fetchAllWorkoutLogs = async (userId: string) => {
+  const rows = [];
+  for (let from = 0; ; from += PAGE_SIZE) {
+    const { data, error } = await supabase
+      .from('workout_logs')
+      .select('*')
+      .eq('user_id', userId)
+      .order('started_at', { ascending: true })
+      .range(from, from + PAGE_SIZE - 1);
+
+    if (error) throw error;
+    rows.push(...(data ?? []));
+    if ((data ?? []).length < PAGE_SIZE) return rows;
+  }
+};
+
+const fetchMovementLogs = async (workoutLogIds: number[]) => {
+  const rows = [];
+  for (let i = 0; i < workoutLogIds.length; i += PAGE_SIZE) {
+    const { data, error } = await supabase
+      .from('movement_logs')
+      .select('*')
+      .in('workout_log_id', workoutLogIds.slice(i, i + PAGE_SIZE))
+      .order('id');
+
+    if (error) throw error;
+    rows.push(...(data ?? []));
+  }
+  return rows;
+};
+
+const fetchPrograms = async (userId: string) => {
+  const { data: enrollments, error } = await supabase
+    .from('user_programs')
+    .select('*')
+    .eq('user_id', userId);
+
+  if (error) throw error;
+
+  const programIds = [...new Set((enrollments ?? []).map((e) => e.program_id))];
+  const enrollmentIds = (enrollments ?? []).map((e) => e.id);
+
+  const [programsResult, sessionsResult, completionsResult] = await Promise.all(
+    [
+      supabase.from('programs').select('*').in('id', programIds),
+      supabase.from('program_sessions').select('*').in('program_id', programIds),
+      supabase
+        .from('program_session_completions')
+        .select('*')
+        .in('user_program_id', enrollmentIds),
+    ],
+  );
+
+  if (programsResult.error) throw programsResult.error;
+  if (sessionsResult.error) throw sessionsResult.error;
+  if (completionsResult.error) throw completionsResult.error;
+
+  return {
+    enrollments: enrollments ?? [],
+    programs: programsResult.data ?? [],
+    sessions: sessionsResult.data ?? [],
+    completions: completionsResult.data ?? [],
+  };
+};
+
+const fetchPatternDebt = async () => {
+  // Cast at the RPC boundary only — see usePatternDebt.
+  const { data, error } = await supabase.rpc(
+    'pattern_debt_movements' as never,
+    {} as never,
+  );
+
+  if (error) {
+    console.warn('pattern_debt_movements failed; exporting null', error);
+    return null;
+  }
+  return data ?? null;
+};
+
+export const buildTrainingExport = async (userId: string) => {
+  const [profileResult, workoutLogs, programs, patternDebt, equipmentResult] =
+    await Promise.all([
+      supabase
+        .from('profiles')
+        .select('username, training_goal')
+        .eq('id', userId)
+        .single(),
+      fetchAllWorkoutLogs(userId),
+      fetchPrograms(userId),
+      fetchPatternDebt(),
+      supabase.from('user_equipment').select('*').eq('user_id', userId),
+    ]);
+
+  const { data: userMovements, error: movementsError } = await supabase
+    .from('user_movements')
+    .select('*')
+    .eq('user_id', userId)
+    .order('canonical_name');
+
+  if (profileResult.error) throw profileResult.error;
+  if (equipmentResult.error) throw equipmentResult.error;
+  if (movementsError) throw movementsError;
+
+  const movementLogs = await fetchMovementLogs(workoutLogs.map((w) => w.id));
+
+  return {
+    meta: {
+      app: 'Bellskill',
+      export_version: EXPORT_VERSION,
+      exported_at: new Date().toISOString(),
+      description:
+        'User-requested export of all training data, intended as context for AI assistants providing workout analysis and coaching.',
+      schema: EXPORT_SCHEMA,
+    },
+    profile: profileResult.data,
+    workout_logs: workoutLogs,
+    movement_logs: movementLogs,
+    user_movements: userMovements ?? [],
+    user_equipment: equipmentResult.data ?? [],
+    programs,
+    pattern_debt: patternDebt,
+  };
+};
+
+export const useExportTrainingData = () => {
+  const session = useSession();
+  const userId = session?.user?.id;
+
+  return useMutation({
+    mutationFn: async () => {
+      if (!userId) throw new Error('Not signed in');
+      const exportData = await buildTrainingExport(userId);
+      const date = exportData.meta.exported_at.slice(0, 10);
+      downloadJson(exportData, `bellskill-export-${date}.json`);
+    },
+  });
+};

--- a/src/pages/AccountPage/AccountPage.test.jsx
+++ b/src/pages/AccountPage/AccountPage.test.jsx
@@ -14,4 +14,11 @@ describe('account page', () => {
     const emailInput = await screen.findByRole('textbox', { name: 'Email' });
     expect(emailInput).toHaveDisplayValue('luke@skywalker.com');
   });
+
+  test('renders the data export section', async () => {
+    const exportButton = await screen.findByRole('button', {
+      name: 'Export my data',
+    });
+    expect(exportButton).toBeInTheDocument();
+  });
 });

--- a/src/pages/AccountPage/AccountPage.tsx
+++ b/src/pages/AccountPage/AccountPage.tsx
@@ -7,6 +7,7 @@ import {
   useConnectSpotify,
   useCreatePortalSession,
   useDisconnectSpotify,
+  useExportTrainingData,
   useSetSubscription,
   useSpotifyConnection,
 } from '~/api';
@@ -36,6 +37,7 @@ export const AccountPage = () => {
     useCreatePortalSession();
   const { mutate: setSubscription, isPending: settingSubscription } =
     useSetSubscription();
+  const { mutate: exportData, isPending: exporting } = useExportTrainingData();
 
   const [username, setUsername] = useState<string>('');
   const [previewEnabled, setPreviewEnabled] = useState<boolean>(
@@ -178,6 +180,21 @@ export const AccountPage = () => {
         </p>
         <Button variant="outline" onClick={handleToggleSound}>
           {soundEnabled ? 'Disable timer sounds' : 'Enable timer sounds'}
+        </Button>
+      </div>
+
+      <div className="flex flex-col gap-1 border-t pt-2">
+        <Label>My Data</Label>
+        <p className="text-xs text-muted-foreground">
+          Download your training history as a JSON file you can share with an
+          AI assistant for analysis and coaching.
+        </p>
+        <Button
+          variant="outline"
+          onClick={() => exportData()}
+          loading={exporting}
+        >
+          Export my data
         </Button>
       </div>
 

--- a/src/utils/downloadJson.test.ts
+++ b/src/utils/downloadJson.test.ts
@@ -1,0 +1,28 @@
+import { downloadJson } from './downloadJson';
+
+describe('downloadJson', () => {
+  test('downloads the data as a JSON file and revokes the object URL', () => {
+    const createObjectURL = vi.fn((_blob: Blob) => 'blob:mock-url');
+    const revokeObjectURL = vi.fn();
+    vi.stubGlobal('URL', {
+      ...URL,
+      createObjectURL,
+      revokeObjectURL,
+    });
+
+    const click = vi
+      .spyOn(HTMLAnchorElement.prototype, 'click')
+      .mockImplementation(() => {});
+
+    downloadJson({ hello: 'world' }, 'export.json');
+
+    expect(createObjectURL).toHaveBeenCalledOnce();
+    const blob = createObjectURL.mock.calls[0][0];
+    expect(blob.type).toBe('application/json');
+    expect(click).toHaveBeenCalledOnce();
+    expect(revokeObjectURL).toHaveBeenCalledWith('blob:mock-url');
+
+    click.mockRestore();
+    vi.unstubAllGlobals();
+  });
+});

--- a/src/utils/downloadJson.test.ts
+++ b/src/utils/downloadJson.test.ts
@@ -2,7 +2,11 @@ import { downloadJson } from './downloadJson';
 
 describe('downloadJson', () => {
   test('downloads the data as a JSON file and revokes the object URL', () => {
-    const createObjectURL = vi.fn((_blob: Blob) => 'blob:mock-url');
+    let capturedBlob: Blob | undefined;
+    const createObjectURL = vi.fn((blob: Blob) => {
+      capturedBlob = blob;
+      return 'blob:mock-url';
+    });
     const revokeObjectURL = vi.fn();
     vi.stubGlobal('URL', {
       ...URL,
@@ -17,8 +21,7 @@ describe('downloadJson', () => {
     downloadJson({ hello: 'world' }, 'export.json');
 
     expect(createObjectURL).toHaveBeenCalledOnce();
-    const blob = createObjectURL.mock.calls[0][0];
-    expect(blob.type).toBe('application/json');
+    expect(capturedBlob?.type).toBe('application/json');
     expect(click).toHaveBeenCalledOnce();
     expect(revokeObjectURL).toHaveBeenCalledWith('blob:mock-url');
 

--- a/src/utils/downloadJson.ts
+++ b/src/utils/downloadJson.ts
@@ -1,0 +1,15 @@
+export const downloadJson = (data: unknown, filename: string) => {
+  const blob = new Blob([JSON.stringify(data, null, 2)], {
+    type: 'application/json',
+  });
+  const url = URL.createObjectURL(blob);
+
+  const anchor = document.createElement('a');
+  anchor.href = url;
+  anchor.download = filename;
+  document.body.appendChild(anchor);
+  anchor.click();
+  anchor.remove();
+
+  URL.revokeObjectURL(url);
+};

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,6 +1,7 @@
 export * from './applySharedWeights';
 export * from './applyWeightMode';
 export * from './bellColors';
+export * from './downloadJson';
 export * from './equipment';
 export * from './formatRungDuration';
 export * from './maxRung';


### PR DESCRIPTION
## Why

Training history locked inside the app can't inform outside analysis. Handing an AI assistant a complete, self-describing export turns any agent into a coach that knows your full history — without giving it database access.

## What

Adds a "My Data" section to the Account page with an "Export my data" button that downloads the user's full training history as a single JSON file, built for AI-assistant consumption: a `meta.schema` readme explains rep schemes, rungs, complex sets, and dual weights so an agent can interpret the rows without seeing the codebase.

The export covers workout logs (paginated past 1000 rows), movement logs, the user's movement library, equipment, program enrollments/sessions/completions, and pattern-debt aggregates (falling back to `null` if that RPC fails). Profile is limited to `username` and `training_goal` — no Stripe fields, Spotify tokens, or analytics.

## How to test

- `npm run compile:ts` and `npm test` — 139 files / 1105 tests pass, including 5 new tests: download util mechanics, export shape, PII exclusion (no `stripe`/`spotify` substrings in the serialized file), and RPC-failure fallback.
- Live against local Supabase seed data: clicked "Export my data" on `/account` and intercepted the download — correct `bellskill-export-<date>.json` filename, all sections populated (12 workout logs, 15 movement logs, 6 movements, 13 pattern-debt rows), no console errors.

## Gallery

![My Data section on the Account page with the Export my data button](https://github.com/user-attachments/assets/a02eab82-6c85-4a3d-b945-420751cc06da)
