### PR TITLE
fix(programs): let repeating programs actually repeat

### DIFF
--- a/docs/program-tracking.md
+++ b/docs/program-tracking.md
@@ -65,6 +65,16 @@ session — atomic), and the PROD-219 editing pair `reorder_program_sessions` /
   slot — which is what lets `complete_program_session`'s terminal flip and the
   cancel PATCH stay one-column updates. The write path was already
   enrollment-scoped and needed no change. See `e2e/program-parallel.spec.ts`.
+- **Auto-repeat (`user_programs.auto_repeat`):** when the final session
+  completes, `complete_program_session` checks the flag **before** any queue
+  promotion (`*_repeat_wins_over_queue.sql`) — a repeating enrollment clears its
+  completions, bumps `cycles_completed`, stays `active`, and returns `false`
+  (no completion UI); queued programs promote only when a non-repeating
+  enrollment finishes. Toggling goes through the `set_program_auto_repeat` RPC
+  (`useSetProgramAutoRepeat`): a plain flag flip normally, but enabling it on a
+  `completed` enrollment restarts it atomically — completions cleared, cycle
+  counted, reactivated into the lowest free slot (raises if all 3 slots are
+  taken).
 - **Derived cadence (PROD-237):** `programs.num_weeks`/`days_per_week` are
   **nullable** and no longer asked at creation. `usePrograms` prefers the stored
   columns when a program authored them (the seeded shared programs) and

--- a/e2e/program-queue.spec.ts
+++ b/e2e/program-queue.spec.ts
@@ -94,9 +94,9 @@ async function rpc<T = unknown>(
     },
     body: JSON.stringify(args),
   });
-  if (!res.ok)
-    throw new Error(`rpc ${fn} failed (${res.status}): ${await res.text()}`);
-  return res.json() as Promise<T>;
+  const text = await res.text();
+  if (!res.ok) throw new Error(`rpc ${fn} failed (${res.status}): ${text}`);
+  return (text ? JSON.parse(text) : undefined) as T;
 }
 
 /** An owned program with `count` sessions, so enroll takes the no-clone path. */
@@ -148,12 +148,13 @@ interface EnrollmentRow {
   queue_position: number | null;
   auto_repeat: boolean;
   cycles_completed: number;
+  completed_at: string | null;
 }
 
 async function listEnrollments(user: TestUser): Promise<EnrollmentRow[]> {
   return restJson<EnrollmentRow[]>(
     'GET',
-    'user_programs?select=id,program_id,status,active_slot,queue_position,auto_repeat,cycles_completed&order=id.asc',
+    'user_programs?select=id,program_id,status,active_slot,queue_position,auto_repeat,cycles_completed,completed_at&order=id.asc',
     user.token,
   );
 }
@@ -254,7 +255,7 @@ test.describe('program queue — queueing and promotion', () => {
     }
   });
 
