### PR TITLE
fix(workout): validate timed rungs in seconds

### DIFF
--- a/src/pages/StartWorkoutPage/components/LadderRepScheme.test.tsx
+++ b/src/pages/StartWorkoutPage/components/LadderRepScheme.test.tsx
@@ -66,6 +66,26 @@ describe('LadderRepScheme — max rungs', () => {
   });
 });
 
+describe('LadderRepScheme — ceilings', () => {
+  test('a timed rung stops at the five-minute ceiling the validator allows', async () => {
+    const onChangeRung = vi.fn();
+    renderLadder({ repScheme: [300], timedRungs: true, onChangeRung });
+
+    await userEvent.click(screen.getByRole('button', { name: '+ sec' }));
+
+    expect(onChangeRung).toHaveBeenCalledWith(0, 300);
+  });
+
+  test('a rep rung stops at the top of its own, smaller range', async () => {
+    const onChangeRung = vi.fn();
+    renderLadder({ repScheme: [50], onChangeRung });
+
+    await userEvent.click(screen.getByRole('button', { name: '+ reps' }));
+
+    expect(onChangeRung).toHaveBeenCalledWith(0, 50);
+  });
+});
+
 describe('LadderRepScheme — rung units', () => {
   test('an active interval timer locks out Time', () => {
     renderLadder({ intervalActive: true });

--- a/src/pages/StartWorkoutPage/components/LadderRepScheme.tsx
+++ b/src/pages/StartWorkoutPage/components/LadderRepScheme.tsx
@@ -7,6 +7,7 @@ import { cn } from '~/lib/utils';
 import {
   MAX_RUNG,
   MAX_RUNG_SYMBOL,
+  MAX_TIMED_RUNG_SECONDS,
   describeRungValue,
   formatRungValue,
   isMaxRung,
@@ -19,7 +20,7 @@ import { ModifyCountButtons } from './ModifyCountButtons';
 // because nudging a two-minute carry a second at a time is unusable. Both bottom
 // out at MAX_RUNG, which reads as "to failure" rather than as a magnitude.
 const REPS_RANGE = { min: MAX_RUNG, max: 50, step: 1 };
-const TIMED_RANGE = { min: MAX_RUNG, max: 300, step: 5 };
+const TIMED_RANGE = { min: MAX_RUNG, max: MAX_TIMED_RUNG_SECONDS, step: 5 };
 
 const MAX_RUNGS = 10;
 
@@ -61,6 +62,10 @@ export const LadderRepScheme = ({
   // Adding/removing rungs can leave the focus past the end; clamp on render.
   const focused = Math.min(focusedRung, repScheme.length - 1);
   const range = timedRungs ? TIMED_RANGE : REPS_RANGE;
+  // The validator rejects a rung past the ceiling, so the picker never hands one
+  // out — winding or typing past either end lands on the end.
+  const clampToRange = (value: number) =>
+    Math.min(range.max, Math.max(range.min, value));
   const label = (rung: number) => formatRungValue(rung, timedRungs);
   const unitLabel = unitNoun === 'set' ? 'Set' : 'Rung';
 
@@ -147,12 +152,12 @@ export const LadderRepScheme = ({
         unit={timedRungs ? 'sec' : 'reps'}
         formatValue={(value) => (isMaxRung(value) ? MAX_RUNG_SYMBOL : null)}
         describeValue={(value) => describeRungValue(value, timedRungs)}
-        onChange={(value) => onChangeRung(focused, value)}
+        onChange={(value) => onChangeRung(focused, clampToRange(value))}
         onClickMinus={() =>
-          onChangeRung(focused, repScheme[focused] - range.step)
+          onChangeRung(focused, clampToRange(repScheme[focused] - range.step))
         }
         onClickPlus={() =>
-          onChangeRung(focused, repScheme[focused] + range.step)
+          onChangeRung(focused, clampToRange(repScheme[focused] + range.step))
         }
       />
 

--- a/src/utils/validateWorkout.test.ts
+++ b/src/utils/validateWorkout.test.ts
@@ -173,6 +173,43 @@ describe('validateWorkout — invalid_reps', () => {
       codes(draft({ movements: [movement({ repScheme: [5, 0] })] })),
     ).not.toContain('invalid_reps');
   });
+
+  // Timed rungs hold seconds, so the rep ceiling would block a carry over 1:40.
+  test.each([[101], [120], [300]])(
+    'passes on a timed rung of %p seconds',
+    (rung: number) => {
+      expect(
+        codes(
+          draft({
+            movements: [movement({ repScheme: [60, rung], timedRungs: true })],
+          }),
+        ),
+      ).not.toContain('invalid_reps');
+    },
+  );
+
+  test.each([[301], [-1], [2.5]])(
+    'errors on a timed rung of %p seconds',
+    (rung: number) => {
+      expect(
+        codes(
+          draft({
+            movements: [movement({ repScheme: [60, rung], timedRungs: true })],
+          }),
+        ),
+      ).toContain('invalid_reps');
+    },
+  );
+
+  test('0 is still the max sentinel on a timed movement', () => {
+    expect(
+      codes(
+        draft({
+          movements: [movement({ repScheme: [60, 0], timedRungs: true })],
+        }),
+      ),
+    ).not.toContain('invalid_reps');
+  });
 });
 
 describe('validateWorkout — non_positive_weight', () => {

--- a/src/utils/validateWorkout.ts
+++ b/src/utils/validateWorkout.ts
@@ -73,7 +73,13 @@ export interface WorkoutValidation {
   warnings: WorkoutIssue[];
 }
 
-const MAX_REP = 100;
+/**
+ * Rung ceilings, in the rung's own unit. Timed rungs hold seconds, so they run
+ * far past the rep ceiling — a five-minute carry is 300. The builder's pickers
+ * read these so the validator and the range you can dial can't drift apart.
+ */
+export const MAX_REP_RUNG = 100;
+export const MAX_TIMED_RUNG_SECONDS = 300;
 /** Generous kettlebell ceiling — absurd, but not impossible, so only a warning. */
 const MAX_PLAUSIBLE_WEIGHT_KG = 100;
 
@@ -146,18 +152,25 @@ export const validateWorkout = (draft: WorkoutDraft): WorkoutValidation => {
         message: 'This movement has an empty rep scheme — add at least one rung.',
         movementIndex,
       });
-    } else if (
+    } else {
+      const maxRungValue = movement.timedRungs
+        ? MAX_TIMED_RUNG_SECONDS
+        : MAX_REP_RUNG;
       // 0 is allowed: it is the max-rung sentinel, not a magnitude.
-      movement.repScheme.some(
-        (rung) => !Number.isInteger(rung) || rung < 0 || rung > MAX_REP,
-      )
-    ) {
-      errors.push({
-        code: 'invalid_reps',
-        severity: 'error',
-        message: `This movement has invalid rep counts — every rung must be a whole number from 1 to ${MAX_REP}, or 0 for max.`,
-        movementIndex,
-      });
+      if (
+        movement.repScheme.some(
+          (rung) => !Number.isInteger(rung) || rung < 0 || rung > maxRungValue,
+        )
+      ) {
+        errors.push({
+          code: 'invalid_reps',
+          severity: 'error',
+          message: movement.timedRungs
+            ? `This movement has invalid rung durations — every rung must be a whole number of seconds from 1 to ${MAX_TIMED_RUNG_SECONDS}, or 0 for max.`
+            : `This movement has invalid rep counts — every rung must be a whole number from 1 to ${MAX_REP_RUNG}, or 0 for max.`,
+          movementIndex,
+        });
+      }
     }
 
     // null is bodyweight, which is a real workout. The rule is "weight, when


### PR DESCRIPTION
## Why

`validateWorkout` capped every rung at 100 with no exemption for timed rungs, but timed rungs hold *seconds* and the builder's `TIMED_RANGE` offers up to 300. Any timed movement over 1:40 failed validation and blocked Start, with a message that made no sense for a duration:

> This movement has invalid rep counts — every rung must be a whole number from 1 to 100, or 0 for max.

Pre-existing and unrelated to #248; noticed while loosening the adjacent rule to let `0` through as the max sentinel. Nothing shipped is affected — every program seed uses 30s or 60s rungs — so it only bit a user building a long carry or hold themselves.

## What

Split the rung ceiling in two — `MAX_REP_RUNG = 100` and `MAX_TIMED_RUNG_SECONDS = 300` — pick the one that matches the rung's unit, and clamp the ladder picker to the range it offers so the validator and the picker cannot drift apart again.

Three parts:

1. **`validateWorkout.ts`** — the `invalid_reps` rule reads `movement.timedRungs` to choose its ceiling, and phrases the message in the right unit ("invalid rung durations — … whole number of seconds from 1 to 300"). Non-integers, negatives, and `0` as the max sentinel behave exactly as before in both units. Still dependency-free with relative imports for the Deno edge runtime.
2. **`LadderRepScheme.tsx`** — `TIMED_RANGE.max` now comes from `MAX_TIMED_RUNG_SECONDS` instead of a duplicated `300`.
3. **`LadderRepScheme.tsx`, the clamp** — driving the real builder turned up the other half of the bug: `onClickPlus` passed `value + step` straight through, so holding **+** ran a timed rung to 6:00 and blocked Start just past the new ceiling. Reps were only ever saved by the validator's ceiling sitting *above* the picker's. Both ends of both units now clamp to the offered range.

## How to test

- `npm test` (1110 passed), `npm run compile:ts`, `npm run lint` — all clean.
- New `invalid_reps` cases: timed rungs of 101/120/300 pass; 301, `-1`, and `2.5` fail; `0` stays valid as max in both units. The existing rep cases are unchanged, so 101 reps still errors.
- New `LadderRepScheme` cases pin the clamp at each ceiling — `+` on a 300s rung stays 300, `+` on a 50-rep rung stays 50.
- In the running app: built a 2-hand Farmers Carry, switched the rep scheme to **Time**, and wound the duration up. It stops at **5:00** with no error and Start enabled. Before the fix the same movement showed the rep-count message at 1:45 with Start dead.

No new case in `supabase/functions/recommend-session/validate.test.ts`: `recommendationToDraft` never sets `timedRungs`, so every recommender rung is reps and the existing `101` rejection is already the right assertion there.

## Gallery

No visual change — the difference is Start enabled versus blocked, covered under How to test. Happy to attach a capture of the 5:00 carry if it's useful.

## Tradeoffs

The alternative was a single ceiling raised to 300 for both units. It's a one-line change and keeps the message simple, which is worth something. It also silently accepts a 250-rep swing, which is exactly the kind of recommendation this validator exists to catch — so the unit-aware ceiling won.
