### PR TITLE
fix(ci): let production db push apply out-of-order migrations

### DIFF
--- a/.github/workflows/supabase-production.yaml
+++ b/.github/workflows/supabase-production.yaml
@@ -32,7 +32,10 @@ jobs:
           version: latest
 
       - run: supabase link --project-ref $SUPABASE_PROJECT_ID
-      - run: supabase db push
+      # --include-all: parallel branches can merge in a different order than their
+      # migration timestamps; without it, push refuses the earlier-stamped ones and
+      # the whole deploy (including edge functions) stalls.
+      - run: supabase db push --include-all
       - name: Deploy edge functions
         run: |
           for dir in supabase/functions/*/; do


### PR DESCRIPTION
## What
One-line CI change: `supabase db push` → `supabase db push --include-all` in the production deploy workflow.

## Why
Parallel worktree branches can merge to main in a different order than their migration timestamps. Ghost pacing (#258) applied `20260815120000` to prod first; Training Mix (#255) then merged with earlier-stamped migrations (`20260815000000/1`), and `db push` refuses out-of-order migrations without `--include-all`. The last three production deploys failed at that step — before the edge-function deploy — leaving prod missing 5 migrations and the `chalk-chat` function (every Chalk request 404s, shown as "Something went wrong — try again").

Staging needs no change: it rebuilds with `db reset --linked`.

## How tested
Confirmed via prod logs (chalk-chat OPTIONS 404), `list_edge_functions` (no chalk-chat), `list_migrations` (last applied = `20260815120000`), and the failed run logs for the three deploys. After merge, will dispatch the workflow manually (merge only touches `.github/`, outside the `supabase/**` path filter) and verify migrations + function land.

## Tradeoffs
Considered renaming the two modality-credits migrations to fresh timestamps instead — but they're already recorded under their current versions in staging/local history, so renaming would make those environments re-apply them and fail on existing objects. `--include-all` is the Supabase-documented remedy; the cost is that future out-of-order merges apply silently, which is the desired behavior for a solo repo with parallel worktrees.