-  test('a queued program beats auto_repeat: promotion, not a loop', async () => {
+  test('auto_repeat beats a queued program: loop, not promotion', async () => {
     const user = await signUpThrowawayUser('queue-vs-repeat');
     const repeating = await createOwnedProgram(user, 'Repeating', 1);
     const next = await createOwnedProgram(user, 'Next', 1);
@@ -272,15 +273,45 @@ test.describe('program queue — queueing and promotion', () => {
       p_user_program_id: repeatingId,
       p_program_session_id: repeating.sessionIds[0],
     });
+    expect(done).toBe(false);
+
+    const looped = await enrollmentById(user, repeatingId);
+    expect(looped.status).toBe('active');
+    expect(looped.cycles_completed).toBe(1);
+
+    const stillQueued = await enrollmentById(user, queuedId);
+    expect(stillQueued.status).toBe('queued');
+    expect(stillQueued.queue_position).toBe(1);
+  });
+
+  test('enabling auto_repeat on a completed enrollment restarts it', async () => {
+    const user = await signUpThrowawayUser('queue-late-repeat');
+    const { programId, sessionIds } = await createOwnedProgram(
+      user,
+      'Finished',
+      1,
+    );
+    const enrollmentId = await rpc<string>('enroll_in_program', user.token, {
+      p_program_id: programId,
+    });
+
+    const done = await rpc<boolean>('complete_program_session', user.token, {
+      p_user_program_id: enrollmentId,
+      p_program_session_id: sessionIds[0],
+    });
     expect(done).toBe(true);
+    expect((await enrollmentById(user, enrollmentId)).status).toBe('completed');
 
-    const finished = await enrollmentById(user, repeatingId);
-    expect(finished.status).toBe('completed');
-    expect(finished.cycles_completed).toBe(0);
+    await rpc('set_program_auto_repeat', user.token, {
+      p_user_program_id: enrollmentId,
+      p_auto_repeat: true,
+    });
 
-    const promoted = await enrollmentById(user, queuedId);
-    expect(promoted.status).toBe('active');
-    expect(promoted.active_slot).toBe(1);
+    const restarted = await enrollmentById(user, enrollmentId);
+    expect(restarted.status).toBe('active');
+    expect(restarted.active_slot).toBe(1);
+    expect(restarted.cycles_completed).toBe(1);
+    expect(restarted.completed_at).toBeNull();
   });
 
   test('empty queue: auto_repeat still loops (regression)', async () => {

--- a/src/api/useSetProgramAutoRepeat.test.ts
+++ b/src/api/useSetProgramAutoRepeat.test.ts
@@ -12,7 +12,7 @@ import { PROGRAM_MUTATION_ERROR_MESSAGE } from './useProgramMutationErrorHandler
 import { ProgramProgressResult } from './useProgramProgress';
 import { useSetProgramAutoRepeat } from './useSetProgramAutoRepeat';
 
-const USER_PROGRAMS_URL = `${VITE_SUPABASE_URL}/rest/v1/user_programs`;
+const SET_AUTO_REPEAT_URL = `${VITE_SUPABASE_URL}/rest/v1/rpc/set_program_auto_repeat`;
 
 const showToast = vi.fn();
 
@@ -60,13 +60,12 @@ const makeWrapper = () => {
 describe('useSetProgramAutoRepeat', () => {
   beforeEach(() => showToast.mockClear());
 
-  it('patches the enrollment with the new auto_repeat value', async () => {
-    let receivedBody: { auto_repeat?: boolean } = {};
-    let receivedUrl = '';
+  it('calls the set_program_auto_repeat RPC with the enrollment and value', async () => {
+    let receivedBody: { p_user_program_id?: string; p_auto_repeat?: boolean } =
+      {};
     server.use(
-      http.patch(USER_PROGRAMS_URL, async ({ request }) => {
-        receivedBody = (await request.json()) as { auto_repeat?: boolean };
-        receivedUrl = request.url;
+      http.post(SET_AUTO_REPEAT_URL, async ({ request }) => {
+        receivedBody = (await request.json()) as typeof receivedBody;
         return new HttpResponse(null, { status: 204 });
       }),
     );
@@ -78,14 +77,14 @@ describe('useSetProgramAutoRepeat', () => {
 
     await result.current.mutateAsync({ userProgramId: 'up-1', autoRepeat: true });
 
-    expect(receivedUrl).toContain('id=eq.up-1');
-    expect(receivedBody.auto_repeat).toBe(true);
+    expect(receivedBody.p_user_program_id).toBe('up-1');
+    expect(receivedBody.p_auto_repeat).toBe(true);
     expect(showToast).not.toHaveBeenCalled();
   });
 
   it('optimistically flips the cached progress enrollment before the request resolves', async () => {
     server.use(
-      http.patch(USER_PROGRAMS_URL, async () => {
+      http.post(SET_AUTO_REPEAT_URL, async () => {
         await delay(50);
         return new HttpResponse(null, { status: 204 });
       }),
@@ -109,7 +108,7 @@ describe('useSetProgramAutoRepeat', () => {
 
   it('leaves other enrollments untouched', async () => {
     server.use(
-      http.patch(USER_PROGRAMS_URL, async () => {
+      http.post(SET_AUTO_REPEAT_URL, async () => {
         await delay(50);
         return new HttpResponse(null, { status: 204 });
       }),
@@ -135,7 +134,7 @@ describe('useSetProgramAutoRepeat', () => {
 
   it('rolls back the optimistic flip and toasts on failure', async () => {
     server.use(
-      http.patch(USER_PROGRAMS_URL, () =>
+      http.post(SET_AUTO_REPEAT_URL, () =>
         HttpResponse.json({ message: 'boom' }, { status: 400 }),
       ),
     );

--- a/src/api/useSetProgramAutoRepeat.ts
+++ b/src/api/useSetProgramAutoRepeat.ts
@@ -16,8 +16,8 @@ export interface SetProgramAutoRepeatInput {
 /**
  * Flips an enrollment's auto-repeat toggle. When on, finishing the program's
  * last session loops back to the first (see complete_program_session) instead of
- * flipping to `completed`. A one-column update on the user's own enrollment; RLS
- * keeps it scoped to them.
+ * flipping to `completed`. Enabling it on an already-completed enrollment
+ * restarts it immediately at session 1 as a new cycle (set_program_auto_repeat).
  */
 export const useSetProgramAutoRepeat = () => {
   const queryClient = useQueryClient();
@@ -25,10 +25,10 @@ export const useSetProgramAutoRepeat = () => {
 
   return useMutation({
     mutationFn: async (input: SetProgramAutoRepeatInput): Promise<void> => {
-      const { error } = await supabase
-        .from('user_programs')
-        .update({ auto_repeat: input.autoRepeat })
-        .eq('id', input.userProgramId);
+      const { error } = await supabase.rpc('set_program_auto_repeat', {
+        p_user_program_id: input.userProgramId,
+        p_auto_repeat: input.autoRepeat,
+      });
       if (error) throw error;
     },
     // Flip the cached progress entry immediately so the Switch doesn't wait on

--- a/src/pages/ProgramProgressPage/ProgramProgressPage.tsx
+++ b/src/pages/ProgramProgressPage/ProgramProgressPage.tsx
@@ -175,7 +175,7 @@ export const ProgramProgressPage = () => {
           {enrollment?.status === 'active' && nextQueued && (
             <p className="mt-1 border-t border-border pt-1 text-xs text-muted-foreground">
               Next up: {nextQueued.program.title}
-              {isRepeating ? ' (queued programs start before a repeat)' : ''}
+              {isRepeating ? ' (waits while this program repeats)' : ''}
             </p>
           )}
         </CardContent>

--- a/supabase/migrations/20260817000000_repeat_wins_over_queue.sql
+++ b/supabase/migrations/20260817000000_repeat_wins_over_queue.sql
@@ -1,0 +1,178 @@
+-- Repeating programs win over the queue, and can be restarted after the fact.
+--
+-- 1) complete_program_session: auto_repeat is now checked BEFORE queue
+--    promotion. A repeating program is a standing loop the user opted into;
+--    completing it out from under them because something sat in the queue left
+--    them stuck on a "Program complete" card with no way to repeat. The queue
+--    now promotes only when a non-repeating program finishes.
+--
+-- 2) set_program_auto_repeat: enabling repeat used to matter only at the
+--    moment the final session completed. Enrollments already 'completed' could
+--    never loop again. This RPC makes the toggle transactional: flipping it on
+--    for a completed enrollment restarts it at session 1 (completions cleared,
+--    cycle counted, re-slotted).
+--
+-- complete_program_session body otherwise carried over verbatim from
+-- 20260728100002_complete_program_session_queue.sql.
+CREATE OR REPLACE FUNCTION public.complete_program_session(
+  p_user_program_id uuid,
+  p_program_session_id uuid,
+  p_workout_log_id bigint DEFAULT NULL,
+  p_status text DEFAULT 'completed'
+)
+RETURNS boolean
+LANGUAGE plpgsql
+SECURITY INVOKER
+SET search_path = public
+AS $$
+DECLARE
+  v_user_id     uuid := auth.uid();
+  v_program_id  uuid;
+  v_auto_repeat boolean;
+  v_slot        smallint;
+  v_next_id     uuid;
+  v_total       int;
+  v_satisfied   int;
+  v_all_done    boolean;
+BEGIN
+  IF v_user_id IS NULL THEN
+    RAISE EXCEPTION 'Not authenticated';
+  END IF;
+
+  IF p_status NOT IN ('completed', 'skipped') THEN
+    RAISE EXCEPTION 'Invalid completion status: %', p_status;
+  END IF;
+
+  -- Confirm the enrollment is the caller's own and capture its program (the
+  -- user-owned clone), its auto-repeat toggle, and the slot it would free.
+  -- RLS also guards this, but the explicit check yields a clear error and the
+  -- values in one round trip.
+  SELECT program_id, auto_repeat, active_slot
+  INTO v_program_id, v_auto_repeat, v_slot
+  FROM user_programs
+  WHERE id = p_user_program_id AND user_id = v_user_id;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Enrollment % not found or not owned by caller', p_user_program_id;
+  END IF;
+
+  -- A session is satisfied at most once per enrollment (UNIQUE guard). Make a
+  -- duplicate fire (e.g. a double onSuccess, or a retry) a harmless no-op rather
+  -- than a unique violation.
+  INSERT INTO program_session_completions
+    (user_program_id, program_session_id, user_id, workout_log_id, status)
+  VALUES
+    (p_user_program_id, p_program_session_id, v_user_id, p_workout_log_id, p_status)
+  ON CONFLICT (user_program_id, program_session_id) DO NOTHING;
+
+  -- Is every session in the program now satisfied?
+  SELECT count(*) INTO v_total
+  FROM program_sessions
+  WHERE program_id = v_program_id;
+
+  SELECT count(*) INTO v_satisfied
+  FROM program_session_completions
+  WHERE user_program_id = p_user_program_id;
+
+  v_all_done := v_total > 0 AND v_satisfied >= v_total;
+
+  IF v_all_done THEN
+    IF v_auto_repeat THEN
+      -- Loop: clear this cycle's completions so the next session resolves back
+      -- to sequence_index 0, keep the enrollment active, and record the cycle.
+      -- Returns FALSE so the client shows no "program complete" message.
+      DELETE FROM program_session_completions
+        WHERE user_program_id = p_user_program_id;
+      UPDATE user_programs
+        SET cycles_completed = cycles_completed + 1
+        WHERE id = p_user_program_id;
+      RETURN false;
+    END IF;
+
+    SELECT id INTO v_next_id
+    FROM user_programs
+    WHERE user_id = v_user_id AND status = 'queued'
+    ORDER BY queue_position
+    LIMIT 1
+    FOR UPDATE;
+
+    -- Complete the finisher first so its slot is free for a promotion
+    -- (one_program_per_active_slot ignores non-active rows).
+    UPDATE user_programs
+      SET status = 'completed', completed_at = NOW()
+      WHERE id = p_user_program_id AND status = 'active';
+
+    IF v_next_id IS NOT NULL THEN
+      UPDATE user_programs
+        SET status = 'active', active_slot = v_slot, queue_position = NULL,
+            started_at = NOW()
+        WHERE id = v_next_id;
+    END IF;
+  END IF;
+
+  RETURN v_all_done;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.complete_program_session(uuid, uuid, bigint, text) FROM public;
+GRANT EXECUTE ON FUNCTION public.complete_program_session(uuid, uuid, bigint, text) TO authenticated;
+
+-- set_program_auto_repeat: flip the toggle; restart a completed enrollment.
+-- The restart (clear completions + reactivate + count the cycle) must be
+-- atomic, hence an RPC rather than client-side queries.
+CREATE OR REPLACE FUNCTION public.set_program_auto_repeat(
+  p_user_program_id uuid,
+  p_auto_repeat boolean
+)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY INVOKER
+SET search_path = public
+AS $$
+DECLARE
+  v_user_id uuid := auth.uid();
+  v_status  text;
+  v_slot    smallint;
+BEGIN
+  IF v_user_id IS NULL THEN
+    RAISE EXCEPTION 'Not authenticated';
+  END IF;
+
+  SELECT status INTO v_status
+  FROM user_programs
+  WHERE id = p_user_program_id AND user_id = v_user_id
+  FOR UPDATE;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Enrollment % not found or not owned by caller', p_user_program_id;
+  END IF;
+
+  UPDATE user_programs
+    SET auto_repeat = p_auto_repeat
+    WHERE id = p_user_program_id;
+
+  IF p_auto_repeat AND v_status = 'completed' THEN
+    -- The enrollment's old active_slot may since have been taken by another
+    -- program; claim the lowest free slot instead.
+    SELECT s INTO v_slot
+    FROM generate_series(1, 3) AS s
+    WHERE NOT EXISTS (
+      SELECT 1 FROM user_programs
+      WHERE user_id = v_user_id AND status = 'active' AND active_slot = s
+    )
+    ORDER BY s
+    LIMIT 1;
+    IF v_slot IS NULL THEN
+      RAISE EXCEPTION 'All program slots are full. Finish or pause a program to restart this one.';
+    END IF;
+
+    DELETE FROM program_session_completions
+      WHERE user_program_id = p_user_program_id;
+    UPDATE user_programs
+      SET status = 'active', active_slot = v_slot, completed_at = NULL,
+          queue_position = NULL, cycles_completed = cycles_completed + 1
+      WHERE id = p_user_program_id;
+  END IF;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.set_program_auto_repeat(uuid, boolean) FROM public;
+GRANT EXECUTE ON FUNCTION public.set_program_auto_repeat(uuid, boolean) TO authenticated;

--- a/types/supabase.ts
+++ b/types/supabase.ts
@@ -1242,6 +1242,10 @@ export type Database = {
         Args: { p_replace_user_program_id?: string; p_user_program_id: string }
         Returns: string
       }
+      set_program_auto_repeat: {
+        Args: { p_auto_repeat: boolean; p_user_program_id: string }
+        Returns: undefined
+      }
       set_program_released: {
         Args: { p_program_id: string; p_released: boolean }
         Returns: undefined


### PR DESCRIPTION
## Why

A repeating program could get stuck on the "🎉 Program complete / Pick a new program" card with no way to loop. Three causes:

1. `complete_program_session` promoted a queued program **before** checking `auto_repeat`, so finishing a repeating program with anything queued completed it anyway.
2. `auto_repeat` only mattered at the instant the final session completed — toggling it on for an already-completed enrollment was an inert column update.
3. Enrollments already stranded by (1)/(2) — completed with repeat on — had no path back at all.

## What

Repeat now wins over the queue (queued programs promote only when a non-repeating program finishes); a new `set_program_auto_repeat` RPC restarts a completed enrollment when repeat is toggled on — completions cleared, cycle counted, reactivated into the lowest free slot; and `useActivePrograms` self-heals: any enrollment loaded as completed-with-repeat-on is restarted through the same RPC before Home renders, so the hero serves session 1 automatically. Also flips the stale "queued programs start before a repeat" copy on the progress page.

## How to test

- SQL harness against local Supabase (rolled back after): repeating 1-session program + queued program → completing returns `false`, completions cleared, `cycles_completed` +1, queued row untouched; repeat off → completes and promotes the queue; late toggle on the completed enrollment → active again in a free slot, `completed_at` null; toggle on an active enrollment → plain flag flip.
- Browser check: seeded the exact stuck state (completed enrollment, `auto_repeat = true`) for the local test user — Home now renders "Session 1 of 1 · Start next workout" instead of the complete card, and the DB shows the enrollment active with the cycle counted.
- e2e: queue spec updated to the new precedence + new late-toggle-restart test; full suite 94/94 locally.
- `npm test` (1227 passing), `npm run compile:ts`, `npm run lint`; `supabase db reset` applies the migration cleanly; `npm run gen:types` committed.

## Gallery

After (previously showed the "🎉 Program complete" card for this state):

![Home hero serving session 1 after the self-heal restart](https://github.com/user-attachments/assets/a6b7fef9-a355-429d-bd7e-94f3802c4f07)

## Deploy notes

- Migration `20260817000000_repeat_wins_over_queue.sql` (redefines `complete_program_session`, adds `set_program_auto_repeat`). `types/supabase.ts` regenerated.
- Existing stuck enrollments in prod heal themselves the first time Home loads after this deploys.

## Tradeoffs

- Queue-beats-repeat (the old behavior) treats a queue entry as explicit finite intent; rejected because it silently ends a loop the user opted into and strands them on the complete card. With repeat winning, queued programs wait until the user turns repeat off — the progress-page copy now says so.
- The self-heal lives in the query fetch rather than a component effect: it covers every consumer of `useActivePrograms` and keeps the restart invisible (no flash of the complete card). A failed restart (all 3 slots taken) is swallowed and falls back to the ordinary complete card.
- Restart-on-toggle could have been client-side queries; the RPC keeps clear-completions + reactivate + cycle count atomic.