### PR TITLE
feat(movements): add marches, band pull-downs, and Pallof presses

### DIFF
--- a/scripts/data/movements.csv
+++ b/scripts/data/movements.csv
@@ -104,6 +104,8 @@ Kettlebell Double Overhead Carry,Kettlebell,2,Double Arm,Shoulders,Expert,Loaded
 Kettlebell Waiter Carry,Kettlebell,1,Single Arm,Shoulders,Intermediate,Loaded Carry,carry
 Kettlebell Bottoms-Up Carry,Kettlebell,1,Single Arm,Forearms,Intermediate,Loaded Carry,carry
 Kettlebell Mixed Rack Carry,Kettlebell,2,Double Arm,Forearms,Intermediate,Loaded Carry,carry
+Kettlebell Suitcase March,Kettlebell,1,Single Arm,Abdominals,Beginner,Loaded Carry,carry
+Double Kettlebell Farmer March,Kettlebell,2,Double Arm,Forearms,Beginner,Loaded Carry,carry
 Kettlebell Windmill,Kettlebell,1,Single Arm,Abdominals,Intermediate,Rotational,rotation
 Advanced Kettlebell Windmill,Kettlebell,1,Single Arm,Abdominals,Intermediate,Rotational,rotation
 Kettlebell Overhead Windmill,Kettlebell,1,Single Arm,Abdominals,Expert,Rotational,rotation
@@ -157,6 +159,8 @@ L-Sit Pull-Up,Bodyweight,1,Double Arm,Back,Expert,Vertical Pull,pull
 Archer Pull-Up,Bodyweight,1,Double Arm,Back,Expert,Vertical Pull,pull
 Muscle-Up,Bodyweight,1,Double Arm,Back,Expert,Vertical Pull,pull
 Gorilla Chin-Up Crunch,Bodyweight,1,Double Arm,Abdominals,Intermediate,Vertical Pull,pull
+Band Pull-Down,Bodyweight,1,Double Arm,Back,Beginner,Vertical Pull,pull
+Single-Arm Band Pull-Down,Bodyweight,1,Single Arm,Back,Beginner,Vertical Pull,pull
 Inverted Row,Bodyweight,1,Double Arm,Back,Beginner,Horizontal Pull,pull
 Wide-Grip Inverted Row,Bodyweight,1,Double Arm,Back,Beginner,Horizontal Pull,pull
 Underhand Inverted Row,Bodyweight,1,Double Arm,Back,Beginner,Horizontal Pull,pull
@@ -257,3 +261,6 @@ Reverse Plank,Bodyweight,1,Double Arm,Abdominals,Beginner,Anti-Extension,core
 Side Plank Hip Dip,Bodyweight,1,Single Arm,Abdominals,Intermediate,Anti-Rotation,core
 Hanging Windshield Wipers,Bodyweight,1,Double Arm,Abdominals,Expert,Rotational,rotation
 Kettlebell Plank Drag,Kettlebell,1,Single Arm,Abdominals,Intermediate,Anti-Rotation,core
+Pallof Press,Bodyweight,1,Double Arm,Abdominals,Beginner,Anti-Rotation,core
+Half-Kneeling Pallof Press,Bodyweight,1,Double Arm,Abdominals,Intermediate,Anti-Rotation,core
+Single-Leg Pallof Press,Bodyweight,1,Double Arm,Abdominals,Expert,Anti-Rotation,core

--- a/supabase/migrations/20260814180000_add_march_band_pallof_movements.sql
+++ b/supabase/migrations/20260814180000_add_march_band_pallof_movements.sql
@@ -1,0 +1,41 @@
+-- Adds loaded marches, band pull-downs, and the Pallof press family.
+-- The slim-catalog reload migration is already applied upstream and will not
+-- re-run, so catalog additions land as a forward migration. Each insert is
+-- guarded on the name because `movements."Movement"` has no unique index, which
+-- keeps this safe on `supabase db reset` (where the reload runs first) and on
+-- re-application.
+INSERT INTO public.movements (
+  "Movement",
+  "Primary Equipment",
+  "# Primary Items",
+  "Single or Double Arm",
+  "Target Muscle Group",
+  "Difficulty Level",
+  "Movement Pattern #1",
+  pattern_credits
+)
+SELECT *
+FROM (
+  VALUES
+    ('Kettlebell Suitcase March', 'Kettlebell', 1, 'Single Arm', 'Abdominals', 'Beginner', 'Loaded Carry', ARRAY['carry']::text[]),
+    ('Double Kettlebell Farmer March', 'Kettlebell', 2, 'Double Arm', 'Forearms', 'Beginner', 'Loaded Carry', ARRAY['carry']::text[]),
+    ('Band Pull-Down', 'Bodyweight', 1, 'Double Arm', 'Back', 'Beginner', 'Vertical Pull', ARRAY['pull']::text[]),
+    ('Single-Arm Band Pull-Down', 'Bodyweight', 1, 'Single Arm', 'Back', 'Beginner', 'Vertical Pull', ARRAY['pull']::text[]),
+    ('Pallof Press', 'Bodyweight', 1, 'Double Arm', 'Abdominals', 'Beginner', 'Anti-Rotation', ARRAY['core']::text[]),
+    ('Half-Kneeling Pallof Press', 'Bodyweight', 1, 'Double Arm', 'Abdominals', 'Intermediate', 'Anti-Rotation', ARRAY['core']::text[]),
+    ('Single-Leg Pallof Press', 'Bodyweight', 1, 'Double Arm', 'Abdominals', 'Expert', 'Anti-Rotation', ARRAY['core']::text[])
+) AS incoming (
+  movement,
+  primary_equipment,
+  primary_item_count,
+  single_or_double_arm,
+  target_muscle_group,
+  difficulty_level,
+  movement_pattern_1,
+  pattern_credits
+)
+WHERE NOT EXISTS (
+  SELECT 1
+  FROM public.movements m
+  WHERE lower(m."Movement") = lower(incoming.movement)
+);


### PR DESCRIPTION
## Why

The catalog had carries but no loaded marches, no band-anchored pulling, and no dedicated anti-rotation press — so three things I actually program had to be logged as custom movements.

## What

Adds seven rows to the movement catalog: kettlebell suitcase march and double farmer march (Loaded Carry), band pull-down and single-arm band pull-down (Vertical Pull), and the Pallof press family — standing, half-kneeling, single-leg (Anti-Rotation).

Bands aren't an equipment class, so the band rows file as `Bodyweight` with the implement named in the movement, following the `Ab Wheel Rollout` precedent in `docs/movement-catalog.md`. That also keeps them reachable in the builder's `none` weight mode.

CSV plus a guarded forward migration, shaped exactly like `20260805020000_add_ab_wheel_core_movements.sql`. No new vocabulary values, so no enum, type, or Explore filter changes.

## How to test

- `npm run movements:check` — 265 movements valid (122 Kettlebell, 143 Bodyweight).
- `npm test` — 1101 passed.
- `supabase db reset` applies the migration cleanly; re-running the file inserts 0 rows, so the name guard is idempotent.
- Explore on `npm run dev`: searched `march`, `pull-down`, and `pallof` — all seven appear with the right pattern, equipment, and difficulty badges. The two kettlebell marches satisfy `kettlebellReachable` (1×/1H and 2×/2H).

## Deploy notes

One data migration, `20260814180000_add_march_band_pallof_movements.sql`. Additive and name-guarded, so it is safe on re-application. No `gen:types` — no schema change.